### PR TITLE
Gradle/Groovy importOrder no longer adds semicolons

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -37,11 +37,15 @@ import com.diffplug.spotless.FormatterStep;
 public final class ImportOrderStep {
 	private final String lineFormat;
 
-	public ImportOrderStep() {
-		this("import %s;");
+	public static ImportOrderStep forGroovy() {
+		return new ImportOrderStep("import %s");
 	}
 
-	public ImportOrderStep(String lineFormat) {
+	public static ImportOrderStep forJava() {
+		return new ImportOrderStep("import %s;");
+	}
+
+	private ImportOrderStep(String lineFormat) {
 		this.lineFormat = lineFormat;
 	}
 
@@ -68,21 +72,21 @@ public final class ImportOrderStep {
 	public static FormatterStep createFromOrder(List<String> importOrder) {
 		// defensive copying and null checking
 		importOrder = requireElementsNonNull(new ArrayList<>(importOrder));
-		return new ImportOrderStep().createFrom(importOrder);
+		return forJava().createFrom(importOrder);
 	}
 
 	/** Static method has been replaced by instance method
 	 * {@link ImportOrderStep#createFrom(String...)}.*/
 	@Deprecated
 	public static FormatterStep createFromOrder(String... importOrder) {
-		return new ImportOrderStep().createFrom(importOrder);
+		return forJava().createFrom(importOrder);
 	}
 
 	/** Static method has been replaced by instance method
 	 * {@link ImportOrderStep#createFrom(File)}.*/
 	@Deprecated
 	public static FormatterStep createFromFile(File importsFile) {
-		return new ImportOrderStep().createFrom(importsFile);
+		return forJava().createFrom(importsFile);
 	}
 
 	private static List<String> getImportOrder(File importsFile) {

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
@@ -34,7 +34,7 @@ final class ImportSorter {
 		this.importsOrder = new ArrayList<>(importsOrder);
 	}
 
-	public String format(String raw) {
+	String format(String raw, String lineFormat) {
 		// parse file
 		Scanner scanner = new Scanner(raw);
 		int firstImportLine = 0;
@@ -79,7 +79,7 @@ final class ImportSorter {
 		}
 		scanner.close();
 
-		List<String> sortedImports = ImportSorterImpl.sort(imports, importsOrder);
+		List<String> sortedImports = ImportSorterImpl.sort(imports, importsOrder, lineFormat);
 		return applyImportsToDocument(raw, firstImportLine, lastImportLine, sortedImports);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -35,18 +35,18 @@ final class ImportSorterImpl {
 	private final List<String> notMatching = new ArrayList<>();
 	private final Set<String> allImportOrderItems = new HashSet<>();
 
-	static List<String> sort(List<String> imports, List<String> importsOrder) {
+	static List<String> sort(List<String> imports, List<String> importsOrder, String lineFormat) {
 		ImportSorterImpl importsSorter = new ImportSorterImpl(importsOrder);
-		return importsSorter.sort(imports);
+		return importsSorter.sort(imports, lineFormat);
 	}
 
-	private List<String> sort(List<String> imports) {
+	private List<String> sort(List<String> imports, String lineFormat) {
 		filterMatchingImports(imports);
 		mergeNotMatchingItems(false);
 		mergeNotMatchingItems(true);
 		mergeMatchingItems();
 
-		return getResult();
+		return getResult(lineFormat);
 	}
 
 	private ImportSorterImpl(List<String> importOrder) {
@@ -218,14 +218,14 @@ final class ImportSorterImpl {
 		}
 	}
 
-	private List<String> getResult() {
+	private List<String> getResult(String lineFormat) {
 		List<String> strings = new ArrayList<>();
 
 		for (String s : template) {
 			if (s.equals(ImportSorter.N)) {
 				strings.add(s);
 			} else {
-				strings.add("import " + s + ";" + ImportSorter.N);
+				strings.add(String.format(lineFormat, s) + ImportSorter.N);
 			}
 		}
 		return strings;

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@
 * LicenseHeaderStep now wont attempt to add license to `module-info.java` ([#272](https://github.com/diffplug/spotless/pull/272)).
 * Updated JSR305 annotation from 3.0.0 to 3.0.2 ([#274](https://github.com/diffplug/spotless/pull/274))
 * Migrated from FindBugs annotations 3.0.0 to SpotBugs annotations 3.1.6 ([#274](https://github.com/diffplug/spotless/pull/274))
+* Gradle/Groovy `importOrder` no longer adds semicolons. ([#237](https://github.com/diffplug/spotless/issues/237))
 
 ### Version 3.14.0 - July 24th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.14.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.14.0))
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -37,11 +37,9 @@ import com.diffplug.spotless.java.ImportOrderStep;
 
 public class GroovyExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "groovy";
-	private final ImportOrderStep importOrderStepFactory;
 
 	public GroovyExtension(SpotlessExtension rootExtension) {
 		super(rootExtension);
-		importOrderStepFactory = new ImportOrderStep("import %s");
 	}
 
 	boolean excludeJava = false;
@@ -79,12 +77,12 @@ public class GroovyExtension extends FormatExtension implements HasBuiltinDelimi
 	}
 
 	public void importOrder(String... importOrder) {
-		addStep(importOrderStepFactory.createFrom(importOrder));
+		addStep(ImportOrderStep.forGroovy().createFrom(importOrder));
 	}
 
 	public void importOrderFile(Object importOrderFile) {
 		Objects.requireNonNull(importOrderFile);
-		addStep(importOrderStepFactory.createFrom(getProject().file(importOrderFile)));
+		addStep(ImportOrderStep.forGroovy().createFrom(getProject().file(importOrderFile)));
 	}
 
 	public GrEclipseConfig greclipse() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -37,9 +37,11 @@ import com.diffplug.spotless.java.ImportOrderStep;
 
 public class GroovyExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "groovy";
+	private final ImportOrderStep importOrderStepFactory;
 
 	public GroovyExtension(SpotlessExtension rootExtension) {
 		super(rootExtension);
+		importOrderStepFactory = new ImportOrderStep("import %s");
 	}
 
 	boolean excludeJava = false;
@@ -73,16 +75,16 @@ public class GroovyExtension extends FormatExtension implements HasBuiltinDelimi
 						"'importOrder([x, y, z])' is deprecated.",
 						"Use 'importOrder x, y, z' instead.",
 						"For details see https://github.com/diffplug/spotless/tree/master/plugin-gradle#applying-to-java-source"));
-		addStep(ImportOrderStep.createFromOrder(importOrder));
+		importOrder(importOrder.toArray(new String[0]));
 	}
 
 	public void importOrder(String... importOrder) {
-		addStep(ImportOrderStep.createFromOrder(importOrder));
+		addStep(importOrderStepFactory.createFrom(importOrder));
 	}
 
 	public void importOrderFile(Object importOrderFile) {
 		Objects.requireNonNull(importOrderFile);
-		addStep(ImportOrderStep.createFromFile(getProject().file(importOrderFile)));
+		addStep(importOrderStepFactory.createFrom(getProject().file(importOrderFile)));
 	}
 
 	public GrEclipseConfig greclipse() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyGradleExtension.java
@@ -23,18 +23,20 @@ import com.diffplug.spotless.java.ImportOrderStep;
 public class GroovyGradleExtension extends FormatExtension {
 	private static final String GRADLE_FILE_EXTENSION = "*.gradle";
 	static final String NAME = "groovyGradle";
+	private final ImportOrderStep importOrderStepFactory;
 
 	public GroovyGradleExtension(SpotlessExtension rootExtension) {
 		super(rootExtension);
+		importOrderStepFactory = new ImportOrderStep("import %s");
 	}
 
 	public void importOrder(String... importOrder) {
-		addStep(ImportOrderStep.createFromOrder(importOrder));
+		addStep(importOrderStepFactory.createFrom(importOrder));
 	}
 
 	public void importOrderFile(Object importOrderFile) {
 		Objects.requireNonNull(importOrderFile);
-		addStep(ImportOrderStep.createFromFile(getProject().file(importOrderFile)));
+		addStep(importOrderStepFactory.createFrom(getProject().file(importOrderFile)));
 	}
 
 	public GroovyExtension.GrEclipseConfig greclipse() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyGradleExtension.java
@@ -23,20 +23,18 @@ import com.diffplug.spotless.java.ImportOrderStep;
 public class GroovyGradleExtension extends FormatExtension {
 	private static final String GRADLE_FILE_EXTENSION = "*.gradle";
 	static final String NAME = "groovyGradle";
-	private final ImportOrderStep importOrderStepFactory;
 
 	public GroovyGradleExtension(SpotlessExtension rootExtension) {
 		super(rootExtension);
-		importOrderStepFactory = new ImportOrderStep("import %s");
 	}
 
 	public void importOrder(String... importOrder) {
-		addStep(importOrderStepFactory.createFrom(importOrder));
+		addStep(ImportOrderStep.forGroovy().createFrom(importOrder));
 	}
 
 	public void importOrderFile(Object importOrderFile) {
 		Objects.requireNonNull(importOrderFile);
-		addStep(importOrderStepFactory.createFrom(getProject().file(importOrderFile)));
+		addStep(ImportOrderStep.forGroovy().createFrom(getProject().file(importOrderFile)));
 	}
 
 	public GroovyExtension.GrEclipseConfig greclipse() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -39,9 +39,11 @@ import com.diffplug.spotless.java.RemoveUnusedImportsStep;
 @SuppressWarnings("deprecation")
 public class JavaExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "java";
+	private final ImportOrderStep importOrderStepFactory;
 
 	public JavaExtension(SpotlessExtension rootExtension) {
 		super(rootExtension);
+		importOrderStepFactory = new ImportOrderStep();
 	}
 
 	// If this constant changes, don't forget to change the similarly-named one in
@@ -71,12 +73,12 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	}
 
 	public void importOrder(String... importOrder) {
-		addStep(ImportOrderStep.createFromOrder(importOrder));
+		addStep(importOrderStepFactory.createFrom(importOrder));
 	}
 
 	public void importOrderFile(Object importOrderFile) {
 		Objects.requireNonNull(importOrderFile);
-		addStep(ImportOrderStep.createFromFile(getProject().file(importOrderFile)));
+		addStep(importOrderStepFactory.createFrom(getProject().file(importOrderFile)));
 	}
 
 	/** Use {@link #eclipse()} instead */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -39,11 +39,9 @@ import com.diffplug.spotless.java.RemoveUnusedImportsStep;
 @SuppressWarnings("deprecation")
 public class JavaExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "java";
-	private final ImportOrderStep importOrderStepFactory;
 
 	public JavaExtension(SpotlessExtension rootExtension) {
 		super(rootExtension);
-		importOrderStepFactory = new ImportOrderStep();
 	}
 
 	// If this constant changes, don't forget to change the similarly-named one in
@@ -73,12 +71,12 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	}
 
 	public void importOrder(String... importOrder) {
-		addStep(importOrderStepFactory.createFrom(importOrder));
+		addStep(ImportOrderStep.forJava().createFrom(importOrder));
 	}
 
 	public void importOrderFile(Object importOrderFile) {
 		Objects.requireNonNull(importOrderFile);
-		addStep(importOrderStepFactory.createFrom(getProject().file(importOrderFile)));
+		addStep(ImportOrderStep.forJava().createFrom(getProject().file(importOrderFile)));
 	}
 
 	/** Use {@link #eclipse()} instead */

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Version 1.15.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Gradle/Groovy `importOrder` no longer adds semicolons. ([#237](https://github.com/diffplug/spotless/issues/237))
 * Skip `package-info.java` and `module-info.java` files from license header formatting. ([#273](https://github.com/diffplug/spotless/pull/273))
 * Updated JSR305 annotation from 3.0.0 to 3.0.2 ([#274](https://github.com/diffplug/spotless/pull/274))
 * Migrated from FindBugs annotations 3.0.0 to SpotBugs annotations 3.1.6 ([#274](https://github.com/diffplug/spotless/pull/274))

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
@@ -34,12 +34,11 @@ public class ImportOrder implements FormatterStepFactory {
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		if (file != null ^ order != null) {
-			ImportOrderStep importOrderStepFactory = new ImportOrderStep();
 			if (file != null) {
 				File importsFile = config.getFileLocator().locateFile(file);
-				return importOrderStepFactory.createFrom(importsFile);
+				return ImportOrderStep.forJava().createFrom(importsFile);
 			} else {
-				return importOrderStepFactory.createFrom(order.split(","));
+				return ImportOrderStep.forJava().createFrom(order.split(","));
 			}
 		} else {
 			throw new IllegalArgumentException("Must specify exactly one of 'file' or 'order'.");

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
@@ -34,11 +34,12 @@ public class ImportOrder implements FormatterStepFactory {
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		if (file != null ^ order != null) {
+			ImportOrderStep importOrderStepFactory = new ImportOrderStep();
 			if (file != null) {
 				File importsFile = config.getFileLocator().locateFile(file);
-				return ImportOrderStep.createFromFile(importsFile);
+				return importOrderStepFactory.createFrom(importsFile);
 			} else {
-				return ImportOrderStep.createFromOrder(order.split(","));
+				return importOrderStepFactory.createFrom(order.split(","));
 			}
 		} else {
 			throw new IllegalArgumentException("Must specify exactly one of 'file' or 'order'.");

--- a/testlib/src/main/resources/java/importsorter/GroovyCodeSortedMisplacedImports.test
+++ b/testlib/src/main/resources/java/importsorter/GroovyCodeSortedMisplacedImports.test
@@ -1,0 +1,13 @@
+import java.lang.Runnable
+import java.lang.Thread
+
+import org.dooda.Didoo
+
+import static java.lang.Exception.*
+import static java.lang.Runnable.*
+
+import static com.foo.Bar
+public class NotDeletedByFormatter {
+}
+import will.not;
+import be.modified;

--- a/testlib/src/main/resources/java/importsorter/GroovyCodeUnsortedMisplacedImports.test
+++ b/testlib/src/main/resources/java/importsorter/GroovyCodeUnsortedMisplacedImports.test
@@ -1,0 +1,16 @@
+import static java.lang.Exception.*
+import org.dooda.Didoo
+/*
+public class IgnoredAndRemoved {
+}
+*/
+import java.lang.Thread;
+// Will be removed {}
+import java.lang.Runnable;
+
+import static java.lang.Runnable.*;
+import static com.foo.Bar;
+public class NotDeletedByFormatter {
+}
+import will.not;
+import be.modified;

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -22,54 +22,52 @@ import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 
 public class ImportOrderStepTest extends ResourceHarness {
-	private static final ImportOrderStep JAVA = new ImportOrderStep();
-	private static final ImportOrderStep GROOVY = new ImportOrderStep("import %s");
 
 	@Test
 	public void sortImportsFromArray() throws Throwable {
-		FormatterStep step = JAVA.createFrom("java", "javax", "org", "\\#com");
+		FormatterStep step = ImportOrderStep.forJava().createFrom("java", "javax", "org", "\\#com");
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void sortImportsFromFile() throws Throwable {
-		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import.properties"));
+		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void sortImportsUnmatched() throws Throwable {
-		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
+		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
 	}
 
 	@Test
 	public void removeDuplicates() throws Throwable {
-		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
+		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeSortedDuplicateImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
 	}
 
 	@Test
 	public void removeComments() throws Throwable {
-		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import.properties"));
+		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeImportComments.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void misplacedImports() throws Throwable {
-		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import.properties"));
+		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedMisplacedImports.test", "java/importsorter/JavaCodeSortedMisplacedImports.test");
 	}
 
 	@Test
 	public void groovyImports() throws Throwable {
-		FormatterStep step = GROOVY.createFrom(createTestFile("java/importsorter/import.properties"));
+		FormatterStep step = ImportOrderStep.forGroovy().createFrom(createTestFile("java/importsorter/import.properties"));
 		assertOnResources(step, "java/importsorter/GroovyCodeUnsortedMisplacedImports.test", "java/importsorter/GroovyCodeSortedMisplacedImports.test");
 	}
 
 	@Test
 	public void doesntThrowIfImportOrderIsntSerializable() {
-		JAVA.createFrom("java", "javax", "org", "\\#com");
+		ImportOrderStep.forJava().createFrom("java", "javax", "org", "\\#com");
 	}
 
 	@Test
@@ -94,7 +92,7 @@ public class ImportOrderStepTest extends ResourceHarness {
 
 			@Override
 			protected FormatterStep create() {
-				return JAVA.createFrom(imports);
+				return ImportOrderStep.forJava().createFrom(imports);
 			}
 		}.testEquals();
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -22,45 +22,54 @@ import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 
 public class ImportOrderStepTest extends ResourceHarness {
+	private static final ImportOrderStep JAVA = new ImportOrderStep();
+	private static final ImportOrderStep GROOVY = new ImportOrderStep("import %s");
+
 	@Test
 	public void sortImportsFromArray() throws Throwable {
-		FormatterStep step = ImportOrderStep.createFromOrder("java", "javax", "org", "\\#com");
+		FormatterStep step = JAVA.createFrom("java", "javax", "org", "\\#com");
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void sortImportsFromFile() throws Throwable {
-		FormatterStep step = ImportOrderStep.createFromFile(createTestFile("java/importsorter/import.properties"));
+		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void sortImportsUnmatched() throws Throwable {
-		FormatterStep step = ImportOrderStep.createFromFile(createTestFile("java/importsorter/import_unmatched.properties"));
+		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
 	}
 
 	@Test
 	public void removeDuplicates() throws Throwable {
-		FormatterStep step = ImportOrderStep.createFromFile(createTestFile("java/importsorter/import_unmatched.properties"));
+		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeSortedDuplicateImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
 	}
 
 	@Test
 	public void removeComments() throws Throwable {
-		FormatterStep step = ImportOrderStep.createFromFile(createTestFile("java/importsorter/import.properties"));
+		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeImportComments.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
 	public void misplacedImports() throws Throwable {
-		FormatterStep step = ImportOrderStep.createFromFile(createTestFile("java/importsorter/import.properties"));
+		FormatterStep step = JAVA.createFrom(createTestFile("java/importsorter/import.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeUnsortedMisplacedImports.test", "java/importsorter/JavaCodeSortedMisplacedImports.test");
 	}
 
 	@Test
+	public void groovyImports() throws Throwable {
+		FormatterStep step = GROOVY.createFrom(createTestFile("java/importsorter/import.properties"));
+		assertOnResources(step, "java/importsorter/GroovyCodeUnsortedMisplacedImports.test", "java/importsorter/GroovyCodeSortedMisplacedImports.test");
+	}
+
+	@Test
 	public void doesntThrowIfImportOrderIsntSerializable() {
-		ImportOrderStep.createFromOrder("java", "javax", "org", "\\#com");
+		JAVA.createFrom("java", "javax", "org", "\\#com");
 	}
 
 	@Test
@@ -85,7 +94,7 @@ public class ImportOrderStepTest extends ResourceHarness {
 
 			@Override
 			protected FormatterStep create() {
-				return ImportOrderStep.createFromOrder(imports);
+				return JAVA.createFrom(imports);
 			}
 		}.testEquals();
 	}


### PR DESCRIPTION
Gradle/Groovy `importOrder` no longer adds semicolons at end of statement.
Fixes #237 .