### PR TITLE
Import Sorter to cope with multi-line comments and misplaced imports

### DIFF
--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -51,6 +51,18 @@ public class ImportOrderStepTest extends ResourceHarness {
 	}
 
 	@Test
+	public void removeComments() throws Throwable {
+		FormatterStep step = ImportOrderStep.createFromFile(createTestFile("java/importsorter/import.properties"));
+		assertOnResources(step, "java/importsorter/JavaCodeImportComments.test", "java/importsorter/JavaCodeSortedImports.test");
+	}
+
+	@Test
+	public void misplacedImports() throws Throwable {
+		FormatterStep step = ImportOrderStep.createFromFile(createTestFile("java/importsorter/import.properties"));
+		assertOnResources(step, "java/importsorter/JavaCodeUnsortedMisplacedImports.test", "java/importsorter/JavaCodeSortedMisplacedImports.test");
+	}
+
+	@Test
 	public void doesntThrowIfImportOrderIsntSerializable() {
 		ImportOrderStep.createFromOrder(NonSerializableList.of("java", "javax", "org", "\\#com"));
 	}

--- a/testlib/src/test/resources/java/importsorter/JavaCodeImportComments.test
+++ b/testlib/src/test/resources/java/importsorter/JavaCodeImportComments.test
@@ -1,0 +1,14 @@
+import static java.lang.Exception.*;
+//Will be removed
+import org.dooda.Didoo; /* Comment removed, import stays */
+import java.lang.Thread; /* Don't */ /* get */ /* confused */
+import java.lang.Runnable;
+/* import org.comments.will
+import org.comments.be
+import org.comments.removed
+*/
+import static java.lang.Runnable.*; 
+/*
+import other.multiline.comments
+import will.be.removed.too */ 
+import static com.foo.Bar

--- a/testlib/src/test/resources/java/importsorter/JavaCodeSortedMisplacedImports.test
+++ b/testlib/src/test/resources/java/importsorter/JavaCodeSortedMisplacedImports.test
@@ -1,0 +1,13 @@
+import java.lang.Runnable;
+import java.lang.Thread;
+
+import org.dooda.Didoo;
+
+import static java.lang.Exception.*;
+import static java.lang.Runnable.*;
+
+import static com.foo.Bar;
+public class NotDeletedByFormatter {
+}
+import will.not;
+import be.sorted;

--- a/testlib/src/test/resources/java/importsorter/JavaCodeUnsortedMisplacedImports.test
+++ b/testlib/src/test/resources/java/importsorter/JavaCodeUnsortedMisplacedImports.test
@@ -1,0 +1,16 @@
+import static java.lang.Exception.*;
+import org.dooda.Didoo;
+/*
+public class IgnoredAndRemoved {
+}
+*/
+import java.lang.Thread;
+// Will be removed {}
+import java.lang.Runnable;
+
+import static java.lang.Runnable.*;
+import static com.foo.Bar
+public class NotDeletedByFormatter {
+}
+import will.not;
+import be.sorted;


### PR DESCRIPTION
The change shall enhance the robustness of the `java.ImportOrderStep` step.
I admit that I basically need it to use it on Groovy code (see #13), but it is also an issue in the java world:

1. If you [comment out imports](https://github.com/diffplug/spotless/blob/18af99d30d4775f6cf7e0c521bca8657bf04e008/testlib/src/test/resources/java/importsorter/JavaCodeImportComments.test#L6-L9), the `java.ImportOrderStep` step will ignore the multi-line comment and use these imports in its sorted list

2. If you have [misplaced imports](https://github.com/diffplug/spotless/blob/18af99d30d4775f6cf7e0c521bca8657bf04e008/testlib/src/test/resources/java/importsorter/JavaCodeUnsortedMisplacedImports.test#L15-L16) (still working on code, or using groovy), the `java.ImportOrderStep` will (delete all code in between)[java.ImportOrderStep].

Two improvements:

1. The `ImportSorter` stops looking for `import` statements, as soon as it finds the [beginning of a scope](https://github.com/diffplug/spotless/blob/18af99d30d4775f6cf7e0c521bca8657bf04e008/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java#L86-L92).
2. The ImportSorter gets a rough idea what multi-line comments are, so that it does not look for tokens (`{`, `import`) within multi-line comments.