### PR TITLE
Require 3.1.0+ version of Maven for Maven plugin

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Require 3.1.0+ version of Maven ([#259](https://github.com/diffplug/spotless/pull/259)).
+
 ### Version 1.13.0 - June 1st 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.13.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.13.0))
 
 * Fixed a bug in configuration file resolution on Windows when file is denoted by a URL. ([#254](https://github.com/diffplug/spotless/pull/254))

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -24,7 +24,7 @@ output = [
 output = prefixDelimiterReplace(input, 'https://{{org}}.github.io/{{name}}/javadoc/spotless-plugin-maven/', '/', stableMaven)
 -->
 
-Spotless is a general-purpose formatting plugin.  It is completely à la carte, but also includes powerful "batteries-included" if you opt-in.
+Spotless is a general-purpose formatting plugin.  It is completely à la carte, but also includes powerful "batteries-included" if you opt-in. Plugin requires a version of Maven higher or equal to 3.1.0.
 
 To people who use your build, it looks like this:
 

--- a/plugin-maven/src/test/resources/pom-build.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-build.xml.mustache
@@ -9,6 +9,10 @@
 
   <name>Spotless Maven Plugin</name>
 
+  <prerequisites>
+    <maven>3.1.0</maven>
+  </prerequisites>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Such runtime requirement exists because plugin uses APIs only available starting from 3.1.0 version of Maven. They are used for artifact resolution and come from the `org.eclipse.aether` package which does not exist in < 3.1.0 Maven versions.

Requirement is declared in a `<prerequisites>` section of the POM. This section is deprecated for regular projects and should only be used by plugins to declare a minimum Maven version. Old versions will make the plugin execution fail with an error:

```
[ERROR] Failed to execute goal c.d.s:spotless-maven-plugin:X.Y.Z:apply (default-cli) on project test: The plugin c.d.s:spotless-maven-plugin:X.Y.Z requires Maven version 3.1.0 -> [Help 1]
```

Also added a note in the README about the minimum required Maven version.

Resolves https://github.com/diffplug/spotless/issues/257