### PR TITLE
Common config-loader for Formatter using Properties.

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseFormatterStep.java
@@ -16,24 +16,18 @@
 package com.diffplug.spotless.extra.java;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.logging.Logger;
 
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.FormatterProperties;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
-
-import groovy.util.Node;
-import groovy.util.NodeList;
-import groovy.util.XmlParser;
-import groovy.xml.QName;
 
 /** Formatter step which calls out to the Eclipse formatter. */
 public final class EclipseFormatterStep {
@@ -46,15 +40,31 @@ public final class EclipseFormatterStep {
 	private static final String FORMATTER_CLASS = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
 	private static final String FORMATTER_METHOD = "format";
 
-	/** Creates a formatter step for the given version and settings file. */
+	/** Creates a formatter step for the given version and settings file.
+	 * Formatter steps based on property configuration should support zero (default configuration)
+	 * to many files. Use {@link #create(Iterable, Provisioner)} instead.*/
+	@Deprecated
 	public static FormatterStep create(File settingsFile, Provisioner provisioner) {
-		return create(defaultVersion(), settingsFile, provisioner);
+		return create(Arrays.asList(settingsFile), provisioner);
 	}
 
 	/** Creates a formatter step for the given version and settings file. */
+	public static FormatterStep create(Iterable<File> settingsFiles, Provisioner provisioner) {
+		return create(defaultVersion(), settingsFiles, provisioner);
+	}
+
+	/** Creates a formatter step for the given version and settings file.
+	 * Formatter steps based on property configuration should support zero (default configuration)
+	 * to many files. Use {@link #create(String, Iterable, Provisioner)} instead.*/
+	@Deprecated
 	public static FormatterStep create(String version, File settingsFile, Provisioner provisioner) {
+		return create(version, Arrays.asList(settingsFile), provisioner);
+	}
+
+	/** Creates a formatter step for the given version and settings files. */
+	public static FormatterStep create(String version, Iterable<File> settingsFiles, Provisioner provisioner) {
 		return FormatterStep.createLazy(NAME,
-				() -> new State(JarState.from(MAVEN_COORDINATE + version, provisioner), settingsFile),
+				() -> new State(JarState.from(MAVEN_COORDINATE + version, provisioner), settingsFiles),
 				State::createFormat);
 	}
 
@@ -70,55 +80,22 @@ public final class EclipseFormatterStep {
 		/** The signature of the settings file. */
 		final FileSignature settings;
 
-		State(JarState jar, File settingsFile) throws Exception {
+		State(JarState jar, final Iterable<File> settingsFiles) throws Exception {
 			this.jarState = Objects.requireNonNull(jar);
-			this.settings = FileSignature.signAsList(settingsFile);
+			this.settings = FileSignature.signAsList(settingsFiles);
 		}
 
 		FormatterFunc createFormat() throws Exception {
-			Properties parsedSettings = parseProperties(settings.getOnlyFile());
+			FormatterProperties preferences = FormatterProperties.from(settings.files());
 
 			ClassLoader classLoader = jarState.getClassLoader();
 
 			// instantiate the formatter and get its format method
 			Class<?> formatterClazz = classLoader.loadClass(FORMATTER_CLASS);
-			Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(parsedSettings);
+			Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(preferences.getProperties());
 			Method method = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
 			return input -> (String) method.invoke(formatter, input);
 		}
 	}
 
-	private static final Logger logger = Logger.getLogger(EclipseFormatterStep.class.getName());
-
-	/** Parses an eclipse properties or XML file, determined dynamically based on the file ending. */
-	private static Properties parseProperties(File file) throws Exception {
-		Properties settings = new Properties();
-		if (!file.exists()) {
-			throw new IllegalArgumentException("Eclipse formatter file '" + file + "' does not exist.");
-		} else if (file.getName().endsWith(".properties")) {
-			try (InputStream input = new FileInputStream(file)) {
-				settings.load(input);
-			}
-			return settings;
-		} else if (file.getName().endsWith(".xml")) {
-			Node xmlSettings = new XmlParser().parse(file);
-			NodeList profiles = xmlSettings.getAt(new QName("profile"));
-			if (profiles.size() > 1) {
-				logger.warning("Eclipse formatter file contains multiple profiles: " + file.getAbsolutePath());
-				for (Object profile : profiles) {
-					Node node = (Node) profile;
-					logger.warning("    " + node.attribute("name"));
-				}
-				logger.warning("Using first profile, recommend deleting others.");
-			}
-			NodeList xmlSettingsElements = xmlSettings.getAt(new QName("profile")).getAt("setting");
-			for (Object xmlSettingsElement : xmlSettingsElements) {
-				Node setting = (Node) xmlSettingsElement;
-				settings.put(setting.attributes().get("id"), setting.attributes().get("value"));
-			}
-			return settings;
-		} else {
-			throw new IllegalArgumentException("Eclipse formatter file must be .properties or .xml");
-		}
-	}
 }

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseFormatterStepTest.java
@@ -17,6 +17,7 @@ package com.diffplug.spotless.extra.java;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -29,14 +30,14 @@ import com.diffplug.spotless.TestProvisioner;
 public class EclipseFormatterStepTest extends ResourceHarness {
 	@Test
 	public void loadPropertiesSettings() throws Throwable {
-		File eclipseFormatFile = createTestFile("java/eclipse/format/formatter.properties");
+		List<File> eclipseFormatFile = createTestFiles("java/eclipse/format/formatter.properties");
 		StepHarness.forStep(EclipseFormatterStep.create(eclipseFormatFile, TestProvisioner.mavenCentral()))
 				.testResource("java/eclipse/format/JavaCodeUnformatted.test", "java/eclipse/format/JavaCodeFormatted.test");
 	}
 
 	@Test
 	public void loadXmlSettings() throws Throwable {
-		File eclipseFormatFile = createTestFile("java/eclipse/format/formatter.xml");
+		List<File> eclipseFormatFile = createTestFiles("java/eclipse/format/formatter.xml");
 		StepHarness.forStep(EclipseFormatterStep.create(eclipseFormatFile, TestProvisioner.mavenCentral()))
 				.testResource("java/eclipse/format/JavaCodeUnformatted.test", "java/eclipse/format/JavaCodeFormatted.test");
 	}
@@ -44,7 +45,7 @@ public class EclipseFormatterStepTest extends ResourceHarness {
 	@Test
 	public void longLiteralProblem() throws Throwable {
 		String folder = "java/eclipse/format/long_literals/";
-		File eclipseFormatFile = createTestFile(folder + "spotless.eclipseformat.xml");
+		List<File> eclipseFormatFile = createTestFiles(folder + "spotless.eclipseformat.xml");
 		StepHarness.forStep(EclipseFormatterStep.create(eclipseFormatFile, TestProvisioner.mavenCentral()))
 				.testResourceUnaffected(folder + "Example1.test")
 				.testResourceUnaffected(folder + "Example2.test");
@@ -52,23 +53,23 @@ public class EclipseFormatterStepTest extends ResourceHarness {
 
 	@Test
 	public void equality() throws IOException {
-		File xmlFile = createTestFile("java/eclipse/format/formatter.xml");
-		File propFile = createTestFile("java/eclipse/format/formatter.properties");
+		List<File> xmlFile = createTestFiles("java/eclipse/format/formatter.xml");
+		List<File> propFile = createTestFiles("java/eclipse/format/formatter.properties");
 		new SerializableEqualityTester() {
-			File settingsFile;
+			List<File> settingsFiles;
 
 			@Override
 			protected void setupTest(API api) {
-				settingsFile = xmlFile;
+				settingsFiles = xmlFile;
 				api.areDifferentThan();
 
-				settingsFile = propFile;
+				settingsFiles = propFile;
 				api.areDifferentThan();
 			}
 
 			@Override
 			protected FormatterStep create() {
-				return EclipseFormatterStep.create(settingsFile, TestProvisioner.mavenCentral());
+				return EclipseFormatterStep.create(settingsFiles, TestProvisioner.mavenCentral());
 			}
 		}.testEquals();
 	}

--- a/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/** Utility manages settings of formatter configured by properties. */
+public class FormatterProperties {
+
+	private final Properties properties;
+
+	private FormatterProperties() {
+		properties = new Properties();
+	}
+
+	/**
+	 * Import settings from a sequence of files (file import is the given order)
+	 *
+	 * @param files
+	 *            Sequence of files
+	 * @throws IllegalArgumentException
+	 *            In case the import of a file fails
+	 */
+	public static FormatterProperties from(File... files) throws IllegalArgumentException {
+		return from(Arrays.asList(files));
+	}
+
+	/**
+	 * Import settings from a sequence of files (file import is the given order)
+	 *
+	 * @param files
+	 *            Sequence of files
+	 * @throws IllegalArgumentException
+	 *            In case the import of a file fails
+	 */
+	public static FormatterProperties from(Iterable<File> files) throws IllegalArgumentException {
+		FormatterProperties properties = new FormatterProperties();
+		files.forEach(file -> properties.add(file));
+		return properties;
+	}
+
+	/**
+	 * Import settings from given file. New settings (with the same ID/key)
+	 * override existing once.
+	 *
+	 * @param settingsFile
+	 *            File
+	 * @throws IllegalArgumentException
+	 *            In case the import of the file fails
+	 */
+	private void add(final File settingsFile) throws IllegalArgumentException {
+		if (!(settingsFile.isFile() || settingsFile.canRead())) {
+			String msg = String.format("Settings file '%s' does not exist or can not be read.", settingsFile);
+			throw new IllegalArgumentException(msg);
+		}
+		try {
+			Properties newSettings = FileParser.parse(settingsFile);
+			properties.putAll(newSettings);
+		} catch (IOException | IllegalArgumentException | NullPointerException exception) {
+			String message = String.format("Failed to add properties from '%s' to formatter settings.", settingsFile);
+			String detailedMessage = exception.getMessage();
+			if (null != detailedMessage) {
+				message += String.format(" %s", detailedMessage);
+			}
+			throw new IllegalArgumentException(message, exception);
+		}
+	}
+
+	/** Returns the accumulated {@link java.util.Properties Properties} */
+	public Properties getProperties() {
+		return properties;
+	}
+
+	private enum FileParser {
+		LINE_ORIENTED("properties", "prefs") {
+			@Override
+			protected Properties execute(File file) throws IOException, IllegalArgumentException {
+				Properties properties = new Properties();
+				try (InputStream inputProperties = new FileInputStream(file)) {
+					properties.load(inputProperties);
+				}
+				return properties;
+			}
+		},
+
+		XML("xml") {
+			@Override
+			protected Properties execute(final File file) throws IOException, IllegalArgumentException {
+				Node rootNode = getRootNode(file);
+				String nodeName = rootNode.getNodeName();
+				if (null == nodeName) {
+					throw new IllegalArgumentException("XML document does not contain a root node.");
+				}
+				return XmlParser.parse(file, rootNode);
+			}
+
+			private Node getRootNode(final File file) throws IOException, IllegalArgumentException {
+				try {
+					/*
+					 * The parser does not validate, since the root node is only
+					 * used to decide on further processing.
+					 */
+					DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+					DocumentBuilder db = dbf.newDocumentBuilder();
+					return db.parse(file).getDocumentElement();
+				} catch (SAXException | ParserConfigurationException e) {
+					throw new IllegalArgumentException("File has no valid XML syntax.", e);
+				}
+
+			}
+
+		};
+		private static final char FILE_EXTENSION_SEPARATOR = '.';
+
+		private final List<String> supportedFileNameExtensions;
+
+		private FileParser(final String... supportedFileNameExtensions) {
+			this.supportedFileNameExtensions = Arrays.asList(supportedFileNameExtensions);
+		}
+
+		protected abstract Properties execute(File file) throws IOException, IllegalArgumentException;
+
+		public static Properties parse(final File file) throws IOException, IllegalArgumentException {
+			String fileNameExtension = getFileNameExtension(file);
+			for (FileParser parser : FileParser.values()) {
+				if (parser.supportedFileNameExtensions.contains(fileNameExtension)) {
+					return parser.execute(file);
+				}
+			}
+			String msg = String.format(
+					"The file name extension '%1$s' is not part of the supported file extensions [%2$s].",
+					fileNameExtension, Arrays.toString(FileParser.values()));
+			throw new IllegalArgumentException(msg);
+
+		}
+
+		private static String getFileNameExtension(File file) {
+			String fileName = file.getName();
+			int seperatorPos = fileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+			return 0 > seperatorPos ? "" : fileName.substring(seperatorPos + 1);
+		}
+
+	}
+
+	private enum XmlParser {
+		PROPERTIES("properties") {
+			@Override
+			protected Properties execute(final File xmlFile, final Node rootNode)
+					throws IOException, IllegalArgumentException {
+				final Properties properties = new Properties();
+				InputStream xmlInput = new FileInputStream(xmlFile);
+				try {
+					properties.loadFromXML(xmlInput);
+				} finally {
+					xmlInput.close();
+				}
+				return properties;
+			}
+		},
+
+		PROFILES("profiles") {
+			@Override
+			protected Properties execute(File file, Node rootNode) throws IOException, IllegalArgumentException {
+				final Properties properties = new Properties();
+				Node firstProfile = getSingleProfile(rootNode);
+				for (Object settingObj : getChildren(firstProfile, "setting")) {
+					Node setting = (Node) settingObj;
+					NamedNodeMap attributes = setting.getAttributes();
+					Node id = attributes.getNamedItem("id");
+					Node value = attributes.getNamedItem("value");
+					if (null == id) {
+						throw new IllegalArgumentException("Node 'setting' does not possess an 'id' attribute.");
+					}
+					String idString = id.getNodeValue();
+					/*
+					 * A missing value is interpreted as an empty string,
+					 * similar to the Properties behavior
+					 */
+					String valString = (null == value) ? "" : value.getNodeValue();
+					properties.setProperty(idString, valString);
+				}
+				return properties;
+			}
+
+			private Node getSingleProfile(final Node rootNode) throws IllegalArgumentException {
+				List<Node> profiles = getChildren(rootNode, "profile");
+				if (profiles.size() == 0) {
+					throw new IllegalArgumentException("The formatter configuration profile files does not contain any 'profile' elements.");
+				}
+				if (profiles.size() > 1) {
+					String message = "Formatter configuration file contains multiple profiles: [";
+					message += profiles.stream().map(profile -> getProfileName(profile))
+							.collect(Collectors.joining("; "));
+					message += "]%n The formatter can only cope with a single profile per configuration file. Please remove the other profiles.";
+					throw new IllegalArgumentException(message);
+				}
+				return profiles.iterator().next();
+			}
+
+			private List<Node> getChildren(final Node node, final String nodeName) {
+				List<Node> matchingChildren = new LinkedList<Node>();
+				NodeList children = node.getChildNodes();
+				for (int i = 0; i < children.getLength(); i++) {
+					Node child = children.item(i);
+					if (child.getNodeName().equals(nodeName)) {
+						matchingChildren.add(child);
+					}
+				}
+				return matchingChildren;
+			}
+
+		};
+
+		private static String getProfileName(Node profile) {
+			Node nameAttribute = profile.getAttributes().getNamedItem("name");
+			return (null == nameAttribute) ? "" : nameAttribute.getNodeValue();
+		}
+
+		private final String rootNodeName;
+
+		private XmlParser(final String rootNodeName) {
+			this.rootNodeName = rootNodeName;
+		}
+
+		@Override
+		public String toString() {
+			return this.rootNodeName;
+		}
+
+		protected abstract Properties execute(File file, Node rootNode) throws IOException, IllegalArgumentException;
+
+		public static Properties parse(final File file, final Node rootNode)
+				throws IOException, IllegalArgumentException {
+			String rootNodeName = rootNode.getNodeName();
+			for (XmlParser parser : XmlParser.values()) {
+				if (parser.rootNodeName.equals(rootNodeName)) {
+					return parser.execute(file, rootNode);
+				}
+			}
+			String msg = String.format("The XML root node '%1$s' is not part of the supported root nodes [%2$s].",
+					rootNodeName, Arrays.toString(XmlParser.values()));
+			throw new IllegalArgumentException(msg);
+		}
+
+	}
+
+}

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -110,7 +110,7 @@ spotless {
 		removeUnusedImports() // removes any unused imports
 
 		eclipseFormatFile 'spotless.eclipseformat.xml'	// XML file dumped out by the Eclipse formatter
-		// If you have an older Eclipse properties file, you can use that too.
+		// If you have Eclipse preference or property files, you can use them too.
 	}
 }
 ```

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
@@ -15,19 +15,14 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.gradle.api.Action;
 
-import com.diffplug.common.base.Errors;
-import com.diffplug.common.io.Files;
+import com.diffplug.spotless.FormatterProperties;
 import com.diffplug.spotless.markdown.FreshMarkStep;
 
 public class FreshMarkExtension extends FormatExtension {
@@ -50,18 +45,12 @@ public class FreshMarkExtension extends FormatExtension {
 		propertyActions.add(action);
 	}
 
-	public void propertiesFile(Object file) {
+	public void propertiesFile(Object... files) {
 		propertyActions.add(map -> {
-			File propFile = getProject().file(file);
-			try (InputStream input = Files.asByteSource(propFile).openBufferedStream()) {
-				Properties props = new Properties();
-				props.load(input);
-				for (String key : props.stringPropertyNames()) {
-					map.put(key, props.getProperty(key));
-				}
-			} catch (IOException e) {
-				throw Errors.asRuntime(e);
-			}
+			FormatterProperties preferences = FormatterProperties.from(getProject().files(files));
+			/* FreshMarkStep.State serializes the properties and not the files.
+			 * Therefore they must be stored in a hash-map like used by Properties.*/
+			preferences.getProperties().forEach((key, value) -> map.put(key.toString(), value));
 		});
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -18,6 +18,7 @@ package com.diffplug.gradle.spotless;
 import java.util.List;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.Project;
 import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
@@ -60,8 +61,11 @@ public class JavaExtension extends FormatExtension {
 		eclipseFormatFile(EclipseFormatterStep.defaultVersion(), eclipseFormatFile);
 	}
 
-	public void eclipseFormatFile(String eclipseVersion, Object eclipseFormatFile) {
-		addStep(EclipseFormatterStep.create(eclipseVersion, getProject().file(eclipseFormatFile), GradleProvisioner.fromProject(getProject())));
+	public void eclipseFormatFile(String eclipseVersion, Object... eclipseFormatFiles) {
+		Project project = getProject();
+		addStep(EclipseFormatterStep.create(eclipseVersion,
+				project.files(eclipseFormatFiles).getFiles(),
+				GradleProvisioner.fromProject(project)));
 	}
 
 	/** Removes any unused imports. */

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -22,7 +22,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -105,6 +107,15 @@ public class ResourceHarness {
 			throw new IllegalArgumentException("No such resource " + filename);
 		}
 		return Resources.toString(url, StandardCharsets.UTF_8);
+	}
+
+	/** Returns Files (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
+	protected List<File> createTestFiles(String... filenames) throws IOException {
+		List<File> files = new ArrayList<File>(filenames.length);
+		for (String filename : filenames) {
+			files.add(createTestFile(filename));
+		}
+		return files;
 	}
 
 	/** Returns a File (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Properties;
+
+import org.assertj.core.api.AbstractAssert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.diffplug.spotless.ResourceHarness;
+
+public class FormatterPropertiesTest extends ResourceHarness {
+
+	@Rule
+	public ExpectedException expectedEx = ExpectedException.none();
+
+	private static final String RESOURCES_ROOT_DIR = "formatter/properties/";
+
+	private static final String[] VALID_SETTINGS_RESOURCES = {
+			RESOURCES_ROOT_DIR + "valid_line_oriented.prefs",
+			RESOURCES_ROOT_DIR + "valid_line_oriented.properties",
+			RESOURCES_ROOT_DIR + "valid_xml_profiles.xml",
+			RESOURCES_ROOT_DIR + "valid_xml_properties.xml"
+	};
+
+	private static final String[] INVALID_SETTINGS_RESOURCES = {
+			RESOURCES_ROOT_DIR + "invalid_xml_profiles.xml",
+			RESOURCES_ROOT_DIR + "invalid_xml_profiles_multiple.xml",
+			RESOURCES_ROOT_DIR + "invalid_xml_profiles_zero.xml",
+			RESOURCES_ROOT_DIR + "invalid_xml_properties.xml"
+	};
+
+	private static final String[] VALID_VALUES = {
+			"string",
+			"true",
+			"42",
+			null
+	};
+
+	@Test
+	public void differntPropertyFileTypes() throws IOException {
+		for (String settingsResource : VALID_SETTINGS_RESOURCES) {
+			File settingsFile = createTestFile(settingsResource);
+			FormatterProperties preferences = FormatterProperties.from(settingsFile);
+			assertFor(preferences)
+					.containsSpecificValuesOf(settingsFile)
+					.containsCommonValueOf(settingsFile);
+		}
+	}
+
+	@Test
+	public void multiplePropertyFiles() throws IOException {
+		LinkedList<File> settingsFiles = new LinkedList<File>();
+		for (String settingsResource : VALID_SETTINGS_RESOURCES) {
+			File settingsFile = createTestFile(settingsResource);
+			settingsFiles.add(settingsFile);
+		}
+		FormatterProperties preferences = FormatterProperties.from(settingsFiles);
+		/* Settings are loaded / overridden in the sequence they are configured. */
+		assertFor(preferences)
+				.containsSpecificValuesOf(settingsFiles)
+				.containsCommonValueOf(settingsFiles.getLast());
+	}
+
+	@Test
+	public void invalidPropertyFiles() throws IOException {
+		for (String settingsResource : INVALID_SETTINGS_RESOURCES) {
+			File settingsFile = createTestFile(settingsResource);
+			boolean exceptionCaught = false;
+			try {
+				FormatterProperties.from(settingsFile);
+			} catch (IllegalArgumentException ex) {
+				exceptionCaught = true;
+				assertThat(ex.getMessage())
+						.as("IllegalArgumentException does not contain absolute path of file '%s'", settingsFile.getName())
+						.contains(settingsFile.getAbsolutePath());
+			}
+			assertThat(exceptionCaught)
+					.as("No IllegalArgumentException thrown when parsing '%s'", settingsFile.getName())
+					.isTrue();
+		}
+	}
+
+	@Test
+	public void nonExisitingFile() throws IOException {
+		boolean exceptionCaught = false;
+		String filePath = "does/not/exist.properties";
+		try {
+			FormatterProperties.from(new File(filePath));
+		} catch (IllegalArgumentException ex) {
+			exceptionCaught = true;
+			assertThat(ex.getMessage())
+					.as("IllegalArgumentException does not contain path of non-existing file.").contains(filePath);
+		}
+		assertThat(exceptionCaught)
+				.as("No IllegalArgumentException thrown for non-existing file.").isTrue();
+	}
+
+	private static class FormatterSettingsAssert extends AbstractAssert<FormatterSettingsAssert, FormatterProperties> {
+
+		public FormatterSettingsAssert(FormatterProperties actual) {
+			super(actual, FormatterSettingsAssert.class);
+		}
+
+		/** Check that the values form all valid files are part of the settings properties. */
+		public FormatterSettingsAssert containsSpecificValuesOf(Collection<File> files) {
+			files.forEach(file -> containsSpecificValuesOf(file));
+			return this;
+		}
+
+		/** Check that the values form a certain valid file are part of the settings properties. */
+		public FormatterSettingsAssert containsSpecificValuesOf(File file) {
+			isNotNull();
+
+			String fileName = file.getName();
+			Properties settingsProps = actual.getProperties();
+			for (String expectedValue : VALID_VALUES) {
+				// A parsable (valid) file contains keys of the following format
+				String validValueName = (null == expectedValue) ? "null" : expectedValue;
+				String key = String.format("%s.%s", fileName, validValueName);
+				if (!settingsProps.containsKey(key)) {
+					failWithMessage("Key <%s> not part of formatter settings.", key);
+				}
+				String value = settingsProps.getProperty(key);
+				if ((null != expectedValue) && (!expectedValue.equals(value))) {
+					failWithMessage("Value of key <%s> is '%s' and not '%s' as expected.", key, value, expectedValue);
+				}
+			}
+			return this;
+		}
+
+		public FormatterSettingsAssert containsCommonValueOf(final File file) {
+			isNotNull();
+
+			String fileName = file.getName();
+			Properties settingsProps = actual.getProperties();
+			String key = "common";
+			if (!settingsProps.containsKey(key)) {
+				failWithMessage("Key <%s> not part of formatter settings. Value '%s' had been expected.", key, fileName);
+			}
+			String value = settingsProps.getProperty(key);
+			if (!fileName.equals(value)) {
+				failWithMessage("Value of key <%s> is '%s' and not '%s' as expected.", key, value, fileName);
+			}
+
+			return this;
+		}
+
+	};
+
+	private static FormatterSettingsAssert assertFor(FormatterProperties actual) {
+		return new FormatterSettingsAssert(actual);
+	}
+
+}

--- a/testlib/src/test/resources/formatter/properties/invalid_xml_profiles.xml
+++ b/testlib/src/test/resources/formatter/properties/invalid_xml_profiles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+	<profile version="Profile without name can be handled">
+		<setting value="Setting needs an ID" />
+	</profile>
+</profiles>

--- a/testlib/src/test/resources/formatter/properties/invalid_xml_profiles_multiple.xml
+++ b/testlib/src/test/resources/formatter/properties/invalid_xml_profiles_multiple.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="42">
+	<profile kind="Profile without a name can be handled."/>
+	<profile name="More than one profile cannot be handled."/>
+</profiles>

--- a/testlib/src/test/resources/formatter/properties/invalid_xml_profiles_zero.xml
+++ b/testlib/src/test/resources/formatter/properties/invalid_xml_profiles_zero.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="42"/>

--- a/testlib/src/test/resources/formatter/properties/invalid_xml_properties.xml
+++ b/testlib/src/test/resources/formatter/properties/invalid_xml_properties.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+	<entry>No valid entry</entry>
+</properties>

--- a/testlib/src/test/resources/formatter/properties/valid_line_oriented.prefs
+++ b/testlib/src/test/resources/formatter/properties/valid_line_oriented.prefs
@@ -1,0 +1,9 @@
+#Some comment
+valid_line_oriented.prefs.string=string
+valid_line_oriented.prefs.true=Gets overridden by next line
+valid_line_oriented.prefs.true=true
+#Another comment
+valid_line_oriented.prefs.42=42
+valid_line_oriented.prefs.null=
+common=valid_line_oriented.prefs
+#Final comment

--- a/testlib/src/test/resources/formatter/properties/valid_line_oriented.properties
+++ b/testlib/src/test/resources/formatter/properties/valid_line_oriented.properties
@@ -1,0 +1,9 @@
+#Some comment
+valid_line_oriented.properties.string=string
+valid_line_oriented.properties.true=Gets overridden by next line
+valid_line_oriented.properties.true=true
+#Another comment
+valid_line_oriented.properties.42=42
+valid_line_oriented.properties.null=
+common=valid_line_oriented.properties
+#Final comment

--- a/testlib/src/test/resources/formatter/properties/valid_xml_profiles.xml
+++ b/testlib/src/test/resources/formatter/properties/valid_xml_profiles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+	<profile kind="Single" name="Profile" version="whatsoever">
+		<setting id="valid_xml_profiles.xml.string" value="string" />
+		<setting id="valid_xml_profiles.xml.true" value="Gets overridden by next line" />
+		<setting id="valid_xml_profiles.xml.true" value="true" />
+		<setting id="valid_xml_profiles.xml.42" value="42" />
+		<setting id="valid_xml_profiles.xml.null"/>
+		<setting id="common" value="valid_xml_profiles.xml" />
+	</profile>
+</profiles>

--- a/testlib/src/test/resources/formatter/properties/valid_xml_properties.xml
+++ b/testlib/src/test/resources/formatter/properties/valid_xml_properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+	<comment>Some comment</comment>
+	<entry key="valid_xml_properties.xml.string">string</entry>
+	<entry key="valid_xml_properties.xml.true">Gets overridden by next line</entry>
+	<entry key="valid_xml_properties.xml.true">true</entry>
+	<entry key="valid_xml_properties.xml.42">42</entry>
+	<entry key="common">valid_xml_properties.xml</entry>
+	<entry key="valid_xml_properties.xml.null"/>
+</properties>


### PR DESCRIPTION
Configuration shall be reusable between formatter by sharing the same configuration file. Reused configuration shall also be modifiable by overwriting a sub-set of the reused properties.
The new FormatterProperties class accepts zero or multiple files; supports Java properties, Eclipse profile and preference files.
The FormatterProperties respects the configuration file order. In case the same property is specified in multiple files new values override the old once.