### PR TITLE
Create a common interface for the license header

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -36,7 +36,7 @@ import com.diffplug.spotless.extra.groovy.GrEclipseFormatterStep;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
 import com.diffplug.spotless.java.ImportOrderStep;
 
-public class GroovyExtension extends FormatExtension {
+public class GroovyExtension extends FormatExtension implements SimpleLicenseHeaderExtension {
 	static final String NAME = "groovy";
 
 	public GroovyExtension(SpotlessExtension rootExtension) {
@@ -55,10 +55,12 @@ public class GroovyExtension extends FormatExtension {
 		this.excludeJava = excludeJava;
 	}
 
+	@Override
 	public LicenseHeaderConfig licenseHeader(String licenseHeader) {
 		return licenseHeader(licenseHeader, JavaExtension.LICENSE_HEADER_DELIMITER);
 	}
 
+	@Override
 	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile) {
 		return licenseHeaderFile(licenseHeaderFile, JavaExtension.LICENSE_HEADER_DELIMITER);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -35,7 +35,7 @@ import com.diffplug.spotless.java.GoogleJavaFormatStep;
 import com.diffplug.spotless.java.ImportOrderStep;
 import com.diffplug.spotless.java.RemoveUnusedImportsStep;
 
-public class JavaExtension extends FormatExtension {
+public class JavaExtension extends FormatExtension implements SimpleLicenseHeaderExtension {
 	static final String NAME = "java";
 
 	public JavaExtension(SpotlessExtension rootExtension) {
@@ -46,10 +46,12 @@ public class JavaExtension extends FormatExtension {
 	// testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java as well
 	static final String LICENSE_HEADER_DELIMITER = "package ";
 
+	@Override
 	public LicenseHeaderConfig licenseHeader(String licenseHeader) {
 		return licenseHeader(licenseHeader, LICENSE_HEADER_DELIMITER);
 	}
 
+	@Override
 	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile) {
 		return licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -26,17 +26,19 @@ import org.gradle.api.tasks.SourceSet;
 
 import com.diffplug.spotless.kotlin.KtLintStep;
 
-public class KotlinExtension extends FormatExtension {
+public class KotlinExtension extends FormatExtension implements SimpleLicenseHeaderExtension {
 	static final String NAME = "kotlin";
 
 	public KotlinExtension(SpotlessExtension rootExtension) {
 		super(rootExtension);
 	}
 
+	@Override
 	public LicenseHeaderConfig licenseHeader(String licenseHeader) {
 		return licenseHeader(licenseHeader, LICENSE_HEADER_DELIMITER);
 	}
 
+	@Override
 	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile) {
 		return licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SimpleLicenseHeaderExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SimpleLicenseHeaderExtension.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+/**
+ *
+ */
+public interface SimpleLicenseHeaderExtension {
+
+	/**
+	 * @param licenseHeader
+	 *            Content that should be at the top of every file.
+	 */
+	FormatExtension.LicenseHeaderConfig licenseHeader(String licenseHeader);
+
+	/**
+	 * @param licenseHeaderFile
+	 *            Content that should be at the top of every file.
+	 */
+	FormatExtension.LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile);
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SimpleLicenseHeaderExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SimpleLicenseHeaderExtensionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class SimpleLicenseHeaderExtensionTest extends GradleIntegrationTest {
+
+	@Test
+	public void testWithCommonInterfaceForConfiguringLicences() throws IOException {
+		// TODO: JLL Convert this to a Kotlin example when supported: https://github.com/gradle/kotlin-dsl/issues/492
+		setFile("build.gradle").toLines(
+				"import com.diffplug.gradle.spotless.SimpleLicenseHeaderExtension",
+				"plugins {",
+				"    id(\"org.jetbrains.kotlin.jvm\") version \"1.2.31\"",
+				"    id(\"com.diffplug.gradle.spotless\")",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        assert (it instanceof SimpleLicenseHeaderExtension) : \"Was `it`\"",
+				"    }",
+				"    java {",
+				"        assert (it instanceof SimpleLicenseHeaderExtension) : \"Was `it`\"",
+				"    }",
+				"}");
+		gradleRunner()
+				.withGradleVersion("4.6")
+				.withArguments("spotlessApply")
+				.forwardOutput()
+				.build();
+	}
+}


### PR DESCRIPTION
Closes #233

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/master/CHANGES.md) and [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md) which includes:

- [ ] a summary of the change
- [ ] a link to the newly created PR

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
