### PR TITLE
Common filter for files not supported by LicenseHeaderStep

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
+import com.diffplug.spotless.SerializableFileFilter;
 
 /** Prefixes a license header before the package statement. */
 public final class LicenseHeaderStep implements Serializable {
@@ -34,6 +35,9 @@ public final class LicenseHeaderStep implements Serializable {
 
 	private static final String NAME = "licenseHeader";
 	private static final String DEFAULT_YEAR_DELIMITER = "-";
+
+	private static final SerializableFileFilter UNSUPPORTED_JVM_FILES_FILTER = SerializableFileFilter.skipFilesNamed(
+			"package-info.java", "package-info.groovy", "module-info.java");
 
 	private final String licenseHeader;
 	private final Pattern delimiterPattern;
@@ -85,6 +89,10 @@ public final class LicenseHeaderStep implements Serializable {
 
 	public static String defaultYearDelimiter() {
 		return DEFAULT_YEAR_DELIMITER;
+	}
+
+	public static SerializableFileFilter unsupportedJvmFilesFilter() {
+		return UNSUPPORTED_JVM_FILES_FILTER;
 	}
 
 	/** The license that we'd like enforced. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -30,7 +30,6 @@ import org.gradle.api.tasks.GroovySourceSet;
 import org.gradle.api.tasks.SourceSet;
 
 import com.diffplug.common.base.StringPrinter;
-import com.diffplug.spotless.SerializableFileFilter;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.groovy.GrEclipseFormatterStep;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
@@ -140,7 +139,7 @@ public class GroovyExtension extends FormatExtension implements HasBuiltinDelimi
 		// ensures that it skips both. See https://github.com/diffplug/spotless/issues/1
 		steps.replaceAll(step -> {
 			if (LicenseHeaderStep.name().equals(step.getName())) {
-				return step.filterByFile(SerializableFileFilter.skipFilesNamed("package-info.java", "package-info.groovy"));
+				return step.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
 			} else {
 				return step;
 			}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.SourceSet;
 
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.SerializableFileFilter;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.java.EclipseFormatterStep;
 import com.diffplug.spotless.extra.java.EclipseJdtFormatterStep;
@@ -187,17 +186,10 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			}
 			target = union;
 		}
-		// LicenseHeaderStep completely blows apart package-info.java & module-info.java;
-		// this common-sense check ensures that it skips package-info.java & module-info.java.
-		//
-		// See:
-		//  - https://github.com/diffplug/spotless/issues/1
-		//  - https://github.com/diffplug/spotless/issues/270
+
 		steps.replaceAll(step -> {
 			if (LicenseHeaderStep.name().equals(step.getName())) {
-				return step.filterByFile(SerializableFileFilter.skipFilesNamed(
-						"package-info.java",
-						"module-info.java"));
+				return step.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
 			} else {
 				return step;
 			}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
@@ -20,15 +20,11 @@ import java.io.File;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.SerializableFileFilter;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
 import com.diffplug.spotless.maven.FormatterStepConfig;
 import com.diffplug.spotless.maven.FormatterStepFactory;
 
 public class LicenseHeader implements FormatterStepFactory {
-
-	private static final SerializableFileFilter UNSUPPORTED_FILES_FILTER = SerializableFileFilter.skipFilesNamed(
-			"package-info.java", "module-info.java");
 
 	@Parameter
 	private String file;
@@ -51,7 +47,7 @@ public class LicenseHeader implements FormatterStepFactory {
 					? createStepFromFile(config, delimiterString)
 					: createStepFromContent(delimiterString);
 
-			return step.filterByFile(UNSUPPORTED_FILES_FILTER);
+			return step.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
 		} else {
 			throw new IllegalArgumentException("Must specify exactly one of 'file' or 'content'.");
 		}


### PR DESCRIPTION
Extracted the filter into a shared constant which is used by all Gradle extensions and Maven mojo.

Resolves #270 