### PR TITLE
Apply IntelliJ-suggested code style issue fixes.

### DIFF
--- a/src/main/java/com/diffplug/gradle/spotless/FormatterStep.java
+++ b/src/main/java/com/diffplug/gradle/spotless/FormatterStep.java
@@ -68,7 +68,7 @@ public interface FormatterStep {
 	}
 
 	/** A FormatterStep which doesn't depend on the input file. */
-	static class FileIndependent implements FormatterStep {
+	class FileIndependent implements FormatterStep {
 		private final String name;
 		private final Throwing.Function<String, String> formatter;
 
@@ -89,12 +89,12 @@ public interface FormatterStep {
 	}
 
 	/** Creates a FormatterStep from the given function. */
-	public static FormatterStep create(String name, Throwing.Function<String, String> formatter) {
+	static FormatterStep create(String name, Throwing.Function<String, String> formatter) {
 		return new FileIndependent(name, formatter);
 	}
 
 	/** Creates a FormatterStep lazily from the given formatterSupplier function. */
-	public static FormatterStep createLazy(String name, Throwing.Supplier<Throwing.Function<String, String>> formatterSupplier) {
+	static FormatterStep createLazy(String name, Throwing.Supplier<Throwing.Function<String, String>> formatterSupplier) {
 		// wrap the supplier as a regular Supplier (not a Throwing.Supplier)
 		Supplier<Throwing.Function<String, String>> rethrowFormatterSupplier = Errors.rethrow().wrap(formatterSupplier);
 		// memoize its result


### PR DESCRIPTION
It's not immediately obvious, but the reason why `static` isn't required for `FileIndependent` is because it's an inner class of an interface. This is because, since interfaces aren't instantiable on their own, an `FileIndependent` can never be enclosed by a `FormatterStep` outer object, and thus it's redundant to label `FileIndependent` as a static class.