### PR TITLE
Fixed maven plugin dependency on plexus-resources

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.10.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Fixed published POM to include dependency on plexus-resources ([#213](https://github.com/diffplug/spotless/pull/213)).
+
 ### Version 1.0.0.BETA3 - February 26th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.0.0.BETA3/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.0.0.BETA3))
 
 * Improved support for multi-module Maven projects ([#210](https://github.com/diffplug/spotless/pull/210)).

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -63,11 +63,13 @@ dependencies {
 		compile project(':lib')
 		compile project(':lib-extra')
 	}
+
+	compile "org.codehaus.plexus:plexus-resources:${VER_PLEXUS_RESOURCES}"
+
 	compileOnly "org.apache.maven:maven-plugin-api:${VER_MAVEN_API}"
 	compileOnly "org.apache.maven.plugin-tools:maven-plugin-annotations:${VER_MAVEN_API}"
 	compileOnly "org.eclipse.aether:aether-api:${VER_ECLIPSE_AETHER}"
 	compileOnly "org.eclipse.aether:aether-util:${VER_ECLIPSE_AETHER}"
-	compileOnly "org.codehaus.plexus:plexus-resources:${VER_PLEXUS_RESOURCES}"
 
 	testCompile project(":testlib")
 	testCompile "junit:junit:${VER_JUNIT}"


### PR DESCRIPTION
POMs for publishing to maven central are generated using `./gradlew generatePomFileForPluginMavenPublication` command. Generated POMs include compile dependencies from gradle build scripts with `<scope>compile</scope>`. Dependency `org.codehaus.plexus:plexus-resources:1.0.1` was declared as compile-only in the gradle build script. This made POM generation skip it. So published plugin did not specify all needed dependencies in it's POM, which resulted in `NoClassDefFoundError` errors.

This PR fixes the problem by declaring `plexus-resources` dependency with compile scope. Generated POM then contains it as a correct scope-compile dependency.

Fixes #212 