### PR TITLE
 Fix an exception when validating license with year

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ You might be looking for:
 
 ### Version 1.12.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Fixed a bug in `LicenseHeaderStep` which caused an exception with some malformed date-aware licenses. ([#222](https://github.com/diffplug/spotless/pull/222))
+
 ### Version 1.11.0 - February 26th 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.11.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.11.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Added default indentation of `4` to `IndentStep`. ([#209](https://github.com/diffplug/spotless/pull/209))

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -140,7 +140,8 @@ public final class LicenseHeaderStep implements Serializable {
 
 	private boolean matchesLicenseWithYearToken(String raw, Matcher matcher) {
 		int startOfTheSecondPart = raw.indexOf(licenseHeaderAfterYearToken);
-		return (raw.startsWith(licenseHeaderBeforeYearToken) && startOfTheSecondPart + licenseHeaderAfterYearToken.length() == matcher.start())
+		return startOfTheSecondPart > licenseHeaderBeforeYearToken.length()
+				&& (raw.startsWith(licenseHeaderBeforeYearToken) && startOfTheSecondPart + licenseHeaderAfterYearToken.length() == matcher.start())
 				&& yearMatcherPattern.matcher(raw.substring(licenseHeaderBeforeYearToken.length(), startOfTheSecondPart)).matches();
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Migrated `plugin-gradle`'s tests away from `TaskInternal#execute` to a custom method to help with Gradle 5.0 migration later on. ([#208](https://github.com/diffplug/spotless/pull/208))
 
+* Fixed a bug in `LicenseHeaderStep` which caused an exception with some malformed date-aware licenses. ([#222](https://github.com/diffplug/spotless/pull/222))
+
 ### Version 3.10.0 - February 15th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.10.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.10.0))
 
 * LicenseHeaderStep now supports customizing the year range separator in copyright notices. ([#199](https://github.com/diffplug/spotless/pull/199))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.10.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Fixed a bug in `LicenseHeaderStep` which caused an exception with some malformed date-aware licenses. ([#222](https://github.com/diffplug/spotless/pull/222))
+
 ### Version 1.0.0.BETA4 - February 27th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.0.0.BETA4/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.0.0.BETA4))
 
 * Fixed published POM to include dependency on plexus-resources ([#213](https://github.com/diffplug/spotless/pull/213)).

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.logging.Logger;
 
 import org.assertj.core.api.AbstractCharSequenceAssert;
@@ -122,11 +123,19 @@ public class ResourceHarness {
 
 	/** Returns a File (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
 	protected File createTestFile(String filename) throws IOException {
+		return createTestFile(filename, UnaryOperator.identity());
+	}
+
+	/**
+	 * Returns a File (in a temporary folder) which has the contents, possibly processed, of the given file from the
+	 * src/test/resources directory.
+	 */
+	protected File createTestFile(String filename, UnaryOperator<String> fileContentsProcessor) throws IOException {
 		int lastSlash = filename.lastIndexOf('/');
 		String name = lastSlash >= 0 ? filename.substring(lastSlash) : filename;
 		File file = newFile(name);
 		file.getParentFile().mkdirs();
-		Files.write(file.toPath(), getTestResource(filename).getBytes(StandardCharsets.UTF_8));
+		Files.write(file.toPath(), fileContentsProcessor.apply(getTestResource(filename)).getBytes(StandardCharsets.UTF_8));
 		return file;
 	}
 

--- a/testlib/src/main/resources/license/FileWithLicenseHeaderAndPlaceholder.test
+++ b/testlib/src/main/resources/license/FileWithLicenseHeaderAndPlaceholder.test
@@ -1,5 +1,5 @@
 /*
- * This is a fake license, __PLACEHOLDER__. ACME corp.
+ * __LICENSE_PLACEHOLDER__
  **/
 package com.acme;
 

--- a/testlib/src/main/resources/license/LicenseHeaderWithPlaceholder
+++ b/testlib/src/main/resources/license/LicenseHeaderWithPlaceholder
@@ -1,0 +1,3 @@
+/*
+ * __LICENSE_PLACEHOLDER__
+ **/

--- a/testlib/src/main/resources/license/LicenseHeaderWithYearToken
+++ b/testlib/src/main/resources/license/LicenseHeaderWithYearToken
@@ -1,3 +1,0 @@
-/*
- * This is a fake license, $YEAR. ACME corp.
- **/

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -33,10 +33,12 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	private static final String KEY_FILE_NOTAPPLIED = "license/MissingLicense.test";
 	private static final String KEY_FILE_APPLIED = "license/HasLicense.test";
 
-	// files to test $YEAR token replacement
-	private static final String KEY_LICENSE_WITH_YEAR_TOKEN = "license/LicenseHeaderWithYearToken";
 	private static final String KEY_FILE_WITHOUT_LICENSE = "license/FileWithoutLicenseHeader.test";
+	// Templates to test with custom license contents
+	private static final String KEY_LICENSE_WITH_PLACEHOLDER = "license/LicenseHeaderWithPlaceholder";
 	private static final String KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER = "license/FileWithLicenseHeaderAndPlaceholder.test";
+	// Licenses to test $YEAR token replacement
+	private static final String LICENSE_HEADER_YEAR = "This is a fake license, $YEAR. ACME corp.";
 
 	// If this constant changes, don't forget to change the similarly-named one in
 	// plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java as well
@@ -56,48 +58,54 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	public void should_apply_license_containing_YEAR_token() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createTestFile(KEY_LICENSE_WITH_YEAR_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
+		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
 
 		StepHarness.forStep(step)
-				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithPlaceholderContaining(currentYear()))
-				.testUnaffected(fileWithPlaceholderContaining(currentYear()))
-				.testUnaffected(fileWithPlaceholderContaining("2003"))
-				.testUnaffected(fileWithPlaceholderContaining("1990-2015"))
-				.test(fileWithPlaceholderContaining("not a year"), fileWithPlaceholderContaining(currentYear()));
+				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"))
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"))
+				.test(fileWithLicenseContaining("Something before license.*/\n/* \n * " + LICENSE_HEADER_YEAR, "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR + "\n **/\n/* Something after license.", "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "not a year"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
 	}
 
 	@Test
 	public void should_apply_license_containing_YEAR_token_with_non_default_year_separator() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createTestFile(KEY_LICENSE_WITH_YEAR_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, ", ");
+		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, ", ");
 
 		StepHarness.forStep(step)
-				.testUnaffected(fileWithPlaceholderContaining("1990, 2015"))
-				.test(fileWithPlaceholderContaining("1990-2015"), fileWithPlaceholderContaining(currentYear()));
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990, 2015"))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
 	}
 
 	@Test
 	public void should_apply_license_containing_YEAR_token_with_special_character_in_year_separator() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createTestFile(KEY_LICENSE_WITH_YEAR_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, "(");
+		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, "(");
 
 		StepHarness.forStep(step)
-				.testUnaffected(fileWithPlaceholderContaining("1990(2015"))
-				.test(fileWithPlaceholderContaining("1990-2015"), fileWithPlaceholderContaining(currentYear()));
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990(2015"))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
 	}
 
 	@Test
 	public void should_apply_license_containing_YEAR_token_with_custom_separator() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createTestFile(KEY_LICENSE_WITH_YEAR_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
+		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
 
 		StepHarness.forStep(step)
-				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithPlaceholderContaining(currentYear()))
-				.testUnaffected(fileWithPlaceholderContaining(currentYear()))
-				.testUnaffected(fileWithPlaceholderContaining("2003"))
-				.testUnaffected(fileWithPlaceholderContaining("1990-2015"))
-				.test(fileWithPlaceholderContaining("not a year"), fileWithPlaceholderContaining(currentYear()));
+				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"))
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "not a year"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
 	}
 
-	private String fileWithPlaceholderContaining(String placeHolderContent) throws IOException {
-		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__PLACEHOLDER__", placeHolderContent);
+	private File createLicenseWith(String contents) throws IOException {
+		return createTestFile(KEY_LICENSE_WITH_PLACEHOLDER, c -> c.replace("__LICENSE_PLACEHOLDER__", contents));
+	}
+
+	private String fileWithLicenseContaining(String license, String yearContent) throws IOException {
+		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__LICENSE_PLACEHOLDER__", license).replace("$YEAR", yearContent);
 	}
 
 	private String currentYear() {


### PR DESCRIPTION
Fix a `StringIndexOutOfBoundsException` in `LicenseHeaderStep` when validating if the license with a year is properly formatted, by checking if the start index of the second part of the license is greater than the length of the first part. This prevents the second part from overlapping the first, which could result in a negative length when obtaining the substring that contains the year.
The exception could happen when the year token is surrounded by the same characters, for example, "Copyright $YEAR DiffPlug", and a license containing "Copyright DiffPlug".

---
Split into two commits for easier review of the refactoring.