### PR TITLE
Add support for scalafmt >= v0.7.0-RC1

### DIFF
--- a/plugin-gradle/src/test/resources/scala/scalafmt/basic.clean
+++ b/plugin-gradle/src/test/resources/scala/scalafmt/basic.clean
@@ -9,7 +9,8 @@ object a
   def foo[
       T: Int#Double#Triple,
       R <% String](
-      @annot1 x: Int @annot2 =
+      @annot1
+      x: Int @annot2 =
         2,
       y: Int = 3)
     : Int = {

--- a/testlib/src/test/resources/scala/scalafmt/basic.clean
+++ b/testlib/src/test/resources/scala/scalafmt/basic.clean
@@ -4,7 +4,8 @@
   x + y
 })
 object a extends b with c {
-  def foo[T: Int#Double#Triple, R <% String](@annot1 x: Int @annot2 = 2,
+  def foo[T: Int#Double#Triple, R <% String](@annot1
+                                             x: Int @annot2 = 2,
                                              y: Int = 3): Int = {
     "match" match {
       case 1 | 2 =>

--- a/testlib/src/test/resources/scala/scalafmt/basic.cleanWithCustomConf
+++ b/testlib/src/test/resources/scala/scalafmt/basic.cleanWithCustomConf
@@ -9,7 +9,8 @@ object a
   def foo[
       T: Int#Double#Triple,
       R <% String](
-      @annot1 x: Int @annot2 =
+      @annot1
+      x: Int @annot2 =
         2,
       y: Int = 3)
     : Int = {


### PR DESCRIPTION
In scalafmt v0.7.0-RC1 the configuration API has been changed a little bit. This PR adds a pourman's  switch (`try... catch...`) to support both older and new versions.

- Add support for scalafmt >= v0.7.0-RC1
- Still supports scalafmt <= v0.6.8
- Make v1.1.0 the default scalafmt version