### PR TITLE
Bugfix for Maven's FileLocatorTest on windows

### DIFF
--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -102,7 +102,6 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		process(files, formatter);
 	}
 
-	@SuppressWarnings("unchecked")
 	private List<File> collectFiles(FormatterFactory formatterFactory) throws MojoExecutionException {
 		Set<String> configuredIncludes = formatterFactory.includes();
 		Set<String> configuredExcludes = formatterFactory.excludes();

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/FileLocatorTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/FileLocatorTest.java
@@ -20,13 +20,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 
 import org.codehaus.plexus.resource.ResourceManager;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import com.diffplug.spotless.LineEnding;
 
 public class FileLocatorTest {
 
@@ -42,6 +46,8 @@ public class FileLocatorTest {
 	public void locateNull() {
 		assertNull(fileLocator.locateFile(null));
 	}
+
+	private static final boolean IS_WINDOWS = LineEnding.PLATFORM_NATIVE.str().equals("\r\n");
 
 	@Test
 	public void locateValidFile() throws Exception {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/FileLocatorTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/FileLocatorTest.java
@@ -25,12 +25,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 import org.codehaus.plexus.resource.ResourceManager;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import com.diffplug.spotless.LineEnding;
 
 public class FileLocatorTest {
 
@@ -47,19 +46,18 @@ public class FileLocatorTest {
 		assertNull(fileLocator.locateFile(null));
 	}
 
-	private static final boolean IS_WINDOWS = LineEnding.PLATFORM_NATIVE.str().equals("\r\n");
-
 	@Test
 	public void locateValidFile() throws Exception {
-		File file = new File("test-config.xml");
-		when(resourceManager.getResourceAsFile(any(), any())).thenReturn(file);
+		String path = Paths.get("tmp", "configs", "my-config.xml").toString();
+		File tmpOutputFile = new File("tmp-my-config.xml");
+		when(resourceManager.getResourceAsFile(any(), any())).thenReturn(tmpOutputFile);
 
-		File locatedFile = fileLocator.locateFile("/tmp/configs/my-config.xml");
+		File locatedFile = fileLocator.locateFile(path);
 
-		assertEquals(file, locatedFile);
+		assertEquals(tmpOutputFile, locatedFile);
 
 		ArgumentCaptor<String> argCaptor = ArgumentCaptor.forClass(String.class);
-		verify(resourceManager).getResourceAsFile(eq("/tmp/configs/my-config.xml"), argCaptor.capture());
+		verify(resourceManager).getResourceAsFile(eq(path), argCaptor.capture());
 		assertThat(argCaptor.getValue()).startsWith("my-config").endsWith(".xml");
 	}
 }


### PR DESCRIPTION
The maven plugin's FileLocatorTest currently fails on Windows.  I added the harnessing we use for fixing windows-specific tests, but I'm not sure how to actually fix it.  Feel free to push up some commits if you know how to fix it :)