### PR TITLE
Bumped to Groovy-Eclipse version 2.9.2 (corresponds to Eclipse 4.8.0).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ You might be looking for:
 
 ### Version 1.14.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Updated default groovy-eclipse from 4.6.3 to 4.8.0 ([#244](https://github.com/diffplug/spotless/pull/244)). New version allows to ignore internal formatter errors/warnings.
 * Updated default eclipse-jdt from 4.7.2 to 4.8.0 ([#239](https://github.com/diffplug/spotless/pull/239)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
@@ -34,7 +34,7 @@ public final class GrEclipseFormatterStep {
 	private static final String NAME = "groovy eclipse formatter";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.groovy.eclipse.GrEclipseFormatterStepImpl";
-	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:	spotless-eclipse-groovy";
+	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-groovy";
 	private static final String DEFAULT_VERSION = "4.8.0";
 	private static final String FORMATTER_METHOD = "format";
 
@@ -63,7 +63,8 @@ public final class GrEclipseFormatterStep {
 	}
 
 	private static FormatterFunc apply(EclipseBasedStepBuilder.State state) throws Exception {
-		Class<?> formatterClazz = getClass(state);		Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(state.getPreferences());
+		Class<?> formatterClazz = getClass(state);
+		Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(state.getPreferences());
 		Method method = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
 		return input -> {
 			try {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
@@ -24,6 +24,7 @@ import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
+import com.diffplug.spotless.extra.EclipseBasedStepBuilder.State;
 
 /** Formatter step which calls out to the Groovy-Eclipse formatter. */
 public final class GrEclipseFormatterStep {
@@ -31,8 +32,10 @@ public final class GrEclipseFormatterStep {
 	private GrEclipseFormatterStep() {}
 
 	private static final String NAME = "groovy eclipse formatter";
-	private static final String FORMATTER_CLASS = "com.diffplug.gradle.spotless.groovy.eclipse.GrEclipseFormatterStepImpl";
-	private static final String DEFAULT_VERSION = "4.6.3";
+	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl";
+	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.groovy.eclipse.GrEclipseFormatterStepImpl";
+	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:	spotless-eclipse-groovy";
+	private static final String DEFAULT_VERSION = "4.8.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	/** Creates a formatter step using the default version for the given settings file. */
@@ -60,8 +63,7 @@ public final class GrEclipseFormatterStep {
 	}
 
 	private static FormatterFunc apply(EclipseBasedStepBuilder.State state) throws Exception {
-		Class<?> formatterClazz = state.loadClass(FORMATTER_CLASS);
-		Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(state.getPreferences());
+		Class<?> formatterClazz = getClass(state);		Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(state.getPreferences());
 		Method method = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
 		return input -> {
 			try {
@@ -72,6 +74,13 @@ public final class GrEclipseFormatterStep {
 				throw (null == exception) ? exceptionWrapper : exception;
 			}
 		};
+	}
+
+	private static Class<?> getClass(State state) {
+		if (state.getMavenCoordinate(MAVEN_GROUP_ARTIFACT).isPresent()) {
+			return state.loadClass(FORMATTER_CLASS);
+		}
+		return state.loadClass(FORMATTER_CLASS_OLD);
 	}
 
 }

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.0.lockfile
@@ -1,0 +1,20 @@
+# Spotless formatter based on Groovy-Eclipse version 2.9.2 (see https://github.com/groovy/groovy-eclipse/releases)
+com.diffplug.spotless:spotless-eclipse-groovy:2.9.2
+com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.100
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.0
+org.eclipse.platform:org.eclipse.core.jobs:3.10.0
+org.eclipse.platform:org.eclipse.core.resources:3.13.0
+org.eclipse.platform:org.eclipse.core.runtime:3.14.0
+org.eclipse.platform:org.eclipse.equinox.app:1.3.500
+org.eclipse.platform:org.eclipse.equinox.common:3.10.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
+#Spotless currently loads all transitive dependencies.
+#jface requires platform specific JARs (not used by formatter), which are not hosted via M2.
+#org.eclipse.platform:org.eclipse.jface.text:3.13.0
+#org.eclipse.platform:org.eclipse.jface:3.14.0
+org.eclipse.platform:org.eclipse.osgi:3.13.0
+org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/DeprecatedGrEclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/DeprecatedGrEclipseFormatterStepTest.java
@@ -33,6 +33,7 @@ public class DeprecatedGrEclipseFormatterStepTest extends ResourceHarness {
 
 	private static final String RESOURCE_PATH = "groovy/greclipse/format/";
 	private static final String CONFIG_FILE = RESOURCE_PATH + "greclipse.properties";
+	private static final String DEPRECATED_VERSION = "4.6.3";
 
 	//String is hard-coded in the GrEclipseFormatter
 	private static final String FORMATTER_FILENAME_REPALCEMENT = "Hello.groovy";
@@ -44,14 +45,14 @@ public class DeprecatedGrEclipseFormatterStepTest extends ResourceHarness {
 	@Test
 	public void nominal() throws Throwable {
 		List<File> config = createTestFiles(CONFIG_FILE);
-		StepHarness.forStep(GrEclipseFormatterStep.create(config, provisioner()))
+		StepHarness.forStep(GrEclipseFormatterStep.create(DEPRECATED_VERSION, config, provisioner()))
 				.testResource(RESOURCE_PATH + "unformatted.test", RESOURCE_PATH + "formatted.test");
 	}
 
 	@Test
 	public void formatterException() throws Throwable {
 		List<File> config = createTestFiles(CONFIG_FILE);
-		StepHarness.forStep(GrEclipseFormatterStep.create(config, provisioner()))
+		StepHarness.forStep(GrEclipseFormatterStep.create(DEPRECATED_VERSION, config, provisioner()))
 				.testException(RESOURCE_PATH + "exception.test", assertion -> {
 					assertion.isInstanceOf(IllegalArgumentException.class);
 					assertion.hasMessageContaining(FORMATTER_FILENAME_REPALCEMENT);
@@ -62,7 +63,7 @@ public class DeprecatedGrEclipseFormatterStepTest extends ResourceHarness {
 	public void configurationException() throws Throwable {
 		String configFileName = "greclipse.exception";
 		List<File> config = createTestFiles(RESOURCE_PATH + configFileName);
-		StepHarness.forStep(GrEclipseFormatterStep.create(config, provisioner()))
+		StepHarness.forStep(GrEclipseFormatterStep.create(DEPRECATED_VERSION, config, provisioner()))
 				.testException(RESOURCE_PATH + "unformatted.test", assertion -> {
 					assertion.isInstanceOf(IllegalArgumentException.class);
 					assertion.hasMessageContaining(configFileName);
@@ -81,7 +82,7 @@ public class DeprecatedGrEclipseFormatterStepTest extends ResourceHarness {
 
 			@Override
 			protected FormatterStep create() {
-				return GrEclipseFormatterStep.create(configFile, provisioner());
+				return GrEclipseFormatterStep.create(DEPRECATED_VERSION, configFile, provisioner());
 			}
 		}.testEquals();
 	}

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
@@ -23,7 +23,7 @@ import com.diffplug.spotless.extra.eclipse.EclipseCommonTests;
 public class GrEclipseFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"2.3.0", "4.6.3"};
+		return new String[]{"2.3.0", "4.6.3", "4.8.0"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Version 3.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Updated default groovy-eclipse from 4.6.3 to 4.8.0 ([#244](https://github.com/diffplug/spotless/pull/244)). New version allows to ignore internal formatter errors/warnings.
 * Updated default eclipse-jdt from 4.7.2 to 4.8.0 ([#239](https://github.com/diffplug/spotless/pull/239)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -191,7 +191,11 @@ spotless {
 }
 ```
 
-The [Groovy-Eclipse](https://github.com/groovy/groovy-eclipse) formatter is based on the Eclipse Java formatter as used by `eclipseFormatFile`. It uses the same configuration parameters plus a few additional ones.  These parameters can be configured within a single file, like the Java properties file [greclipse.properties](../lib-extra/src/test/resources/groovy/greclipse/format/greclipse.properties) in the previous example.  The formatter step can also load the [exported Eclipse properties](../ECLIPSE_SCREENSHOTS.md) and augment it with the `org.codehaus.groovy.eclipse.ui.prefs` from the Eclipse workspace as shown below.
+The [Groovy-Eclipse](https://github.com/groovy/groovy-eclipse) formatter is based on the Eclipse Java formatter as used by `eclipseFormatFile`. It uses the same configuration parameters plus a few additional ones.  These parameters can be configured within a single file, like the Java properties file [greclipse.properties](../lib-extra/src/test/resources/groovy/greclipse/format/greclipse.properties) in the previous example. The formatter step can also load the [exported Eclipse properties](../ECLIPSE_SCREENSHOTS.md) and augment it with the `org.codehaus.groovy.eclipse.ui.prefs` from the Eclipse workspace as shown below.
+
+[Groovy-Eclipse](https://github.com/groovy/groovy-eclipse) formatter errors/warnings lead
+per default to a build failure. This behavior can be changed by adding the property/key value: `ignoreFormatterProblems=true` to the configuration. In this scenario, files
+causing problems, will not be modified by this formatter step.
 
 ```gradle
 spotless {


### PR DESCRIPTION
Using Groovy-Eclipse version 2.9.2.
As requested, the version used by the user configuration is equal to the "corresponding" Eclipse version (4.8.0). Note that not every transitive dependency is equal to the one used by Eclipse 4.8.0, but this should not have an impact on the formatter behaviour. 