### PR TITLE
fix readme on how to use sql extension

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -265,10 +265,10 @@ spotless {
 ```gradle
 spotless {
 	sql {
-		// you have to specify the target
+		// default value for target files
 		target '**/*.sql'
 		// configFile is optional, arguments available here: https://github.com/diffplug/spotless/blob/master/lib/src/main/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStep.java
-		dbeaverSql().configFile('dbeaver.props')
+		dbeaver().configFile('dbeaver.props')
 	}
 }
 ```


### PR DESCRIPTION
The dbeaver formatter is configured using `dbeaver()` instead of
`dbeaverSql()` as mentioned in the README
(see com.diffplug.gradle.spotless.SqlExtensionTest)

Also the target configuration is optional and is configured to `**/*.sql` by default