### PR TITLE
Groovy-Eclipse  3.0.0

### DIFF
--- a/_ext/eclipse-groovy/build.gradle
+++ b/_ext/eclipse-groovy/build.gradle
@@ -12,13 +12,13 @@ ext {
 		// the once used during code formatting
 		'org.codehaus.groovy':'+', // Groovy compiler patches supporting use within GrEclipse and Groovy itself
 		'org.codehaus.groovy.eclipse.core':'+', // Groovy core classes (provides central logging used by formatter)
-		//'org.eclipse.jdt.core':"${VER_JDT_PATCH}", // Patches org.eclipse.jdt.core classes supporting use within GrEclipse (provides AST generator)
+		'org.eclipse.jdt.core':'+', // Patches org.eclipse.jdt.core classes supporting use within GrEclipse (provides AST generator)
 		'org.eclipse.jdt.groovy.core':'+' // Extends org.eclipse.jdt.core for Groovy
 	]
 
 	internalJars = [
 		//Jars included by org.codehaus.groovy
-		"**/groovy-all-${VER_GROOVY}-indy", // Use Groovy compiler compatible with GrEclipse instead of localGroovy
+		"**/groovy-${VER_GROOVY}-indy", // Use Groovy compiler compatible with GrEclipse instead of localGroovy
 		'**/groovy-eclipse', // Patches/Overrides some of the Groovy compiler classes
 		'**/eclipse-trace', // Provides logging capabilities for groovy-eclipse
 

--- a/_ext/eclipse-groovy/gradle.properties
+++ b/_ext/eclipse-groovy/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Groovy-Eclipse version used for the fat-JAR.
 # See https://github.com/groovy/groovy-eclipse/releases for further information about Groovy-Eclipse versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=2.9.2
+ext_version=3.0.0
 ext_artifactId=spotless-eclipse-groovy
 ext_description=Groovy Eclipse's formatter bundled for Spotless
 
@@ -12,8 +12,7 @@ ext_group=com.diffplug.spotless
 ext_VER_JAVA=1.8
 
 # Compile
-VER_ECLIPSE=4.7
+VER_ECLIPSE=4.8
 VER_SPOTLESS_ECLISPE_BASE=[3.0.0,4.0.0[
 VER_ECLISPE_JFACE=[3.12.0,4.0.0[
-VER_GROOVY=2.5.0
-VER_JDT_PATCH=3.13.100.xx-201801041714-e47-RELEASE
+VER_GROOVY=2.6.0

--- a/_ext/eclipse-groovy/src/main/java/com/diffplug/spotless/extra/eclipse/groovy/SpotlessLogService.java
+++ b/_ext/eclipse-groovy/src/main/java/com/diffplug/spotless/extra/eclipse/groovy/SpotlessLogService.java
@@ -369,7 +369,7 @@ public class SpotlessLogService implements ExtendedLogService, ExtendedLogReader
 		}
 
 		public SimpleLogEntry(LogLevel level, String message, Throwable execption) {
-			this(level, message, Optional.of(execption));
+			this(level, message, Optional.ofNullable(execption));
 		}
 
 		private SimpleLogEntry(LogLevel level, String message, Optional<Throwable> execption) {

--- a/_ext/eclipse-groovy/src/test/java/com/diffplug/spotless/extra/eclipse/groovy/GrEclipseFormatterStepImplTest.java
+++ b/_ext/eclipse-groovy/src/test/java/com/diffplug/spotless/extra/eclipse/groovy/GrEclipseFormatterStepImplTest.java
@@ -31,7 +31,7 @@ public class GrEclipseFormatterStepImplTest {
 	private final static TestData TEST_DATA = TestData.getTestDataOnFileSystem();
 	private final static String PARSER_EXCEPTION = "class Test { void method() {} ";
 	private final static String SCANNER_EXCEPTION = "{";
-	private final static String BOUNDED_WILDCARDS = "foo(Map<String, ? extends Object> e) {}";
+	private final static String BOUNDED_WILDCARDS = "foo(Map<String, ? extends  Object> e)\n{\ne.clear();\n}";
 
 	@Test
 	public void defaultFormat() throws Throwable {
@@ -71,10 +71,15 @@ public class GrEclipseFormatterStepImplTest {
 		format(SCANNER_EXCEPTION, config -> {});
 	}
 
-	/** Test the handling bounded wildcards templates */
-	@Test(expected = IllegalArgumentException.class)
+	/**
+	 * Test the handling bounded wildcards templates
+	 * No exception since Groovy-Eclipse 3.0.0.
+	 */
+	@Test
 	public void boundedWildCards() throws Throwable {
-		format(BOUNDED_WILDCARDS, config -> {});
+		String output = format(BOUNDED_WILDCARDS, config -> {});
+		assertEquals("Groovy formatter does  notformat after bounded wildcards correctly.",
+				BOUNDED_WILDCARDS.replace("\n", " "), output);
 	}
 
 	@Test


### PR DESCRIPTION
Upgrade of Spotless Eclipse Groovy formatter to Groovy 2.6 / Groovy-Eclipse 3.0.0 as requested in #237.