### PR TITLE
Extend FileSignature to be sensitive to file order and duplicates.

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -187,7 +187,7 @@ public final class GitAttributesLineEndings {
 					.filter(file -> file != null && file.exists() && file.isFile())
 					.collect(Collectors.toList());
 			// sign it for up-to-date checking
-			signature = FileSignature.from(toSign);
+			signature = FileSignature.signAsSet(toSign);
 		}
 
 		/** Returns all of the .gitattributes files which affect the given files. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
@@ -72,7 +72,7 @@ public final class EclipseFormatterStep {
 
 		State(JarState jar, File settingsFile) throws Exception {
 			this.jarState = Objects.requireNonNull(jar);
-			this.settings = FileSignature.from(settingsFile);
+			this.settings = FileSignature.signAsList(settingsFile);
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -70,7 +70,7 @@ public final class JarState implements Serializable {
 			logger.log(Level.SEVERE, "You probably need to add a repository containing the `" + mavenCoordinate + "` artifact to your buildscript, e.g.: repositories { mavenCentral() }", e);
 			throw e;
 		}
-		FileSignature fileSignature = FileSignature.from(jars);
+		FileSignature fileSignature = FileSignature.signAsSet(jars);
 		return new JarState(mavenCoordinate, fileSignature, jars);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -21,8 +21,6 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Collections;
-import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -63,8 +61,7 @@ public class ScalaFmtStep {
 
 		State(String version, Provisioner provisioner, @Nullable File configFile) throws IOException {
 			this.jarState = JarState.from(MAVEN_COORDINATE + version, provisioner);
-			List<File> toSign = configFile == null ? Collections.emptyList() : Collections.singletonList(configFile);
-			this.configSignature = FileSignature.from(toSign);
+			this.configSignature = FileSignature.signAsList(configFile);
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+public class FileSignatureTest extends ResourceHarness {
+
+	private final static String[] inputPaths = {"A", "C", "C", "A", "B"};
+	private final static String[] expectedPathList = inputPaths;
+	private final static String[] expectedPathSet = {"A", "B", "C"};
+
+	@Test
+	public void testFromList() throws IOException {
+		Collection<File> inputFiles = getTestFiles(inputPaths);
+		FileSignature signature = FileSignature.signAsList(inputFiles);
+		Collection<File> expectedFiles = getTestFiles(expectedPathList);
+		Collection<File> outputFiles = signature.files();
+		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
+	}
+
+	@Test
+	public void testFromSet() throws IOException {
+		Collection<File> inputFiles = getTestFiles(inputPaths);
+		FileSignature signature = FileSignature.signAsSet(inputFiles);
+		Collection<File> expectedFiles = getTestFiles(expectedPathSet);
+		Collection<File> outputFiles = signature.files();
+		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
+	}
+
+	private List<File> getTestFiles(final String[] paths) throws IOException {
+		final List<File> result = new ArrayList<File>(paths.length);
+		for (String path : paths) {
+			result.add(createTestFile(path, ""));
+		}
+		return result;
+	}
+
+}


### PR DESCRIPTION
FileSignature#fromSet corresponds to original behavior FileSignature#from.
FileSignature#fromList is sensitive to file order and duplicates.
Moved checks for 'null' files from caller into FileSignature