### PR TITLE
Fixed some newline issues for running tests on Windows

### DIFF
--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java
@@ -78,10 +78,10 @@ public class EncodingTest extends GradleIntegrationTest {
 				"}");
 		write("test.java", "µ");
 		write("utf32.encoded", LineEnding.UNIX, Charset.forName("UTF-32"), "µ");
-		Assert.assertEquals("µ\n", read("utf32.encoded", LineEnding.UNIX, Charset.forName("UTF-32")));
+		Assert.assertEquals("µ\n", read("utf32.encoded", Charset.forName("UTF-32")));
 
 		gradleRunner().withArguments("spotlessApply").build();
 		Assert.assertEquals("??\n", read("test.java"));
-		Assert.assertEquals("A\n", read("utf32.encoded", LineEnding.UNIX, Charset.forName("UTF-32")));
+		Assert.assertEquals("A\n", read("utf32.encoded", Charset.forName("UTF-32")));
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
@@ -27,11 +27,8 @@ import org.junit.Test;
 
 import com.diffplug.common.base.Errors;
 import com.diffplug.common.base.StringPrinter;
-import com.diffplug.spotless.LineEnding;
 
 public class GradleIncrementalResolutionTest extends GradleIntegrationTest {
-	private static final boolean IS_UNIX = LineEnding.PLATFORM_NATIVE.str().equals("\n");
-
 	@Test
 	public void failureDoesntTriggerAll() throws IOException {
 		write("build.gradle",
@@ -60,9 +57,9 @@ public class GradleIncrementalResolutionTest extends GradleIntegrationTest {
 		checkRanAgainst("abc");
 		// apply will run against all three the first time
 		applyRanAgainst("abc");
-		// for some reason, it appears unix has higher resolution on which files need to be checked
-		applyRanAgainst(IS_UNIX ? "b" : "abc");
-		// but nobody the last time
+		// the second time, it will only run on the file that was changes
+		applyRanAgainst("b");
+		// and nobody the last time
 		applyRanAgainst("");
 
 		// if we change just one file

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
@@ -27,6 +27,7 @@ import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Assert;
+import org.junit.Before;
 
 import com.diffplug.common.base.Errors;
 import com.diffplug.common.base.StringPrinter;
@@ -36,6 +37,11 @@ import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.ResourceHarness;
 
 public class GradleIntegrationTest extends ResourceHarness {
+	@Before
+	public void gitAttributes() throws IOException {
+		write(".gitattributes", "* text eol=lf");
+	}
+
 	protected GradleRunner gradleRunner() throws IOException {
 		return GradleRunner.create().withProjectDir(rootFolder()).withPluginClasspath();
 	}

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -110,31 +110,20 @@ public class ResourceHarness {
 		return Assertions.assertThat(newFile(path)).usingCharset(StandardCharsets.UTF_8);
 	}
 
-	protected String read(Path path) throws IOException {
-		return read(path, LineEnding.UNIX);
-	}
-
 	protected String read(String path) throws IOException {
-		return read(path, LineEnding.UNIX);
+		return read(newFile(path).toPath());
 	}
 
-	protected String read(String path, LineEnding ending) throws IOException {
-		return read(path, ending, StandardCharsets.UTF_8);
+	protected String read(Path path) throws IOException {
+		return read(path, StandardCharsets.UTF_8);
 	}
 
-	protected String read(Path path, LineEnding ending) throws IOException {
-		return read(path, ending, StandardCharsets.UTF_8);
+	protected String read(String path, Charset encoding) throws IOException {
+		return read(newFile(path).toPath(), encoding);
 	}
 
-	protected String read(String path, LineEnding ending, Charset encoding) throws IOException {
-		Path target = newFile(path).toPath();
-		return read(target, ending, encoding);
-	}
-
-	protected String read(Path path, LineEnding ending, Charset encoding) throws IOException {
-		String content = new String(Files.readAllBytes(path), encoding);
-		String allUnixNewline = LineEnding.toUnix(content);
-		return allUnixNewline.replace("\n", ending.str());
+	protected String read(Path path, Charset encoding) throws IOException {
+		return new String(Files.readAllBytes(path), encoding);
 	}
 
 	protected void replace(String path, String toReplace, String replaceWith) throws IOException {

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -34,7 +34,10 @@ public class StepHarness {
 
 	/** Creates a harness for testing steps which don't depend on the file. */
 	public static StepHarness forStep(FormatterStep step) {
-		return new StepHarness(input -> step.format(input, new File("")));
+		// We don't care if an individual FormatterStep is misbehaving on line-endings, because
+		// Formatter fixes that.  No reason to care in tests either.  It's likely to pop up when
+		// running tests on Windows from time-to-time
+		return new StepHarness(input -> LineEnding.toUnix(step.format(input, new File(""))));
 	}
 
 	/** Creates a harness for testing a formatter whose steps don't depend on the file. */


### PR DESCRIPTION
Spotless' CI only run on Linux, so it doesn't run on Windows very often.  Spotless doesn't have any known Windows bugs, but if you checkout the Spotless repo and ran the tests, a lot of them would fail because of line-endings issues.

This fixes them.