### PR TITLE
Add missing groovy plugin check

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -24,6 +24,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.plugins.GroovyBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.GroovySourceSet;
 import org.gradle.api.tasks.SourceSet;
@@ -106,7 +107,7 @@ public class GroovyExtension extends FormatExtension {
 	protected void setupTask(SpotlessTask task) {
 		if (target == null) {
 			JavaPluginConvention convention = getProject().getConvention().getPlugin(JavaPluginConvention.class);
-			if (convention == null) {
+			if (convention == null || !getProject().getPlugins().hasPlugin(GroovyBasePlugin.class)) {
 				throw new GradleException("You must apply the groovy plugin before the spotless plugin if you are using the groovy extension.");
 			}
 			//Add all Groovy files (may contain Java files as well)

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GroovyDefaultTargetTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GroovyDefaultTargetTest.java
@@ -42,8 +42,6 @@ public class GroovyDefaultTargetTest extends GradleIntegrationTest {
 				"plugins {",
 				"    id 'com.diffplug.gradle.spotless'",
 				"}",
-				"repositories { mavenLocal() }",
-				"",
 				"apply plugin: 'groovy'",
 				"",
 				"spotless {",
@@ -83,8 +81,6 @@ public class GroovyDefaultTargetTest extends GradleIntegrationTest {
 				"plugins {",
 				"    id 'com.diffplug.gradle.spotless'",
 				"}",
-				"repositories { mavenLocal() }",
-				"",
 				"apply plugin: 'groovy'",
 				"",
 				"spotless {",
@@ -99,6 +95,27 @@ public class GroovyDefaultTargetTest extends GradleIntegrationTest {
 			Assert.fail("Exception expected when running 'excludeJava' in combination with 'target'.");
 		} catch (Throwable t) {
 			Assertions.assertThat(t).hasMessageContaining("'excludeJava' is not supported");
+		}
+	}
+
+	@Test
+	public void groovyPluginMissingCheck() throws IOException {
+		write("build.gradle",
+				"plugins {",
+				"    id 'com.diffplug.gradle.spotless'",
+				"}",
+				"apply plugin: 'java'",
+				"",
+				"spotless {",
+				"    groovy {",
+				"    }",
+				"}");
+
+		try {
+			gradleRunner().withArguments("spotlessApply").build();
+			Assert.fail("Exception expected when using 'groovy' without 'target' if groovy-plugin is not applied.");
+		} catch (Throwable t) {
+			Assertions.assertThat(t).hasMessageContaining("must apply the groovy plugin before");
 		}
 	}
 


### PR DESCRIPTION
Add missing groovy plugin check to assure that GroovySourceSet is found. Required in case groovy extension is configured without target.