### PR TITLE
Update badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # <img align="left" src="images/spotless_logo.png"> Spotless: Keep your code spotless with Gradle
 
 [![Gradle plugin](https://img.shields.io/badge/plugins.gradle.org-com.diffplug.gradle.spotless-blue.svg)](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless)
-[![JCenter artifact](https://img.shields.io/badge/mavenCentral-com.diffplug.gradle.spotless%3Aspotless-blue.svg)](https://bintray.com/diffplug/opensource/spotless/view)
+[![JCenter artifact](https://img.shields.io/badge/mavenCentral-com.diffplug.gradle.spotless%3Aspotless-blue.svg?label=JCenter)](https://bintray.com/diffplug/opensource/spotless/view)
 [![Latest version](http://img.shields.io/badge/latest-1.3.3-blue.svg)](CHANGES.md)
 [![Changelog](http://img.shields.io/badge/changelog-1.4.0--SNAPSHOT-brightgreen.svg)](CHANGES.md)
 [![Travis CI](https://travis-ci.org/diffplug/spotless.svg?branch=master)](https://travis-ci.org/diffplug/spotless)
-[![License](https://img.shields.io/badge/license-Apache-brightgreen.svg)](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
+[![License](https://img.shields.io/github/license/diffplug/spotless.svg)](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 [![Join the chat at https://gitter.im/diffplug/gitfromscratch](https://img.shields.io/badge/gitter-live_chat-brightgreen.svg)](https://gitter.im/diffplug/spotless)
 
 Spotless can check and apply formatting for any plain-text file, with special support for Markdown and Java.  It supports several formatters out of the box, including:


### PR DESCRIPTION
The JCentral-badge has the wrong label and shields.io is providing an API for a licence-badge, so there is no need to make a custom badge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/diffplug/spotless/16)
<!-- Reviewable:end -->
