### PR TITLE
Feature/common property support

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -187,7 +187,7 @@ public final class GitAttributesLineEndings {
 					.filter(file -> file != null && file.exists() && file.isFile())
 					.collect(Collectors.toList());
 			// sign it for up-to-date checking
-			signature = FileSignature.from(toSign, FileSignature.Ignore.ORDER_AND_DUPLICATES);
+			signature = FileSignature.fromSet(toSign);
 		}
 
 		/** Returns all of the .gitattributes files which affect the given files. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -187,7 +187,7 @@ public final class GitAttributesLineEndings {
 					.filter(file -> file != null && file.exists() && file.isFile())
 					.collect(Collectors.toList());
 			// sign it for up-to-date checking
-			signature = FileSignature.from(toSign);
+			signature = FileSignature.from(toSign, FileSignature.Ignore.ORDER_AND_DUPLICATES);
 		}
 
 		/** Returns all of the .gitattributes files which affect the given files. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
@@ -20,7 +20,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -48,14 +48,14 @@ public final class EclipseFormatterStep {
 	private static final String FORMATTER_METHOD = "format";
 
 	/** Creates a formatter step for the given version and settings file. */
-	public static FormatterStep create(File settingsFile, Provisioner provisioner) {
-		return create(defaultVersion(), settingsFile, provisioner);
+	public static FormatterStep create(Collection<File> settingsFiles, Provisioner provisioner) {
+		return create(defaultVersion(), settingsFiles, provisioner);
 	}
 
 	/** Creates a formatter step for the given version and settings file. */
-	public static FormatterStep create(String version, File settingsFile, Provisioner provisioner) {
+	public static FormatterStep create(String version, Collection<File> settingsFiles, Provisioner provisioner) {
 		return FormatterStep.createLazy(NAME,
-				() -> new State(JarState.from(MAVEN_COORDINATE + version, provisioner), settingsFile),
+				() -> new State(JarState.from(MAVEN_COORDINATE + version, provisioner), settingsFiles),
 				State::createFormat);
 	}
 
@@ -71,11 +71,9 @@ public final class EclipseFormatterStep {
 		/** The signature of the settings file. */
 		final FileSignature settings;
 
-		State(JarState jar, File settingsFile) throws Exception {
+		State(JarState jar, final Collection<File> settingsFiles) throws Exception {
 			this.jarState = Objects.requireNonNull(jar);
-			this.settings = FileSignature.from(
-					Arrays.asList(settingsFile),
-					FileSignature.Ignore.PREVIOUS_DUPLICATES);
+			this.settings = FileSignature.fromList(settingsFiles);
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -72,7 +73,9 @@ public final class EclipseFormatterStep {
 
 		State(JarState jar, File settingsFile) throws Exception {
 			this.jarState = Objects.requireNonNull(jar);
-			this.settings = FileSignature.from(settingsFile);
+			this.settings = FileSignature.from(
+					Arrays.asList(settingsFile),
+					FileSignature.Ignore.PREVIOUS_DUPLICATES);
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
@@ -17,6 +17,7 @@ package com.diffplug.spotless.extra.java;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 
 import org.junit.Test;
 
@@ -29,14 +30,14 @@ import com.diffplug.spotless.TestProvisioner;
 public class EclipseFormatterStepTest extends ResourceHarness {
 	@Test
 	public void loadPropertiesSettings() throws Throwable {
-		File eclipseFormatFile = createTestFile("java/eclipse/format/formatter.properties");
+		Collection<File> eclipseFormatFile = createTestFiles("java/eclipse/format/formatter.properties");
 		StepHarness.forStep(EclipseFormatterStep.create(eclipseFormatFile, TestProvisioner.mavenCentral()))
 				.testResource("java/eclipse/format/JavaCodeUnformatted.test", "java/eclipse/format/JavaCodeFormatted.test");
 	}
 
 	@Test
 	public void loadXmlSettings() throws Throwable {
-		File eclipseFormatFile = createTestFile("java/eclipse/format/formatter.xml");
+		Collection<File> eclipseFormatFile = createTestFiles("java/eclipse/format/formatter.xml");
 		StepHarness.forStep(EclipseFormatterStep.create(eclipseFormatFile, TestProvisioner.mavenCentral()))
 				.testResource("java/eclipse/format/JavaCodeUnformatted.test", "java/eclipse/format/JavaCodeFormatted.test");
 	}
@@ -44,7 +45,7 @@ public class EclipseFormatterStepTest extends ResourceHarness {
 	@Test
 	public void longLiteralProblem() throws Throwable {
 		String folder = "java/eclipse/format/long_literals/";
-		File eclipseFormatFile = createTestFile(folder + "spotless.eclipseformat.xml");
+		Collection<File> eclipseFormatFile = createTestFiles(folder + "spotless.eclipseformat.xml");
 		StepHarness.forStep(EclipseFormatterStep.create(eclipseFormatFile, TestProvisioner.mavenCentral()))
 				.testResourceUnaffected(folder + "Example1.test")
 				.testResourceUnaffected(folder + "Example2.test");
@@ -52,23 +53,23 @@ public class EclipseFormatterStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws IOException {
-		File xmlFile = createTestFile("java/eclipse/format/formatter.xml");
-		File propFile = createTestFile("java/eclipse/format/formatter.properties");
+		Collection<File> xmlFile = createTestFiles("java/eclipse/format/formatter.xml");
+		Collection<File> propFile = createTestFiles("java/eclipse/format/formatter.properties");
 		new SerializableEqualityTester() {
-			File settingsFile;
+			Collection<File> settingsFiles;
 
 			@Override
 			protected void setupTest(API api) {
-				settingsFile = xmlFile;
+				settingsFiles = xmlFile;
 				api.areDifferentThan();
 
-				settingsFile = propFile;
+				settingsFiles = propFile;
 				api.areDifferentThan();
 			}
 
 			@Override
 			protected FormatterStep create() {
-				return EclipseFormatterStep.create(settingsFile, TestProvisioner.mavenCentral());
+				return EclipseFormatterStep.create(settingsFiles, TestProvisioner.mavenCentral());
 			}
 		}.testEquals();
 	}

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -22,32 +22,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.Objects;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Computes a signature for any needed files. */
 public final class FileSignature implements Serializable {
 	private static final long serialVersionUID = 1L;
-
-	/** Ignore certain changes of the file list for signature calculation */
-	public static enum Ignore {
-		/** Signature does not depend on the order of files (if multiple are specified) changes. */
-		ORDER,
-		/** Signature does not change in case duplicates of files are added/removed (duplicates after first occurrence are ignored). */
-		NEXT_DUPLICATES,
-		/** Signature does not change in case duplicates of files are added/removed (duplicates before last occurrence are ignored). */
-		PREVIOUS_DUPLICATES;
-		/** Signature does not depend on the order of files or whether duplicates of files are removed/added. */
-		public static final EnumSet<Ignore> ORDER_AND_DUPLICATES = EnumSet.of(ORDER, NEXT_DUPLICATES);
-	}
 
 	/*
 	 * Transient because not needed to uniquely identify a FileSignature instance, and also because
@@ -61,8 +44,24 @@ public final class FileSignature implements Serializable {
 	private final long[] filesizes;
 	private final long[] lastModified;
 
-	public static FileSignature from(File... files) throws IOException {
-		return from(Arrays.asList(files));
+	/** Creates file signature whereas order of the files remains unchanged. */
+	public static FileSignature fromList(File... files) throws IOException {
+		return fromList(Arrays.asList(files));
+	}
+
+	/** Creates file signature whereas order of the files remains unchanged. */
+	public static FileSignature fromList(Collection<File> files) throws IOException {
+		return new FileSignature(files);
+	}
+
+	/** Creates file signature insensitive to the order of the files. */
+	public static FileSignature fromSet(File... files) throws IOException {
+		return fromSet(Arrays.asList(files));
+	}
+
+	/** Creates file signature insensitive to the order of the files. */
+	public static FileSignature fromSet(Collection<File> files) throws IOException {
+		return new FileSignature(toSortedSet(Objects.requireNonNull(files)));
 	}
 
 	private FileSignature(final Collection<File> files) throws IOException {
@@ -95,90 +94,15 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	/**
-	 * Creates file signature for a file.
-	 *
-	 * @param file
-	 * 			File used for signature generation.
-	 * @return Signature for file
-	 */
-	public static FileSignature from(final File file) throws IOException {
-		return from(Arrays.asList(file), EnumSet.noneOf(Ignore.class));
-	}
-
-	/**
-	 * Creates file signature for a list of files.
-	 *
-	 * @param files
-	 * 			Files used for signature generation.
-	 * @return Signature for files
-	 */
-	public static FileSignature from(final Collection<File> files) throws IOException {
-		return from(files, EnumSet.noneOf(Ignore.class));
-	}
-
-	/**
-	 * Creates file signature for none or multiple files.
-	 *
-	 * @param files
-	 * 			Files used for signature generation.
-	 * @param ignore
-	 * 			Ignore a feature of the provided files when generating signature
-	 * @return Signature for files
-	 */
-	public static FileSignature from(final Collection<File> files, final Ignore ignore) throws IOException {
-		return from(files, EnumSet.of(ignore));
-	}
-
-	/**
-	 * Creates file signature for none or multiple files.
-	 *
-	 * @param files
-	 * 			Files used for signature generation.
-	 * @param ignores
-	 * 			Ignore features of the provided files when generating signature
-	 * @return Signature for files
-	 */
-	public static FileSignature from(Collection<File> files, final EnumSet<Ignore> ignores) throws IOException {
-		if (ignores.contains(Ignore.ORDER)) {
-			/* The content of the input argument is not touched. We make a copy. */
-			List<File> fileList = new ArrayList<File>(files);
-			Collections.sort(fileList);
-			files = fileList;
-			if (ignores.contains(Ignore.NEXT_DUPLICATES)
-					|| ignores.contains(Ignore.PREVIOUS_DUPLICATES)) {
-				toSortedSet(files);
-			}
-		} else if (ignores.contains(Ignore.NEXT_DUPLICATES)) {
-			/* Duplicates of sorted collections had been handled by optimized function above. */
-			files = new LinkedHashSet<File>(files);
-		} else if (ignores.contains(Ignore.PREVIOUS_DUPLICATES)) {
-			/* PREVIOUS_DUPLICATES can be ignored if NEXT_DUPLICATES had already removed the duplicates. */
-			List<File> fileList = new LinkedList<File>(files);
-			toSetRemovingPrevious(fileList);
-			files = fileList;
-		}
-		return new FileSignature(files);
-	}
-
-	/** Converts unsorted list into set by removing previous occurrences */
-	private static <T extends Comparable<T>> void toSetRemovingPrevious(final List<T> unsortedList) {
-		Set<T> set = new TreeSet<T>();
-		ListIterator<T> current = unsortedList.listIterator(unsortedList.size());
-		ListIterator<T> previous = null;
-		while (current.hasPrevious()) {
-			previous = current;
-			if (!set.add(current.previous())) {
-				previous.remove();
-			}
-		}
-	}
-
-	/** Converts a sorted collection into a sorted set by removing all duplicates. */
-	private static <T extends Comparable<T>> void toSortedSet(final Collection<T> sortedCollection) {
+	/** Returns a "sortedSet" by copying the input to an ArrayList, sorting, and removing duplicates. */
+	private static <T extends Comparable<T>> List<T> toSortedSet(Collection<T> unsorted) {
+		// copy the whole unsorted into a list
+		List<T> result = new ArrayList<>((Collection<T>) unsorted);
+		// sort it
+		Collections.sort(result);
 		// remove any duplicates (normally there won't be any)
-		if (sortedCollection.size() > 1) {
-			Iterator<T> iter = sortedCollection.iterator();
+		if (result.size() > 1) {
+			Iterator<T> iter = result.iterator();
 			T last = iter.next();
 			while (iter.hasNext()) {
 				T next = iter.next();
@@ -189,5 +113,6 @@ public final class FileSignature implements Serializable {
 				}
 			}
 		}
+		return result;
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -22,9 +22,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.TreeSet;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -32,81 +37,148 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public final class FileSignature implements Serializable {
 	private static final long serialVersionUID = 1L;
 
+	/** Ignore certain changes of the file list for signature calculation */
+	public static enum Ignore {
+		/** Signature does not depend on the order of files (if multiple are specified) changes. */
+		ORDER,
+		/** Signature does not change in case duplicates of files are added/removed (duplicates after first occurrence are ignored). */
+		NEXT_DUPLICATES,
+		/** Signature does not change in case duplicates of files are added/removed (duplicates before last occurrence are ignored). */
+		PREVIOUS_DUPLICATES;
+		/** Signature does not depend on the order of files or whether duplicates of files are removed/added. */
+		public static final EnumSet<Ignore> ORDER_AND_DUPLICATES = EnumSet.of(ORDER, NEXT_DUPLICATES);
+	}
+
 	/*
 	 * Transient because not needed to uniquely identify a FileSignature instance, and also because
 	 * Gradle only needs this class to be Serializable so it can compare FileSignature instances for
 	 * incremental builds.
 	 */
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	private final transient List<File> sortedFiles;
+	private final transient Collection<File> files;
 
-	@SuppressWarnings("unused")
 	private final String[] filenames;
-	@SuppressWarnings("unused")
 	private final long[] filesizes;
-	@SuppressWarnings("unused")
 	private final long[] lastModified;
 
 	public static FileSignature from(File... files) throws IOException {
 		return from(Arrays.asList(files));
 	}
 
-	public static FileSignature from(Iterable<File> files) throws IOException {
-		List<File> sortedFiles = toSortedSet(Objects.requireNonNull(files));
+	private FileSignature(final Collection<File> files) throws IOException {
+		this.files = files;
 
-		String[] filenames = new String[sortedFiles.size()];
-		long[] filesizes = new long[sortedFiles.size()];
-		long[] lastModified = new long[sortedFiles.size()];
+		filenames = new String[this.files.size()];
+		filesizes = new long[this.files.size()];
+		lastModified = new long[this.files.size()];
 
 		int i = 0;
-		for (File file : sortedFiles) {
+		for (File file : this.files) {
 			filenames[i] = file.getCanonicalPath();
 			filesizes[i] = file.length();
 			lastModified[i] = file.lastModified();
 			++i;
 		}
-
-		return new FileSignature(sortedFiles, filenames, filesizes, lastModified);
-	}
-
-	private FileSignature(List<File> sortedFiles, String[] filenames, long[] filesizes, long[] lastModified) {
-		this.sortedFiles = sortedFiles;
-		this.filenames = filenames;
-		this.filesizes = filesizes;
-		this.lastModified = lastModified;
 	}
 
 	/** Returns all of the files in this signature, throwing an exception if there are more or less than 1 file. */
 	public Collection<File> files() {
-		return Collections.unmodifiableList(sortedFiles);
+		return Collections.unmodifiableCollection(files);
 	}
 
 	/** Returns the only file in this signature, throwing an exception if there are more or less than 1 file. */
 	public File getOnlyFile() {
-		if (sortedFiles.size() == 1) {
-			return sortedFiles.get(0);
+		if (files.size() == 1) {
+			return files.iterator().next();
 		} else {
-			throw new IllegalArgumentException("Expected one file, but was " + sortedFiles.size());
+			throw new IllegalArgumentException("Expected one file, but was " + files.size());
 		}
 	}
 
-	/** Returns a "sortedSet" by copying the input to an ArrayList, sorting, and removing duplicates. */
-	private static <T extends Comparable<T>> List<T> toSortedSet(Iterable<T> unsorted) {
-		// copy the whole unsorted into a list
-		List<T> result;
-		if (unsorted instanceof Collection) {
-			result = new ArrayList<>((Collection<T>) unsorted);
-		} else {
-			result = new ArrayList<>();
-			for (T element : unsorted) {
-				result.add(element);
+	/**
+	 * Creates file signature for a file.
+	 *
+	 * @param file
+	 * 			File used for signature generation.
+	 * @return Signature for file
+	 */
+	public static FileSignature from(final File file) throws IOException {
+		return from(Arrays.asList(file), EnumSet.noneOf(Ignore.class));
+	}
+
+	/**
+	 * Creates file signature for a list of files.
+	 *
+	 * @param files
+	 * 			Files used for signature generation.
+	 * @return Signature for files
+	 */
+	public static FileSignature from(final Collection<File> files) throws IOException {
+		return from(files, EnumSet.noneOf(Ignore.class));
+	}
+
+	/**
+	 * Creates file signature for none or multiple files.
+	 *
+	 * @param files
+	 * 			Files used for signature generation.
+	 * @param ignore
+	 * 			Ignore a feature of the provided files when generating signature
+	 * @return Signature for files
+	 */
+	public static FileSignature from(final Collection<File> files, final Ignore ignore) throws IOException {
+		return from(files, EnumSet.of(ignore));
+	}
+
+	/**
+	 * Creates file signature for none or multiple files.
+	 *
+	 * @param files
+	 * 			Files used for signature generation.
+	 * @param ignores
+	 * 			Ignore features of the provided files when generating signature
+	 * @return Signature for files
+	 */
+	public static FileSignature from(Collection<File> files, final EnumSet<Ignore> ignores) throws IOException {
+		if (ignores.contains(Ignore.ORDER)) {
+			/* The content of the input argument is not touched. We make a copy. */
+			List<File> fileList = new ArrayList<File>(files);
+			Collections.sort(fileList);
+			files = fileList;
+			if (ignores.contains(Ignore.NEXT_DUPLICATES)
+					|| ignores.contains(Ignore.PREVIOUS_DUPLICATES)) {
+				toSortedSet(files);
+			}
+		} else if (ignores.contains(Ignore.NEXT_DUPLICATES)) {
+			/* Duplicates of sorted collections had been handled by optimized function above. */
+			files = new LinkedHashSet<File>(files);
+		} else if (ignores.contains(Ignore.PREVIOUS_DUPLICATES)) {
+			/* PREVIOUS_DUPLICATES can be ignored if NEXT_DUPLICATES had already removed the duplicates. */
+			List<File> fileList = new LinkedList<File>(files);
+			toSetRemovingPrevious(fileList);
+			files = fileList;
+		}
+		return new FileSignature(files);
+	}
+
+	/** Converts unsorted list into set by removing previous occurrences */
+	private static <T extends Comparable<T>> void toSetRemovingPrevious(final List<T> unsortedList) {
+		Set<T> set = new TreeSet<T>();
+		ListIterator<T> current = unsortedList.listIterator(unsortedList.size());
+		ListIterator<T> previous = null;
+		while (current.hasPrevious()) {
+			previous = current;
+			if (!set.add(current.previous())) {
+				previous.remove();
 			}
 		}
-		// sort it
-		Collections.sort(result);
+	}
+
+	/** Converts a sorted collection into a sorted set by removing all duplicates. */
+	private static <T extends Comparable<T>> void toSortedSet(final Collection<T> sortedCollection) {
 		// remove any duplicates (normally there won't be any)
-		if (result.size() > 1) {
-			Iterator<T> iter = result.iterator();
+		if (sortedCollection.size() > 1) {
+			Iterator<T> iter = sortedCollection.iterator();
 			T last = iter.next();
 			while (iter.hasNext()) {
 				T next = iter.next();
@@ -117,6 +189,5 @@ public final class FileSignature implements Serializable {
 				}
 			}
 		}
-		return result;
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/** Utility manages settings of formatter configured by properties. */
+public class FormatterProperties {
+
+	private static final Logger LOG = Logger.getLogger(FormatterProperties.class.getName());
+
+	private final Properties properties;
+
+	/**
+	 * Per default the property list is empty and the formatters default
+	 * settings are used.
+	 */
+	public FormatterProperties() {
+		properties = new Properties();
+	}
+
+	/**
+	 * Import settings from a sequence of files (file import is the given order)
+	 *
+	 * @param settingsFiles
+	 *            Sequence of files
+	 * @throws IllegalArgumentException
+	 *            In case the import of a file fails
+	 */
+	public void add(final Iterable<File> settingsFiles) throws IllegalArgumentException {
+		settingsFiles.forEach(file -> add(file));
+	}
+
+	/**
+	 * Import settings from given file. New settings (with the same ID/key)
+	 * override existing once.
+	 *
+	 * @param settingsFile
+	 *            File
+	 * @throws IllegalArgumentException
+	 *            In case the import of the file fails
+	 */
+	public void add(final File settingsFile) throws IllegalArgumentException {
+		if (!(settingsFile.isFile() || settingsFile.canRead())) {
+			String msg = String.format("Settings file '%s' does not exist or can not be read.", settingsFile);
+			throw new IllegalArgumentException(msg);
+		}
+		try {
+			Properties newSettings = FileParser.parse(settingsFile);
+			properties.putAll(newSettings);
+		} catch (IOException | IllegalArgumentException | NullPointerException exception) {
+			StringBuffer message = new StringBuffer(
+					String.format("Failed to add properties from '%s' to formatter settings.", settingsFile));
+			String detailedMessage = exception.getMessage();
+			if (null != detailedMessage) {
+				message.append(String.format(" %s", detailedMessage));
+			}
+			throw new IllegalArgumentException(message.toString(), exception);
+		}
+	}
+
+	/**
+	 * Get accumulated {@link java.util.Properties Properties}
+	 * @return Properties
+	 */
+	public Properties getProperties() {
+		return properties;
+	}
+
+	/**
+	 * Returns a {@link java.util.Set Set} view for the underlying property map.
+	 *
+	 * @return Property set
+	 */
+	public Set<Map.Entry<Object, Object>> entrySet() {
+		return properties.entrySet();
+	}
+
+	private enum FileParser {
+		LINE_ORIENTED("properties", "prefs") {
+			@Override
+			protected Properties execute(File file) throws IOException, IllegalArgumentException {
+				Properties properties = new Properties();
+				InputStream inputProperties = new FileInputStream(file);
+				try {
+					properties.load(inputProperties);
+				} finally {
+					inputProperties.close();
+				}
+				return properties;
+			}
+		},
+
+		XML("xml") {
+			@Override
+			protected Properties execute(final File file) throws IOException, IllegalArgumentException {
+				Node rootNode = getRootNode(file);
+				String nodeName = rootNode.getNodeName();
+				if (null == nodeName) {
+					throw new IllegalArgumentException("XML document does not contain a root node.");
+				}
+				return XmlParser.parse(file, rootNode);
+			}
+
+			private Node getRootNode(final File file) throws IOException, IllegalArgumentException {
+				try {
+					/*
+					 * The parser does not validate, since the root node is only
+					 * used to decide on further processing.
+					 */
+					DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+					DocumentBuilder db = dbf.newDocumentBuilder();
+					return db.parse(file).getDocumentElement();
+				} catch (SAXException | ParserConfigurationException e) {
+					throw new IllegalArgumentException("File has no valid XML syntax.", e);
+				}
+
+			}
+
+		};
+		private static final char FILE_EXTENSION_SEPARATOR = '.';
+
+		private final List<String> supportedFileNameExtensions;
+
+		private FileParser(final String... supportedFileNameExtensions) {
+			this.supportedFileNameExtensions = Arrays.asList(supportedFileNameExtensions);
+		}
+
+		protected abstract Properties execute(File file) throws IOException, IllegalArgumentException;
+
+		public static Properties parse(final File file) throws IOException, IllegalArgumentException {
+			String fileNameExtension = getFileNameExtension(file);
+			for (FileParser parser : FileParser.values()) {
+				if (parser.supportedFileNameExtensions.contains(fileNameExtension)) {
+					return parser.execute(file);
+				}
+			}
+			String msg = String.format(
+					"The file name extension '%1$s' is not part of the supported file extensions [%2$s].",
+					fileNameExtension, Arrays.toString(FileParser.values()));
+			throw new IllegalArgumentException(msg);
+
+		}
+
+		private static String getFileNameExtension(File file) {
+			final String fileName = file.getName();
+			String fileNameExt = "";
+			int seperatorPos = fileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+			if (0 < seperatorPos) {
+				fileNameExt = fileName.substring(seperatorPos + 1);
+			}
+			return fileNameExt;
+		}
+
+	}
+
+	private enum XmlParser {
+		PROPERTIES("properties") {
+			@Override
+			protected Properties execute(final File xmlFile, final Node rootNode)
+					throws IOException, IllegalArgumentException {
+				final Properties properties = new Properties();
+				InputStream xmlInput = new FileInputStream(xmlFile);
+				try {
+					properties.loadFromXML(xmlInput);
+				} finally {
+					xmlInput.close();
+				}
+				return properties;
+			}
+		},
+
+		PROFILES("profiles") {
+			@Override
+			protected Properties execute(File file, Node rootNode) throws IOException, IllegalArgumentException {
+				final Properties properties = new Properties();
+				Node firstProfile = getFirstProfile(file, rootNode);
+				if (null != firstProfile) {
+					for (Object settingObj : getChildren(firstProfile, "setting")) {
+						Node setting = (Node) settingObj;
+						NamedNodeMap attributes = setting.getAttributes();
+						Node id = attributes.getNamedItem("id");
+						Node value = attributes.getNamedItem("value");
+						if (null == id) {
+							throw new IllegalArgumentException("Node 'setting' does not possess an 'id' attribute.");
+						}
+						String idString = id.getNodeValue();
+						/*
+						 * A missing value is interpreted as an empty string,
+						 * similar to the Properties behavior
+						 */
+						String valString = (null == value) ? "" : value.getNodeValue();
+						properties.setProperty(idString, valString);
+					}
+				}
+				return properties;
+			}
+
+			@Nullable
+			private Node getFirstProfile(File file, final Node rootNode) {
+				List<Node> profiles = getChildren(rootNode, "profile");
+				if (profiles.size() > 1) {
+					String message = String.format("Formatter configuration file contains multiple profiles: '%s'%n    ",
+							file.getAbsolutePath());
+					message += profiles.stream().map(profile -> getProfileName(profile))
+							.collect(Collectors.joining("; "));
+					LOG.config(message);
+				}
+				Node firstProvile = null;
+				if (profiles.size() == 0) {
+					String msg = String.format(
+							"Using formatter default configuration since formatter configuration file does not contain a profile: '%s'",
+							file.getAbsolutePath());
+					LOG.config(msg);
+				} else {
+					firstProvile = profiles.iterator().next();
+					LOG.finest(String.format("Using profile '%s' from: '%s'", getProfileName(firstProvile), file.getAbsolutePath()));
+				}
+				return firstProvile;
+			}
+
+			private List<Node> getChildren(final Node node, final String nodeName) {
+				List<Node> matchingChildren = new LinkedList<Node>();
+				NodeList children = node.getChildNodes();
+				for (int i = 0; i < children.getLength(); i++) {
+					Node child = children.item(i);
+					if (child.getNodeName().equals(nodeName)) {
+						matchingChildren.add(child);
+					}
+				}
+				return matchingChildren;
+			}
+
+		};
+
+		private static String getProfileName(Node profile) {
+			Node nameAttribute = profile.getAttributes().getNamedItem("name");
+			return (null == nameAttribute) ? "" : nameAttribute.getNodeValue();
+		}
+
+		private final String rootNodeName;
+
+		private XmlParser(final String rootNodeName) {
+			this.rootNodeName = rootNodeName;
+		}
+
+		@Override
+		public String toString() {
+			return this.rootNodeName;
+		}
+
+		protected abstract Properties execute(File file, Node rootNode) throws IOException, IllegalArgumentException;
+
+		public static Properties parse(final File file, final Node rootNode)
+				throws IOException, IllegalArgumentException {
+			String rootNodeName = rootNode.getNodeName();
+			for (XmlParser parser : XmlParser.values()) {
+				if (parser.rootNodeName.equals(rootNodeName)) {
+					return parser.execute(file, rootNode);
+				}
+			}
+			String msg = String.format("The XML root node '%1$s' is not part of the supported root nodes [%2$s].",
+					rootNodeName, Arrays.toString(XmlParser.values()));
+			throw new IllegalArgumentException(msg);
+		}
+
+	}
+
+}

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -70,7 +70,7 @@ public final class JarState implements Serializable {
 			logger.log(Level.SEVERE, "You probably need to add a repository containing the `" + mavenCoordinate + "` artifact to your buildscript, e.g.: repositories { mavenCentral() }", e);
 			throw e;
 		}
-		FileSignature fileSignature = FileSignature.from(jars, FileSignature.Ignore.ORDER_AND_DUPLICATES);
+		FileSignature fileSignature = FileSignature.fromSet(jars);
 		return new JarState(mavenCoordinate, fileSignature, jars);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -70,7 +70,7 @@ public final class JarState implements Serializable {
 			logger.log(Level.SEVERE, "You probably need to add a repository containing the `" + mavenCoordinate + "` artifact to your buildscript, e.g.: repositories { mavenCentral() }", e);
 			throw e;
 		}
-		FileSignature fileSignature = FileSignature.from(jars);
+		FileSignature fileSignature = FileSignature.from(jars, FileSignature.Ignore.ORDER_AND_DUPLICATES);
 		return new JarState(mavenCoordinate, fileSignature, jars);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -64,7 +64,7 @@ public class ScalaFmtStep {
 		State(String version, Provisioner provisioner, @Nullable File configFile) throws IOException {
 			this.jarState = JarState.from(MAVEN_COORDINATE + version, provisioner);
 			List<File> toSign = configFile == null ? Collections.emptyList() : Collections.singletonList(configFile);
-			this.configSignature = FileSignature.from(toSign, FileSignature.Ignore.ORDER_AND_DUPLICATES);
+			this.configSignature = FileSignature.fromSet(toSign);
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -64,7 +64,7 @@ public class ScalaFmtStep {
 		State(String version, Provisioner provisioner, @Nullable File configFile) throws IOException {
 			this.jarState = JarState.from(MAVEN_COORDINATE + version, provisioner);
 			List<File> toSign = configFile == null ? Collections.emptyList() : Collections.singletonList(configFile);
-			this.configSignature = FileSignature.from(toSign);
+			this.configSignature = FileSignature.from(toSign, FileSignature.Ignore.ORDER_AND_DUPLICATES);
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -110,7 +110,7 @@ spotless {
 		removeUnusedImports() // removes any unused imports
 
 		eclipseFormatFile 'spotless.eclipseformat.xml'	// XML file dumped out by the Eclipse formatter
-		// If you have an older Eclipse properties file, you can use that too.
+		// If you have Eclipse preference or property files, you can use them too.
 	}
 }
 ```
@@ -139,10 +139,10 @@ To apply freshmark to all of the `.md` files in your project, with all of your p
 ```gradle
 spotless {
 	freshmark {
-		target 'README.md', 'CONTRIBUTING.md'	// defaults to '**/*.md'
-		propertiesFile('gradle.properties')		// loads all the properties in the given file
+		target 'README.md', 'CONTRIBUTING.md'			// defaults to '**/*.md'
+		propertiesFile 'fresh.xml', 'mark.properties'	// loads all the properties in the given files
 		properties {
-			it.put('key', 'value')				// specify other properties manually
+			it.put('key', 'value')						// specify other properties manually
 		}
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
@@ -15,19 +15,14 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.gradle.api.Action;
 
-import com.diffplug.common.base.Errors;
-import com.diffplug.common.io.Files;
+import com.diffplug.spotless.FormatterProperties;
 import com.diffplug.spotless.markdown.FreshMarkStep;
 
 public class FreshMarkExtension extends FormatExtension {
@@ -50,17 +45,12 @@ public class FreshMarkExtension extends FormatExtension {
 		propertyActions.add(action);
 	}
 
-	public void propertiesFile(Object file) {
+	public void propertiesFile(Object... files) {
 		propertyActions.add(map -> {
-			File propFile = getProject().file(file);
-			try (InputStream input = Files.asByteSource(propFile).openBufferedStream()) {
-				Properties props = new Properties();
-				props.load(input);
-				for (String key : props.stringPropertyNames()) {
-					map.put(key, props.getProperty(key));
-				}
-			} catch (IOException e) {
-				throw Errors.asRuntime(e);
+			FormatterProperties properties = new FormatterProperties();
+			properties.add(getProject().files(files));
+			for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+				map.put(entry.getKey().toString(), entry.getValue());
 			}
 		});
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -18,6 +18,7 @@ package com.diffplug.gradle.spotless;
 import java.util.List;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.Project;
 import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
@@ -60,8 +61,11 @@ public class JavaExtension extends FormatExtension {
 		eclipseFormatFile(EclipseFormatterStep.defaultVersion(), eclipseFormatFile);
 	}
 
-	public void eclipseFormatFile(String eclipseVersion, Object eclipseFormatFile) {
-		addStep(EclipseFormatterStep.create(eclipseVersion, getProject().file(eclipseFormatFile), GradleProvisioner.fromProject(getProject())));
+	public void eclipseFormatFile(String eclipseVersion, Object... eclipseFormatFiles) {
+		Project project = getProject();
+		addStep(EclipseFormatterStep.create(eclipseVersion,
+				project.files(eclipseFormatFiles).getFiles(),
+				GradleProvisioner.fromProject(project)));
 	}
 
 	/** Removes any unused imports. */

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -22,7 +22,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -105,6 +107,15 @@ public class ResourceHarness {
 			throw new IllegalArgumentException("No such resource " + filename);
 		}
 		return Resources.toString(url, StandardCharsets.UTF_8);
+	}
+
+	/** Returns Files (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
+	protected Collection<File> createTestFiles(String... filenames) throws IOException {
+		Collection<File> files = new ArrayList<File>(filenames.length);
+		for (String filename : filenames) {
+			files.add(createTestFile(filename));
+		}
+		return files;
 	}
 
 	/** Returns a File (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -15,155 +15,36 @@
  */
 package com.diffplug.spotless;
 
-import static com.diffplug.spotless.FileSignature.Ignore;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
 public class FileSignatureTest extends ResourceHarness {
 
-	@Parameters(name = "{0}")
-	public static Collection<Object[]> data() {
-		List<Object[]> io = new LinkedList<Object[]>();
-		io.addAll(
-				test(EnumSet.noneOf(Ignore.class))
-						.input()
-						.expected()
-						.input("A")
-						.expected("A")
-						.input("B", "A", "A")
-						.expected("B", "A", "A")
-						.asList());
-		io.addAll(
-				test(Ignore.ORDER)
-						.input()
-						.expected()
-						.input("A")
-						.expected("A")
-						.input("C", "A", "A", "B")
-						.expected("A", "A", "B", "C")
-						.asList());
-		io.addAll(
-				test(Ignore.NEXT_DUPLICATES)
-						.input()
-						.expected()
-						.input("A")
-						.expected("A")
-						.input("A", "B", "A")
-						.expected("A", "B")
-						.input("A", "C", "A", "B")
-						.expected("A", "C", "B")
-						.asList());
-		io.addAll(
-				test(Ignore.PREVIOUS_DUPLICATES)
-						.input()
-						.expected()
-						.input("A")
-						.expected("A")
-						.input("A", "B", "A")
-						.expected("B", "A")
-						.input("B", "A", "C", "A")
-						.expected("B", "C", "A")
-						.asList());
-		io.addAll(
-				test(Ignore.ORDER_AND_DUPLICATES)
-						.input()
-						.expected()
-						.input("A")
-						.expected("A")
-						.input("A", "C", "C", "A", "B")
-						.expected("A", "B", "C")
-						.asList());
-		return io;
-	}
-
-	private static TestData test(final Ignore ignore) {
-		return new TestData(EnumSet.of(ignore));
-	}
-
-	private static TestData test(EnumSet<Ignore> ignores) {
-		return new TestData(ignores);
-	}
-
-	private static class TestData {
-		private final EnumSet<Ignore> ignores;
-		private final List<String[]> inputPaths;
-		private final List<String[]> expectedPaths;
-
-		public TestData(final EnumSet<Ignore> ignores) {
-			this.ignores = ignores;
-			this.inputPaths = new LinkedList<String[]>();
-			this.expectedPaths = new LinkedList<String[]>();
-		}
-
-		public TestData input(String... filePaths) {
-			this.inputPaths.add(filePaths);
-			return this;
-		}
-
-		public TestData expected(String... filePaths) {
-			this.expectedPaths.add(filePaths);
-			return this;
-		}
-
-		public List<Object[]> asList() {
-			if (inputPaths.size() != expectedPaths.size()) {
-				String msg = String.format("Unequal number of inputs (%d) and expected outputs (%d).",
-						inputPaths.size(),
-						expectedPaths.size());
-				throw new IllegalArgumentException(msg);
-			}
-			List<Object[]> result = new ArrayList<Object[]>(inputPaths.size());
-			Iterator<String[]> inputPathsItr = inputPaths.iterator();
-			Iterator<String[]> expectedPathsItr = expectedPaths.iterator();
-			while (inputPathsItr.hasNext()) {
-				String[] inputPaths = inputPathsItr.next();
-				List<String> inputPathList = Arrays.asList(inputPaths);
-				String testName = String.format("Files %s, Ignores %s", inputPathList, ignores);
-				result.add(new Object[]{
-						testName,
-						ignores,
-						inputPaths,
-						expectedPathsItr.next()
-				});
-			}
-			return result;
-		}
-
-	}
-
-	@Parameter()
-	public String testCaseNameNotUsed;
-
-	@Parameter(value = 1)
-	public EnumSet<Ignore> ignores;
-
-	@Parameter(value = 2)
-	public String[] inputPaths;
-
-	@Parameter(value = 3)
-	public String[] expectedPaths;
+	private final static String[] inputPaths = {"A", "C", "C", "A", "B"};
+	private final static String[] expectedPathList = inputPaths;
+	private final static String[] expectedPathSet = {"A", "B", "C"};
 
 	@Test
-	public void testCreate() throws IOException {
+	public void testFromList() throws IOException {
 		Collection<File> inputFiles = getTestFiles(inputPaths);
-		FileSignature signature = FileSignature.from(inputFiles, ignores);
-		Collection<File> expectedFiles = getTestFiles(expectedPaths);
+		FileSignature signature = FileSignature.fromList(inputFiles);
+		Collection<File> expectedFiles = getTestFiles(expectedPathList);
+		Collection<File> outputFiles = signature.files();
+		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
+	}
+
+	@Test
+	public void testFromSet() throws IOException {
+		Collection<File> inputFiles = getTestFiles(inputPaths);
+		FileSignature signature = FileSignature.fromSet(inputFiles);
+		Collection<File> expectedFiles = getTestFiles(expectedPathSet);
 		Collection<File> outputFiles = signature.files();
 		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import static com.diffplug.spotless.FileSignature.Ignore;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class FileSignatureTest extends ResourceHarness {
+
+	@Parameters(name = "{0}")
+	public static Collection<Object[]> data() {
+		List<Object[]> io = new LinkedList<Object[]>();
+		io.addAll(
+				test(EnumSet.noneOf(Ignore.class))
+						.input()
+						.expected()
+						.input("A")
+						.expected("A")
+						.input("B", "A", "A")
+						.expected("B", "A", "A")
+						.asList());
+		io.addAll(
+				test(Ignore.ORDER)
+						.input()
+						.expected()
+						.input("A")
+						.expected("A")
+						.input("C", "A", "A", "B")
+						.expected("A", "A", "B", "C")
+						.asList());
+		io.addAll(
+				test(Ignore.NEXT_DUPLICATES)
+						.input()
+						.expected()
+						.input("A")
+						.expected("A")
+						.input("A", "B", "A")
+						.expected("A", "B")
+						.input("A", "C", "A", "B")
+						.expected("A", "C", "B")
+						.asList());
+		io.addAll(
+				test(Ignore.PREVIOUS_DUPLICATES)
+						.input()
+						.expected()
+						.input("A")
+						.expected("A")
+						.input("A", "B", "A")
+						.expected("B", "A")
+						.input("B", "A", "C", "A")
+						.expected("B", "C", "A")
+						.asList());
+		io.addAll(
+				test(Ignore.ORDER_AND_DUPLICATES)
+						.input()
+						.expected()
+						.input("A")
+						.expected("A")
+						.input("A", "C", "C", "A", "B")
+						.expected("A", "B", "C")
+						.asList());
+		return io;
+	}
+
+	private static TestData test(final Ignore ignore) {
+		return new TestData(EnumSet.of(ignore));
+	}
+
+	private static TestData test(EnumSet<Ignore> ignores) {
+		return new TestData(ignores);
+	}
+
+	private static class TestData {
+		private final EnumSet<Ignore> ignores;
+		private final List<String[]> inputPaths;
+		private final List<String[]> expectedPaths;
+
+		public TestData(final EnumSet<Ignore> ignores) {
+			this.ignores = ignores;
+			this.inputPaths = new LinkedList<String[]>();
+			this.expectedPaths = new LinkedList<String[]>();
+		}
+
+		public TestData input(String... filePaths) {
+			this.inputPaths.add(filePaths);
+			return this;
+		}
+
+		public TestData expected(String... filePaths) {
+			this.expectedPaths.add(filePaths);
+			return this;
+		}
+
+		public List<Object[]> asList() {
+			if (inputPaths.size() != expectedPaths.size()) {
+				String msg = String.format("Unequal number of inputs (%d) and expected outputs (%d).",
+						inputPaths.size(),
+						expectedPaths.size());
+				throw new IllegalArgumentException(msg);
+			}
+			List<Object[]> result = new ArrayList<Object[]>(inputPaths.size());
+			Iterator<String[]> inputPathsItr = inputPaths.iterator();
+			Iterator<String[]> expectedPathsItr = expectedPaths.iterator();
+			while (inputPathsItr.hasNext()) {
+				String[] inputPaths = inputPathsItr.next();
+				List<String> inputPathList = Arrays.asList(inputPaths);
+				String testName = String.format("Files %s, Ignores %s", inputPathList, ignores);
+				result.add(new Object[]{
+						testName,
+						ignores,
+						inputPaths,
+						expectedPathsItr.next()
+				});
+			}
+			return result;
+		}
+
+	}
+
+	@Parameter()
+	public String testCaseNameNotUsed;
+
+	@Parameter(value = 1)
+	public EnumSet<Ignore> ignores;
+
+	@Parameter(value = 2)
+	public String[] inputPaths;
+
+	@Parameter(value = 3)
+	public String[] expectedPaths;
+
+	@Test
+	public void testCreate() throws IOException {
+		Collection<File> inputFiles = getTestFiles(inputPaths);
+		FileSignature signature = FileSignature.from(inputFiles, ignores);
+		Collection<File> expectedFiles = getTestFiles(expectedPaths);
+		Collection<File> outputFiles = signature.files();
+		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
+	}
+
+	private List<File> getTestFiles(final String[] paths) throws IOException {
+		final List<File> result = new ArrayList<File>(paths.length);
+		for (String path : paths) {
+			result.add(createTestFile(path, ""));
+		}
+		return result;
+	}
+
+}

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Properties;
+
+import org.assertj.core.api.AbstractAssert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.diffplug.spotless.ResourceHarness;
+
+public class FormatterPropertiesTest extends ResourceHarness {
+
+	@Rule
+	public ExpectedException expectedEx = ExpectedException.none();
+
+	private static final String RESOURCES_ROOT_DIR = "formatter/properties/";
+
+	private static final String[] VALID_SETTINGS_RESOURCES = {
+			RESOURCES_ROOT_DIR + "valid_line_oriented.prefs",
+			RESOURCES_ROOT_DIR + "valid_line_oriented.properties",
+			RESOURCES_ROOT_DIR + "valid_xml_profiles.xml",
+			RESOURCES_ROOT_DIR + "valid_xml_properties.xml"
+	};
+
+	private static final String[] INVALID_SETTINGS_RESOURCES = {
+			RESOURCES_ROOT_DIR + "invalid_xml_profiles.xml",
+			RESOURCES_ROOT_DIR + "invalid_xml_properties.xml"
+	};
+
+	private static final String[] VALID_VALUES = {
+			"string",
+			"true",
+			"42",
+			null
+	};
+
+	@Test
+	public void differntPropertyFileTypes() throws IOException {
+		for (String settingsResource : VALID_SETTINGS_RESOURCES) {
+			File settingsFile = createTestFile(settingsResource);
+			FormatterProperties settings = new FormatterProperties();
+			settings.add(settingsFile);
+			assertFor(settings)
+					.containsSpecificValuesOf(settingsFile)
+					.containsCommonValueOf(settingsFile);
+		}
+	}
+
+	@Test
+	public void multiplePropertyFiles() throws IOException {
+		LinkedList<File> settingsFiles = new LinkedList<File>();
+		for (String settingsResource : VALID_SETTINGS_RESOURCES) {
+			File settingsFile = createTestFile(settingsResource);
+			settingsFiles.add(settingsFile);
+		}
+		FormatterProperties settings = new FormatterProperties();
+		settings.add(settingsFiles);
+		/* Settings are loaded / overridden in the sequence they are configured. */
+		assertFor(settings)
+				.containsSpecificValuesOf(settingsFiles)
+				.containsCommonValueOf(settingsFiles.getLast());
+	}
+
+	@Test
+	public void invalidPropertyFiles() throws IOException {
+		for (String settingsResource : INVALID_SETTINGS_RESOURCES) {
+			File settingsFile = createTestFile(settingsResource);
+			FormatterProperties settings = new FormatterProperties();
+			boolean exceptionCought = false;
+			try {
+				settings.add(settingsFile);
+			} catch (IllegalArgumentException ex) {
+				exceptionCought = true;
+				assertThat(ex.getMessage())
+						.as("IllegalArgumentException does not contain absolute path of file '%s'", settingsFile.getName())
+						.contains(settingsFile.getAbsolutePath());
+			}
+			assertThat(exceptionCought)
+					.as("No IllegalArgumentException thrown when parsing '%s'", settingsFile.getName())
+					.isTrue();
+		}
+	}
+
+	@Test
+	public void nonExisitingFile() throws IOException {
+		FormatterProperties settings = new FormatterProperties();
+		boolean exceptionCought = false;
+		String filePath = "does/not/exist.properties";
+		try {
+			settings.add(new File(filePath));
+		} catch (IllegalArgumentException ex) {
+			exceptionCought = true;
+			assertThat(ex.getMessage())
+					.as("IllegalArgumentException does not contain path of non-existing file.").contains(filePath);
+		}
+		assertThat(exceptionCought)
+				.as("No IllegalArgumentException thrown for non-existing file.").isTrue();
+	}
+
+	private static class FormatterSettingsAssert extends AbstractAssert<FormatterSettingsAssert, FormatterProperties> {
+
+		public FormatterSettingsAssert(FormatterProperties actual) {
+			super(actual, FormatterSettingsAssert.class);
+		}
+
+		/** Check that the values form all valid files are part of the settings properties. */
+		public FormatterSettingsAssert containsSpecificValuesOf(Collection<File> files) {
+			files.forEach(file -> containsSpecificValuesOf(file));
+			return this;
+		}
+
+		/** Check that the values form a certain valid file are part of the settings properties. */
+		public FormatterSettingsAssert containsSpecificValuesOf(File file) {
+			isNotNull();
+
+			String fileName = file.getName();
+			Properties settingsProps = actual.getProperties();
+			for (String expectedValue : VALID_VALUES) {
+				// A parsable (valid) file contains keys of the following format
+				String validValueName = (null == expectedValue) ? "null" : expectedValue;
+				String key = String.format("%s.%s", fileName, validValueName);
+				if (!settingsProps.containsKey(key)) {
+					failWithMessage("Key <%s> not part of formatter settings.", key);
+				}
+				String value = settingsProps.getProperty(key);
+				if ((null != expectedValue) && (!expectedValue.equals(value))) {
+					failWithMessage("Value of key <%s> is '%s' and not '%s' as expected.", key, value, expectedValue);
+				}
+			}
+			return this;
+		}
+
+		public FormatterSettingsAssert containsCommonValueOf(final File file) {
+			isNotNull();
+
+			String fileName = file.getName();
+			Properties settingsProps = actual.getProperties();
+			String key = "common";
+			if (!settingsProps.containsKey(key)) {
+				failWithMessage("Key <%s> not part of formatter settings. Value '%s' had been expected.", key, fileName);
+			}
+			String value = settingsProps.getProperty(key);
+			if (!fileName.equals(value)) {
+				failWithMessage("Value of key <%s> is '%s' and not '%s' as expected.", key, value, fileName);
+			}
+
+			return this;
+		}
+
+	};
+
+	private static FormatterSettingsAssert assertFor(FormatterProperties actual) {
+		return new FormatterSettingsAssert(actual);
+	}
+
+}

--- a/testlib/src/test/resources/formatter/properties/invalid_xml_profiles.xml
+++ b/testlib/src/test/resources/formatter/properties/invalid_xml_profiles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+	<profile version="Profile without name can be handled">
+		<setting value="Setting needs an ID" />
+	</profile>
+</profiles>

--- a/testlib/src/test/resources/formatter/properties/invalid_xml_properties.xml
+++ b/testlib/src/test/resources/formatter/properties/invalid_xml_properties.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+	<entry>No valid entry</entry>
+</properties>

--- a/testlib/src/test/resources/formatter/properties/valid_line_oriented.prefs
+++ b/testlib/src/test/resources/formatter/properties/valid_line_oriented.prefs
@@ -1,0 +1,9 @@
+#Some comment
+valid_line_oriented.prefs.string=string
+valid_line_oriented.prefs.true=Gets overridden by next line
+valid_line_oriented.prefs.true=true
+#Another comment
+valid_line_oriented.prefs.42=42
+valid_line_oriented.prefs.null=
+common=valid_line_oriented.prefs
+#Final comment

--- a/testlib/src/test/resources/formatter/properties/valid_line_oriented.properties
+++ b/testlib/src/test/resources/formatter/properties/valid_line_oriented.properties
@@ -1,0 +1,9 @@
+#Some comment
+valid_line_oriented.properties.string=string
+valid_line_oriented.properties.true=Gets overridden by next line
+valid_line_oriented.properties.true=true
+#Another comment
+valid_line_oriented.properties.42=42
+valid_line_oriented.properties.null=
+common=valid_line_oriented.properties
+#Final comment

--- a/testlib/src/test/resources/formatter/properties/valid_xml_profiles.xml
+++ b/testlib/src/test/resources/formatter/properties/valid_xml_profiles.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+	<profile kind="First" name="Used Profile" version="SomeVersion">
+		<setting id="valid_xml_profiles.xml.string" value="string" />
+		<setting id="valid_xml_profiles.xml.true" value="Gets overridden by next line" />
+		<setting id="valid_xml_profiles.xml.true" value="true" />
+		<setting id="valid_xml_profiles.xml.42" value="42" />
+		<setting id="valid_xml_profiles.xml.null"/>
+		<setting id="common" value="valid_xml_profiles.xml" />
+	</profile>
+	<profile kind="Second" name="Skipped Profile" version="AnotherVersion">
+		<setting id="valid_xml_profiles.xml.string" value="Second profile should be skipped" />
+		<setting id="valid_xml_profiles.xml.true" value="Second profile should be skipped" />
+		<setting id="valid_xml_profiles.xml.42" value="Second profile should be skipped" />
+		<setting id="valid_xml_profiles.xml.null" value="Second profile should be skipped" />
+		<setting id="common" value="Second profile should be skipped" />
+	</profile>
+</profiles>

--- a/testlib/src/test/resources/formatter/properties/valid_xml_properties.xml
+++ b/testlib/src/test/resources/formatter/properties/valid_xml_properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+	<comment>Some comment</comment>
+	<entry key="valid_xml_properties.xml.string">string</entry>
+	<entry key="valid_xml_properties.xml.true">Gets overridden by next line</entry>
+	<entry key="valid_xml_properties.xml.true">true</entry>
+	<entry key="valid_xml_properties.xml.42">42</entry>
+	<entry key="common">valid_xml_properties.xml</entry>
+	<entry key="valid_xml_properties.xml.null"/>
+</properties>


### PR DESCRIPTION
Feature provides unified handling of property files, meaning the reading of property files is decoupled from the formatter steps which are configured by properties. 
All property based formatter steps allow configuration by multiple property files. The following formats are currently supported:

- Java properties (*.xml, *.properties) 
- Eclipse profiles (*.xml)
- Eclipse preferences (*.pref)

The feature is backward compatible and requires no reconfiguration. Hence the corresponding configuration method (e.g. `propertiesFile`) remains unchanged and allows the configuration of multiple files.
All corresponding formatter steps also allow to specify no property files at all. In this case default configuration will by applied.

Gradle favors configuration injection over inheritance. Configuration injection is  possible by allowing the reuse of property files for multiple formatter steps, but also by allowing properties to overwrite each other. Hence the `FileSignature` needs to be sensitive to file order.

The implemented Gradle interface does not follow the Gradle DSL naming convention which clearly distinguish methods accepting a single or multiple arguments (e.g. `file`/`files`). Be aware that in some cases (e.g. `eclipseFormatFile`), the `spotless` methods as such instantiate and not only configures the formatter step. So the current implementation tries to follow the `spotless` rule to keep the normal configuration (a single property file) simple. It is even not desired to stress in the documentation the point that all property based formatter steps can be equally configured. Instead error messages should guide the user, not only mentioning if the configuration is not accepted, but list the allowed options.

A use-case of this feature will be the Groovy-Eclipse Formatter, which basically uses the JDT configuration but also provides the configuration of a few Groovy specific parameters. Hence this feature assures that an existing JDT profile can be reused and the Groovy specific parameters can be added in a dedicated configuration file. Furthermore it allows to override some of the JDT configuration for the Java code embedded within Groovy files.