### PR TITLE
Detect all Java source by default

### DIFF
--- a/src/main/java/com/diffplug/gradle/spotless/java/JavaExtension.java
+++ b/src/main/java/com/diffplug/gradle/spotless/java/JavaExtension.java
@@ -81,7 +81,7 @@ public class JavaExtension extends FormatExtension {
 			}
 			UnionFileCollection union = new UnionFileCollection();
 			for (SourceSet sourceSet : javaPlugin.getSourceSets()) {
-				union.add(sourceSet.getJava());
+				union.add(sourceSet.getAllJava());
 			}
 			target = union;
 		}

--- a/src/test/java/com/diffplug/gradle/spotless/java/JavaDefaultTargetTest.java
+++ b/src/test/java/com/diffplug/gradle/spotless/java/JavaDefaultTargetTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless.java;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.diffplug.gradle.spotless.GradleIntegrationTest;
+
+public class JavaDefaultTargetTest extends GradleIntegrationTest {
+	@Test
+	public void integration() throws IOException {
+		write("build.gradle",
+				"plugins {",
+				"    id 'com.diffplug.gradle.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"apply plugin: 'groovy'",
+				"",
+				"spotless {",
+				"    java {",
+				"        googleJavaFormat()",
+				"    }",
+				"}");
+		String input = getTestResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		write("src/main/java/test.java", input);
+		write("src/main/groovy/test.java", input);
+		write("src/main/groovy/test.groovy", input);
+
+		// write appends a line ending so re-read to see what groovy currently looks like
+		String groovyInput = read("src/main/groovy/test.groovy");
+
+		gradleRunner().forwardOutput().withArguments("spotlessApply").build();
+
+		String result = read("src/main/java/test.java");
+		String output = getTestResource("java/googlejavaformat/JavaCodeFormatted.test");
+		Assert.assertEquals("Java code in the java directory should be formatted.", output, result);
+
+		result = read("src/main/groovy/test.java");
+		Assert.assertEquals("Java code in the groovy directory should be formatted.", output, result);
+
+		result = read("src/main/groovy/test.groovy");
+		Assert.assertEquals("Groovy code in the groovy directory should not be formatted.", groovyInput, result);
+	}
+}


### PR DESCRIPTION
Fixes #59, by using the getAllJava() method on SourceSet instead
of getJava(). The main application where this is useful is projects
that do joint Java/Groovy compilation, which sometimes requires putting
Java source into the Groovy directory. getAllJava() correctly picks up
all of these source files.

The test is a modified copy of the GoogleJavaFormatTest. The main oddity
in this test is that a side-effect of the GradleIntegrationTest.write()
methods is that a newline is always present at the end of the file. This
means that you can't round trip a file through write()/read() and
expect it to be the same. To avoid modifying that behavior, since I'm
not sure how much other tests depend on it, I just re-read the groovy
source after writing to ensure I could verify it wasn't changed by
spotlessApply.