### PR TITLE
Get ready for greclipse to land

### DIFF
--- a/_ext/greclipse/build.gradle
+++ b/_ext/greclipse/build.gradle
@@ -358,7 +358,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 	from javadoc.destinationDir
 }
 
-def isSnapshot = project.version.endsWith('-SNAPSHOT')
+def isSnapshot = grec_version.endsWith('-SNAPSHOT')
 // pulls the credentials from either the environment variable or gradle.properties
 def cred = {
 	if (System.env[it] != null) {
@@ -387,6 +387,7 @@ model {
 					// add MavenCentral requirements to the POM
 					asNode().children().last() + {
 						resolveStrategy = Closure.DELEGATE_FIRST
+						name project.grec_artifactId
 						description project.grec_description
 						url "https://github.com/${project.grec_org}/${project.name}"
 						scm {

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -126,4 +126,15 @@ public class TestProvisioner {
 	}
 
 	private static final Supplier<Provisioner> mavenLocal = createLazyWithRepositories(repo -> repo.mavenLocal());
+
+	/** Creates a Provisioner for the Sonatype snapshots maven repo for development purpose. */
+	public static Provisioner snapshots() {
+		return snapshots.get();
+	}
+
+	private static final Supplier<Provisioner> snapshots = createLazyWithRepositories(repo -> {
+		repo.maven(setup -> {
+			setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots");
+		});
+	});
 }


### PR DESCRIPTION
I published greclipse to the public oss snapshots repo, and added the oss snapshots repo to TestProvisioners.  If you write your greclipse tests against `TestProvisioner.snapshots()`, the tests that pass on your machine should also pass on Travis.