### PR TITLE
LicenseHeaderStep exclude module-info.java

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.15.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* LicenseHeaderStep now wont attempt to add license to `module-info.java` ([#272](https://github.com/diffplug/spotless/pull/272)).
+
 ### Version 3.14.0 - July 24th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.14.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.14.0))
 
 * Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/issues/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -187,11 +187,17 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			}
 			target = union;
 		}
-		// LicenseHeaderStep completely blows apart package-info.java - this common-sense check ensures that
-		// it skips package-info.java. See https://github.com/diffplug/spotless/issues/1
+		// LicenseHeaderStep completely blows apart package-info.java & module-info.java;
+		// this common-sense check ensures that it skips package-info.java & module-info.java.
+		//
+		// See:
+		//  - https://github.com/diffplug/spotless/issues/1
+		//  - https://github.com/diffplug/spotless/issues/270
 		steps.replaceAll(step -> {
 			if (LicenseHeaderStep.name().equals(step.getName())) {
-				return step.filterByFile(SerializableFileFilter.skipFilesNamed("package-info.java"));
+				return step.filterByFile(SerializableFileFilter.skipFilesNamed(
+						"package-info.java",
+						"module-info.java"));
 			} else {
 				return step;
 			}


### PR DESCRIPTION
After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/master/CHANGES.md) and [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md) which includes:

- [ ] a summary of the change
- [ ] a link to the newly created PR

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.
