### PR TITLE
Support for google-java-format's style option (AOSP style)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ You might be looking for:
 * Updated default ktlint from 0.6.1 to 0.14.0
 * Updated default google-java-format from 1.3 to 1.5
 * Updated default eclipse-jdt from 4.7.1 to 4.7.2
+* Added a configuration option to `googleJavaFormat` to switch the formatter style ([#193](https://github.com/diffplug/spotless/pull/193))
 
 ### Version 1.8.0 - January 2nd 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.8.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.8.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,8 @@
 * Updated default ktlint from 0.6.1 to 0.14.0
 * Updated default google-java-format from 1.3 to 1.5
 * Updated default eclipse-jdt from 4.7.1 to 4.7.2
+* Added a configuration option to `googleJavaFormat` to switch the formatter style ([#193](https://github.com/diffplug/spotless/pull/193))
+  + Use `googleJavaFormat().aosp()` to use AOSP-compliant style (4-space indentation) instead of the default Google Style
 
 ### Version 3.8.0 - January 2nd 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.8.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.8.0))
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -147,7 +147,9 @@ spotless {
 ```gradle
 spotless {
   java {
-    googleJavaFormat() // googleJavaFormat('1.1') to specify a specific version
+    googleJavaFormat()
+    // optional: you can specify a specific version and/or switch to AOSP style
+    googleJavaFormat('1.1').aosp()
     // you can then layer other format steps, such as
     licenseHeaderFile 'spotless.license.java'
   }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -100,8 +100,8 @@ public class JavaExtension extends FormatExtension {
 	}
 
 	/** Uses the [google-java-format](https://github.com/google/google-java-format) jar to format source code. */
-	public void googleJavaFormat() {
-		googleJavaFormat(GoogleJavaFormatStep.defaultVersion());
+	public GoogleJavaFormatConfig googleJavaFormat() {
+		return googleJavaFormat(GoogleJavaFormatStep.defaultVersion());
 	}
 
 	/**
@@ -110,9 +110,36 @@ public class JavaExtension extends FormatExtension {
 	 * Limited to published versions.  See [issue #33](https://github.com/diffplug/spotless/issues/33#issuecomment-252315095)
 	 * for an workaround for using snapshot versions.
 	 */
-	public void googleJavaFormat(String version) {
+	public GoogleJavaFormatConfig googleJavaFormat(String version) {
 		Objects.requireNonNull(version);
-		addStep(GoogleJavaFormatStep.create(version, GradleProvisioner.fromProject(getProject())));
+		return new GoogleJavaFormatConfig(version);
+	}
+
+	public class GoogleJavaFormatConfig {
+		final String version;
+		String style;
+
+		GoogleJavaFormatConfig(String version) {
+			this.version = Objects.requireNonNull(version);
+			this.style = GoogleJavaFormatStep.defaultStyle();
+			addStep(createStep());
+		}
+
+		public void style(String style) {
+			this.style = Objects.requireNonNull(style);
+			replaceStep(createStep());
+		}
+
+		public void aosp() {
+			style("AOSP");
+		}
+
+		private FormatterStep createStep() {
+			Project project = getProject();
+			return GoogleJavaFormatStep.create(version,
+					style,
+					GradleProvisioner.fromProject(project));
+		}
 	}
 
 	public EclipseConfig eclipse() {

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -37,9 +37,20 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
+	public void behaviorWithAospStyle() throws Exception {
+		FormatterStep step = GoogleJavaFormatStep.create("1.2", "AOSP", TestProvisioner.mavenCentral());
+		StepHarness.forStep(step)
+				.testResource("java/googlejavaformat/JavaCodeUnformatted.test", "java/googlejavaformat/JavaCodeFormattedAOSP.test")
+				.testResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test", "java/googlejavaformat/JavaCodeWithLicenseFormattedAOSP.test")
+				.testResource("java/googlejavaformat/JavaCodeWithLicensePackageUnformatted.test", "java/googlejavaformat/JavaCodeWithLicensePackageFormattedAOSP.test")
+				.testResource("java/googlejavaformat/JavaCodeWithPackageUnformatted.test", "java/googlejavaformat/JavaCodeWithPackageFormattedAOSP.test");
+	}
+
+	@Test
 	public void equality() throws Exception {
 		new SerializableEqualityTester() {
 			String version = "1.2";
+			String style = "";
 
 			@Override
 			protected void setupTest(API api) {
@@ -48,12 +59,15 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 				// change the version, and it's different
 				version = "1.1";
 				api.areDifferentThan();
+				// change the style, and it's different
+				style = "AOSP";
+				api.areDifferentThan();
 			}
 
 			@Override
 			protected FormatterStep create() {
 				String finalVersion = this.version;
-				return GoogleJavaFormatStep.create(finalVersion, TestProvisioner.mavenCentral());
+				return GoogleJavaFormatStep.create(finalVersion, style, TestProvisioner.mavenCentral());
 			}
 		}.testEquals();
 	}

--- a/testlib/src/test/resources/java/googlejavaformat/JavaCodeFormattedAOSP.test
+++ b/testlib/src/test/resources/java/googlejavaformat/JavaCodeFormattedAOSP.test
@@ -1,0 +1,11 @@
+
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+    public static void main(String[] args) {
+        System.out.println("hello");
+        UsedB.someMethod();
+        UsedA.someMethod();
+    }
+}

--- a/testlib/src/test/resources/java/googlejavaformat/JavaCodeWithLicenseFormattedAOSP.test
+++ b/testlib/src/test/resources/java/googlejavaformat/JavaCodeWithLicenseFormattedAOSP.test
@@ -1,0 +1,15 @@
+/*
+ * Some license stuff.
+ * Very official.
+ */
+
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+    public static void main(String[] args) {
+        System.out.println("hello");
+        UsedB.someMethod();
+        UsedA.someMethod();
+    }
+}

--- a/testlib/src/test/resources/java/googlejavaformat/JavaCodeWithLicensePackageFormattedAOSP.test
+++ b/testlib/src/test/resources/java/googlejavaformat/JavaCodeWithLicensePackageFormattedAOSP.test
@@ -1,0 +1,12 @@
+package hello.world;
+
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+    public static void main(String[] args) {
+        System.out.println("hello");
+        UsedB.someMethod();
+        UsedA.someMethod();
+    }
+}

--- a/testlib/src/test/resources/java/googlejavaformat/JavaCodeWithPackageFormattedAOSP.test
+++ b/testlib/src/test/resources/java/googlejavaformat/JavaCodeWithPackageFormattedAOSP.test
@@ -1,0 +1,12 @@
+package hello.world;
+
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+    public static void main(String[] args) {
+        System.out.println("hello");
+        UsedB.someMethod();
+        UsedA.someMethod();
+    }
+}


### PR DESCRIPTION
The google-java-format CLI exposes an option `--aosp` to switch from the default Google Java Style to AOSP-compliant style (4-space indentation).  Such a configuration option is missing from Spotless.

This PR adds a corresponding configuration option to Spotloss:

```
spotless {
  java {
    googleJavaFormat().aosp()
  }
}
```

Internally, google-java-format implements the style option as an [enum](
https://github.com/google/google-java-format/blob/ffd249435da670ceac70488975c81b24257f01a6/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java#L34) class. Therefore, I've added a second, more general configuration option to switch to any possible enum value. However, as of version 1.5, the only values are `GOOGLE` (default) and `AOSP`.

```
spotless {
  java {
    googleJavaFormat('1.5').style('AOSP')
  }
}
```
