### PR TITLE
Correct Gradle configuration snippet

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -317,8 +317,8 @@ For instance, the following configuration treats `1990, 2003` as a valid year ra
 
 ```gradle
 spotless {
-  format java {
-     licenseHeader(''Licensed under Apache-2.0 $YEAR').yearSeparator(', ')
+  java {
+    licenseHeader('Licensed under Apache-2.0 $YEAR').yearSeparator(', ')
   }
 }
 ```


### PR DESCRIPTION
Correct snippet in README for license header with custom year separator,
remove incorrect usage/call of `format` method and remove a duplicated
single quote in the license header string.