### PR TITLE
Allow custom separator for years in license header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ You might be looking for:
 
 ### Version 1.10.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* LicenseHeaderStep now supports customizing the year range separator in copyright notices. ([#199](https://github.com/diffplug/spotless/pull/199))
+
 ### Version 1.9.0 - February 5th 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.9.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.9.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Updated default ktlint from 0.6.1 to 0.14.0

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.10.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* LicenseHeaderStep now supports customizing the year range separator in copyright notices. ([#199](https://github.com/diffplug/spotless/pull/199)
+
 ### Version 3.9.0 - February 5th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.9.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.9.0))
 
 * Updated default ktlint from 0.6.1 to 0.14.0

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -307,9 +307,21 @@ The `licenseHeader` and `licenseHeaderFile` steps will generate license headers 
 * A generated license header will _not_ be updated when
   * a single year is already present, e.g.
   `/* Licensed under Apache-2.0 1990. */`
-  * a hyphen-separated year range is already present, e.g.
+  * a year range is already present, e.g.
   `/* Licensed under Apache-2.0 1990-2003. */`
   * the `$YEAR` token is otherwise missing
+
+The separator for the year range defaults to the hyphen character, e.g `1990-2003`, but can be customized with the `yearSeparator` property.
+
+For instance, the following configuration treats `1990, 2003` as a valid year range.
+
+```gradle
+spotless {
+  format java {
+     licenseHeader(''Licensed under Apache-2.0 $YEAR').yearSeparator(', ')
+  }
+}
+```
 
 
 <a name="custom"></a>

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -345,26 +345,90 @@ public class FormatExtension {
 		indentWithTabs(4);
 	}
 
+	abstract class LicenseHeaderConfig {
+
+		String delimiter;
+		String yearSeparator;
+
+		public LicenseHeaderConfig(String delimiter) {
+			this.delimiter = Objects.requireNonNull(delimiter, "delimiter");
+		}
+
+		/**
+		 * @param delimiter
+		 *            Spotless will look for a line that starts with this regular expression pattern to know what the "top" is.
+		 */
+		public LicenseHeaderConfig delimiter(String delimiter) {
+			this.delimiter = Objects.requireNonNull(delimiter, "delimiter");
+			replaceStep(createStep());
+			return this;
+		}
+
+		/**
+		 * @param yearSeparator
+		 *           The characters used to separate the first and last years in multi years patterns.
+		 */
+		public LicenseHeaderConfig yearSeparator(String yearSeparator) {
+			this.yearSeparator = Objects.requireNonNull(yearSeparator, "yearSeparator");
+			replaceStep(createStep());
+			return this;
+		}
+
+		abstract FormatterStep createStep();
+	}
+
+	class LicenseStringHeaderConfig extends LicenseHeaderConfig {
+
+		private String header;
+
+		LicenseStringHeaderConfig(String delimiter, String header) {
+			super(delimiter);
+			this.header = Objects.requireNonNull(header, "header");
+		}
+
+		FormatterStep createStep() {
+			return LicenseHeaderStep.createFromHeader(header, delimiter, yearSeparator);
+		}
+	}
+
+	class LicenseFileHeaderConfig extends LicenseHeaderConfig {
+
+		private Object headerFile;
+
+		LicenseFileHeaderConfig(String delimiter, Object headerFile) {
+			super(delimiter);
+			this.headerFile = Objects.requireNonNull(headerFile, "headerFile");
+		}
+
+		FormatterStep createStep() {
+			return LicenseHeaderStep
+					.createFromFile(getProject().file(headerFile), getEncoding(), delimiter,
+							yearSeparator);
+		}
+	}
+
 	/**
 	 * @param licenseHeader
-	 *            Content that should be at the top of every file
+	 *            Content that should be at the top of every file.
 	 * @param delimiter
-	 *            Spotless will look for a line that starts with this to know what the "top" is.
+	 *            Spotless will look for a line that starts with this regular expression pattern to know what the "top" is.
 	 */
-	public void licenseHeader(String licenseHeader, String delimiter) {
-		addStep(LicenseHeaderStep.createFromHeader(licenseHeader, delimiter));
+	public LicenseHeaderConfig licenseHeader(String licenseHeader, String delimiter) {
+		LicenseHeaderConfig config = new LicenseStringHeaderConfig(delimiter, licenseHeader);
+		addStep(config.createStep());
+		return config;
 	}
 
 	/**
 	 * @param licenseHeaderFile
-	 *            Content that should be at the top of every file
+	 *            Content that should be at the top of every file.
 	 * @param delimiter
-	 *            Spotless will look for a line that starts with this to know what the "top" is.
+	 *            Spotless will look for a line that starts with this regular expression pattern to know what the "top" is.
 	 */
-	public void licenseHeaderFile(Object licenseHeaderFile, String delimiter) {
-		Objects.requireNonNull(licenseHeaderFile, "licenseHeaderFile");
-		Objects.requireNonNull(delimiter, "delimiter");
-		addStep(LicenseHeaderStep.createFromFile(getProject().file(licenseHeaderFile), getEncoding(), delimiter));
+	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile, String delimiter) {
+		LicenseHeaderConfig config = new LicenseFileHeaderConfig(delimiter, licenseHeaderFile);
+		addStep(config.createStep());
+		return config;
 	}
 
 	/** Sets up a format task according to the values in this extension. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -55,12 +55,12 @@ public class GroovyExtension extends FormatExtension {
 		this.excludeJava = excludeJava;
 	}
 
-	public void licenseHeader(String licenseHeader) {
-		licenseHeader(licenseHeader, JavaExtension.LICENSE_HEADER_DELIMITER);
+	public LicenseHeaderConfig licenseHeader(String licenseHeader) {
+		return licenseHeader(licenseHeader, JavaExtension.LICENSE_HEADER_DELIMITER);
 	}
 
-	public void licenseHeaderFile(Object licenseHeaderFile) {
-		licenseHeaderFile(licenseHeaderFile, JavaExtension.LICENSE_HEADER_DELIMITER);
+	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile) {
+		return licenseHeaderFile(licenseHeaderFile, JavaExtension.LICENSE_HEADER_DELIMITER);
 	}
 
 	/** Method interface has been changed to

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -46,12 +46,12 @@ public class JavaExtension extends FormatExtension {
 	// testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java as well
 	static final String LICENSE_HEADER_DELIMITER = "package ";
 
-	public void licenseHeader(String licenseHeader) {
-		licenseHeader(licenseHeader, LICENSE_HEADER_DELIMITER);
+	public LicenseHeaderConfig licenseHeader(String licenseHeader) {
+		return licenseHeader(licenseHeader, LICENSE_HEADER_DELIMITER);
 	}
 
-	public void licenseHeaderFile(Object licenseHeaderFile) {
-		licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
+	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile) {
+		return licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
 	}
 
 	/** Method interface has been changed to

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -33,12 +33,12 @@ public class KotlinExtension extends FormatExtension {
 		super(rootExtension);
 	}
 
-	public void licenseHeader(String licenseHeader) {
-		licenseHeader(licenseHeader, LICENSE_HEADER_DELIMITER);
+	public LicenseHeaderConfig licenseHeader(String licenseHeader) {
+		return licenseHeader(licenseHeader, LICENSE_HEADER_DELIMITER);
 	}
 
-	public void licenseHeaderFile(Object licenseHeaderFile) {
-		licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
+	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile) {
+		return licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
 	}
 
 	/** Adds the specified version of [ktlint](https://github.com/shyiko/ktlint). */

--- a/plugin-gradle/src/test/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader.test
+++ b/plugin-gradle/src/test/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader.test
@@ -1,0 +1,5 @@
+// License Header 2012, 2014
+@file:JvmName("SomeFileName")
+package my.test
+
+object AnObject

--- a/plugin-gradle/src/test/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader2.test
+++ b/plugin-gradle/src/test/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader2.test
@@ -1,0 +1,5 @@
+// License Header 2012-2014
+@file:JvmName("SomeFileName")
+package my.test
+
+object AnObject

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -66,6 +66,36 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				.test(fileWithPlaceholderContaining("not a year"), fileWithPlaceholderContaining(currentYear()));
 	}
 
+	@Test
+	public void should_apply_license_containing_YEAR_token_with_non_default_year_separator() throws Throwable {
+		FormatterStep step = LicenseHeaderStep.createFromFile(createTestFile(KEY_LICENSE_WITH_YEAR_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, ", ");
+
+		StepHarness.forStep(step)
+				.testUnaffected(fileWithPlaceholderContaining("1990, 2015"))
+				.test(fileWithPlaceholderContaining("1990-2015"), fileWithPlaceholderContaining(currentYear()));
+	}
+
+	@Test
+	public void should_apply_license_containing_YEAR_token_with_special_character_in_year_separator() throws Throwable {
+		FormatterStep step = LicenseHeaderStep.createFromFile(createTestFile(KEY_LICENSE_WITH_YEAR_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, "(");
+
+		StepHarness.forStep(step)
+				.testUnaffected(fileWithPlaceholderContaining("1990(2015"))
+				.test(fileWithPlaceholderContaining("1990-2015"), fileWithPlaceholderContaining(currentYear()));
+	}
+
+	@Test
+	public void should_apply_license_containing_YEAR_token_with_custom_separator() throws Throwable {
+		FormatterStep step = LicenseHeaderStep.createFromFile(createTestFile(KEY_LICENSE_WITH_YEAR_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
+
+		StepHarness.forStep(step)
+				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithPlaceholderContaining(currentYear()))
+				.testUnaffected(fileWithPlaceholderContaining(currentYear()))
+				.testUnaffected(fileWithPlaceholderContaining("2003"))
+				.testUnaffected(fileWithPlaceholderContaining("1990-2015"))
+				.test(fileWithPlaceholderContaining("not a year"), fileWithPlaceholderContaining(currentYear()));
+	}
+
 	private String fileWithPlaceholderContaining(String placeHolderContent) throws IOException {
 		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__PLACEHOLDER__", placeHolderContent);
 	}


### PR DESCRIPTION
I've recently noticed the support for YEAR templates in license headers.

Unfortunately our code doesn't use the hyphen character but coma to separate year ranges (for example https://github.com/delphix/delphix-os/blob/a0f0d0dd2ed6832f0cca929a44b71bd8f33fee32/usr/src/uts/common/fs/zfs/dmu_zfetch.c#L27)

In this review, we are adding support in the library and gradle-plugin to configure the separator. 

Instead of adding a third optional argument to the licenseHeader/licenseHeaderFile gradle configurations, we're creating a license header extension object which can be used as

```
format java {
  licenseHeader {
    header 'some-string'
    delimiter 'package'
    yearSeparator '-'
  }
}
```

However, both because most users won't need the advanced configuration and for backwards compatibility, we're maintaining support for the the existing syntax (the implementation always creates the extension, but that is transparent to users).

We've updated the Gradle plugin README.md to document and new feature and provide examples of both the simple (one line) and advanced (with licenseHeader extension) syntaxes.

We've updated the unit test for the license header step to cover the new feature, and updated the KotlinExtensionTest to cover the new gradle syntax (It appears that this is the only test covering the license header in the gradle plugin).