### PR TITLE
Provided formatter versions for JDT 4.7.3a and 4.6.2.

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -32,7 +32,7 @@ public final class EclipseJdtFormatterStep {
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.java.EclipseJdtFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-jdt";
-	private static final String DEFAULT_VERSION = "4.8.0";
+	private static final String DEFAULT_VERSION = "4.7.3a";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.6.2.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.6.2.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on JDT version 4.6.2 (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_6_maintenance to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.12.2
+org.eclipse.platform:org.eclipse.core.commands:3.9.100
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.0
+org.eclipse.platform:org.eclipse.core.jobs:3.10.0
+org.eclipse.platform:org.eclipse.core.resources:3.13.0
+org.eclipse.platform:org.eclipse.core.runtime:3.14.0
+org.eclipse.platform:org.eclipse.equinox.app:1.3.500
+org.eclipse.platform:org.eclipse.equinox.common:3.10.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.13.0
+org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.7.3a.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.7.3a.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on JDT version 4.7.3a (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_7_maintenance to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.13.101
+org.eclipse.platform:org.eclipse.core.commands:3.9.100
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.0
+org.eclipse.platform:org.eclipse.core.jobs:3.10.0
+org.eclipse.platform:org.eclipse.core.resources:3.13.0
+org.eclipse.platform:org.eclipse.core.runtime:3.14.0
+org.eclipse.platform:org.eclipse.equinox.app:1.3.500
+org.eclipse.platform:org.eclipse.equinox.common:3.10.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.13.0
+org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
@@ -24,7 +24,7 @@ public class EclipseJdtFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.6.1", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.8.0"};
+		return new String[]{"4.6.1", "4.6.2", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.7.3a", "4.8.0"};
 	}
 
 	@Override

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
 public final class PaddedCell {
 	/** The kind of result. */
 	public enum Type {
-	CONVERGE, CYCLE, DIVERGE;
+		CONVERGE, CYCLE, DIVERGE;
 
 		/** Creates a PaddedCell with the given file and steps. */
 		PaddedCell create(File file, List<String> steps) {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
-* Updated default eclipse-jdt from 4.7.2 to 4.8.0 ([#239](https://github.com/diffplug/spotless/pull/239)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
+* Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/pull/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 
 ### Version 3.13.0 - June 1st 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.13.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.13.0))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
-* Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/pull/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
+* Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/issues/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 
 ### Version 3.13.0 - June 1st 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.13.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.13.0))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 1.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
-* Updated default eclipse-jdt from 4.7.2 to 4.8.0 ([#239](https://github.com/diffplug/spotless/pull/239)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
+* Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/pull/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Require 3.1.0+ version of Maven ([#259](https://github.com/diffplug/spotless/pull/259)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 1.14.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
-* Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/pull/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
+* Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/issues/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).
 * Require 3.1.0+ version of Maven ([#259](https://github.com/diffplug/spotless/pull/259)).
 * Eclipse formatter versions decoupled from Spotless formatter step implementations to allow independent updates of M2 based Eclipse dependencies. ([#253](https://github.com/diffplug/spotless/pull/253))
 


### PR DESCRIPTION
Provided formatter versions for JDT 4.7.3a and 4.6.2. JDT 4.7.3a is new default version.

Fixes #263.