### PR TITLE
Spotless Eclipse CDT 9.4.4 (log service)

### DIFF
--- a/_ext/eclipse-cdt/build.gradle
+++ b/_ext/eclipse-cdt/build.gradle
@@ -7,7 +7,7 @@ ext {
 	
 	p2Dependencies = [
 		'org.eclipse.cdt.core':'+', // CodeFormatter and related
-	]
+		]
 
 }
 
@@ -21,6 +21,10 @@ dependencies {
 	compile ("org.eclipse.platform:org.eclipse.jface.text:${VER_ECLISPE_JFACE}") {
 		exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt'
 	}
+	// Required to by CCorePlugin calling CDTLogWriter
+	compile "com.ibm.icu:icu4j:${VER_IBM_ICU}"
+	// Required to by CCorePlugin calling PositionTrackerManager
+	compile "org.eclipse.platform:org.eclipse.core.filebuffers:${VER_ECLISPE_PLATFORM}"
 }
 
 

--- a/_ext/eclipse-cdt/gradle.properties
+++ b/_ext/eclipse-cdt/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Eclipse-CDT version used for the fat-JAR.
 # See https://www.eclipse.org/cdt/ for further information about Eclipse-CDT versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=9.4.3
+ext_version=9.4.4
 ext_artifactId=spotless-eclipse-cdt
 ext_description=Eclipse's CDT C/C++ formatter bundled for Spotless
 ext_org=diffplug
@@ -14,3 +14,5 @@ ext_VER_JAVA=1.8
 VER_ECLIPSE_CDT=9.4
 VER_SPOTLESS_ECLISPE_BASE=[3.0.0,4.0.0[
 VER_ECLISPE_JFACE=[3.12.0,4.0.0[
+VER_ECLISPE_PLATFORM=[3.6.0,4.0.0[
+VER_IBM_ICU=[61,62[

--- a/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImpl.java
+++ b/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImpl.java
@@ -40,7 +40,7 @@ public class EclipseCdtFormatterStepImpl {
 		LogErrorService logService = new LogErrorService();
 		SpotlessEclipseFramework.setup(
 				config -> {
-					config.applyDefault();;
+					config.applyDefault();
 					config.add(ExtendedLogService.class, logService);
 					config.add(ExtendedLogReaderService.class, logService);
 				},
@@ -48,8 +48,7 @@ public class EclipseCdtFormatterStepImpl {
 					plugins.applyDefault();
 					plugins.add(new FileBuffersPlugin());
 					plugins.add(new CCorePlugin());
-				}
-		);
+				});
 		Stream<Entry<Object, Object>> stream = settings.entrySet().stream();
 		Map<String, String> settingsMap = stream.collect(Collectors.toMap(
 				e -> String.valueOf(e.getKey()),

--- a/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImpl.java
+++ b/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImpl.java
@@ -21,7 +21,11 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.formatter.CodeFormatter;
+import org.eclipse.core.internal.filebuffers.FileBuffersPlugin;
+import org.eclipse.equinox.log.ExtendedLogReaderService;
+import org.eclipse.equinox.log.ExtendedLogService;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.text.edits.TextEdit;
@@ -33,12 +37,18 @@ public class EclipseCdtFormatterStepImpl {
 	private final CodeFormatter codeFormatter;
 
 	public EclipseCdtFormatterStepImpl(Properties settings) throws Exception {
+		LogErrorService logService = new LogErrorService();
 		SpotlessEclipseFramework.setup(
-				bundles -> {}, //CDT does not use the internal Eclipse feature
 				config -> {
-					config.changeSystemLineSeparator();
+					config.applyDefault();;
+					config.add(ExtendedLogService.class, logService);
+					config.add(ExtendedLogReaderService.class, logService);
 				},
-				plugins -> {} //CDT does not use other Eclipse plugins
+				plugins -> {
+					plugins.applyDefault();
+					plugins.add(new FileBuffersPlugin());
+					plugins.add(new CCorePlugin());
+				}
 		);
 		Stream<Entry<Object, Object>> stream = settings.entrySet().stream();
 		Map<String, String> settingsMap = stream.collect(Collectors.toMap(

--- a/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/LogErrorService.java
+++ b/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/LogErrorService.java
@@ -35,14 +35,14 @@ import org.osgi.service.log.LogService;
 import org.osgi.service.log.LoggerConsumer;
 
 /**
- * Simple log service for errors. 
+ * Simple log service for errors.
  * The CDT formatter logs warnings for dedicated regional problems.
  * For example the CDT formatter logs a warning for standard C function provider
  * methods which do not use dedicated typedef for their return type.
  * The warnings do not contain any information about the type or source of problem.
  * Furthermore the other regions of the code(-line) are correctly formatted.
  * Hence the useless warnings are eaten. Just errors are logged (though it seems
- * that the formatter does not log any messages with an error level). 
+ * that the formatter does not log any messages with an error level).
  */
 public class LogErrorService implements ExtendedLogService, ExtendedLogReaderService {
 

--- a/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/LogErrorService.java
+++ b/_ext/eclipse-cdt/src/main/java/com/diffplug/spotless/extra/eclipse/cdt/LogErrorService.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.extra.eclipse.cdt;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Optional;
+
+import org.eclipse.core.internal.runtime.InternalPlatform;
+import org.eclipse.equinox.log.ExtendedLogReaderService;
+import org.eclipse.equinox.log.ExtendedLogService;
+import org.eclipse.equinox.log.LogFilter;
+import org.eclipse.equinox.log.Logger;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogEntry;
+import org.osgi.service.log.LogLevel;
+import org.osgi.service.log.LogListener;
+import org.osgi.service.log.LogService;
+import org.osgi.service.log.LoggerConsumer;
+
+/**
+ * Simple log service for errors. 
+ * The CDT formatter logs warnings for dedicated regional problems.
+ * For example the CDT formatter logs a warning for standard C function provider
+ * methods which do not use dedicated typedef for their return type.
+ * The warnings do not contain any information about the type or source of problem.
+ * Furthermore the other regions of the code(-line) are correctly formatted.
+ * Hence the useless warnings are eaten. Just errors are logged (though it seems
+ * that the formatter does not log any messages with an error level). 
+ */
+public class LogErrorService implements ExtendedLogService, ExtendedLogReaderService {
+
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(int level, String message) {}
+
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(int level, String message, Throwable exception) {
+		log(level, message);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(ServiceReference sr, int level, String message) {
+		log(level, message);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(ServiceReference sr, int level, String message, Throwable exception) {
+		log(level, message, exception);
+	}
+
+	@Override
+	public void log(Object context, int level, String message) {
+		log(level, message);
+	}
+
+	@SuppressWarnings("deprecation") ////Backward compatibility with Eclipse OSGI 3.12
+	@Override
+	public void log(Object context, int level, String message, Throwable exception) {
+		LogLevel logLevel;
+		switch (level) {
+		case LogService.LOG_DEBUG:
+			logLevel = LogLevel.DEBUG;
+			break;
+		case LogService.LOG_INFO:
+			logLevel = LogLevel.INFO;
+			break;
+		case LogService.LOG_ERROR:
+			logLevel = LogLevel.ERROR;
+			break;
+		case LogService.LOG_WARNING:
+			logLevel = LogLevel.WARN;
+			break;
+		default:
+			logLevel = LogLevel.AUDIT;
+		}
+		log(new SimpleLogEntry(logLevel, message, exception));
+	}
+
+	@Override
+	public boolean isLoggable(int level) {
+		return true;
+	}
+
+	@Override
+	public String getName() {
+		return LogErrorService.class.getSimpleName();
+	}
+
+	@Override
+	public Logger getLogger(String loggerName) {
+		return this;
+	}
+
+	@Override
+	public Logger getLogger(Bundle bundle, String loggerName) {
+		return this;
+	}
+
+	@Override
+	public void addLogListener(LogListener listener) {
+		//Nothing to do
+	}
+
+	@Override
+	public void removeLogListener(LogListener listener) {
+		//Nothing to do
+	}
+
+	public void log(LogEntry entry) {
+		if (LogLevel.ERROR == entry.getLogLevel()) {
+			System.err.println(entry.toString());
+		}
+	}
+
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public Enumeration<LogEntry> getLog() {
+		return Collections.emptyEnumeration(); //We do not provide historical information
+	}
+
+	@Override
+	public void addLogListener(LogListener listener, LogFilter filter) {
+		addLogListener(listener); //Listener must filter if required
+
+	}
+
+	@Override
+	public org.osgi.service.log.Logger getLogger(Class<?> clazz) {
+		return this;
+	}
+
+	@Override
+	@Deprecated
+	public <L extends org.osgi.service.log.Logger> L getLogger(String name, Class<L> loggerType) {
+		throw new UnsupportedOperationException("Logger Factory currently not supported.");
+	}
+
+	@Override
+	@Deprecated
+	public <L extends org.osgi.service.log.Logger> L getLogger(Class<?> clazz, Class<L> loggerType) {
+		return getLogger(getName(), loggerType);
+	}
+
+	@Override
+	@Deprecated
+	public <L extends org.osgi.service.log.Logger> L getLogger(Bundle bundle, String name, Class<L> loggerType) {
+		return getLogger(getName(), loggerType);
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return false;
+	}
+
+	@Override
+	public void trace(String message) {
+		log(new SimpleLogEntry(LogLevel.TRACE, message));
+	}
+
+	@Override
+	public void trace(String format, Object arg) {
+		trace(String.format(format, arg));
+	}
+
+	@Override
+	public void trace(String format, Object arg1, Object arg2) {
+		trace(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void trace(String format, Object... arguments) {
+		trace(String.format(format, arguments));
+	}
+
+	@Override
+	@Deprecated
+	public <E extends Exception> void trace(LoggerConsumer<E> consumer) throws E {
+		throw new UnsupportedOperationException("Logger Consumer currently not supported.");
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return false;
+	}
+
+	@Override
+	public void debug(String message) {
+		log(new SimpleLogEntry(LogLevel.DEBUG, message));
+	}
+
+	@Override
+	public void debug(String format, Object arg) {
+		debug(String.format(format, arg));
+	}
+
+	@Override
+	public void debug(String format, Object arg1, Object arg2) {
+		debug(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void debug(String format, Object... arguments) {
+		trace(String.format(format, arguments));
+	}
+
+	@Override
+	@Deprecated
+	public <E extends Exception> void debug(LoggerConsumer<E> consumer) throws E {
+		throw new UnsupportedOperationException("Logger Consumer currently not supported.");
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return false;
+	}
+
+	@Override
+	public void info(String message) {
+		log(new SimpleLogEntry(LogLevel.INFO, message));
+	}
+
+	@Override
+	public void info(String format, Object arg) {
+		info(String.format(format, arg));
+	}
+
+	@Override
+	public void info(String format, Object arg1, Object arg2) {
+		info(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void info(String format, Object... arguments) {
+		info(String.format(format, arguments));
+	}
+
+	@Override
+	@Deprecated
+	public <E extends Exception> void info(LoggerConsumer<E> consumer) throws E {
+		throw new UnsupportedOperationException("Logger Consumer currently not supported.");
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return false;
+	}
+
+	@Override
+	public void warn(String message) {
+		log(new SimpleLogEntry(LogLevel.WARN, message));
+	}
+
+	@Override
+	public void warn(String format, Object arg) {
+		warn(String.format(format, arg));
+	}
+
+	@Override
+	public void warn(String format, Object arg1, Object arg2) {
+		warn(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void warn(String format, Object... arguments) {
+		warn(String.format(format, arguments));
+	}
+
+	@Override
+	@Deprecated
+	public <E extends Exception> void warn(LoggerConsumer<E> consumer) throws E {
+		throw new UnsupportedOperationException("Logger Consumer currently not supported.");
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return true;
+	}
+
+	@Override
+	public void error(String message) {
+		log(new SimpleLogEntry(LogLevel.ERROR, message));
+	}
+
+	@Override
+	public void error(String format, Object arg) {
+		error(String.format(format, arg));
+	}
+
+	@Override
+	public void error(String format, Object arg1, Object arg2) {
+		error(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void error(String format, Object... arguments) {
+		error(String.format(format, arguments));
+	}
+
+	@Override
+	@Deprecated
+	public <E extends Exception> void error(LoggerConsumer<E> consumer) throws E {
+		throw new UnsupportedOperationException("Logger Consumer currently not supported.");
+	}
+
+	@Override
+	public void audit(String message) {
+		log(new SimpleLogEntry(LogLevel.AUDIT, message));
+	}
+
+	@Override
+	public void audit(String format, Object arg) {
+		audit(String.format(format, arg));
+	}
+
+	@Override
+	public void audit(String format, Object arg1, Object arg2) {
+		audit(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void audit(String format, Object... arguments) {
+		audit(String.format(format, arguments));
+	}
+
+	public static class SimpleLogEntry implements LogEntry {
+
+		private final LogLevel level;
+		private final String message;
+		private final Optional<Throwable> execption;
+
+		public SimpleLogEntry(LogLevel level, String message) {
+			this(level, message, Optional.empty());
+		}
+
+		public SimpleLogEntry(LogLevel level, String message, Throwable execption) {
+			this(level, message, Optional.ofNullable(execption));
+		}
+
+		private SimpleLogEntry(LogLevel level, String message, Optional<Throwable> execption) {
+			this.level = level;
+			this.message = message;
+			this.execption = execption;
+		}
+
+		@Override
+		public Bundle getBundle() {
+			//Return the spotless framework bundle
+			return InternalPlatform.getDefault().getBundleContext().getBundle();
+		}
+
+		@SuppressWarnings({"rawtypes", "unchecked"})
+		@Override
+		public ServiceReference getServiceReference() {
+			return null;
+		}
+
+		@Override
+		@Deprecated
+		//Backward compatibility with Eclipse OSGI 3.12
+		public int getLevel() {
+			switch (level) {
+			case DEBUG:
+			case TRACE:
+				return LogService.LOG_DEBUG;
+			case AUDIT:
+			case INFO:
+				return LogService.LOG_INFO;
+			case ERROR:
+				return LogService.LOG_ERROR;
+			case WARN:
+				return LogService.LOG_WARNING;
+			}
+			return LogService.LOG_ERROR; //Don't fail here. Just log it as error. This is anyway just for debugging internal problems.
+		}
+
+		@Override
+		public String getMessage() {
+			return message;
+		}
+
+		@Override
+		public Throwable getException() {
+			return execption.orElse(null);
+		}
+
+		@Override
+		public long getTime() {
+			return 0;
+		}
+
+		@Override
+		public String toString() {
+			StringWriter result = new StringWriter();
+			result.write(message);
+			if (execption.isPresent()) {
+				result.write('\n');
+				result.write(execption.get().toString());
+				result.write('\n');
+				execption.get().printStackTrace(new PrintWriter(result));
+			}
+			return result.toString();
+		}
+
+		@Override
+		public LogLevel getLogLevel() {
+			return level;
+		}
+
+		@Override
+		public String getLoggerName() {
+			return this.getClass().getSimpleName();
+		}
+
+		@Override
+		public long getSequence() {
+			return 0;
+		}
+
+		@Override
+		public String getThreadInfo() {
+			return null;
+		}
+
+		@Override
+		public StackTraceElement getLocation() {
+			return null;
+		}
+
+	}
+
+}

--- a/_ext/eclipse-cdt/src/test/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImplTest.java
+++ b/_ext/eclipse-cdt/src/test/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImplTest.java
@@ -45,6 +45,9 @@ public class EclipseCdtFormatterStepImplTest {
 
 	private final static String ILLEGAL_CHAR = Character.toString((char) 254);
 
+	private final static String FUNCT_PTR_UNFORMATTED = "void  (*getFunc(void))  (int);";
+	private final static String FUNCT_PTR_FORMATTED = "void (*getFunc(void)) (int);";
+
 	@Test
 	public void defaultFormat() throws Throwable {
 		String output = format(CPP_UNFORMATTED, config -> {});
@@ -79,6 +82,12 @@ public class EclipseCdtFormatterStepImplTest {
 		String output = format(DOXYGEN_HTML + CPP_FORMATTED, config -> {});
 		assertEquals("HTML comments not ignored by formatter.",
 				DOXYGEN_HTML + CPP_FORMATTED, output);
+	}
+
+	@Test
+	public void regionWarning() throws Throwable {
+		String output = format(FUNCT_PTR_UNFORMATTED, config -> {});
+		assertEquals("Code not formatted at all due to regional error.", FUNCT_PTR_FORMATTED, output);
 	}
 
 	private static String format(final String input, final Consumer<Properties> config) throws Exception {


### PR DESCRIPTION
There had been already integration tests to check the formatter behaviour in case of errors (AST, parsing, configuration). In all these scenarios, the CDT formatter silently continued on a best effort approach.
Hence the surrounding CDT core plugin had never been activated, to keep the transitive dependencies of the Spotless extension to a minimum.
Unfortunately it has been found in real life scenarios, that the regional formatter has the tendency to log warnings. A corresponding integration test step has been added.
Hence this fix provides a logging service. The service only logs errors and eats warnings for the following reasons:

- Warning occurs on common C constructs
- In case the warning occurs, just a small part of the code line is not formatted (kept as it is). The rest of the line and the rest of the file is properly formatted.
- Warning contains no detailed information about the kind of problem
- Warning contains no information about the source of problem