### PR TITLE
Align Java Eclipse formatter gradle interface with greclipse/scala

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -112,7 +112,7 @@ spotless {
 
 		removeUnusedImports() // removes any unused imports
 
-		eclipseFormatFile 'spotless.eclipseformat.xml'	// XML file dumped out by the Eclipse formatter
+		eclipse().configFile 'spotless.eclipseformat.xml'	// XML file dumped out by the Eclipse formatter
 		// If you have Eclipse preference or property files, you can use them too.
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SelfTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SelfTest.java
@@ -94,7 +94,7 @@ public class SelfTest {
 				java.target("**/*.java");
 				java.licenseHeaderFile("spotless.license.java");
 				java.importOrderFile("spotless.importorder");
-				java.eclipseFormatFile("spotless.eclipseformat.xml");
+				java.eclipse().configFile("spotless.eclipseformat.xml");
 				java.trimTrailingWhitespace();
 				java.customLazy("Lambda fix", () -> raw -> {
 					if (!raw.contains("public class SelfTest ")) {

--- a/spotlessSelf.gradle
+++ b/spotlessSelf.gradle
@@ -23,7 +23,7 @@ spotless {
 		bumpThisNumberIfACustomStepChanges(1)
 		licenseHeaderFile 'spotless.license'
 		importOrderFile   'spotless.importorder'
-		eclipseFormatFile 'spotless.eclipseformat.xml'
+		eclipse().configFile 'spotless.eclipseformat.xml'
 		trimTrailingWhitespace()
 		removeUnusedImports()
 	}


### PR DESCRIPTION
To complete my open task [as discussed](https://github.com/diffplug/spotless/pull/94#issuecomment-291269722).
I checked the old `eclipseFormatFile` manually before I modified `spotlessSelf.gradle`. Let me know if you prefer an automated test.