### PR TITLE
Any exception should break the build

### DIFF
--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
@@ -54,7 +54,7 @@ public class EclipseFormatterStepTest extends ResourceHarness {
 	public void equality() throws IOException {
 		File xmlFile = createTestFile("java/eclipse/format/formatter.xml");
 		File propFile = createTestFile("java/eclipse/format/formatter.properties");
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			File settingsFile;
 
 			@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
@@ -60,11 +60,9 @@ public class EclipseFormatterStepTest extends ResourceHarness {
 			@Override
 			protected void setupTest(API api) {
 				settingsFile = xmlFile;
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				settingsFile = propFile;
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
@@ -15,14 +15,12 @@
  */
 package com.diffplug.spotless;
 
-import java.io.File;
 import java.io.Serializable;
-import java.nio.file.Path;
 
 /** A policy for handling exceptions in the format. */
 public interface FormatExceptionPolicy extends Serializable, NoLambda {
 	/** Called for every error in the formatter. */
-	void handleError(Throwable e, FormatterStep step, File file, Path rootDir);
+	void handleError(Throwable e, FormatterStep step, String relativePath);
 
 	/**
 	 * Returns a byte array representation of everything inside this `FormatExceptionPolicy`.

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 import java.nio.file.Path;
 
 /** A policy for handling exceptions in the format. */
-public interface FormatExceptionPolicy extends Serializable {
+public interface FormatExceptionPolicy extends Serializable, NoLambda {
 	/** Called for every error in the formatter. */
 	void handleError(Throwable e, FormatterStep step, File file, Path rootDir);
 

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Path;
+
+/** A policy for handling exceptions in the format. */
+public interface FormatExceptionPolicy extends Serializable {
+	/** Called for every error in the formatter. */
+	void handleError(Throwable e, FormatterStep step, File file, Path rootDir);
+
+	/**
+	 * Returns a byte array representation of everything inside this `FormatExceptionPolicy`.
+	 *
+	 * The main purpose of this method is to ensure one can't instantiate this class with lambda
+	 * expressions, which are notoriously difficult to serialize and deserialize properly.
+	 */
+	public byte[] toBytes();
+
+	/**
+	 * A policy which rethrows subclasses of `Error` and logs other kinds of Exception.
+	 */
+	public static FormatExceptionPolicy failOnlyOnError() {
+		return new FormatExceptionPolicyLegacy();
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
@@ -28,10 +28,18 @@ class FormatExceptionPolicyLegacy extends NoLambda.EqualityBasedOnSerialization 
 	@Override
 	public void handleError(Throwable e, FormatterStep step, File file, Path rootDir) {
 		if (e instanceof Error) {
-			logger.severe("Step '" + step.getName() + "' found problem in '" + rootDir.relativize(file.toPath()) + "':\n" + e.getMessage());
+			error(e, step, file, rootDir);
 			throw ((Error) e);
 		} else {
-			logger.log(Level.WARNING, "Unable to apply step '" + step.getName() + "' to '" + rootDir.relativize(file.toPath()), e);
+			warning(e, step, file, rootDir);
 		}
+	}
+
+	static void error(Throwable e, FormatterStep step, File file, Path rootDir) {
+		logger.severe("Step '" + step.getName() + "' found problem in '" + rootDir.relativize(file.toPath()) + "':\n" + e.getMessage());
+	}
+
+	static void warning(Throwable e, FormatterStep step, File file, Path rootDir) {
+		logger.log(Level.WARNING, "Unable to apply step '" + step.getName() + "' to '" + rootDir.relativize(file.toPath()), e);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class FormatExceptionPolicyLegacy implements FormatExceptionPolicy {
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger logger = Logger.getLogger(Formatter.class.getName());
+
+	@Override
+	public void handleError(Throwable e, FormatterStep step, File file, Path rootDir) {
+		if (e instanceof Error) {
+			logger.severe("Step '" + step.getName() + "' found problem in '" + rootDir.relativize(file.toPath()) + "':\n" + e.getMessage());
+			throw ((Error) e);
+		} else {
+			logger.log(Level.WARNING, "Unable to apply step '" + step.getName() + "' to '" + rootDir.relativize(file.toPath()), e);
+		}
+	}
+
+	@Override
+	public byte[] toBytes() {
+		return LazyForwardingEquality.toBytes(this);
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
@@ -15,8 +15,6 @@
  */
 package com.diffplug.spotless;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -26,20 +24,20 @@ class FormatExceptionPolicyLegacy extends NoLambda.EqualityBasedOnSerialization 
 	private static final Logger logger = Logger.getLogger(Formatter.class.getName());
 
 	@Override
-	public void handleError(Throwable e, FormatterStep step, File file, Path rootDir) {
+	public void handleError(Throwable e, FormatterStep step, String relativePath) {
 		if (e instanceof Error) {
-			error(e, step, file, rootDir);
+			error(e, step, relativePath);
 			throw ((Error) e);
 		} else {
-			warning(e, step, file, rootDir);
+			warning(e, step, relativePath);
 		}
 	}
 
-	static void error(Throwable e, FormatterStep step, File file, Path rootDir) {
-		logger.severe("Step '" + step.getName() + "' found problem in '" + rootDir.relativize(file.toPath()) + "':\n" + e.getMessage());
+	static void error(Throwable e, FormatterStep step, String relativePath) {
+		logger.log(Level.SEVERE, "Step '" + step.getName() + "' found problem in '" + relativePath + "':\n" + e.getMessage(), e);
 	}
 
-	static void warning(Throwable e, FormatterStep step, File file, Path rootDir) {
-		logger.log(Level.WARNING, "Unable to apply step '" + step.getName() + "' to '" + rootDir.relativize(file.toPath()), e);
+	static void warning(Throwable e, FormatterStep step, String relativePath) {
+		logger.log(Level.WARNING, "Unable to apply step '" + step.getName() + "' to '" + relativePath + "'", e);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyLegacy.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-class FormatExceptionPolicyLegacy implements FormatExceptionPolicy {
+class FormatExceptionPolicyLegacy extends NoLambda.EqualityBasedOnSerialization implements FormatExceptionPolicy {
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger logger = Logger.getLogger(Formatter.class.getName());
@@ -33,10 +33,5 @@ class FormatExceptionPolicyLegacy implements FormatExceptionPolicy {
 		} else {
 			logger.log(Level.WARNING, "Unable to apply step '" + step.getName() + "' to '" + rootDir.relativize(file.toPath()), e);
 		}
-	}
-
-	@Override
-	public byte[] toBytes() {
-		return LazyForwardingEquality.toBytes(this);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyStrict.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyStrict.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A policy for handling exceptions in the format.  Any exceptions will
+ * halt the build except for a specifically excluded path or step.
+ */
+public class FormatExceptionPolicyStrict extends NoLambda.EqualityBasedOnSerialization implements FormatExceptionPolicy {
+	private static final long serialVersionUID = 1L;
+
+	private final Set<String> excludeSteps = new TreeSet<>();
+	private final Set<String> excludePaths = new TreeSet<>();
+
+	/** Adds a step name to exclude. */
+	public void excludeStep(String stepName) {
+		excludeSteps.add(stepName);
+	}
+
+	/** Adds a realtive pathx to exclude. */
+	public void excludePath(String relativePath) {
+		excludePaths.add(relativePath);
+	}
+
+	@Override
+	public void handleError(Throwable e, FormatterStep step, File file, Path rootDir) {
+		if (excludeSteps.contains(step.getName())) {
+			FormatExceptionPolicyLegacy.warning(e, step, file, rootDir);
+		} else {
+			String path = rootDir.relativize(file.toPath()).toString();
+			if (excludePaths.contains(path)) {
+				FormatExceptionPolicyLegacy.warning(e, step, file, rootDir);
+			} else {
+				FormatExceptionPolicyLegacy.error(e, step, file, rootDir);
+				throw ThrowingEx.asRuntimeRethrowError(e);
+			}
+		}
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyStrict.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyStrict.java
@@ -15,8 +15,6 @@
  */
 package com.diffplug.spotless;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -41,15 +39,14 @@ public class FormatExceptionPolicyStrict extends NoLambda.EqualityBasedOnSeriali
 	}
 
 	@Override
-	public void handleError(Throwable e, FormatterStep step, File file, Path rootDir) {
+	public void handleError(Throwable e, FormatterStep step, String relativePath) {
 		if (excludeSteps.contains(step.getName())) {
-			FormatExceptionPolicyLegacy.warning(e, step, file, rootDir);
+			FormatExceptionPolicyLegacy.warning(e, step, relativePath);
 		} else {
-			String path = rootDir.relativize(file.toPath()).toString();
-			if (excludePaths.contains(path)) {
-				FormatExceptionPolicyLegacy.warning(e, step, file, rootDir);
+			if (excludePaths.contains(relativePath)) {
+				FormatExceptionPolicyLegacy.warning(e, step, relativePath);
 			} else {
-				FormatExceptionPolicyLegacy.error(e, step, file, rootDir);
+				FormatExceptionPolicyLegacy.error(e, step, relativePath);
 				throw ThrowingEx.asRuntimeRethrowError(e);
 			}
 		}

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -225,7 +225,8 @@ public final class Formatter implements Serializable {
 					unix = LineEnding.toUnix(formatted);
 				}
 			} catch (Throwable e) {
-				exceptionPolicy.handleError(e, step, file, rootDir);
+				String relativePath = rootDir.relativize(file.toPath()).toString();
+				exceptionPolicy.handleError(e, step, relativePath);
 			}
 		}
 		return unix;

--- a/lib/src/main/java/com/diffplug/spotless/LazyForwardingEquality.java
+++ b/lib/src/main/java/com/diffplug/spotless/LazyForwardingEquality.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  * of lazily-computed state.  The state's serialized form is used to implement
  * equals() and hashCode(), so you don't have to.
  */
-public abstract class LazyForwardingEquality<T extends Serializable> implements Serializable {
+public abstract class LazyForwardingEquality<T extends Serializable> implements Serializable, NoLambda {
 	private static final long serialVersionUID = 1L;
 
 	/** Lazily initialized - null indicates that the state has not yet been set. */
@@ -81,12 +81,17 @@ public abstract class LazyForwardingEquality<T extends Serializable> implements 
 	}
 
 	@Override
+	public byte[] toBytes() {
+		return toBytes(state());
+	}
+
+	@Override
 	public final boolean equals(Object other) {
 		if (other == null) {
 			return false;
 		} else if (getClass().equals(other.getClass())) {
-			Serializable otherState = ((LazyForwardingEquality<?>) other).state();
-			return Arrays.equals(toBytes(otherState), toBytes(state()));
+			LazyForwardingEquality<?> otherCast = (LazyForwardingEquality<?>) other;
+			return Arrays.equals(otherCast.toBytes(), toBytes());
 		} else {
 			return false;
 		}
@@ -94,7 +99,7 @@ public abstract class LazyForwardingEquality<T extends Serializable> implements 
 
 	@Override
 	public final int hashCode() {
-		return Arrays.hashCode(toBytes(state()));
+		return Arrays.hashCode(toBytes());
 	}
 
 	static byte[] toBytes(Serializable obj) {

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -76,10 +76,25 @@ public enum LineEnding {
 		}
 	}
 
-	private static final Policy WINDOWS_POLICY = file -> WINDOWS.str();
-	private static final Policy UNIX_POLICY = file -> UNIX.str();
+	static class ConstantLineEndingPolicy extends NoLambda.EqualityBasedOnSerialization implements Policy {
+		private static final long serialVersionUID = 1L;
+
+		final String lineEnding;
+
+		ConstantLineEndingPolicy(String lineEnding) {
+			this.lineEnding = lineEnding;
+		}
+
+		@Override
+		public String getEndingFor(File file) {
+			return lineEnding;
+		}
+	}
+
+	private static final Policy WINDOWS_POLICY = new ConstantLineEndingPolicy(WINDOWS.str());
+	private static final Policy UNIX_POLICY = new ConstantLineEndingPolicy(UNIX.str());
 	private static final String _platformNative = System.getProperty("line.separator");
-	private static final Policy _platformNativePolicy = file -> _platformNative;
+	private static final Policy _platformNativePolicy = new ConstantLineEndingPolicy(_platformNative);
 
 	/** Returns the standard line ending for this policy. */
 	public String str() {
@@ -93,7 +108,7 @@ public enum LineEnding {
 	// @formatter:on
 
 	/** A policy for line endings which can vary based on the specific file being requested. */
-	public interface Policy extends Serializable {
+	public interface Policy extends Serializable, NoLambda {
 		/** Returns the line ending appropriate for the given file. */
 		String getEndingFor(File file);
 

--- a/lib/src/main/java/com/diffplug/spotless/NoLambda.java
+++ b/lib/src/main/java/com/diffplug/spotless/NoLambda.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Marker interface to prevent lambda implementations of
+ * single-method interfaces that require serializability.
+ *
+ * In order for Spotless to support up-to-date checks, all
+ * of its parameters must be {@link Serializable} so that
+ * entries can be written to file, and they must implement
+ * equals and hashCode correctly.
+ *
+ * This interface and its standard implementation,
+ * {@link EqualityBasedOnSerialization}, are a quick way
+ * to accomplish these goals.
+ */
+public interface NoLambda extends Serializable {
+	/**
+	 * Returns a byte array representation of everything inside this `SerializableFileFilter`.
+	 *
+	 * The main purpose of this method is to ensure one can't instantiate this class with lambda
+	 * expressions, which are notoriously difficult to serialize and deserialize properly. (See
+	 * `SerializableFileFilterImpl.SkipFilesNamed` for an example of how to make a serializable
+	 * subclass.)
+	 */
+	public byte[] toBytes();
+
+	/** An implementation of NoLambda in which equality is based on the serialized representation of itself. */
+	public static abstract class EqualityBasedOnSerialization implements NoLambda {
+		private static final long serialVersionUID = 1733798699224768949L;
+
+		@Override
+		public byte[] toBytes() {
+			return LazyForwardingEquality.toBytes(this);
+		}
+
+		@Override
+		public int hashCode() {
+			return Arrays.hashCode(toBytes());
+		}
+
+		@Override
+		public boolean equals(Object otherObj) {
+			if (otherObj == null) {
+				return false;
+			} else if (otherObj.getClass().equals(this.getClass())) {
+				EqualityBasedOnSerialization other = (EqualityBasedOnSerialization) otherObj;
+				return Arrays.equals(toBytes(), other.toBytes());
+			} else {
+				return false;
+			}
+		}
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/SerializableFileFilter.java
+++ b/lib/src/main/java/com/diffplug/spotless/SerializableFileFilter.java
@@ -17,49 +17,11 @@ package com.diffplug.spotless;
 
 import java.io.FileFilter;
 import java.io.Serializable;
-import java.util.Arrays;
 
 /** A file filter with full support for serialization. */
-public interface SerializableFileFilter extends FileFilter, Serializable {
+public interface SerializableFileFilter extends FileFilter, Serializable, NoLambda {
 	/** Creates a FileFilter which will accept all files except files with the given name. */
 	public static SerializableFileFilter skipFilesNamed(String name) {
 		return new SerializableFileFilterImpl.SkipFilesNamed(name);
-	}
-
-	/**
-	 * Returns a byte array representation of everything inside this `SerializableFileFilter`.
-	 *
-	 * The main purpose of this method is to ensure one can't instantiate this class with lambda
-	 * expressions, which are notoriously difficult to serialize and deserialize properly. (See
-	 * `SerializableFileFilterImpl.SkipFilesNamed` for an example of how to make a serializable
-	 * subclass.)
-	 */
-	public byte[] toBytes();
-
-	/** An implementation of SerializableFileFilter in which equality is based on the serialized representation. */
-	public static abstract class EqualityBasedOnSerialization implements SerializableFileFilter {
-		private static final long serialVersionUID = 1733798699224768949L;
-
-		@Override
-		public byte[] toBytes() {
-			return LazyForwardingEquality.toBytes(this);
-		}
-
-		@Override
-		public int hashCode() {
-			return Arrays.hashCode(toBytes());
-		}
-
-		@Override
-		public boolean equals(Object otherObj) {
-			if (otherObj == null) {
-				return false;
-			} else if (otherObj.getClass().equals(this.getClass())) {
-				EqualityBasedOnSerialization other = (EqualityBasedOnSerialization) otherObj;
-				return Arrays.equals(toBytes(), other.toBytes());
-			} else {
-				return false;
-			}
-		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/SerializableFileFilterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/SerializableFileFilterImpl.java
@@ -19,7 +19,7 @@ import java.io.File;
 import java.util.Objects;
 
 class SerializableFileFilterImpl {
-	static class SkipFilesNamed extends SerializableFileFilter.EqualityBasedOnSerialization {
+	static class SkipFilesNamed extends NoLambda.EqualityBasedOnSerialization implements SerializableFileFilter {
 		private static final long serialVersionUID = 1L;
 
 		private final String nameToSkip;

--- a/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
+++ b/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
@@ -101,14 +101,24 @@ public final class ThrowingEx {
 	public static RuntimeException unwrapCause(Throwable e) {
 		Throwable cause = e.getCause();
 		if (cause == null) {
-			return ifErrorRethrowElseAsRuntime(e);
+			return asRuntimeRethrowError(e);
 		} else {
-			return ifErrorRethrowElseAsRuntime(cause);
+			return asRuntimeRethrowError(cause);
 		}
 	}
 
-	/** Rethrows errors, wraps and returns everything else as a runtime exception. */
-	private static RuntimeException ifErrorRethrowElseAsRuntime(Throwable e) {
+	/**
+	 * Rethrows errors, wraps and returns everything else as a runtime exception.
+	 *
+	 * try {
+	 *     doSomething();
+	 * } catch (Throwable e) {
+	 *     throw asRuntimeRethrowError(e);
+	 * }
+	 * ```
+	 *
+	 * */
+	static RuntimeException asRuntimeRethrowError(Throwable e) {
 		if (e instanceof Error) {
 			throw (Error) e;
 		} else if (e instanceof RuntimeException) {

--- a/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
+++ b/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
@@ -94,11 +94,11 @@ public final class ThrowingEx {
 	 * try {
 	 *     doSomething();
 	 * } catch (Throwable e) {
-	 *     throw unwrapAsRuntimeOrRethrow(e);
+	 *     throw unwrapCause(e);
 	 * }
 	 * ```
 	 */
-	public static RuntimeException unwrapAsRuntimeOrRethrow(Throwable e) {
+	public static RuntimeException unwrapCause(Throwable e) {
 		Throwable cause = e.getCause();
 		if (cause == null) {
 			return ifErrorRethrowElseAsRuntime(e);

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -97,7 +97,7 @@ public class KtLintStep {
 					String formatted = (String) formatterMethod.invoke(ktlint, input, ruleSets, formatterCallback);
 					return formatted;
 				} catch (InvocationTargetException e) {
-					throw ThrowingEx.unwrapAsRuntimeOrRethrow(e);
+					throw ThrowingEx.unwrapCause(e);
 				}
 			};
 		}

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
@@ -18,7 +18,9 @@ package com.diffplug.spotless.markdown;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
@@ -60,11 +62,13 @@ public class FreshMarkStep {
 
 		/** The jar that contains the eclipse formatter. */
 		final JarState jarState;
-		final Map<String, ?> properties;
+		final NavigableMap<String, ?> properties;
 
 		State(JarState jarState, Map<String, ?> properties) {
 			this.jarState = Objects.requireNonNull(jarState);
-			this.properties = Objects.requireNonNull(properties);
+			// because equality is computed based on serialization, it's important to order the properties
+			// before writing them
+			this.properties = new TreeMap<>(Objects.requireNonNull(properties));
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -33,6 +33,7 @@ import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.UnionFileCollection;
 
+import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LazyForwardingEquality;
@@ -103,6 +104,18 @@ public class FormatExtension {
 	/** Sets the encoding to use (defaults to {@link SpotlessExtension#getEncoding()}. */
 	public void setEncoding(Charset charset) {
 		encoding = Objects.requireNonNull(charset);
+	}
+
+	FormatExceptionPolicyStrict exceptionPolicy = new FormatExceptionPolicyStrict();
+
+	/** Ignores errors in the given step. */
+	public void ignoreErrorForStep(String stepName) {
+		exceptionPolicy.excludeStep(stepName);
+	}
+
+	/** Ignores errors for the given relative path. */
+	public void ignoreErrorForPath(String relativePath) {
+		exceptionPolicy.excludePath(relativePath);
 	}
 
 	/** Sets encoding to use (defaults to {@link SpotlessExtension#getEncoding()}). */
@@ -340,6 +353,7 @@ public class FormatExtension {
 	protected void setupTask(SpotlessTask task) {
 		task.setPaddedCell(paddedCell);
 		task.setEncoding(getEncoding().name());
+		task.setExceptionPolicy(exceptionPolicy);
 		task.setTarget(target);
 		task.setSteps(steps);
 		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> task.target));

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -33,6 +34,8 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 
+import com.diffplug.spotless.FormatExceptionPolicy;
+import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
@@ -73,6 +76,17 @@ public class SpotlessTask extends DefaultTask {
 
 	public void setPaddedCell(boolean paddedCell) {
 		this.paddedCell = paddedCell;
+	}
+
+	@Input
+	protected FormatExceptionPolicy exceptionPolicy = new FormatExceptionPolicyStrict();
+
+	public void setExceptionPolicy(FormatExceptionPolicy exceptionPolicy) {
+		this.exceptionPolicy = Objects.requireNonNull(exceptionPolicy);
+	}
+
+	public FormatExceptionPolicy getExceptionPolicy() {
+		return exceptionPolicy;
 	}
 
 	@InputFiles

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrow.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrow.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +32,7 @@ import com.diffplug.spotless.LineEnding;
 public class ErrorShouldRethrow extends GradleIntegrationTest {
 	@Test
 	public void noSwearing() throws Exception {
-		File build = write("build.gradle",
+		write("build.gradle",
 				"plugins {",
 				"    id 'com.diffplug.gradle.spotless'",
 				"}",
@@ -53,16 +52,7 @@ public class ErrorShouldRethrow extends GradleIntegrationTest {
 		String expectedToStartWith = StringPrinter.buildStringFromLines(
 				":spotlessMiscStep 'no swearing' found problem in 'README.md':",
 				"No swearing!",
-				" FAILED",
-				"",
-				"FAILURE: Build failed with an exception.",
-				"",
-				"* Where:",
-				"Build file '" + build + "' line: 9",
-				"",
-				"* What went wrong:",
-				"Execution failed for task ':spotlessMisc'.",
-				"> No swearing!");
+				"java.lang.AssertionError: No swearing!").trim();
 		int numNewlines = CharMatcher.is('\n').countIn(expectedToStartWith);
 		List<String> actualLines = Splitter.on('\n').splitToList(LineEnding.toUnix(result.getOutput()));
 		String actualStart = actualLines.subList(0, numNewlines + 1).stream().collect(Collectors.joining("\n"));

--- a/testlib/src/main/java/com/diffplug/spotless/SerializableEqualityTester.java
+++ b/testlib/src/main/java/com/diffplug/spotless/SerializableEqualityTester.java
@@ -25,7 +25,7 @@ import java.util.List;
 import com.diffplug.common.base.Box;
 import com.diffplug.common.testing.EqualsTester;
 
-public abstract class StepEqualityTester {
+public abstract class SerializableEqualityTester {
 	protected abstract Serializable create();
 
 	protected abstract void setupTest(API api) throws Exception;

--- a/testlib/src/main/java/com/diffplug/spotless/StepEqualityTester.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepEqualityTester.java
@@ -28,10 +28,6 @@ public abstract class StepEqualityTester {
 	protected abstract void setupTest(API api) throws Exception;
 
 	public interface API {
-		void assertThis();
-
-		void assertThisEqualToThis();
-
 		void areDifferentThan();
 	}
 
@@ -40,20 +36,16 @@ public abstract class StepEqualityTester {
 		Box<List<Object>> currentGroup = Box.of(new ArrayList<>());
 		API api = new API() {
 			@Override
-			public void assertThis() {
-				currentGroup.get().add(create());
-			}
-
-			@Override
-			public void assertThisEqualToThis() {
-				assertThis();
-				assertThis();
-			}
-
-			@Override
 			public void areDifferentThan() {
-				allGroups.add(currentGroup.get());
-				currentGroup.set(new ArrayList<>());
+				currentGroup.modify(current -> {
+					// create two instances, and add them to the group
+					current.add(create());
+					current.add(create());
+					// add this group to the list of all groups
+					allGroups.add(current);
+					// and return a new blank group for the next call
+					return new ArrayList<>();
+				});
 			}
 		};
 		try {

--- a/testlib/src/main/java/com/diffplug/spotless/StepEqualityTester.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepEqualityTester.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +23,7 @@ import com.diffplug.common.base.Box;
 import com.diffplug.common.testing.EqualsTester;
 
 public abstract class StepEqualityTester {
-	protected abstract FormatterStep create();
+	protected abstract Serializable create();
 
 	protected abstract void setupTest(API api) throws Exception;
 

--- a/testlib/src/test/java/com/diffplug/spotless/FilterByFileFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FilterByFileFormatterStepTest.java
@@ -34,7 +34,7 @@ public class FilterByFileFormatterStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			String state;
 			String filter;
 

--- a/testlib/src/test/java/com/diffplug/spotless/FilterByFileFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FilterByFileFormatterStepTest.java
@@ -43,19 +43,15 @@ public class FilterByFileFormatterStepTest extends ResourceHarness {
 				// no filter, standard state
 				state = "state";
 				filter = null;
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// same state, but now with a filter
 				filter = "a";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// same state, but now with a filter
 				filter = "b";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// same filter, but the state has changed
 				state = "otherState";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
@@ -53,7 +53,19 @@ public class FormatterTest {
 				steps.add(EndWithNewlineStep.create());
 				api.areDifferentThan();
 
-				// TODO: create some second exception policy to test this
+				{
+					FormatExceptionPolicyStrict standard = new FormatExceptionPolicyStrict();
+					standard.excludePath("path");
+					exceptionPolicy = standard;
+					api.areDifferentThan();
+				}
+
+				{
+					FormatExceptionPolicyStrict standard = new FormatExceptionPolicyStrict();
+					standard.excludeStep("step");
+					exceptionPolicy = standard;
+					api.areDifferentThan();
+				}
 			}
 
 			@Override

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.diffplug.common.base.StandardSystemProperty;
+import com.diffplug.spotless.generic.EndWithNewlineStep;
+
+public class FormatterTest {
+	@Test
+	public void equality() {
+		new StepEqualityTester() {
+			private LineEnding.Policy lineEndingsPolicy = LineEnding.UNIX.createPolicy();
+			private Charset encoding = StandardCharsets.UTF_8;
+			private Path rootDir = Paths.get(StandardSystemProperty.USER_DIR.value());
+			private List<FormatterStep> steps = new ArrayList<>();
+			private FormatExceptionPolicy exceptionPolicy = FormatExceptionPolicy.failOnlyOnError();
+
+			@Override
+			protected void setupTest(API api) throws Exception {
+				api.assertThisEqualToThis();
+				api.areDifferentThan();
+
+				lineEndingsPolicy = LineEnding.WINDOWS.createPolicy();
+				api.assertThisEqualToThis();
+				api.areDifferentThan();
+
+				encoding = StandardCharsets.UTF_16;
+				api.assertThisEqualToThis();
+				api.areDifferentThan();
+
+				rootDir = rootDir.getParent();
+				api.assertThisEqualToThis();
+				api.areDifferentThan();
+
+				steps.add(EndWithNewlineStep.create());
+				api.assertThisEqualToThis();
+				api.areDifferentThan();
+
+				// TODO: create some second exception policy to test this
+			}
+
+			@Override
+			protected Formatter create() {
+				return Formatter.builder()
+						.lineEndingsPolicy(lineEndingsPolicy)
+						.encoding(encoding)
+						.rootDir(rootDir)
+						.steps(steps)
+						.exceptionPolicy(exceptionPolicy)
+						.build();
+			}
+		}.testEquals();
+	}
+}

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
@@ -39,23 +39,18 @@ public class FormatterTest {
 
 			@Override
 			protected void setupTest(API api) throws Exception {
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				lineEndingsPolicy = LineEnding.WINDOWS.createPolicy();
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				encoding = StandardCharsets.UTF_16;
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				rootDir = rootDir.getParent();
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				steps.add(EndWithNewlineStep.create());
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				// TODO: create some second exception policy to test this

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
@@ -30,7 +30,7 @@ import com.diffplug.spotless.generic.EndWithNewlineStep;
 public class FormatterTest {
 	@Test
 	public void equality() {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			private LineEnding.Policy lineEndingsPolicy = LineEnding.UNIX.createPolicy();
 			private Charset encoding = StandardCharsets.UTF_8;
 			private Path rootDir = Paths.get(StandardSystemProperty.USER_DIR.value());

--- a/testlib/src/test/java/com/diffplug/spotless/generic/EndWithNewlineStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/EndWithNewlineStepTest.java
@@ -38,7 +38,6 @@ public class EndWithNewlineStepTest {
 		new StepEqualityTester() {
 			@Override
 			protected void setupTest(API api) {
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/EndWithNewlineStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/EndWithNewlineStepTest.java
@@ -18,7 +18,7 @@ package com.diffplug.spotless.generic;
 import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 
 public class EndWithNewlineStepTest {
@@ -35,7 +35,7 @@ public class EndWithNewlineStepTest {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			@Override
 			protected void setupTest(API api) {
 				api.areDifferentThan();

--- a/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
@@ -65,19 +65,15 @@ public class IndentStepTest extends ResourceHarness {
 
 			@Override
 			protected void setupTest(API api) {
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				numSpacesPerTab = 4;
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				type = IndentStep.Type.TAB;
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				numSpacesPerTab = 2;
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.generic.IndentStep;
 
 public class IndentStepTest extends ResourceHarness {
@@ -59,7 +59,7 @@ public class IndentStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			IndentStep.Type type = IndentStep.Type.SPACE;
 			int numSpacesPerTab = 2;
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -82,19 +82,15 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 			@Override
 			protected void setupTest(API api) {
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				delimiter = "crate";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				header = "APACHE";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 
 				delimiter = "package";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
 
 public class LicenseHeaderStepTest extends ResourceHarness {
@@ -76,7 +76,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			String header = "LICENSE";
 			String delimiter = "package";
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/TrimTrailingWhitespaceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/TrimTrailingWhitespaceStepTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 
 public class TrimTrailingWhitespaceStepTest extends ResourceHarness {
@@ -51,7 +51,7 @@ public class TrimTrailingWhitespaceStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			@Override
 			protected void setupTest(API api) {
 				api.areDifferentThan();

--- a/testlib/src/test/java/com/diffplug/spotless/generic/TrimTrailingWhitespaceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/TrimTrailingWhitespaceStepTest.java
@@ -54,7 +54,6 @@ public class TrimTrailingWhitespaceStepTest extends ResourceHarness {
 		new StepEqualityTester() {
 			@Override
 			protected void setupTest(API api) {
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
@@ -38,7 +38,7 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			String version = "1.1";
 
 			@Override

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -44,11 +44,9 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 			@Override
 			protected void setupTest(API api) {
 				// same version == same
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the version, and it's different
 				version = "1.0";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -63,19 +63,15 @@ public class ImportOrderStepTest extends ResourceHarness {
 			@Override
 			protected void setupTest(API api) {
 				// same version == same
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the version, and it's different
 				imports = ImmutableList.of("a");
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the version, and it's different
 				imports = ImmutableList.of("b");
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the version, and it's different
 				imports = ImmutableList.of("a", "b");
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -23,7 +23,7 @@ import com.diffplug.common.collect.ImmutableList;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.NonSerializableList;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 
 public class ImportOrderStepTest extends ResourceHarness {
 	@Test
@@ -57,7 +57,7 @@ public class ImportOrderStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			ImmutableList<String> imports = ImmutableList.of();
 
 			@Override

--- a/testlib/src/test/java/com/diffplug/spotless/java/RemoveUnusedImportsStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/RemoveUnusedImportsStepTest.java
@@ -38,7 +38,6 @@ public class RemoveUnusedImportsStepTest {
 		new StepEqualityTester() {
 			@Override
 			protected void setupTest(API api) {
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/java/RemoveUnusedImportsStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/RemoveUnusedImportsStepTest.java
@@ -18,7 +18,7 @@ package com.diffplug.spotless.java;
 import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
@@ -35,7 +35,7 @@ public class RemoveUnusedImportsStepTest {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			@Override
 			protected void setupTest(API api) {
 				api.areDifferentThan();

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -43,11 +43,9 @@ public class KtLintStepTest extends ResourceHarness {
 			@Override
 			protected void setupTest(API api) {
 				// same version == same
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the version, and it's different
 				version = "0.2.1";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
@@ -37,7 +37,7 @@ public class KtLintStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			String version = "0.2.2";
 
 			@Override

--- a/testlib/src/test/java/com/diffplug/spotless/markdown/FreshMarkStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/markdown/FreshMarkStepTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
@@ -37,7 +37,7 @@ public class FreshMarkStepTest {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			String version = "1.3.1";
 			Map<String, Object> props = new HashMap<>();
 

--- a/testlib/src/test/java/com/diffplug/spotless/markdown/FreshMarkStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/markdown/FreshMarkStepTest.java
@@ -44,15 +44,12 @@ public class FreshMarkStepTest {
 			@Override
 			protected void setupTest(API api) {
 				// same version and props == same
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the version, and it's different
 				version = "1.3.0";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the props, and it's different
 				props.put("1", "2");
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -50,19 +50,15 @@ public class ScalaFmtStepTest extends ResourceHarness {
 			@Override
 			protected void setupTest(API api) throws IOException {
 				// same version == same
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the version, and it's different
 				version = "0.5.0";
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// add a config file, and its different
 				configFile = createTestFile("scala/scalafmt/scalafmt.conf");
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 				// change the config file and its different
 				configFile = createTestFile("scala/scalafmt/scalafmt2.conf");
-				api.assertThisEqualToThis();
 				api.areDifferentThan();
 			}
 

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepEqualityTester;
+import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
@@ -43,7 +43,7 @@ public class ScalaFmtStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws Exception {
-		new StepEqualityTester() {
+		new SerializableEqualityTester() {
 			String version = "0.5.1";
 			File configFile = null;
 


### PR DESCRIPTION
Right now, if any exception is thrown by a FormatterStep, it will silently print a warning and that's it.  This is a problem for two reasons:

1. Before Spotless 3.x, the eclipse formatter would intermittently fail to due to classpath conflicts.  It made sense to let these slip by so that Spotless would still be usable, but now with 3.x classloader isolation spotless is much more reliable - there's no longer any reason to let these slip by.

2. With up-to-date checking, it's hard to get a second chance to see an error.  This is especially troublesome for rules like FreshMark.

This PR makes any exceptions fail the build, along with a mechanism to allow a specific failure to sneak by.  In order to implement this functionality, it also found and fixed some bugs to make `Formatter` fully support equals/hashCode/Serializable, and improved the tests.