### PR TITLE
Fix licenseHeader for Kotlin code starting with `@file:...`

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.6.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Fix licenseHeader so it works with Kotlin files starting with `@file:...` instead of `package ...` ([#136](https://github.com/diffplug/spotless/issues/136)).
+
 ### Version 3.5.1 - August 14th 2017 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.5.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.5.1))
 
 * Fixed `kotlinGradle` linting [Gradle Kotlin DSL](https://github.com/gradle/kotlin-dsl) files throwing `ParseException` ([#132](https://github.com/diffplug/spotless/issues/132)).

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -25,8 +25,8 @@ import org.gradle.api.tasks.SourceSet;
 import com.diffplug.spotless.kotlin.KtLintStep;
 
 public class KotlinExtension extends FormatExtension {
-	// The delimiter has the '^' prepended to the regex where the pattern is compiled.
-	static final String LICENSE_HEADER_DELIMITER = "(package |@file)";
+	// '^' is prepended to the regex in LICENSE_HEADER_DELIMITER later in FormatExtension.licenseHeader(String, String)
+	private static final String LICENSE_HEADER_DELIMITER = "(package |@file)";
 	static final String NAME = "kotlin";
 
 	public KotlinExtension(SpotlessExtension rootExtension) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -25,6 +25,8 @@ import org.gradle.api.tasks.SourceSet;
 import com.diffplug.spotless.kotlin.KtLintStep;
 
 public class KotlinExtension extends FormatExtension {
+	// The delimiter has the '^' prepended to the regex where the pattern is compiled.
+	static final String LICENSE_HEADER_DELIMITER = "(package |@file)";
 	static final String NAME = "kotlin";
 
 	public KotlinExtension(SpotlessExtension rootExtension) {
@@ -32,11 +34,11 @@ public class KotlinExtension extends FormatExtension {
 	}
 
 	public void licenseHeader(String licenseHeader) {
-		licenseHeader(licenseHeader, JavaExtension.LICENSE_HEADER_DELIMITER);
+		licenseHeader(licenseHeader, LICENSE_HEADER_DELIMITER);
 	}
 
 	public void licenseHeaderFile(Object licenseHeaderFile) {
-		licenseHeaderFile(licenseHeaderFile, JavaExtension.LICENSE_HEADER_DELIMITER);
+		licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
 	}
 
 	/** Adds the specified version of [ktlint](https://github.com/shyiko/ktlint). */

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -15,12 +15,16 @@
  */
 package com.diffplug.gradle.spotless;
 
+import java.io.File;
 import java.io.IOException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class KotlinExtensionTest extends GradleIntegrationTest {
+	private static final String HEADER = "// License Header";
+
 	@Test
 	public void integration() throws IOException {
 		write("build.gradle",
@@ -39,5 +43,30 @@ public class KotlinExtensionTest extends GradleIntegrationTest {
 		String result = read("src/main/kotlin/basic.kt");
 		String formatted = getTestResource("kotlin/ktlint/basic.clean");
 		Assert.assertEquals(formatted, result);
+	}
+
+	@Test
+	public void testWithHeader() throws IOException {
+		write("build.gradle",
+				"plugins {",
+				"    id 'nebula.kotlin' version '1.0.6'",
+				"    id 'com.diffplug.gradle.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        licenseHeader('" + HEADER + "')",
+				"        ktlint()",
+				"    }",
+				"}");
+		final File testFile = write("src/main/kotlin/test.kt", getTestResource("kotlin/licenseheader/KotlinCodeWithoutHeader.test"));
+		final String original = read(testFile.toPath());
+		gradleRunner().withArguments("spotlessApply").build();
+		final String result = read(testFile.toPath());
+		// Make sure the header gets added.
+		Assertions.assertThat(result).startsWith(HEADER);
+		// Make sure that the rest of the file is still there with nothing removed.
+		Assertions.assertThat(result).endsWith(original);
+
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -63,10 +63,13 @@ public class KotlinExtensionTest extends GradleIntegrationTest {
 		final String original = read(testFile.toPath());
 		gradleRunner().withArguments("spotlessApply").build();
 		final String result = read(testFile.toPath());
-		// Make sure the header gets added.
-		Assertions.assertThat(result).startsWith(HEADER);
-		// Make sure that the rest of the file is still there with nothing removed.
-		Assertions.assertThat(result).endsWith(original);
-
+		Assertions
+				.assertThat(result)
+				// Make sure the header gets added.
+				.startsWith(HEADER)
+				// Make sure that the rest of the file is still there with nothing removed.
+				.endsWith(original)
+				// Make sure that no additional stuff got added to the file.
+				.contains(HEADER + '\n' + original);
 	}
 }

--- a/plugin-gradle/src/test/resources/kotlin/licenseheader/KotlinCodeWithoutHeader.test
+++ b/plugin-gradle/src/test/resources/kotlin/licenseheader/KotlinCodeWithoutHeader.test
@@ -1,0 +1,4 @@
+@file:JvmName("SomeFileName")
+package my.test
+
+object AnObject { }


### PR DESCRIPTION
Closes #136