### PR TITLE
Eclipse 4.8.0 (JDT)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ You might be looking for:
 
 ### Version 1.14.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Updated default eclipse-jdt from 4.7.2 to 4.8.0 ([#239](https://github.com/diffplug/spotless/pull/239)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 
 ### Version 1.13.0 - June 1st 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.11.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.13.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 
 import com.diffplug.common.base.Errors;
@@ -149,6 +150,12 @@ public class EclipseBasedStepBuilder {
 			//Keep the IllegalArgumentException since it contains detailed information
 			FormatterProperties preferences = FormatterProperties.from(settingsFiles.files());
 			return preferences.getProperties();
+		}
+
+		/** Returns first coordinate from sorted set that starts with a given prefix.*/
+		public Optional<String> getMavenCoordinate(String prefix) {
+			return jarState.getMavenCoordinates().stream()
+					.filter(coordinate -> coordinate.startsWith(prefix)).findFirst();
 		}
 
 		/** Load class based on the given configuration of JAR provider and Maven coordinates. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -52,8 +52,9 @@ public final class EclipseJdtFormatterStep {
 	}
 
 	private static Class<?> getClass(State state) {
-		if (state.getMavenCoordinate(MAVEN_GROUP_ARTIFACT).isPresent())
+		if (state.getMavenCoordinate(MAVEN_GROUP_ARTIFACT).isPresent()) {
 			return state.loadClass(FORMATTER_CLASS);
+		}
 		return state.loadClass(FORMATTER_CLASS_OLD);
 	}
 }

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -29,8 +29,10 @@ public final class EclipseJdtFormatterStep {
 	private EclipseJdtFormatterStep() {}
 
 	private static final String NAME = "eclipse jdt formatter";
-	private static final String FORMATTER_CLASS = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
-	private static final String DEFAULT_VERSION = "4.7.2";
+	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
+	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.java.EclipseJdtFormatterStepImpl";
+	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-jdt";
+	private static final String DEFAULT_VERSION = "4.8.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {
@@ -43,9 +45,15 @@ public final class EclipseJdtFormatterStep {
 	}
 
 	private static FormatterFunc apply(State state) throws Exception {
-		Class<?> formatterClazz = state.loadClass(FORMATTER_CLASS);
+		Class<?> formatterClazz = getClass(state);
 		Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(state.getPreferences());
 		Method method = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
 		return input -> (String) method.invoke(formatter, input);
+	}
+
+	private static Class<?> getClass(State state) {
+		if (state.getMavenCoordinate(MAVEN_GROUP_ARTIFACT).isPresent())
+			return state.loadClass(FORMATTER_CLASS);
+		return state.loadClass(FORMATTER_CLASS_OLD);
 	}
 }

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.8.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.8.0.lockfile
@@ -1,0 +1,17 @@
+# Spotless formatter based on JDT version 4.8.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.14.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.100
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.0
+org.eclipse.platform:org.eclipse.core.jobs:3.10.0
+org.eclipse.platform:org.eclipse.core.resources:3.13.0
+org.eclipse.platform:org.eclipse.core.runtime:3.14.0
+org.eclipse.platform:org.eclipse.equinox.app:1.3.500
+org.eclipse.platform:org.eclipse.equinox.common:3.10.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.13.0
+org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
@@ -24,7 +24,7 @@ public class EclipseJdtFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.6.1", "4.6.3", "4.7.0", "4.7.1", "4.7.2"};
+		return new String[]{"4.6.1", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.8.0"};
 	}
 
 	@Override

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -42,8 +42,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public final class JarState implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-	@SuppressWarnings("unused")
-	private final Set<String> mavenCoordinates;
+	private final TreeSet<String> mavenCoordinates;
 	@SuppressWarnings("unused")
 	private final FileSignature fileSignature;
 
@@ -91,5 +90,10 @@ public final class JarState implements Serializable {
 	 */
 	public ClassLoader getClassLoader() {
 		return SpotlessCache.instance().classloader(this);
+	}
+
+	/** Returns unmodifiable view on sorted Maven coordinates */
+	public Set<String> getMavenCoordinates() {
+		return Collections.unmodifiableSet(mavenCoordinates);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -42,7 +42,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public final class JarState implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-	private final TreeSet<String> mavenCoordinates;
+	private final Set<String> mavenCoordinates;
 	@SuppressWarnings("unused")
 	private final FileSignature fileSignature;
 

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
 public final class PaddedCell {
 	/** The kind of result. */
 	public enum Type {
-		CONVERGE, CYCLE, DIVERGE;
+	CONVERGE, CYCLE, DIVERGE;
 
 		/** Creates a PaddedCell with the given file and steps. */
 		PaddedCell create(File file, List<String> steps) {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Version 3.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Updated default eclipse-jdt from 4.7.2 to 4.8.0 ([#239](https://github.com/diffplug/spotless/pull/239)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 
 ### Version 3.13.0 - June 1st 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.13.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.13.0))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Version 1.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Updated default eclipse-jdt from 4.7.2 to 4.8.0 ([#239](https://github.com/diffplug/spotless/pull/239)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Require 3.1.0+ version of Maven ([#259](https://github.com/diffplug/spotless/pull/259)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 


### PR DESCRIPTION
Made Spotless-Eclipse-JDT 4.8.0 default version.
Added functionality to lookup Maven Coordinate information from Jar-State as @nedtwigg proposed in #234.
This PR fixes issues #226 and #191.