### PR TITLE
Upgrade annotations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ You might be looking for:
 
 ### Version 1.15.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Updated JSR305 annotation from 3.0.0 to 3.0.2 ([#274](https://github.com/diffplug/spotless/pull/274))
+* Migrated from FindBugs annotations 3.0.0 to SpotBugs annotations 3.1.6 ([#274](https://github.com/diffplug/spotless/pull/274))
+
 ### Version 1.14.0 - July 24th 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.14.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.14.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Updated default groovy-eclipse from 4.6.3 to 4.8.0 ([#244](https://github.com/diffplug/spotless/pull/244)). New version allows to ignore internal formatter errors/warnings.

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -56,9 +56,8 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 		html.enabled = true
 	}
 }
-// we'll want the findbugs annotations (they don't have a 3.0.1 version)
 dependencies {
 	compileOnly 'net.jcip:jcip-annotations:1.0'
 	compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.6'
-	compileOnly 'com.google.code.findbugs:jsr305:3.0.0'
+	compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 }

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -58,6 +58,7 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 }
 // we'll want the findbugs annotations (they don't have a 3.0.1 version)
 dependencies {
-	compileOnly 'com.google.code.findbugs:annotations:3.0.0'
+	compileOnly 'net.jcip:jcip-annotations:1.0'
+	compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.6'
 	compileOnly 'com.google.code.findbugs:jsr305:3.0.0'
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 ### Version 3.15.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
 * LicenseHeaderStep now wont attempt to add license to `module-info.java` ([#272](https://github.com/diffplug/spotless/pull/272)).
+* Updated JSR305 annotation from 3.0.0 to 3.0.2 ([#274](https://github.com/diffplug/spotless/pull/274))
+* Migrated from FindBugs annotations 3.0.0 to SpotBugs annotations 3.1.6 ([#274](https://github.com/diffplug/spotless/pull/274))
 
 ### Version 3.14.0 - July 24th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.14.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.14.0))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 ### Version 1.15.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
 * Skip `package-info.java` and `module-info.java` files from license header formatting. ([#273](https://github.com/diffplug/spotless/pull/273))
+* Updated JSR305 annotation from 3.0.0 to 3.0.2 ([#274](https://github.com/diffplug/spotless/pull/274))
+* Migrated from FindBugs annotations 3.0.0 to SpotBugs annotations 3.1.6 ([#274](https://github.com/diffplug/spotless/pull/274))
 
 ### Version 1.14.0 - July 24th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.14.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.14.0))
 


### PR DESCRIPTION
Thanks for your great product, I use this to keep my `.md`, `.gradle` and `.java` clean.
I want to suggest upgrading annotations:

1. JSR305 annotation has 3.0.2 release [maintained by amaembo](https://github.com/amaembo/jsr-305), it has better pom and javadoc for users.
2. According to [SpotBugs migration guide](http://spotbugs.readthedocs.io/en/stable/migration.html), `com.google.code.findbugs:annotations` can be migrated to `com.github.spotbugs:spotbugs-annotations` and `net.jcip:jcip-annotations`.