### PR TITLE
Fun with line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ spotless {
 			// each step receives a string as input, and should output
 			// a formatted string as output.
 		}
+		
+		// If you don't specify a format specific line ending, the spotless-global setting will be used.
+		lineEndings = 'UNIX'
 	}
 
 	// If you'd like to specify that files should always have a certain line ending, you can,

--- a/README.md
+++ b/README.md
@@ -156,20 +156,20 @@ spotless {
 			// when writing a custom step, it will be helpful to know
 			// how the formatting process works, which is as follows:
 
-			// 1) Load each target file, and convert it to unix-style line endings ('\n')
+			// 1) Load each target file
 			// 2) Pass its content through a series of steps, feeding the output of each step to the next
-			// 3) Put the correct line endings back on, then either check or apply
+			// 3) Then either check or apply
 
 			// each step receives a string as input, and should output
-			// a formatted string as output.  Each step can trust that its
-			// input will have unix newlines, and it must promise to output
-			// only unix newlines.  Other than that, anything is fair game!
+			// a formatted string as output.
 		}
 	}
 
 	// If you'd like to specify that files should always have a certain line ending, you can,
-	// but the default value of PLATFORM_NATIVE is *highly* recommended
-	lineEndings = PLATFORM_NATIVE 	// can be WINDOWS, UNIX, or PLATFORM_NATIVE
+	// but the default value of PLATFORM_NATIVE is *highly* recommended.
+	// DERIVED means the line ending is derived for each file based on the first line ending
+	// in its content. If none is found PLATFORM_NATIVE is used.
+	lineEndings = 'PLATFORM_NATIVE' 	// can be WINDOWS, UNIX, PLATFORM_NATIVE or DERIVED
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,12 @@ dependencies {
 		// UNCOMMENT TO DOWNLOAD SOURCE JARS
 		//embeddedJars "p2:${name}.source:${ver}"
 	}
-
+	
 	configurations.compile.extendsFrom(configurations.embeddedJars)
+	
+	testCompile 'org.mockito:mockito-core:1.10.19', {
+		exclude group:'org.hamcrest', module: 'hamcrest-core'
+	}
 }
 
 jar {

--- a/src/main/java/com/diffplug/gradle/spotless/FileEndingStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/FileEndingStep.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+public class FileEndingStep {
+	private LineEnding lineEnding;
+	private LineEndingService lineEndingService;
+
+	public FileEndingStep(LineEnding lineEnding) {
+		this(lineEnding, new LineEndingService());
+	}
+
+	FileEndingStep(LineEnding lineEnding, LineEndingService lineEndingService) {
+		this.lineEnding = lineEnding;
+		this.lineEndingService = lineEndingService;
+
+	}
+
+	public String format(String input) {
+		String lineSeparator = lineEndingService.getLineSeparatorOrDefault(lineEnding, input);
+		int indexOfLastNonWhitespaceCharacter = lineEndingService.indexOfLastNonWhitespaceCharacter(input);
+
+		if (indexOfLastNonWhitespaceCharacter == -1) {
+			return lineSeparator;
+		}
+
+		StringBuilder builder = new StringBuilder(indexOfLastNonWhitespaceCharacter + 2);
+		builder.append(input, 0, indexOfLastNonWhitespaceCharacter + 1);
+		builder.append(lineSeparator);
+		return builder.toString();
+	}
+}

--- a/src/main/java/com/diffplug/gradle/spotless/FileEndingStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/FileEndingStep.java
@@ -18,6 +18,7 @@ package com.diffplug.gradle.spotless;
 public class FileEndingStep {
 	private LineEnding lineEnding;
 	private LineEndingService lineEndingService;
+	private boolean clobber = true;
 
 	public FileEndingStep(LineEnding lineEnding) {
 		this(lineEnding, new LineEndingService());
@@ -26,10 +27,17 @@ public class FileEndingStep {
 	FileEndingStep(LineEnding lineEnding, LineEndingService lineEndingService) {
 		this.lineEnding = lineEnding;
 		this.lineEndingService = lineEndingService;
+	}
 
+	public void disableClobber() {
+		this.clobber = false;
 	}
 
 	public String format(String input) {
+		return clobber ? formatWithClobber(input) : formatWithoutClobber(input);
+	}
+
+	public String formatWithClobber(String input) {
 		String lineSeparator = lineEndingService.getLineSeparatorOrDefault(lineEnding, input);
 		int indexOfLastNonWhitespaceCharacter = lineEndingService.indexOfLastNonWhitespaceCharacter(input);
 
@@ -42,4 +50,10 @@ public class FileEndingStep {
 		builder.append(lineSeparator);
 		return builder.toString();
 	}
+
+	public String formatWithoutClobber(String input) {
+		String lineSeparator = lineEndingService.getLineSeparatorOrDefault(lineEnding, input);
+		return input.endsWith(lineSeparator) ? input : input + lineSeparator;
+	}
+
 }

--- a/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -134,36 +134,7 @@ public class FormatExtension {
 
 	/** Ensures that files end with a single newline. */
 	public void endWithNewline() {
-		custom("endWithNewline", raw -> {
-			// simplifies the logic below if we can assume length > 0
-			if (raw.isEmpty()) {
-				return "\n";
-			}
-
-			// find the last character which has real content
-			int lastContentCharacter = raw.length() - 1;
-			char c;
-			while (lastContentCharacter >= 0) {
-				c = raw.charAt(lastContentCharacter);
-				if (c == '\n' || c == '\t' || c == ' ') {
-					--lastContentCharacter;
-				} else {
-					break;
-				}
-			}
-
-			// if it's already clean, no need to create another string
-			if (lastContentCharacter == -1) {
-				return "\n";
-			} else if (lastContentCharacter == raw.length() - 2 && raw.charAt(raw.length() - 1) == '\n') {
-				return raw;
-			} else {
-				StringBuilder builder = new StringBuilder(lastContentCharacter + 2);
-				builder.append(raw, 0, lastContentCharacter + 1);
-				builder.append('\n');
-				return builder.toString();
-			}
-		});
+		customLazy("endWithNewline", () -> new FileEndingStep(root.getLineEndings())::format);
 	}
 
 	/** Ensures that the files are indented using spaces. */

--- a/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -45,10 +45,7 @@ public class FormatExtension {
 	protected FileCollection target;
 
 	/**
-	 * FileCollections pass through raw.
-	 * Strings are treated as the 'include' arg to fileTree, with project.rootDir as the dir.
-	 * List<String> are treates as the 'includes' arg to fileTree, with project.rootDir as the dir.
-	 * Anything else gets passed to getProject().files().
+	 * FileCollections pass through raw. Strings are treated as the 'include' arg to fileTree, with project.rootDir as the dir. List<String> are treates as the 'includes' arg to fileTree, with project.rootDir as the dir. Anything else gets passed to getProject().files().
 	 */
 	public void target(Object... targets) {
 		if (targets.length == 0) {
@@ -92,8 +89,6 @@ public class FormatExtension {
 
 	/**
 	 * Adds the given custom step, which is constructed lazily for performance reasons.
-	 *
-	 * The resulting function will receive a string with unix-newlines, and it must return a string unix newlines.
 	 */
 	public void customLazy(String name, Throwing.Supplier<Throwing.Function<String, String>> formatterSupplier) {
 		for (FormatterStep step : steps) {
@@ -104,12 +99,12 @@ public class FormatExtension {
 		steps.add(FormatterStep.createLazy(name, formatterSupplier));
 	}
 
-	/** Adds a custom step. Receives a string with unix-newlines, must return a string with unix newlines. */
+	/** Adds a custom step. */
 	public void custom(String name, Closure<String> formatter) {
 		custom(name, formatter::call);
 	}
 
-	/** Adds a custom step. Receives a string with unix-newlines, must return a string with unix newlines. */
+	/** Adds a custom step. */
 	public void custom(String name, Throwing.Function<String, String> formatter) {
 		customLazy(name, () -> formatter);
 	}
@@ -122,7 +117,7 @@ public class FormatExtension {
 	/** Highly efficient find-replace regex. */
 	public void customReplaceRegex(String name, String regex, String replacement) {
 		customLazy(name, () -> {
-			Pattern pattern = Pattern.compile(regex, Pattern.UNIX_LINES | Pattern.MULTILINE);
+			Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
 			return raw -> pattern.matcher(raw).replaceAll(replacement);
 		});
 	}
@@ -158,19 +153,23 @@ public class FormatExtension {
 	}
 
 	/**
-	 * @param licenseHeader Content that should be at the top of every file
-	 * @param delimiter Spotless will look for a line that starts with this to know what the "top" is.
+	 * @param licenseHeader
+	 *            Content that should be at the top of every file
+	 * @param delimiter
+	 *            Spotless will look for a line that starts with this to know what the "top" is.
 	 */
 	public void licenseHeader(String licenseHeader, String delimiter) {
-		customLazy(LicenseHeaderStep.NAME, () -> new LicenseHeaderStep(licenseHeader, delimiter)::format);
+		customLazy(LicenseHeaderStep.NAME, () -> new LicenseHeaderStep(licenseHeader, delimiter, root.getLineEndings())::format);
 	}
 
 	/**
-	 * @param licenseHeaderFile Content that should be at the top of every file
-	 * @param delimiter Spotless will look for a line that starts with this to know what the "top" is.
+	 * @param licenseHeaderFile
+	 *            Content that should be at the top of every file
+	 * @param delimiter
+	 *            Spotless will look for a line that starts with this to know what the "top" is.
 	 */
 	public void licenseHeaderFile(Object licenseHeaderFile, String delimiter) {
-		customLazy(LicenseHeaderStep.NAME, () -> new LicenseHeaderStep(getProject().file(licenseHeaderFile), delimiter)::format);
+		customLazy(LicenseHeaderStep.NAME, () -> new LicenseHeaderStep(getProject().file(licenseHeaderFile), delimiter, root.getLineEndings())::format);
 	}
 
 	/** Sets up a FormatTask according to the values in this extension. */

--- a/src/main/java/com/diffplug/gradle/spotless/FormatTask.java
+++ b/src/main/java/com/diffplug/gradle/spotless/FormatTask.java
@@ -34,8 +34,6 @@ public class FormatTask extends DefaultTask {
 	@Input
 	public boolean check = false;
 	@Input
-	public LineEnding lineEndings = LineEnding.PLATFORM_NATIVE;
-	@Input
 	public List<FormatterStep> steps = new ArrayList<>();
 
 	@TaskAction
@@ -44,7 +42,7 @@ public class FormatTask extends DefaultTask {
 			throw new GradleException("You must specify 'Iterable<File> toFormat'");
 		}
 		// combine them into the master formatter
-		Formatter formatter = new Formatter(lineEndings, getProject().getProjectDir().toPath(), steps);
+		Formatter formatter = new Formatter(getProject().getProjectDir().toPath(), steps);
 
 		// perform the check
 		if (check) {

--- a/src/main/java/com/diffplug/gradle/spotless/Formatter.java
+++ b/src/main/java/com/diffplug/gradle/spotless/Formatter.java
@@ -32,11 +32,8 @@ public class Formatter {
 	private final Path projectDirectory;
 	private final List<FormatterStep> steps;
 	private final Logger logger = Logging.getLogger(Formatter.class);
-	private final LineEndingStep normalizerInput = new LineEndingStep(LineEnding.UNIX);
-	private final LineEndingStep normalizerOutput;
 
-	public Formatter(LineEnding lineEnding, Path projectDirectory, List<FormatterStep> steps) {
-		this.normalizerOutput = new LineEndingStep(lineEnding);
+	public Formatter(Path projectDirectory, List<FormatterStep> steps) {
 		this.projectDirectory = projectDirectory;
 		this.steps = new ArrayList<>(steps);
 	}
@@ -44,55 +41,35 @@ public class Formatter {
 	/** Returns true iff the given file's formatting is up-to-date. */
 	public boolean isClean(File file) throws IOException {
 		String raw = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
-		String unix = normalizerInput.format(raw);
-
-		// check the newlines
-		int totalNewLines = (int) unix.codePoints().filter(val -> val == '\n').count();
-		int windowsNewLines = raw.length() - unix.length();
-		if (normalizerOutput.getConcreteLineEnding() == LineEnding.WINDOWS) {
-			if (windowsNewLines != totalNewLines) {
-				return false;
-			}
-		} else {
-			if (windowsNewLines != 0) {
-				return false;
-			}
-		}
 
 		// check the other formats
-		String formatted = applyAll(unix, file);
+		String formatted = applyAll(raw, file);
 
-		// return true iff the formatted string equals the unix one
-		return formatted.equals(unix);
+		// return true iff the formatted string equals raw
+		return formatted.equals(raw);
 	}
 
 	/** Applies formatting to the given file. */
 	public void applyFormat(File file) throws IOException {
 		String raw = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
-		String unix = normalizerInput.format(raw);
 
 		// enforce the format
-		unix = applyAll(unix, file);
-
-		// convert the line endings if necessary
-		if (normalizerOutput.getConcreteLineEnding() != LineEnding.UNIX) {
-			unix = normalizerOutput.format(unix);
-		}
+		raw = applyAll(raw, file);
 
 		// write out the file
-		Files.write(file.toPath(), unix.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
+		Files.write(file.toPath(), raw.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
 	}
 
 	/** Returns the result of calling all of the FormatterSteps. */
-	String applyAll(String unix, File file) {
+	String applyAll(String raw, File file) {
 		for (FormatterStep step : steps) {
 			try {
-				unix = step.format(unix, file);
+				raw = step.format(raw, file);
 			} catch (Throwable e) {
 				logger.warn("Unable to apply step " + step.getName() + " to " + projectDirectory.relativize(file.toPath()) + ": " + e.getMessage());
 				logger.info("Exception is ", e);
 			}
 		}
-		return unix;
+		return raw;
 	}
 }

--- a/src/main/java/com/diffplug/gradle/spotless/FormatterStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/FormatterStep.java
@@ -25,9 +25,6 @@ import com.diffplug.common.base.Throwing;
 
 /**
  * An implementation of this class specifies a single step in a formatting process.
- *
- * The input is guaranteed to have unix-style newlines, and the output is required
- * to not introduce any windows-style newlines as well.
  */
 public interface FormatterStep {
 	/** The name of the step, for debugging purposes. */
@@ -36,9 +33,9 @@ public interface FormatterStep {
 	/**
 	 * Returns a formatted version of the given content.
 	 *
-	 * @param raw File's content, guaranteed to have unix-style newlines ('\n')
+	 * @param raw File's content
 	 * @param file the File which is being formatted
-	 * @return The formatted content, guaranteed to only have unix-style newlines
+	 * @return The formatted content
 	 * @throws Throwable
 	 */
 	String format(String raw, File file) throws Throwable;

--- a/src/main/java/com/diffplug/gradle/spotless/IndentStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/IndentStep.java
@@ -72,6 +72,7 @@ public class IndentStep {
 			}
 
 			// find the start of the next line
+			// this works even for lines ending with \r\n
 			lineStart = raw.indexOf('\n', contentStart);
 			if (lineStart == -1) {
 				// if we're at the end, append all of it

--- a/src/main/java/com/diffplug/gradle/spotless/LicenseHeaderStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/LicenseHeaderStep.java
@@ -32,22 +32,20 @@ public class LicenseHeaderStep {
 	private final Pattern delimiterPattern;
 
 	/** The license that we'd like enforced. */
-	public LicenseHeaderStep(String license, String delimiter) {
+	public LicenseHeaderStep(String license, String delimiter, LineEnding lineEnding) {
 		if (delimiter.contains("\n")) {
 			throw new GradleException("The delimiter must not contain any newlines.");
 		}
-		// sanitize the input license
-		license = license.replace("\r", "");
-		if (!license.endsWith("\n")) {
-			license = license + "\n";
-		}
-		this.license = license;
-		this.delimiterPattern = Pattern.compile('^' + delimiter, Pattern.UNIX_LINES | Pattern.MULTILINE);
+		FileEndingStep normalizer = new FileEndingStep(lineEnding);
+		normalizer.disableClobber();
+
+		this.license = normalizer.format(license);
+		this.delimiterPattern = Pattern.compile('^' + delimiter, Pattern.MULTILINE);
 	}
 
 	/** Reads the license file from the given file. */
-	public LicenseHeaderStep(File licenseFile, String delimiter) throws IOException {
-		this(new String(Files.readAllBytes(licenseFile.toPath()), StandardCharsets.UTF_8), delimiter);
+	public LicenseHeaderStep(File licenseFile, String delimiter, LineEnding lineEnding) throws IOException {
+		this(new String(Files.readAllBytes(licenseFile.toPath()), StandardCharsets.UTF_8), delimiter, lineEnding);
 	}
 
 	/** Formats the given string. */

--- a/src/main/java/com/diffplug/gradle/spotless/LineEnding.java
+++ b/src/main/java/com/diffplug/gradle/spotless/LineEnding.java
@@ -17,15 +17,11 @@ package com.diffplug.gradle.spotless;
 
 /** The line endings written by the tool. */
 public enum LineEnding {
-	PLATFORM_NATIVE(System.getProperty("line.separator")), WINDOWS("\r\n"), UNIX("\n");
+	PLATFORM_NATIVE, WINDOWS, UNIX, DERIVED, UNCERTAIN;
 
-	public final String string;
+	// Must not be set to UNCERTAIN
+	public static final LineEnding DEFAULT = PLATFORM_NATIVE;
 
-	private LineEnding(String ending) {
-		this.string = ending;
-	}
-
-	public boolean isWin() {
-		return string.equals("\r\n");
-	}
+	// Must not be set to DERIVED or UNCERTAIN
+	public static final LineEnding DERIVED_FALLBACK = PLATFORM_NATIVE;
 }

--- a/src/main/java/com/diffplug/gradle/spotless/LineEndingService.java
+++ b/src/main/java/com/diffplug/gradle/spotless/LineEndingService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.function.Supplier;
+
+public class LineEndingService {
+
+	private Supplier<String> lineSeparator = () -> System.lineSeparator();
+
+	void setLineSeparator(Supplier<String> lineSeparator) {
+		this.lineSeparator = lineSeparator;
+	}
+
+	public LineEnding determineLineEnding(String raw) {
+		return determineLineEnding(raw, LineEnding.UNCERTAIN);
+	}
+
+	private LineEnding determineLineEnding(String raw, LineEnding fallback) {
+		int firstCR = raw.indexOf("\r");
+		int firstLF = raw.indexOf("\n");
+
+		if (isWindows(firstCR, firstLF)) {
+			return LineEnding.WINDOWS;
+		}
+
+		if (isUnix(firstCR, firstLF)) {
+			return LineEnding.UNIX;
+		}
+
+		return fallback;
+	}
+
+	private static boolean isWindows(int firstCR, int firstLF) {
+		if (firstCR == -1 && firstLF == -1) {
+			return false;
+		}
+		return firstCR + 1 == firstLF;
+	}
+
+	private static boolean isUnix(int firstCR, int firstLF) {
+		if (firstLF == -1) {
+			return false;
+		}
+		if (firstCR == -1) {
+			return true;
+		}
+		return firstCR > firstLF;
+	}
+
+	public LineEnding getPlatformLineEnding() {
+		String separator = getPlatformLineSeparator();
+
+		switch (separator) {
+		case "\r\n":
+			return LineEnding.WINDOWS;
+		case "\n":
+			return LineEnding.UNIX;
+		default:
+			throw new InternalError("Shouldn't happen.");
+		}
+	}
+
+	String getPlatformLineSeparator() {
+		String separator = lineSeparator.get();
+
+		if ("\r\n".equals(separator) || "\n".equals(separator)) {
+			return separator;
+		}
+
+		throw new UnsupportedOperationException("Determined native line separator is not supported!");
+	}
+
+}

--- a/src/main/java/com/diffplug/gradle/spotless/LineEndingStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/LineEndingStep.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+public class LineEndingStep {
+
+	private final EOLNormalizer normalizer;
+
+	public LineEndingStep(LineEnding lineEnding) {
+		this(lineEnding, new LineEndingService());
+	}
+
+	LineEndingStep(LineEnding lineEnding, LineEndingService lineEndingService) {
+		normalizer = forLineEnding(lineEnding, lineEndingService);
+	}
+
+	private static EOLNormalizer forLineEnding(LineEnding lineEnding, LineEndingService lineEndingService) {
+		switch (lineEnding) {
+		case UNIX:
+			return new UnixEOLNormalizer();
+		case WINDOWS:
+			return new WindowsEOLNormalizer();
+		case PLATFORM_NATIVE:
+			return new PlatformNativeEOLNormalizer(lineEndingService);
+		case DERIVED:
+			return new DerivedEOLNormalizer(lineEndingService);
+		case UNCERTAIN:
+			return new NoEOLNormalizer();
+		default:
+			throw new IllegalArgumentException("No EOLNormalizer specified for LineEnding");
+		}
+	}
+
+	public String format(String raw) {
+		return normalizer.format(raw);
+	}
+
+	public LineEnding getConcreteLineEnding() {
+		return normalizer.getConcreteLineEnding();
+	}
+
+	static interface EOLNormalizer {
+		String format(String input);
+
+		/**
+		 * @deprecated Only used for interim purpose.
+		 */
+		LineEnding getConcreteLineEnding();
+	}
+
+	static class UnixEOLNormalizer implements EOLNormalizer {
+		@Override
+		public String format(String input) {
+			return input.replace("\r\n", "\n");
+		}
+
+		@Override
+		public LineEnding getConcreteLineEnding() {
+			return LineEnding.UNIX;
+		}
+
+	}
+
+	static class WindowsEOLNormalizer implements EOLNormalizer {
+		@Override
+		public String format(String input) {
+			String unix = input.replace("\r\n", "\n");
+			return unix.replace("\n", "\r\n");
+		}
+
+		@Override
+		public LineEnding getConcreteLineEnding() {
+			return LineEnding.WINDOWS;
+		}
+	}
+
+	static class NoEOLNormalizer implements EOLNormalizer {
+		@Override
+		public String format(String input) {
+			return input;
+		}
+
+		@Override
+		public LineEnding getConcreteLineEnding() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	static class DerivedEOLNormalizer implements EOLNormalizer {
+		private EOLNormalizer delegate;
+		private LineEndingService lineEndingService;
+
+		public DerivedEOLNormalizer(LineEndingService lineEndingService) {
+			this.lineEndingService = lineEndingService;
+		}
+
+		@Override
+		public String format(String input) {
+			LineEnding lineEnding = lineEndingService.determineLineEnding(input);
+			switch (lineEnding) {
+			case UNCERTAIN:
+				delegate = new NoEOLNormalizer();
+				break;
+			case UNIX:
+				delegate = new UnixEOLNormalizer();
+				break;
+			case WINDOWS:
+				delegate = new WindowsEOLNormalizer();
+				break;
+			default:
+				throw new IllegalStateException("Unexpected result from LineEndingService");
+			}
+			return delegate.format(input);
+		}
+
+		@Override
+		public LineEnding getConcreteLineEnding() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	static class PlatformNativeEOLNormalizer implements EOLNormalizer {
+		private EOLNormalizer delegate;
+
+		public PlatformNativeEOLNormalizer(LineEndingService lineEndingService) {
+			LineEnding lineEnding = lineEndingService.getPlatformLineEnding();
+			switch (lineEnding) {
+			case UNIX:
+				delegate = new UnixEOLNormalizer();
+				break;
+			case WINDOWS:
+				delegate = new WindowsEOLNormalizer();
+				break;
+			default:
+				throw new IllegalStateException("Unexpected result from LineEndingService");
+			}
+		}
+
+		@Override
+		public String format(String input) {
+			return delegate.format(input);
+		}
+
+		@Override
+		public LineEnding getConcreteLineEnding() {
+			return delegate.getConcreteLineEnding();
+		}
+	}
+
+}

--- a/src/main/java/com/diffplug/gradle/spotless/LineEndingStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/LineEndingStep.java
@@ -48,17 +48,8 @@ public class LineEndingStep {
 		return normalizer.format(raw);
 	}
 
-	public LineEnding getConcreteLineEnding() {
-		return normalizer.getConcreteLineEnding();
-	}
-
 	static interface EOLNormalizer {
 		String format(String input);
-
-		/**
-		 * @deprecated Only used for interim purpose.
-		 */
-		LineEnding getConcreteLineEnding();
 	}
 
 	static class UnixEOLNormalizer implements EOLNormalizer {
@@ -66,12 +57,6 @@ public class LineEndingStep {
 		public String format(String input) {
 			return input.replace("\r\n", "\n");
 		}
-
-		@Override
-		public LineEnding getConcreteLineEnding() {
-			return LineEnding.UNIX;
-		}
-
 	}
 
 	static class WindowsEOLNormalizer implements EOLNormalizer {
@@ -80,22 +65,12 @@ public class LineEndingStep {
 			String unix = input.replace("\r\n", "\n");
 			return unix.replace("\n", "\r\n");
 		}
-
-		@Override
-		public LineEnding getConcreteLineEnding() {
-			return LineEnding.WINDOWS;
-		}
 	}
 
 	static class NoEOLNormalizer implements EOLNormalizer {
 		@Override
 		public String format(String input) {
 			return input;
-		}
-
-		@Override
-		public LineEnding getConcreteLineEnding() {
-			throw new UnsupportedOperationException();
 		}
 	}
 
@@ -125,11 +100,6 @@ public class LineEndingStep {
 			}
 			return delegate.format(input);
 		}
-
-		@Override
-		public LineEnding getConcreteLineEnding() {
-			throw new UnsupportedOperationException();
-		}
 	}
 
 	static class PlatformNativeEOLNormalizer implements EOLNormalizer {
@@ -152,11 +122,6 @@ public class LineEndingStep {
 		@Override
 		public String format(String input) {
 			return delegate.format(input);
-		}
-
-		@Override
-		public LineEnding getConcreteLineEnding() {
-			return delegate.getConcreteLineEnding();
 		}
 	}
 

--- a/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -34,7 +34,7 @@ public class SpotlessExtension {
 	}
 
 	/** Line endings (if any). */
-	LineEnding lineEndings = LineEnding.PLATFORM_NATIVE;
+	LineEnding lineEndings = LineEnding.DEFAULT;
 
 	public LineEnding getLineEndings() {
 		return lineEndings;

--- a/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -29,6 +29,8 @@ import groovy.lang.Closure;
 public class SpotlessExtension {
 	final Project project;
 
+	Map<String, FormatExtension> formats = new LinkedHashMap<>();
+
 	public SpotlessExtension(Project project) {
 		this.project = project;
 	}
@@ -43,8 +45,6 @@ public class SpotlessExtension {
 	public void setLineEndings(LineEnding lineEndings) {
 		this.lineEndings = lineEndings;
 	}
-
-	Map<String, FormatExtension> formats = new LinkedHashMap<>();
 
 	/** Configures the special java-specific extension. */
 	public void java(Closure<JavaExtension> closure) {

--- a/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -67,7 +67,6 @@ public class SpotlessPlugin implements Plugin<Project> {
 
 	FormatTask createTask(String name, FormatExtension subExtension, boolean check) throws Exception {
 		FormatTask task = project.getTasks().create(EXTENSION + capitalize(name) + (check ? CHECK : APPLY), FormatTask.class);
-		task.lineEndings = extension.lineEndings;
 		task.check = check;
 		// sets toFormat and steps
 		subExtension.setupTask(task);

--- a/src/main/java/com/diffplug/gradle/spotless/java/EclipseFormatterStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/java/EclipseFormatterStep.java
@@ -48,7 +48,7 @@ public class EclipseFormatterStep {
 	}
 
 	public String format(String raw) throws Exception {
-		TextEdit edit = codeFormatter.format(CodeFormatter.K_COMPILATION_UNIT, raw, 0, raw.length(), 0, LineEnding.UNIX.string);
+		TextEdit edit = codeFormatter.format(CodeFormatter.K_COMPILATION_UNIT, raw, 0, raw.length(), 0, "\n");
 		if (edit == null) {
 			throw new IllegalArgumentException("Invalid java syntax for formatting.");
 		} else {

--- a/src/main/java/com/diffplug/gradle/spotless/java/ImportSorterImpl.java
+++ b/src/main/java/com/diffplug/gradle/spotless/java/ImportSorterImpl.java
@@ -21,6 +21,8 @@ import java.util.*;
 /*not thread safe*/
 class ImportSorterImpl {
 
+	private static final String RS = "\u001E";
+
 	private List<String> template = new ArrayList<String>();
 	private Map<String, List<String>> matchingImports = new HashMap<String, List<String>>();
 	private ArrayList<String> notMatching = new ArrayList<String>();
@@ -131,7 +133,7 @@ class ImportSorterImpl {
 					// no order is specified
 					if (template.size() > 0 && (template.get(template.size() - 1).startsWith("static"))) {
 						// insert N after last static import
-						template.add(ImportSorterStep.N);
+						template.add(RS);
 					}
 					template.add(notMatchingItem);
 				} else {
@@ -190,23 +192,23 @@ class ImportSorterImpl {
 				// replace order item by matching import statements
 				// this is a mess and it is only a luck that it works :-]
 				template.remove(i);
-				if (i != 0 && !template.get(i - 1).equals(ImportSorterStep.N)) {
-					template.add(i, ImportSorterStep.N);
+				if (i != 0 && !template.get(i - 1).equals(RS)) {
+					template.add(i, RS);
 					i++;
 				}
-				if (i + 1 < template.size() && !template.get(i + 1).equals(ImportSorterStep.N)
-						&& !template.get(i).equals(ImportSorterStep.N)) {
-					template.add(i, ImportSorterStep.N);
+				if (i + 1 < template.size() && !template.get(i + 1).equals(RS)
+						&& !template.get(i).equals(RS)) {
+					template.add(i, RS);
 				}
 				template.addAll(i, matchingItems);
-				if (i != 0 && !template.get(i - 1).equals(ImportSorterStep.N)) {
-					template.add(i, ImportSorterStep.N);
+				if (i != 0 && !template.get(i - 1).equals(RS)) {
+					template.add(i, RS);
 				}
 
 			}
 		}
 		// if there is \n on the end, remove it
-		if (template.size() > 0 && template.get(template.size() - 1).equals(ImportSorterStep.N)) {
+		if (template.size() > 0 && template.get(template.size() - 1).equals(RS)) {
 			template.remove(template.size() - 1);
 		}
 	}
@@ -215,10 +217,10 @@ class ImportSorterImpl {
 		ArrayList<String> strings = new ArrayList<String>();
 
 		for (String s : template) {
-			if (s.equals(ImportSorterStep.N)) {
-				strings.add(s);
+			if (s.equals(RS)) {
+				strings.add("");
 			} else {
-				strings.add("import " + s + ";" + ImportSorterStep.N);
+				strings.add("import " + s + ";");
 			}
 		}
 		return strings;

--- a/src/main/java/com/diffplug/gradle/spotless/java/JavaExtension.java
+++ b/src/main/java/com/diffplug/gradle/spotless/java/JavaExtension.java
@@ -45,15 +45,15 @@ public class JavaExtension extends FormatExtension {
 	}
 
 	public void importOrder(List<String> importOrder) {
-		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(importOrder)::format);
+		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(importOrder, root.getLineEndings())::format);
 	}
 
 	public void importOrderFile(Object importOrderFile) {
-		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(getProject().file(importOrderFile))::format);
+		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(getProject().file(importOrderFile), root.getLineEndings())::format);
 	}
 
 	public void eclipseFormatFile(Object eclipseFormatFile) {
-		customLazy(EclipseFormatterStep.NAME, () -> EclipseFormatterStep.load(getProject().file(eclipseFormatFile))::format);
+		customLazy(EclipseFormatterStep.NAME, () -> EclipseFormatterStep.load(getProject().file(eclipseFormatFile), root.getLineEndings())::format);
 	}
 
 	/** If the user hasn't specified the files yet, we'll assume he/she means all of the java files. */
@@ -71,7 +71,7 @@ public class JavaExtension extends FormatExtension {
 			target = union;
 		}
 		// LicenseHeaderStep completely blows apart package-info.java - this common-sense check ensures that
-		// it skips package-info.java.  See https://github.com/diffplug/spotless/issues/1
+		// it skips package-info.java. See https://github.com/diffplug/spotless/issues/1
 		steps.replaceAll(step -> {
 			if (LicenseHeaderStep.NAME.equals(step.getName())) {
 				return step.filterByFile(file -> !file.getName().equals("package-info.java"));

--- a/src/main/java/com/diffplug/gradle/spotless/java/JavaExtension.java
+++ b/src/main/java/com/diffplug/gradle/spotless/java/JavaExtension.java
@@ -45,15 +45,15 @@ public class JavaExtension extends FormatExtension {
 	}
 
 	public void importOrder(List<String> importOrder) {
-		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(importOrder, root.getLineEndings())::format);
+		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(importOrder, getLineEndings())::format);
 	}
 
 	public void importOrderFile(Object importOrderFile) {
-		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(getProject().file(importOrderFile), root.getLineEndings())::format);
+		customLazy(ImportSorterStep.NAME, () -> new ImportSorterStep(getProject().file(importOrderFile), getLineEndings())::format);
 	}
 
 	public void eclipseFormatFile(Object eclipseFormatFile) {
-		customLazy(EclipseFormatterStep.NAME, () -> EclipseFormatterStep.load(getProject().file(eclipseFormatFile), root.getLineEndings())::format);
+		customLazy(EclipseFormatterStep.NAME, () -> EclipseFormatterStep.load(getProject().file(eclipseFormatFile), getLineEndings())::format);
 	}
 
 	/** If the user hasn't specified the files yet, we'll assume he/she means all of the java files. */

--- a/src/test/java/com/diffplug/gradle/spotless/EndWithNewlineTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/EndWithNewlineTest.java
@@ -35,7 +35,7 @@ public class EndWithNewlineTest extends FormatExtensionTest {
 	private void endWithNewlineTest(String before, String after) throws Exception {
 		super.assertTask(test -> {
 			test.root.setLineEndings(LineEnding.UNIX);
-			test.dontDoLineEndingNormalization();
+			test.dontDoDefaultLineEndingNormalization();
 
 			test.endWithNewline();
 		}, before, after);

--- a/src/test/java/com/diffplug/gradle/spotless/EndWithNewlineTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/EndWithNewlineTest.java
@@ -15,10 +15,12 @@
  */
 package com.diffplug.gradle.spotless;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class EndWithNewlineTest extends ResourceTest {
 	@Test
+	@Ignore("temporary")
 	public void trimTrailingNewlines() throws Exception {
 		endWithNewlineTest("", "\n");
 		endWithNewlineTest("\n");

--- a/src/test/java/com/diffplug/gradle/spotless/FileEndingStepTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/FileEndingStepTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class FileEndingStepTest {
+	@Test
+	public void testFormat_Windows() {
+		FileEndingStep classUnderTest = new FileEndingStep(LineEnding.WINDOWS);
+		endWithNewlineTest(classUnderTest, "", "\r\n");
+		endWithNewlineTest(classUnderTest, "\n", "\r\n");
+		endWithNewlineTest(classUnderTest, "\n\n\t\r\n\n", "\r\n");
+		endWithNewlineTest(classUnderTest, "line", "line\r\n");
+		endWithNewlineTest(classUnderTest, "line\n", "line\r\n");
+		endWithNewlineTest(classUnderTest, "line\nline\n\n\n\n", "line\nline\r\n");
+		endWithNewlineTest(classUnderTest, "line\nline\r\n\n\t\n\n", "line\nline\r\n");
+	}
+
+	@Test
+	public void testFormat_Unix() {
+		FileEndingStep classUnderTest = new FileEndingStep(LineEnding.UNIX);
+		endWithNewlineTest(classUnderTest, "", "\n");
+		endWithNewlineTest(classUnderTest, "\n", "\n");
+		endWithNewlineTest(classUnderTest, "\n\n\t\r\n\n", "\n");
+		endWithNewlineTest(classUnderTest, "line", "line\n");
+		endWithNewlineTest(classUnderTest, "line\n", "line\n");
+		endWithNewlineTest(classUnderTest, "line\nline\n\n\n\n", "line\nline\n");
+		endWithNewlineTest(classUnderTest, "line\nline\r\n\n\t\n\n", "line\nline\n");
+	}
+
+	@Test
+	public void testFormat_Derived() {
+		LineEndingService lineEndingService = new LineEndingService();
+		lineEndingService.setLineSeparator(() -> "\r\n"); // platform native separator for the fallback
+
+		FileEndingStep classUnderTest = new FileEndingStep(LineEnding.DERIVED, lineEndingService);
+		endWithNewlineTest(classUnderTest, "", "\r\n"); // Fallback is here in use
+		endWithNewlineTest(classUnderTest, "\n", "\r\n");
+		endWithNewlineTest(classUnderTest, "\n\n\t\r\n\n", "\n");
+		endWithNewlineTest(classUnderTest, "line", "line\r\n"); // and here
+		endWithNewlineTest(classUnderTest, "line\n", "line\n");
+		endWithNewlineTest(classUnderTest, "line\nline\n\n\n\n", "line\nline\n");
+		endWithNewlineTest(classUnderTest, "line\nline\r\n\n\t\n\n", "line\nline\n");
+	}
+
+	private void endWithNewlineTest(FileEndingStep step, String before, String expectedAfter) {
+		String after = step.format(before);
+		assertThat(after, is(expectedAfter));
+	}
+}

--- a/src/test/java/com/diffplug/gradle/spotless/FileEndingStepTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/FileEndingStepTest.java
@@ -60,6 +60,25 @@ public class FileEndingStepTest {
 		endWithNewlineTest(classUnderTest, "line\nline\r\n\n\t\n\n", "line\nline\n");
 	}
 
+	@Test
+	public void testFormat_ClobberDisabled() {
+		FileEndingStep classUnderTest = new FileEndingStep(LineEnding.UNIX);
+		classUnderTest.disableClobber();
+
+		endWithNewlineTest(classUnderTest, "", "\n");
+		endWithNewlineTest(classUnderTest, "\n", "\n");
+		endWithNewlineTest(classUnderTest, "\n\n\t\r\n\n", "\n\n\t\r\n\n");
+		endWithNewlineTest(classUnderTest, "line", "line\n");
+		endWithNewlineTest(classUnderTest, "line\n", "line\n");
+		endWithNewlineTest(classUnderTest, "line\nline\n\n\n\n", "line\nline\n\n\n\n");
+		endWithNewlineTest(classUnderTest, "line\nline\r\n\n\t\n\n", "line\nline\r\n\n\t\n\n");
+
+		classUnderTest = new FileEndingStep(LineEnding.WINDOWS);
+		classUnderTest.disableClobber();
+
+		endWithNewlineTest(classUnderTest, "line\nline\n\n\n\n", "line\nline\n\n\n\n\r\n");
+	}
+
 	private void endWithNewlineTest(FileEndingStep step, String before, String expectedAfter) {
 		String after = step.format(before);
 		assertThat(after, is(expectedAfter));

--- a/src/test/java/com/diffplug/gradle/spotless/FormatExtensionTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/FormatExtensionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Assert;
+
+public abstract class FormatExtensionTest extends ResourceTest {
+	/** Tests that the formatExtension causes the given change. */
+	protected void assertTask(Consumer<FormatExtension> test, String before, String afterExpected) throws Exception {
+		// create the task
+		FormatTask task = createTask(test);
+		// create the test file
+		File testFile = folder.newFile();
+		Files.write(testFile.toPath(), before.getBytes(StandardCharsets.UTF_8));
+		// set the task to use this test file
+		task.target = Collections.singleton(testFile);
+		// run the task
+		task.format();
+		// check what the task did
+		String afterActual = new String(Files.readAllBytes(testFile.toPath()), StandardCharsets.UTF_8);
+		Assert.assertEquals(afterExpected, afterActual);
+	}
+
+	/** Creates a FormatTask based on the given consumer. */
+	private static FormatTask createTask(Consumer<FormatExtension> test) throws Exception {
+		Project project = ProjectBuilder.builder().build();
+		SpotlessPlugin plugin = project.getPlugins().apply(SpotlessPlugin.class);
+
+		AtomicReference<FormatExtension> ref = new AtomicReference<>();
+		plugin.getExtension().format("underTest", ext -> {
+			ref.set(ext);
+			test.accept(ext);
+		});
+
+		boolean check = false;
+		return plugin.createTask("underTest", ref.get(), check);
+	}
+}

--- a/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -37,37 +37,6 @@ public class FormatTaskTest extends ResourceTest {
 	}
 
 	@Test(expected = GradleException.class)
-	@Ignore("temporary")
-	public void testLineEndingsCheckFail() throws IOException {
-		task.check = true;
-		// task.lineEndings = LineEnding.UNIX;
-		task.target = Collections.singleton(createTestFile("testFile", "\r\n"));
-		task.execute();
-	}
-
-	@Test
-	@Ignore("temporary")
-	public void testLineEndingsCheckPass() throws IOException {
-		task.check = true;
-		// task.lineEndings = LineEnding.UNIX;
-		task.target = Collections.singleton(createTestFile("testFile", "\n"));
-		task.execute();
-	}
-
-	@Test
-	@Ignore("temporary")
-	public void testLineEndingsApply() throws IOException {
-		File testFile = createTestFile("testFile", "\r\n");
-
-		task.check = false;
-		// task.lineEndings = LineEnding.UNIX;
-		task.target = Collections.singleton(testFile);
-		task.execute();
-
-		assertFileContent("\n", testFile);
-	}
-
-	@Test(expected = GradleException.class)
 	public void testStepCheckFail() throws IOException {
 		File testFile = createTestFile("testFile", "apple");
 		task.target = Collections.singleton(testFile);

--- a/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -23,6 +23,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class FormatTaskTest extends ResourceTest {
@@ -36,27 +37,30 @@ public class FormatTaskTest extends ResourceTest {
 	}
 
 	@Test(expected = GradleException.class)
+	@Ignore("temporary")
 	public void testLineEndingsCheckFail() throws IOException {
 		task.check = true;
-		task.lineEndings = LineEnding.UNIX;
+		// task.lineEndings = LineEnding.UNIX;
 		task.target = Collections.singleton(createTestFile("testFile", "\r\n"));
 		task.execute();
 	}
 
 	@Test
+	@Ignore("temporary")
 	public void testLineEndingsCheckPass() throws IOException {
 		task.check = true;
-		task.lineEndings = LineEnding.UNIX;
+		// task.lineEndings = LineEnding.UNIX;
 		task.target = Collections.singleton(createTestFile("testFile", "\n"));
 		task.execute();
 	}
 
 	@Test
+	@Ignore("temporary")
 	public void testLineEndingsApply() throws IOException {
 		File testFile = createTestFile("testFile", "\r\n");
 
 		task.check = false;
-		task.lineEndings = LineEnding.UNIX;
+		// task.lineEndings = LineEnding.UNIX;
 		task.target = Collections.singleton(testFile);
 		task.execute();
 

--- a/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderStepTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderStepTest.java
@@ -28,19 +28,19 @@ public class LicenseHeaderStepTest extends ResourceTest {
 
 	@Test
 	public void fromString() throws Throwable {
-		LicenseHeaderStep step = new LicenseHeaderStep(getTestResource(KEY_LICENSE), JavaExtension.LICENSE_HEADER_DELIMITER);
+		LicenseHeaderStep step = new LicenseHeaderStep(getTestResource(KEY_LICENSE), JavaExtension.LICENSE_HEADER_DELIMITER, LineEnding.DERIVED);
 		assertStep(step::format, KEY_FILE_NOTAPPLIED, KEY_FILE_APPLIED);
 	}
 
 	@Test
 	public void fromFile() throws Throwable {
-		LicenseHeaderStep step = new LicenseHeaderStep(createTestFile(KEY_LICENSE), JavaExtension.LICENSE_HEADER_DELIMITER);
+		LicenseHeaderStep step = new LicenseHeaderStep(createTestFile(KEY_LICENSE), JavaExtension.LICENSE_HEADER_DELIMITER, LineEnding.DERIVED);
 		assertStep(step::format, KEY_FILE_NOTAPPLIED, KEY_FILE_APPLIED);
 	}
 
 	@Test
 	public void efficient() throws Throwable {
-		LicenseHeaderStep step = new LicenseHeaderStep("LicenseHeader\n", "contentstart");
+		LicenseHeaderStep step = new LicenseHeaderStep("LicenseHeader\n", "contentstart", LineEnding.UNIX);
 		String alreadyCorrect = "LicenseHeader\ncontentstart";
 		Assert.assertEquals(alreadyCorrect, step.format(alreadyCorrect));
 		// If no change is required, it should return the exact same string for efficiency reasons
@@ -49,9 +49,9 @@ public class LicenseHeaderStepTest extends ResourceTest {
 
 	@Test
 	public void sanitized() throws Throwable {
-		// The sanitizer should add a \n
-		LicenseHeaderStep step = new LicenseHeaderStep("LicenseHeader", "contentstart");
-		String alreadyCorrect = "LicenseHeader\ncontentstart";
+		// The sanitizer should add the line separator for the LineEnding
+		LicenseHeaderStep step = new LicenseHeaderStep("LicenseHeader", "contentstart", LineEnding.WINDOWS);
+		String alreadyCorrect = "LicenseHeader\r\ncontentstart";
 		Assert.assertEquals(alreadyCorrect, step.format(alreadyCorrect));
 		Assert.assertTrue(alreadyCorrect == step.format(alreadyCorrect));
 	}
@@ -59,7 +59,7 @@ public class LicenseHeaderStepTest extends ResourceTest {
 	@Test
 	public void sanitizerDoesntGoTooFar() throws Throwable {
 		// if the user wants extra lines after the header, we shouldn't clobber them
-		LicenseHeaderStep step = new LicenseHeaderStep("LicenseHeader\n\n", "contentstart");
+		LicenseHeaderStep step = new LicenseHeaderStep("LicenseHeader\n\n", "contentstart", LineEnding.UNIX);
 		String alreadyCorrect = "LicenseHeader\n\ncontentstart";
 		Assert.assertEquals(alreadyCorrect, step.format(alreadyCorrect));
 		Assert.assertTrue(alreadyCorrect == step.format(alreadyCorrect));

--- a/src/test/java/com/diffplug/gradle/spotless/LineEndingServiceTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/LineEndingServiceTest.java
@@ -47,6 +47,29 @@ public class LineEndingServiceTest {
 	}
 
 	@Test
+	public void testGetLineSeparatorOrDefault() {
+		assertGetLineSeparatorOrDefault(LineEnding.UNIX, "", "\n");
+		assertGetLineSeparatorOrDefault(LineEnding.WINDOWS, "", "\r\n");
+
+		assertGetLineSeparatorOrDefault(LineEnding.DERIVED, "foobar\n", "\n");
+		assertGetLineSeparatorOrDefault(LineEnding.DERIVED, "foobar\r\n", "\r\n");
+
+		classUnderTest.setLineSeparator(() -> "\r\n");
+		assertGetLineSeparatorOrDefault(LineEnding.PLATFORM_NATIVE, "", "\r\n");
+		assertGetLineSeparatorOrDefault(LineEnding.DERIVED, "foobar", "\r\n");
+
+		classUnderTest.setLineSeparator(() -> "\n");
+		assertGetLineSeparatorOrDefault(LineEnding.PLATFORM_NATIVE, "", "\n");
+		assertGetLineSeparatorOrDefault(LineEnding.DERIVED, "foobar", "\n");
+	}
+
+	private void assertGetLineSeparatorOrDefault(LineEnding lineEnding, String rawForDerivedEnding, String expectedLineSeparator) {
+		String lineSeparator = classUnderTest.getLineSeparatorOrDefault(lineEnding, rawForDerivedEnding);
+
+		assertThat(lineSeparator, is(expectedLineSeparator));
+	}
+
+	@Test
 	public void testGetPlatformLineSeparator_Unix() {
 		classUnderTest.setLineSeparator(() -> "\n");
 
@@ -69,5 +92,27 @@ public class LineEndingServiceTest {
 		classUnderTest.setLineSeparator(() -> "foo");
 
 		classUnderTest.getPlatformLineSeparator();
+	}
+
+	@Test
+	public void testIndexOfLastNonWhitespaceCharacter() {
+		assertIndexOfLastNonWhitespaceCharacter("", -1);
+		assertIndexOfLastNonWhitespaceCharacter("  ", -1);
+		assertIndexOfLastNonWhitespaceCharacter(" \n \t\t\n ", -1);
+		assertIndexOfLastNonWhitespaceCharacter("", -1);
+
+		assertIndexOfLastNonWhitespaceCharacter("foobar", 5);
+		assertIndexOfLastNonWhitespaceCharacter("foobar  ", 5);
+		assertIndexOfLastNonWhitespaceCharacter("foobar\t\n\n", 5);
+
+		assertIndexOfLastNonWhitespaceCharacter("foo\nbar", 6);
+		assertIndexOfLastNonWhitespaceCharacter("foo\nbar  ", 6);
+		assertIndexOfLastNonWhitespaceCharacter("foo\nbar\t\n\n", 6);
+	}
+
+	private void assertIndexOfLastNonWhitespaceCharacter(String text, int expectedIndex) {
+		int indexOfLastNonWhitespaceCharacter = classUnderTest.indexOfLastNonWhitespaceCharacter(text);
+
+		assertThat(indexOfLastNonWhitespaceCharacter, is(expectedIndex));
 	}
 }

--- a/src/test/java/com/diffplug/gradle/spotless/LineEndingServiceTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/LineEndingServiceTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class LineEndingServiceTest {
+
+	private LineEndingService classUnderTest = new LineEndingService();
+
+	@Test
+	public void testDetermineLineEnding() {
+		assertLineEndingDetermination("foobar\r\nhello world\r\n", LineEnding.WINDOWS);
+		assertLineEndingDetermination("foobar\r\nhello world\n", LineEnding.WINDOWS);
+		assertLineEndingDetermination("foobar\r\n", LineEnding.WINDOWS);
+
+		assertLineEndingDetermination("foobar\nhello world\n", LineEnding.UNIX);
+		assertLineEndingDetermination("foobar\nhello world\r\n", LineEnding.UNIX);
+		assertLineEndingDetermination("foobar\n", LineEnding.UNIX);
+
+		assertLineEndingDetermination("foobar", LineEnding.UNCERTAIN);
+
+		// Don't care about legacy Mac EOL
+		assertLineEndingDetermination("foobar\r", LineEnding.UNCERTAIN);
+	}
+
+	private void assertLineEndingDetermination(String raw, LineEnding expectedLineEnding) {
+		LineEnding lineEnding = classUnderTest.determineLineEnding(raw);
+
+		assertThat(lineEnding, is(expectedLineEnding));
+	}
+
+	@Test
+	public void testGetPlatformLineSeparator_Unix() {
+		classUnderTest.setLineSeparator(() -> "\n");
+
+		String separator = classUnderTest.getPlatformLineSeparator();
+
+		assertThat(separator, is("\n"));
+	}
+
+	@Test
+	public void testGetPlatformLineSeparator_Windows() {
+		classUnderTest.setLineSeparator(() -> "\r\n");
+
+		String separator = classUnderTest.getPlatformLineSeparator();
+
+		assertThat(separator, is("\r\n"));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testGetPlatformLineSeparator_dubious() {
+		classUnderTest.setLineSeparator(() -> "foo");
+
+		classUnderTest.getPlatformLineSeparator();
+	}
+}

--- a/src/test/java/com/diffplug/gradle/spotless/LineEndingStepTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/LineEndingStepTest.java
@@ -18,7 +18,6 @@ package com.diffplug.gradle.spotless;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -26,7 +25,6 @@ import com.diffplug.gradle.spotless.LineEndingStep.EOLNormalizer;
 
 public class LineEndingStepTest extends ResourceTest {
 	@Test
-	@Ignore("This kind of test doesn't work until assertStep is refactored")
 	public void normalizeToUnixFromFile() throws Throwable {
 		LineEndingStep eol = new LineEndingStep(LineEnding.UNIX);
 		assertStep(eol::format, "EOLWindows.test", "EOLUnix.test");
@@ -35,7 +33,6 @@ public class LineEndingStepTest extends ResourceTest {
 	}
 
 	@Test
-	@Ignore("This kind of test doesn't work until assertStep is refactored")
 	public void normalizeToWindowsFromFile() throws Throwable {
 		LineEndingStep eol = new LineEndingStep(LineEnding.WINDOWS);
 		assertStep(eol::format, "EOLWindows.test", "EOLWindows.test");
@@ -44,7 +41,6 @@ public class LineEndingStepTest extends ResourceTest {
 	}
 
 	@Test
-	@Ignore("This kind of test doesn't work until assertStep is refactored")
 	public void normalizeToDerivedEOLFromFile() throws Throwable {
 		LineEndingStep eol = new LineEndingStep(LineEnding.DERIVED);
 		assertStep(eol::format, "EOLWindows.test", "EOLWindows.test");
@@ -53,7 +49,6 @@ public class LineEndingStepTest extends ResourceTest {
 	}
 
 	@Test
-	@Ignore("This kind of test doesn't work until assertStep is refactored")
 	public void normalizeToPlatformNativeFromFile_Windows() throws Throwable {
 		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
 		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.WINDOWS);
@@ -65,7 +60,6 @@ public class LineEndingStepTest extends ResourceTest {
 	}
 
 	@Test
-	@Ignore("This kind of test doesn't work until assertStep is refactored")
 	public void normalizeToPlatformNativeFromFile_Unix() throws Throwable {
 		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
 		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.UNIX);
@@ -77,7 +71,6 @@ public class LineEndingStepTest extends ResourceTest {
 	}
 
 	@Test(expected = IllegalStateException.class)
-	@Ignore("This kind of test doesn't work until assertStep is refactored")
 	public void normalizeToPlatformNativeFromFile_UnexpectedServiceResult() throws Throwable {
 		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
 		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.UNCERTAIN);

--- a/src/test/java/com/diffplug/gradle/spotless/LineEndingStepTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/LineEndingStepTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.diffplug.gradle.spotless.LineEndingStep.EOLNormalizer;
+
+public class LineEndingStepTest extends ResourceTest {
+	@Test
+	@Ignore("This kind of test doesn't work until assertStep is refactored")
+	public void normalizeToUnixFromFile() throws Throwable {
+		LineEndingStep eol = new LineEndingStep(LineEnding.UNIX);
+		assertStep(eol::format, "EOLWindows.test", "EOLUnix.test");
+		assertStep(eol::format, "EOLMixed.test", "EOLUnix.test");
+		assertStep(eol::format, "EOLUnix.test", "EOLUnix.test");
+	}
+
+	@Test
+	@Ignore("This kind of test doesn't work until assertStep is refactored")
+	public void normalizeToWindowsFromFile() throws Throwable {
+		LineEndingStep eol = new LineEndingStep(LineEnding.WINDOWS);
+		assertStep(eol::format, "EOLWindows.test", "EOLWindows.test");
+		assertStep(eol::format, "EOLMixed.test", "EOLWindows.test");
+		assertStep(eol::format, "EOLUnix.test", "EOLWindows.test");
+	}
+
+	@Test
+	@Ignore("This kind of test doesn't work until assertStep is refactored")
+	public void normalizeToDerivedEOLFromFile() throws Throwable {
+		LineEndingStep eol = new LineEndingStep(LineEnding.DERIVED);
+		assertStep(eol::format, "EOLWindows.test", "EOLWindows.test");
+		assertStep(eol::format, "EOLMixed.test", "EOLWindows.test"); // first line contains '\r\n'
+		assertStep(eol::format, "EOLUnix.test", "EOLUnix.test");
+	}
+
+	@Test
+	@Ignore("This kind of test doesn't work until assertStep is refactored")
+	public void normalizeToPlatformNativeFromFile_Windows() throws Throwable {
+		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
+		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.WINDOWS);
+
+		LineEndingStep eol = new LineEndingStep(LineEnding.PLATFORM_NATIVE, lineEndingServiceMock);
+		assertStep(eol::format, "EOLWindows.test", "EOLWindows.test");
+		assertStep(eol::format, "EOLMixed.test", "EOLWindows.test");
+		assertStep(eol::format, "EOLUnix.test", "EOLWindows.test");
+	}
+
+	@Test
+	@Ignore("This kind of test doesn't work until assertStep is refactored")
+	public void normalizeToPlatformNativeFromFile_Unix() throws Throwable {
+		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
+		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.UNIX);
+
+		LineEndingStep eol = new LineEndingStep(LineEnding.PLATFORM_NATIVE, lineEndingServiceMock);
+		assertStep(eol::format, "EOLWindows.test", "EOLUnix.test");
+		assertStep(eol::format, "EOLMixed.test", "EOLUnix.test");
+		assertStep(eol::format, "EOLUnix.test", "EOLUnix.test");
+	}
+
+	@Test(expected = IllegalStateException.class)
+	@Ignore("This kind of test doesn't work until assertStep is refactored")
+	public void normalizeToPlatformNativeFromFile_UnexpectedServiceResult() throws Throwable {
+		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
+		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.UNCERTAIN);
+
+		new LineEndingStep(LineEnding.PLATFORM_NATIVE, lineEndingServiceMock);
+	}
+
+	@Test
+	public void normalizeToUnix() {
+		EOLNormalizer normalizer = new LineEndingStep.UnixEOLNormalizer();
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \r\nline 3", "line 1\nline 2 \nline 3");
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \nline 3", "line 1\nline 2 \nline 3");
+		assertEOLnormalization(normalizer, "line 1\nline 2 \nline 3", "line 1\nline 2 \nline 3");
+	}
+
+	@Test
+	public void normalizeToWindows() {
+		EOLNormalizer normalizer = new LineEndingStep.WindowsEOLNormalizer();
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \r\nline 3", "line 1\r\nline 2 \r\nline 3");
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \nline 3", "line 1\r\nline 2 \r\nline 3");
+		assertEOLnormalization(normalizer, "line 1\nline 2 \nline 3", "line 1\r\nline 2 \r\nline 3");
+	}
+
+	@Test
+	public void normalizeToDerivedEOL() {
+		EOLNormalizer normalizer = new LineEndingStep.DerivedEOLNormalizer(new LineEndingService());
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \r\nline 3", "line 1\r\nline 2 \r\nline 3");
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \nline 3", "line 1\r\nline 2 \r\nline 3");
+		assertEOLnormalization(normalizer, "line 1\nline 2 \nline 3", "line 1\nline 2 \nline 3");
+	}
+
+	@Test
+	public void normalizeToPlatformNative() {
+		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
+		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.UNIX);
+		EOLNormalizer normalizer = new LineEndingStep.PlatformNativeEOLNormalizer(lineEndingServiceMock);
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \r\nline 3", "line 1\nline 2 \nline 3");
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \nline 3", "line 1\nline 2 \nline 3");
+		assertEOLnormalization(normalizer, "line 1\nline 2 \nline 3", "line 1\nline 2 \nline 3");
+
+		lineEndingServiceMock = Mockito.mock(LineEndingService.class);
+		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.WINDOWS);
+		normalizer = new LineEndingStep.PlatformNativeEOLNormalizer(lineEndingServiceMock);
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \r\nline 3", "line 1\r\nline 2 \r\nline 3");
+		assertEOLnormalization(normalizer, "line 1\r\nline 2 \nline 3", "line 1\r\nline 2 \r\nline 3");
+		assertEOLnormalization(normalizer, "line 1\nline 2 \nline 3", "line 1\r\nline 2 \r\nline 3");
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void normalizeToPlatformNative_UnexpectedServiceResult() {
+		LineEndingService lineEndingServiceMock = Mockito.mock(LineEndingService.class);
+		Mockito.when(lineEndingServiceMock.getPlatformLineEnding()).thenReturn(LineEnding.UNCERTAIN);
+		new LineEndingStep.PlatformNativeEOLNormalizer(lineEndingServiceMock);
+	}
+
+	private void assertEOLnormalization(LineEndingStep.EOLNormalizer normalizer, String before, String expectedAfter) {
+		String after = normalizer.format(before);
+		assertThat(after, is(expectedAfter));
+	}
+}

--- a/src/test/java/com/diffplug/gradle/spotless/LineEndingTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/LineEndingTest.java
@@ -17,27 +17,19 @@ package com.diffplug.gradle.spotless;
 
 import org.junit.Test;
 
-public class EndWithNewlineTest extends FormatExtensionTest {
+public class LineEndingTest extends FormatExtensionTest {
 	@Test
-	public void trimTrailingNewlines() throws Exception {
-		endWithNewlineTest("", "\n");
-		endWithNewlineTest("\n");
-		endWithNewlineTest("\n\n\n\n", "\n");
-		endWithNewlineTest("line", "line\n");
-		endWithNewlineTest("line\n");
-		endWithNewlineTest("line\nline\n\n\n\n", "line\nline\n");
+	public void lineEndingNormalizationIsActiveByDefault() throws Exception {
+		testNormalization(LineEnding.UNIX, "line\r\n", "line\n");
+		testNormalization(LineEnding.UNIX, "line\n", "line\n");
+		testNormalization(LineEnding.WINDOWS, "line\n", "line\r\n");
+		testNormalization(LineEnding.WINDOWS, "line\r\n", "line\r\n");
+		testNormalization(LineEnding.DERIVED, "line\r\nfoobar\n", "line\r\nfoobar\r\n");
 	}
 
-	private void endWithNewlineTest(String before) throws Exception {
-		endWithNewlineTest(before, before);
-	}
-
-	private void endWithNewlineTest(String before, String after) throws Exception {
+	private void testNormalization(LineEnding lineEnding, String before, String after) throws Exception {
 		super.assertTask(test -> {
-			test.root.setLineEndings(LineEnding.UNIX);
-			test.dontDoLineEndingNormalization();
-
-			test.endWithNewline();
+			test.root.setLineEndings(lineEnding);
 		}, before, after);
 	}
 }

--- a/src/test/java/com/diffplug/gradle/spotless/ResourceTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/ResourceTest.java
@@ -33,7 +33,7 @@ import org.junit.rules.TemporaryFolder;
 
 import com.diffplug.common.base.Throwing;
 
-public class ResourceTest {
+public abstract class ResourceTest {
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
 
@@ -82,34 +82,4 @@ public class ResourceTest {
 		Assert.assertEquals(expected, formatted);
 	}
 
-	/** Creates a FormatTask based on the given consumer. */
-	public static FormatTask createTask(Consumer<FormatExtension> test) throws Exception {
-		Project project = ProjectBuilder.builder().build();
-		SpotlessPlugin plugin = project.getPlugins().apply(SpotlessPlugin.class);
-
-		AtomicReference<FormatExtension> ref = new AtomicReference<>();
-		plugin.getExtension().format("underTest", ext -> {
-			ref.set(ext);
-			test.accept(ext);
-		});
-
-		boolean check = false;
-		return plugin.createTask("underTest", ref.get(), check);
-	}
-
-	/** Tests that the formatExtension causes the given change. */
-	protected void assertTask(Consumer<FormatExtension> test, String before, String afterExpected) throws Exception {
-		// create the task
-		FormatTask task = createTask(test);
-		// create the test file
-		File testFile = folder.newFile();
-		Files.write(testFile.toPath(), before.getBytes(StandardCharsets.UTF_8));
-		// set the task to use this test file
-		task.target = Collections.singleton(testFile);
-		// run the task
-		task.format();
-		// check what the task did
-		String afterActual = new String(Files.readAllBytes(testFile.toPath()), StandardCharsets.UTF_8);
-		Assert.assertEquals(afterExpected, afterActual);
-	}
 }

--- a/src/test/java/com/diffplug/gradle/spotless/ResourceTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/ResourceTest.java
@@ -74,13 +74,11 @@ public class ResourceTest {
 
 	/** Reads the given resource from "before", applies the step, and makes sure the result is "after". */
 	protected void assertStep(Throwing.Function<String, String> step, String unformattedPath, String expectedPath) throws Throwable {
-		String unformatted = getTestResource(unformattedPath).replace("\r", ""); // unix-ified input
-		String formatted = step.apply(unformatted);
-		// no windows newlines
-		Assert.assertEquals(-1, formatted.indexOf('\r'));
+		String unformatted = getTestResource(unformattedPath);
+		String expected = getTestResource(expectedPath);
 
-		// unix-ify the test resource output in case git screwed it up
-		String expected = getTestResource(expectedPath).replace("\r", ""); // unix-ified output
+		String formatted = step.apply(unformatted);
+
 		Assert.assertEquals(expected, formatted);
 	}
 
@@ -103,8 +101,6 @@ public class ResourceTest {
 	protected void assertTask(Consumer<FormatExtension> test, String before, String afterExpected) throws Exception {
 		// create the task
 		FormatTask task = createTask(test);
-		// force unix line endings, since we're passing in raw strings
-		task.lineEndings = LineEnding.UNIX;
 		// create the test file
 		File testFile = folder.newFile();
 		Files.write(testFile.toPath(), before.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/com/diffplug/gradle/spotless/TrimTrailingWhitespaceTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/TrimTrailingWhitespaceTest.java
@@ -56,7 +56,7 @@ public class TrimTrailingWhitespaceTest extends FormatExtensionTest {
 
 	private void trimTrailingWhitespaceTestCase(String before, String after) throws Exception {
 		super.assertTask(test -> {
-			test.dontDoLineEndingNormalization();
+			test.dontDoDefaultLineEndingNormalization();
 			test.trimTrailingWhitespace();
 		}, before, after);
 	}

--- a/src/test/java/com/diffplug/gradle/spotless/TrimTrailingWhitespaceTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/TrimTrailingWhitespaceTest.java
@@ -15,10 +15,12 @@
  */
 package com.diffplug.gradle.spotless;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class TrimTrailingWhitespaceTest extends ResourceTest {
 	@Test
+	@Ignore("temporary")
 	public void trimTrailingWhitespace() throws Exception {
 		trimTrailingWhitespaceTestCase("");
 		trimTrailingWhitespaceTestCase("\n");
@@ -41,6 +43,13 @@ public class TrimTrailingWhitespaceTest extends ResourceTest {
 		trimTrailingWhitespaceTestCase("Line  \nLine  ", "Line\nLine");
 		trimTrailingWhitespaceTestCase("  Line  \nLine  ", "  Line\nLine");
 		trimTrailingWhitespaceTestCase("  Line  \n  Line  ", "  Line\n  Line");
+
+		trimTrailingWhitespaceTestCase("Line\r\nLine");
+		trimTrailingWhitespaceTestCase("Line \r\nLine", "Line\r\nLine");
+		trimTrailingWhitespaceTestCase("Line\r\nLine ", "Line\r\nLine");
+		trimTrailingWhitespaceTestCase("Line \r\nLine ", "Line\r\nLine");
+		trimTrailingWhitespaceTestCase(" Line \r\nLine ", " Line\r\nLine");
+		trimTrailingWhitespaceTestCase(" Line \r\n Line ", " Line\r\n Line");
 	}
 
 	private void trimTrailingWhitespaceTestCase(String before) throws Exception {

--- a/src/test/java/com/diffplug/gradle/spotless/TrimTrailingWhitespaceTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/TrimTrailingWhitespaceTest.java
@@ -15,12 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
-public class TrimTrailingWhitespaceTest extends ResourceTest {
+public class TrimTrailingWhitespaceTest extends FormatExtensionTest {
 	@Test
-	@Ignore("temporary")
 	public void trimTrailingWhitespace() throws Exception {
 		trimTrailingWhitespaceTestCase("");
 		trimTrailingWhitespaceTestCase("\n");
@@ -58,6 +56,7 @@ public class TrimTrailingWhitespaceTest extends ResourceTest {
 
 	private void trimTrailingWhitespaceTestCase(String before, String after) throws Exception {
 		super.assertTask(test -> {
+			test.dontDoLineEndingNormalization();
 			test.trimTrailingWhitespace();
 		}, before, after);
 	}

--- a/src/test/java/com/diffplug/gradle/spotless/java/EclipseFormatterStepTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/java/EclipseFormatterStepTest.java
@@ -20,25 +20,26 @@ import java.io.File;
 import org.gradle.api.GradleException;
 import org.junit.Test;
 
+import com.diffplug.gradle.spotless.LineEnding;
 import com.diffplug.gradle.spotless.ResourceTest;
 
 public class EclipseFormatterStepTest extends ResourceTest {
 	@Test
 	public void loadPropertiesSettings() throws Throwable {
 		// setting for the formatter
-		EclipseFormatterStep step = EclipseFormatterStep.load(createTestFile("formatter.properties"));
+		EclipseFormatterStep step = EclipseFormatterStep.load(createTestFile("formatter.properties"), LineEnding.DERIVED);
 		assertStep(step::format, "JavaCodeUnformatted.test", "JavaCodeFormatted.test");
 	}
 
 	@Test
 	public void loadXmlSettings() throws Throwable {
 		// setting for the formatter
-		EclipseFormatterStep step = EclipseFormatterStep.load(createTestFile("formatter.xml"));
+		EclipseFormatterStep step = EclipseFormatterStep.load(createTestFile("formatter.xml"), LineEnding.DERIVED);
 		assertStep(step::format, "JavaCodeUnformatted.test", "JavaCodeFormatted.test");
 	}
 
 	@Test(expected = GradleException.class)
 	public void loadUnknownSettings() throws Exception {
-		EclipseFormatterStep.load(new File("formatter.unknown"));
+		EclipseFormatterStep.load(new File("formatter.unknown"), LineEnding.DERIVED);
 	}
 }

--- a/src/test/java/com/diffplug/gradle/spotless/java/ImportSorterStepTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/java/ImportSorterStepTest.java
@@ -19,24 +19,25 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.diffplug.gradle.spotless.LineEnding;
 import com.diffplug.gradle.spotless.ResourceTest;
 
 public class ImportSorterStepTest extends ResourceTest {
 	@Test
 	public void sortImportsFromArray() throws Throwable {
-		ImportSorterStep step = new ImportSorterStep(Arrays.asList("java", "javax", "org", "\\#com"));
+		ImportSorterStep step = new ImportSorterStep(Arrays.asList("java", "javax", "org", "\\#com"), LineEnding.DERIVED);
 		assertStep(step::format, "JavaCodeUnsortedImports.test", "JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void sortImportsFromFile() throws Throwable {
-		ImportSorterStep step = new ImportSorterStep(createTestFile("import.properties"));
+		ImportSorterStep step = new ImportSorterStep(createTestFile("import.properties"), LineEnding.DERIVED);
 		assertStep(step::format, "JavaCodeUnsortedImports.test", "JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void sortImportsUnmatched() throws Throwable {
-		ImportSorterStep step = new ImportSorterStep(createTestFile("import_unmatched.properties"));
+		ImportSorterStep step = new ImportSorterStep(createTestFile("import_unmatched.properties"), LineEnding.DERIVED);
 		assertStep(step::format, "JavaCodeUnsortedImportsUnmatched.test", "JavaCodeSortedImportsUnmatched.test");
 	}
 }

--- a/src/test/resources/.gitattributes
+++ b/src/test/resources/.gitattributes
@@ -1,0 +1,3 @@
+EOLMixed.test -text
+EOLUnix.test -text
+EOLWindows.test -text

--- a/src/test/resources/EOLMixed.test
+++ b/src/test/resources/EOLMixed.test
@@ -1,0 +1,28 @@
+package com.github.youribonnaffe.gradle.format;
+
+import java.util.function.Function;
+
+
+public class Java8Test {
+    public void doStuff() throws Exception {
+        Function<String, Integer> example = Integer::parseInt;
+        example.andThen(val -> {
+            return val + 2;
+        } );
+        SimpleEnum val = SimpleEnum.A;
+        switch (val) {
+            case A:
+                break;
+            case B:
+                break;
+            case C:
+                break;
+            default:
+                throw new Exception();
+        }
+    }
+
+    public enum SimpleEnum {
+        A, B, C;
+    }
+}

--- a/src/test/resources/EOLUnix.test
+++ b/src/test/resources/EOLUnix.test
@@ -1,0 +1,28 @@
+package com.github.youribonnaffe.gradle.format;
+
+import java.util.function.Function;
+
+
+public class Java8Test {
+    public void doStuff() throws Exception {
+        Function<String, Integer> example = Integer::parseInt;
+        example.andThen(val -> {
+            return val + 2;
+        } );
+        SimpleEnum val = SimpleEnum.A;
+        switch (val) {
+            case A:
+                break;
+            case B:
+                break;
+            case C:
+                break;
+            default:
+                throw new Exception();
+        }
+    }
+
+    public enum SimpleEnum {
+        A, B, C;
+    }
+}

--- a/src/test/resources/EOLWindows.test
+++ b/src/test/resources/EOLWindows.test
@@ -1,0 +1,28 @@
+package com.github.youribonnaffe.gradle.format;
+
+import java.util.function.Function;
+
+
+public class Java8Test {
+    public void doStuff() throws Exception {
+        Function<String, Integer> example = Integer::parseInt;
+        example.andThen(val -> {
+            return val + 2;
+        } );
+        SimpleEnum val = SimpleEnum.A;
+        switch (val) {
+            case A:
+                break;
+            case B:
+                break;
+            case C:
+                break;
+            default:
+                throw new Exception();
+        }
+    }
+
+    public enum SimpleEnum {
+        A, B, C;
+    }
+}


### PR DESCRIPTION
Recently I've run into trouble using spotless for a project that uses git.

With the default line ending setting `PLATFORM_NATIVE` spotless works on both Linux and Windows, as long as git checks out the relevant files with CRLF-line-endings under Windows. If someone uses git without its eol-conversion, `PLATFORM_NATIVE` won't work on Windows.
Setting the line ending to `UNIX` is only an option in cases, where you can ensure the repository is only used on Linux or checked-out as-is on Windows.

But even without git, the current line ending setting options lack flexibility: Imagine a project, where CRLFs as well as LFs are used for text files. For example shell-scripts are sometimes forced to use LFs even on Windows.

I like your design of having different formatter steps which can be added to the plugin and configured by a `FormatExtension` :smiley:. So why not doing the same for the EOL-stuff? I see two thinks to do:

1. Introduce the possibility to derive the requested line ending from the current file
2. Rework the normalization into its own step, so line ending setting can be set per format

Removing the normalization from `Formatter` is non-trivial, as all the currently existing steps rely on getting a String normalized to LFs. But it is necessary, as a `LineEndingStep` that retrieves already normalized strings doesn't make sense.

I'm attaching an implementation proposal. I have splitted it in 5 (hopefully comprehensible) commits. Please let me know what you think. If there is something I should rework, don't hesitate to bring it up. :-)

The proposal is fully backward compatible to the current version. Instead of `PLATFORM_NATIVE`, I would prefere having `DERIVED` as the default, but this kind of API-change should be your decision.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/diffplug/spotless/22)
<!-- Reviewable:end -->
