### PR TITLE
Remove redundant null check in ResourceHarness

### DIFF
--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
@@ -196,7 +195,7 @@ public class ResourceHarness {
 
 		private WriteAsserter(File file) {
 			file.getParentFile().mkdirs();
-			this.file = Objects.requireNonNull(file);
+			this.file = file;
 		}
 
 		public File toLines(String... lines) throws IOException {


### PR DESCRIPTION
Remove the null check in constructor of WriterAsserter as the reference
being checked is guaranteed to be non-null (a NullPointerException would
be thrown in a previous statement).

I'm proposing the removal of the null check instead of moving it up in the call chain because no other null check is being done in the class (methods and ReadAsserter).