### PR TITLE
Fix typos in FormatExceptionPolicyStrict

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyStrict.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicyStrict.java
@@ -34,7 +34,7 @@ public class FormatExceptionPolicyStrict extends NoLambda.EqualityBasedOnSeriali
 		excludeSteps.add(Objects.requireNonNull(stepName));
 	}
 
-	/** Adds a realtive pathx to exclude. */
+	/** Adds a relative path to exclude. */
 	public void excludePath(String relativePath) {
 		excludePaths.add(Objects.requireNonNull(relativePath));
 	}


### PR DESCRIPTION
Fix typos in JavaDoc of method `excludePath(String)`.