### PR TITLE
Migrate away from Gradle-internal Task#execute to our own method

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.11.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Migrated `plugin-gradle`'s tests away from `TaskInternal#execute` to an custom method to help with Gradle 5.0 migration later on.
+
 ### Version 3.10.0 - February 15th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.10.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.10.0))
 
 * LicenseHeaderStep now supports customizing the year range separator in copyright notices. ([#199](https://github.com/diffplug/spotless/pull/199)

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,11 +2,11 @@
 
 ### Version 3.11.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
-* Migrated `plugin-gradle`'s tests away from `TaskInternal#execute` to an custom method to help with Gradle 5.0 migration later on.
+* Migrated `plugin-gradle`'s tests away from `TaskInternal#execute` to a custom method to help with Gradle 5.0 migration later on. ([#208](https://github.com/diffplug/spotless/pull/208))
 
 ### Version 3.10.0 - February 15th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.10.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.10.0))
 
-* LicenseHeaderStep now supports customizing the year range separator in copyright notices. ([#199](https://github.com/diffplug/spotless/pull/199)
+* LicenseHeaderStep now supports customizing the year range separator in copyright notices. ([#199](https://github.com/diffplug/spotless/pull/199))
 
 ### Version 3.9.0 - February 5th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.9.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.9.0))
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static com.diffplug.gradle.spotless.Tasks.execute;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -25,7 +27,6 @@ import java.util.regex.Pattern;
 import org.assertj.core.api.Assertions;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
-import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Test;
 
@@ -49,7 +50,7 @@ public class DiffMessageFormatterTest extends ResourceHarness {
 		return task;
 	}
 
-	private void assertTaskFailure(SpotlessTask task, String... expectedLines) {
+	private void assertTaskFailure(SpotlessTask task, String... expectedLines) throws Exception {
 		String msg = getTaskErrorMessage(task);
 
 		String firstLine = "The following files had format violations:\n";
@@ -61,13 +62,12 @@ public class DiffMessageFormatterTest extends ResourceHarness {
 		Assertions.assertThat(middle).isEqualTo(expectedMessage.substring(0, expectedMessage.length() - 1));
 	}
 
-	protected String getTaskErrorMessage(SpotlessTask task) {
+	protected String getTaskErrorMessage(SpotlessTask task) throws Exception {
 		try {
-			task.execute();
-			throw new AssertionError("Expected a TaskExecutionException");
-		} catch (TaskExecutionException e) {
-			GradleException cause = (GradleException) e.getCause();
-			return cause.getMessage();
+			execute(task);
+			throw new AssertionError("Expected a GradleException");
+		} catch (GradleException e) {
+			return e.getMessage();
 		}
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static com.diffplug.gradle.spotless.Tasks.execute;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -44,26 +46,26 @@ public class FormatTaskTest extends ResourceHarness {
 	}
 
 	@Test(expected = GradleException.class)
-	public void testLineEndingsCheckFail() throws IOException {
+	public void testLineEndingsCheckFail() throws Exception {
 		checkTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 		checkTask.setTarget(Collections.singleton(setFile("testFile").toContent("\r\n")));
-		checkTask.execute();
+		execute(checkTask);
 	}
 
 	@Test
-	public void testLineEndingsCheckPass() throws IOException {
+	public void testLineEndingsCheckPass() throws Exception {
 		checkTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 		checkTask.setTarget(Collections.singleton(setFile("testFile").toContent("\n")));
-		checkTask.execute();
+		execute(checkTask);
 	}
 
 	@Test
-	public void testLineEndingsApply() throws IOException {
+	public void testLineEndingsApply() throws Exception {
 		File testFile = setFile("testFile").toContent("\r\n");
 
 		applyTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 		applyTask.setTarget(Collections.singleton(testFile));
-		applyTask.execute();
+		execute(applyTask);
 
 		assertFile(testFile).hasContent("\n");
 	}
@@ -79,29 +81,29 @@ public class FormatTaskTest extends ResourceHarness {
 				"        @@ -1 +1 @@",
 				"        -apple",
 				"        +aple");
-		Assertions.assertThatThrownBy(() -> checkTask.execute()).hasStackTraceContaining(diff);
+		Assertions.assertThatThrownBy(() -> execute(checkTask)).hasStackTraceContaining(diff);
 
 		assertFile(testFile).hasContent("apple");
 	}
 
 	@Test
-	public void testStepCheckPass() throws IOException {
+	public void testStepCheckPass() throws Exception {
 		File testFile = setFile("testFile").toContent("aple");
 		checkTask.setTarget(Collections.singleton(testFile));
 
 		checkTask.addStep(FormatterStep.createNeverUpToDate("double-p", content -> content.replace("pp", "p")));
-		checkTask.execute();
+		execute(checkTask);
 
 		assertFile(testFile).hasContent("aple");
 	}
 
 	@Test
-	public void testStepApply() throws IOException {
+	public void testStepApply() throws Exception {
 		File testFile = setFile("testFile").toContent("apple");
 		applyTask.setTarget(Collections.singleton(testFile));
 
 		applyTask.addStep(FormatterStep.createNeverUpToDate("double-p", content -> content.replace("pp", "p")));
-		applyTask.execute();
+		execute(applyTask);
 
 		assertFile(testFile).hasContent("aple");
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Tasks.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Tasks.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.diffplug.gradle.spotless;
 
 final class Tasks {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Tasks.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Tasks.java
@@ -1,0 +1,9 @@
+package com.diffplug.gradle.spotless;
+
+final class Tasks {
+	private Tasks() {}
+
+	static void execute(SpotlessTask task) throws Exception {
+		task.performAction(Mocks.mockIncrementalTaskInputs(task.getTarget()));
+	}
+}


### PR DESCRIPTION
As per the commit message, the purpose of this PR is as follows:

```text
Previously, plugin-gradle's tests produced warning messages saying that
"The TaskInternal.execute() method has been deprecated and is scheduled
to be removed in Gradle 5.0". This commit is an attempt to fix that so
that we're better prepared to migrate to Gradle 5.0 when it arrives.
```