### PR TITLE
Applied new paddedCell to gradle formatting.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	repositories { maven { url 'https://plugins.gradle.org/m2/' }}
+	repositories { maven { url 'https://plugins.gradle.org/m2/' } }
 	dependencies {
 		classpath "com.diffplug.gradle:goomph:${VER_GOOMPH}"
 		classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${VER_BINTRAY}"

--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -117,7 +117,8 @@ model {
 						username = cred('nexus_user')
 						password = cred('nexus_pass')
 					}
-				}}
+				}
+			}
 		}
 	}
 }

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -142,6 +142,8 @@ Configuration for Groovy is similar to [Java](#java).  Most java steps, like `li
 
 The groovy formatter's default behavior is to format all `.groovy` and `.java` files found in the Groovy source directories.  If you would like to exclude the `.java` files, set the parameter `excludeJava`, or you can set the `target` parameter as described in the [Custom rules](#custom) section.
 
+Due to cyclic ambiguities of groovy formatter results, e.g. for nested closures, the use of [paddedCell()](../PADDEDCELL.md) and/or [Custom rules](#custom) is recommended to bandaid over this third-party formatter problem.
+
 ```gradle
 apply plugin: 'groovy'
 ...
@@ -154,7 +156,7 @@ spotless {
 	groovy {
 		licenseHeaderFile 'spotless.license.java'
 		excludeJava() // excludes all Java sources within the Groovy source dirs from formatting
-
+		paddedCell() // Avoid cyclic ambiguities
 		// the Groovy Eclipse formatter extends the Java Eclipse formatter,
 		// so it formats Java files by default (unless `excludeJava` is used).
 		greclipse().configFile('greclipse.properties')

--- a/spotlessSelf.gradle
+++ b/spotlessSelf.gradle
@@ -1,4 +1,4 @@
-buildscript { repositories { jcenter() }}
+buildscript { repositories { jcenter() } }
 
 // applied by SelfTest
 plugins {
@@ -32,9 +32,9 @@ spotless {
 			include '**/*.gradle'
 			exclude '_ext/**'
 		}
+		paddedCell()
 		custom 'noInternalDeps', noInternalDepsClosure
-		custom 'preventFormatPingPong', { return it.replaceAll('}[ \t]+}', '}}') }
-		bumpThisNumberIfACustomStepChanges(1)
+		bumpThisNumberIfACustomStepChanges(3)
 		greclipse().configFile('spotless.eclipseformat.xml', 'spotless.groovyformat.prefs')
 	}
 	freshmark {


### PR DESCRIPTION
Due to @nedtwigg fix for #106 I think it would be good to use `paddedCell` for the gradle formatting and also warn the user that the GrEclipse formatting results are unstable.