### PR TITLE
Makes dependency on Java check configurable

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -104,6 +104,23 @@ public class SpotlessExtension {
 		}
 	}
 
+	boolean enforceCheck = true;
+
+	/** Returns `true` if Gradle's `check` task should run `spotlessCheck`; `false` otherwise. */
+	public boolean isEnforceCheck() {
+		return enforceCheck;
+	}
+
+	/**
+	 * Configures Gradle's `check` task to run `spotlessCheck` if `true`,
+	 * but to not do so if `false`.
+	 *
+	 * `true` by default.
+	 */
+	public void setEnforceCheck(boolean enforceCheck) {
+		this.enforceCheck = enforceCheck;
+	}
+
 	private <T extends FormatExtension> void configure(String name, Class<T> clazz, Action<T> configure) {
 		T value = maybeCreate(name, clazz);
 		configure.execute(value);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -103,9 +103,11 @@ public class SpotlessPlugin implements Plugin<Project> {
 		// Add our check task as a dependency on the global check task
 		// getTasks() returns a "live" collection, so this works even if the
 		// task doesn't exist at the time this call is made
-		project.getTasks()
-				.matching(task -> task.getName().equals(JavaBasePlugin.CHECK_TASK_NAME))
-				.all(task -> task.dependsOn(rootCheckTask));
+		if (spotlessExtension.enforceCheck) {
+			project.getTasks()
+					.matching(task -> task.getName().equals(JavaBasePlugin.CHECK_TASK_NAME))
+					.all(task -> task.dependsOn(rootCheckTask));
+		}
 
 		// clear spotless' cache when the user does a clean
 		project.getTasks()


### PR DESCRIPTION
As discussed in #79, though not strictly related to that issue, we can relax the dependency from Java's check task to spotlessCheck. 

For backwards compatibility, and to respect @nedtwigg 's opinion on the philosophy of this project, the default is to add the dependency.