### PR TITLE
Include Maven version requirement in the generated POM

### DIFF
--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -64,6 +64,8 @@ def cred = {
 	}
 }
 
+final MAVEN_PLUGIN_ARTIFACT_NAME = 'spotless-maven-plugin'
+
 model {
 	publishing {
 		publications {
@@ -97,8 +99,12 @@ model {
 								distribution 'repo'
 							}
 						}
+						if (project.ext.artifactId == MAVEN_PLUGIN_ARTIFACT_NAME) {
+							// Maven plugin required Maven 3.1.0+ to run
+							prerequisites { maven '3.1.0' }
+						}
 						developers {
-							if (project.ext.artifactId == 'spotless-plugin-maven') {
+							if (project.ext.artifactId == MAVEN_PLUGIN_ARTIFACT_NAME) {
 								developer {
 									id 'lutovich'
 									name 'Konstantin Lutovich'

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@
 * Skip `package-info.java` and `module-info.java` files from license header formatting. ([#273](https://github.com/diffplug/spotless/pull/273))
 * Updated JSR305 annotation from 3.0.0 to 3.0.2 ([#274](https://github.com/diffplug/spotless/pull/274))
 * Migrated from FindBugs annotations 3.0.0 to SpotBugs annotations 3.1.6 ([#274](https://github.com/diffplug/spotless/pull/274))
+* Fix Maven version prerequisite in the generated POM ([#289](https://github.com/diffplug/spotless/pull/289))
 
 ### Version 1.14.0 - July 24th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.14.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.14.0))
 

--- a/plugin-maven/src/test/resources/pom-build.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-build.xml.mustache
@@ -9,6 +9,7 @@
 
   <name>Spotless Maven Plugin</name>
 
+  <!-- Require plugin to be built with Maven 3.1.0+ -->
   <prerequisites>
     <maven>3.1.0</maven>
   </prerequisites>

--- a/plugin-maven/src/test/resources/pom-test.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-test.xml.mustache
@@ -8,6 +8,11 @@
 
     <name>Spotless Maven Plugin Tests</name>
 
+    <!-- Require plugin to be tested with Maven 3.1.0+ -->
+    <prerequisites>
+        <maven>3.1.0</maven>
+    </prerequisites>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Before this PR, it was only included in the POM used to build the plugin. It is different from the POM that's being published to Maven Central. Later is generated using `generatePomFileForPluginMavenPublication` gradle task. This resulted in Maven version requirement not being enforced and builds failing with confusing error messages.

Also added `prerequisites` section to the POM used to test the plugin.