### PR TITLE
No license headers for package-info and module-info in Maven

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.15.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Skip `package-info.java` and `module-info.java` files from license header formatting. ([#273](https://github.com/diffplug/spotless/pull/273))
+
 ### Version 1.14.0 - July 24th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.14.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.14.0))
 
 * Updated default eclipse-jdt from 4.7.2 to 4.7.3a ([#263](https://github.com/diffplug/spotless/issues/263)). New version fixes a bug preventing Java code formatting within JavaDoc comments ([#191](https://github.com/diffplug/spotless/issues/191)).

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
@@ -97,10 +97,37 @@ public class LicenseHeaderTest extends MavenIntegrationTest {
 		assertFile(path).hasContent(KOTLIN_LICENSE_HEADER + '\n' + noLicenseHeader);
 	}
 
+	@Test
+	public void unsupportedPackageInfo() throws Exception {
+		testUnsupportedFile("package-info.java");
+	}
+
+	@Test
+	public void unsupportedModuleInfo() throws Exception {
+		testUnsupportedFile("module-info.java");
+	}
+
 	private void runTest() throws Exception {
 		String path = "src/main/java/test.java";
 		setFile(path).toResource("license/MissingLicense.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
 		assertFile(path).sameAsResource("license/HasLicense.test");
+	}
+
+	private void testUnsupportedFile(String file) throws Exception {
+		writePomWithJavaSteps(
+				"<licenseHeader>",
+				"  <content>",
+				"// Hello!",
+				"  </content>",
+				"</licenseHeader>");
+
+		String path = "src/main/java/com/diffplug/spotless/" + file;
+		setFile(path).toResource("license/" + file);
+
+		mavenRunner().withArguments("spotless:apply").runNoError();
+
+		// file should remain the same
+		assertFile(path).sameAsResource("license/" + file);
 	}
 }

--- a/testlib/src/main/resources/license/module-info.java
+++ b/testlib/src/main/resources/license/module-info.java
@@ -1,0 +1,6 @@
+module com.diffplug.spotless {
+
+    requires com.diffplug.durian;
+
+    exports com.diffplug.spotless;
+}

--- a/testlib/src/main/resources/license/package-info.java
+++ b/testlib/src/main/resources/license/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Test package-info.java file.
+ * <p>
+ * Used only by integration tests.
+ *
+ * @since 1.0
+ */
+package com.diffplug.spotless;


### PR DESCRIPTION
These two files are currently not supported by the license header step and might get formatted incorrectly.

PR makes Maven plugin exclude both `package-info.java` and `module-info.java`.

Related to #270 