### PR TITLE
Findbugs -> Spotbugs (Begin updating for support for JDK 10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 		classpath "com.gradle.publish:plugin-publish-plugin:${VER_PLUGIN_PUBLISH}"
 		classpath "org.ajoberstar:gradle-git:${VER_GRADLE_GIT}"
 		classpath "ch.raffael.pegdown-doclet:pegdown-doclet:${VER_PEGDOWN_DOCLET}"
+		classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:${VER_SPOTBUGS_PLUGIN}"
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,8 @@ artifactIdGradle=spotless-plugin-gradle
 
 # Build requirements
 VER_JAVA=1.8
-VER_FINDBUGS=3.0.1
+VER_SPOTBUGS=3.1.6
+VER_SPOTBUGS_PLUGIN=1.6.2
 VER_BINTRAY=1.7.3
 VER_PLUGIN_PUBLISH=0.9.7
 VER_GOOMPH=3.8.1

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -1,3 +1,8 @@
+buildscript {
+	repositories { maven { url 'https://plugins.gradle.org/m2/' } }
+	dependencies { classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:${VER_SPOTBUGS_PLUGIN}" }
+}
+
 //////////
 // JAVA //
 //////////
@@ -29,23 +34,23 @@ eclipseResourceFilters {
 }
 
 //////////////
-// FINDBUGS //
+// SPOTBUGS //
 //////////////
-apply plugin: 'findbugs'
-findbugs {
-	toolVersion = VER_FINDBUGS
+apply plugin: 'com.github.spotbugs'
+spotbugs {
+	toolVersion = VER_SPOTBUGS
 	sourceSets = [
 		// don't check the test code
 		sourceSets.main
 	]
 	ignoreFailures = false 	// bug free or it doesn't ship!
-	reportsDir = file('build/findbugs')
+	reportsDir = file('build/spotbugs')
 	effort = 'max'			// min|default|max
 	reportLevel = 'medium'	// low|medium|high (low = sensitive to even minor mistakes)
 	omitVisitors = []		// bugs that we want to ignore
 }
 // HTML instead of XML
-tasks.withType(FindBugs) {
+tasks.withType(com.github.spotbugs.SpotBugsTask) {
 	reports {
 		xml.enabled = false
 		html.enabled = true

--- a/lib-extra/build.gradle
+++ b/lib-extra/build.gradle
@@ -22,5 +22,5 @@ dependencies {
 }
 
 // we'll hold the core lib to a high standard
-findbugs { reportLevel = 'low' } // low|medium|high (low = sensitive to even minor mistakes)
+spotbugs { reportLevel = 'low' } // low|medium|high (low = sensitive to even minor mistakes)
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -12,4 +12,4 @@ dependencies {
 }
 
 // we'll hold the core lib to a high standard
-findbugs { reportLevel = 'low' } // low|medium|high (low = sensitive to even minor mistakes)
+spotbugs { reportLevel = 'low' } // low|medium|high (low = sensitive to even minor mistakes)

--- a/testlib/build.gradle
+++ b/testlib/build.gradle
@@ -13,5 +13,5 @@ dependencies {
 }
 
 // we'll hold the testlib to a low standard (prize brevity)
-findbugs { reportLevel = 'high' } // low|medium|high (low = sensitive to even minor mistakes)
+spotbugs { reportLevel = 'high' } // low|medium|high (low = sensitive to even minor mistakes)
 


### PR DESCRIPTION
Findbugs doesn't support JDK 10. Spotbugs does.

I don't think this is really worth of a change-log change. This is all internal stuff.
