### PR TITLE
Removed import order from google-java-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ spotless {
 		googleJavaFormat() // googleJavaFormat('1.1') to specify a specific version
 		// you can then layer other format steps, such as
 		licenseHeaderFile 'spotless.license.java'
-		importOrder ['java', 'javax', 'org', 'com', 'com.diffplug', '']
 	}
 }
 ```


### PR DESCRIPTION
See https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing - a re-ordering of import will/should result in a `spotlessCheck` failure, as gjf will re-arrange the imports according to the style guide.