### PR TITLE
Using Maven dependency mediation

### DIFF
--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -15,9 +15,12 @@
  */
 package com.diffplug.spotless.maven;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -53,10 +56,18 @@ public class ArtifactResolver {
 		this.log = Objects.requireNonNull(log);
 	}
 
+	/** Use {@link ArtifactResolver#resolve(Collection) instead.} */
+	@Deprecated
 	public Set<File> resolve(String mavenCoordinate) {
-		Artifact artifact = new DefaultArtifact(mavenCoordinate);
-		Dependency dependency = new Dependency(artifact, null);
-		CollectRequest collectRequest = new CollectRequest(dependency, repositories);
+		return resolve(Arrays.asList(mavenCoordinate));
+	}
+
+	public Set<File> resolve(Collection<String> mavenCoordinate) {
+		List<Dependency> dependencies = mavenCoordinate.stream()
+				.map(coordinateString -> new DefaultArtifact(coordinateString))
+				.map(artifact -> new Dependency(artifact, null))
+				.collect(toList());
+		CollectRequest collectRequest = new CollectRequest((Dependency) null, dependencies, repositories);
 		DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, ACCEPT_ALL_FILTER);
 
 		DependencyResult dependencyResult = resolveDependencies(dependencyRequest);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
@@ -15,8 +15,6 @@
  */
 package com.diffplug.spotless.maven;
 
-import static java.util.stream.Collectors.toSet;
-
 import java.util.Objects;
 
 import com.diffplug.spotless.Provisioner;
@@ -27,9 +25,7 @@ public class MavenProvisioner {
 
 	public static Provisioner create(ArtifactResolver artifactResolver) {
 		Objects.requireNonNull(artifactResolver);
-
-		return mavenCoords -> mavenCoords.stream()
-				.flatMap(coord -> artifactResolver.resolve(coord).stream())
-				.collect(toSet());
+		return mavenCoords -> artifactResolver.resolve(mavenCoords);
 	}
+
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
@@ -15,8 +15,6 @@
  */
 package com.diffplug.spotless.maven;
 
-import java.util.Objects;
-
 import com.diffplug.spotless.Provisioner;
 
 /** Maven integration for Provisioner. */
@@ -24,8 +22,7 @@ public class MavenProvisioner {
 	private MavenProvisioner() {}
 
 	public static Provisioner create(ArtifactResolver artifactResolver) {
-		Objects.requireNonNull(artifactResolver);
-		return mavenCoords -> artifactResolver.resolve(mavenCoords);
+		return artifactResolver::resolve;
 	}
 
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
@@ -26,7 +26,7 @@ public class MavenProvisionerTest extends MavenIntegrationTest {
 				"  <version>4.8.0</version>",
 				"</eclipse>");
 		setFile("formatter.xml").toResource("java/eclipse/formatter.xml");
-		resolveDependencies();
+		assertResolveDependenciesWorks();
 	}
 
 	@Test
@@ -35,12 +35,14 @@ public class MavenProvisionerTest extends MavenIntegrationTest {
 				"<googleJavaFormat>",
 				"  <version>1.2</version>",
 				"</googleJavaFormat>");
-		resolveDependencies();
+		assertResolveDependenciesWorks();
 	}
 
-	private void resolveDependencies() throws Exception {
+	private void assertResolveDependenciesWorks() throws Exception {
 		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/eclipse/JavaCodeUnformatted.test");
+		String unformattedContent = "package  a;";
+		setFile(path).toContent(unformattedContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).hasContent(unformattedContent.replace("  ", " "));
 	}
 }


### PR DESCRIPTION
Currently Spotless uses 2 kinds of dependencies:

- Resolved dependency list without any transitives (not fully implemented yet)
- Single ("root") dependencies

The `Provisioner` interface supports "dependency lists" (currently always resolving transitives).
The previous  `MavenProvisioner` implementation took individually each dependency as a root dependency, resolves it (and its transitives) and puts the JARs into a hash set.

There had been quite an evolution how Maven resolves transitives. Please refer to the [Transitive Dependencies documentation](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies) for details.

The whole issue is NOT affecting the current formatters (due to the simple dependency structure of current formatters). However, the `maven-plugin` `Provisioner` should not interfere with the dependency resolution of `Maven` to avoid bugs in future evolution of `Spotless`.