### PR TITLE
Extension requiring external libraries on demand use the buildscript of the root project for lookup

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -83,6 +83,20 @@ Spotless can check and apply formatting to any plain-text file, using simple rul
 * [FreshMark](https://github.com/diffplug/freshmark) (markdown with variables)
 * Any user-defined function which takes an unformatted string and outputs a formatted version.
 
+Formatters relying on external libraries (like Eclipse and Google formatters), use the repositories specified in the **root project** build script to download missing libraries on demand. All external libraries are available via [Maven Central](http://search.maven.org/), so a typical script looks like:
+```gradle
+buildscript { repositories { mavenCentral() } }
+
+plugins {
+	id 'com.diffplug.gradle.spotless'
+	id 'java'
+}
+
+spotless {
+	java { googleJavaFormat() }
+}
+```
+
 Contributions are welcome, see [the contributing guide](../CONTRIBUTING.md) for development info.
 
 Spotless requires Gradle to be running on JRE 8+.<sup>See [issue #7](https://github.com/diffplug/spotless/issues/7) for details.</sup>

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -83,20 +83,6 @@ Spotless can check and apply formatting to any plain-text file, using simple rul
 * [FreshMark](https://github.com/diffplug/freshmark) (markdown with variables)
 * Any user-defined function which takes an unformatted string and outputs a formatted version.
 
-Formatters relying on external libraries (like Eclipse and Google formatters), use the repositories specified in the **root project** build script to download missing libraries on demand. All external libraries are available via [Maven Central](http://search.maven.org/), so a typical script looks like:
-```gradle
-buildscript { repositories { mavenCentral() } }
-
-plugins {
-	id 'com.diffplug.gradle.spotless'
-	id 'java'
-}
-
-spotless {
-	java { googleJavaFormat() }
-}
-```
-
 Contributions are welcome, see [the contributing guide](../CONTRIBUTING.md) for development info.
 
 Spotless requires Gradle to be running on JRE 8+.<sup>See [issue #7](https://github.com/diffplug/spotless/issues/7) for details.</sup>

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -23,6 +23,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 
+import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.Provisioner;
 
 /** Gradle integration for Provisioner. */
@@ -36,11 +37,16 @@ public class GradleProvisioner {
 				Dependency[] deps = mavenCoords.stream()
 						.map(project.getBuildscript().getDependencies()::create)
 						.toArray(Dependency[]::new);
-				Configuration config = project.getBuildscript().getConfigurations().detachedConfiguration(deps);
+				Configuration config = project.getRootProject().getBuildscript().getConfigurations().detachedConfiguration(deps);
 				config.setDescription(mavenCoords.toString());
 				return config.resolve();
 			} catch (Exception e) {
-				logger.log(Level.SEVERE, "You probably need to add a repository containing the '" + mavenCoords + "' artifact, e.g.: 'buildscript { repositories { mavenCentral() }}'", e);
+				logger.log(Level.SEVERE,
+						StringPrinter.buildStringFromLines("You probably need to add a repository containing the '" + mavenCoords + "' artifact in the 'build.gradle' of your root project.",
+								"E.g.: 'buildscript { repositories { mavenCentral() }}'",
+								"Note that included buildscripts (using 'apply from') do not share their buildscript repositories with the underlying project.",
+								"You have to specify the missing repository explicitly in the buildscript of the root project."),
+						e);
 				throw e;
 			}
 		};


### PR DESCRIPTION
With #99 the current project was used, which makes the resulting configuration unnecessarily complex for multi-project builds.