### PR TITLE
Provisioner can provide dependencies without their transitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ You might be looking for:
 
 ### Version 1.15.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Extended dependency provisioner to exclude transitives on request ([#297](https://github.com/diffplug/spotless/pull/297)).This prevents unnecessary downloads of unused transitive dependencies for Eclipse based formatter steps.
 * Updated default groovy-eclipse from 4.8.0 to 4.8.1 ([#288](https://github.com/diffplug/spotless/pull/288)). New version is based on [Groovy-Eclipse 3.0.0](https://github.com/groovy/groovy-eclipse/wiki/3.0.0-Release-Notes).
 * Integrated Eclipse WTP formatter ([#290](https://github.com/diffplug/spotless/pull/290))
 * Updated JSR305 annotation from 3.0.0 to 3.0.2 ([#274](https://github.com/diffplug/spotless/pull/274))

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -152,7 +152,7 @@ public class EclipseBasedStepBuilder {
 
 		/** State constructor expects that all passed items are not modified afterwards */
 		protected State(String formatterStepExt, Provisioner jarProvisioner, List<String> dependencies, Iterable<File> settingsFiles) throws IOException {
-			this.jarState = JarState.from(dependencies, false, jarProvisioner);
+			this.jarState = JarState.withoutTransitives(dependencies, jarProvisioner);
 			this.settingsFiles = FileSignature.signAsList(settingsFiles);
 			this.formatterStepExt = formatterStepExt;
 		}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -152,7 +152,7 @@ public class EclipseBasedStepBuilder {
 
 		/** State constructor expects that all passed items are not modified afterwards */
 		protected State(String formatterStepExt, Provisioner jarProvisioner, List<String> dependencies, Iterable<File> settingsFiles) throws IOException {
-			this.jarState = JarState.from(dependencies, jarProvisioner);
+			this.jarState = JarState.from(dependencies, false, jarProvisioner);
 			this.settingsFiles = FileSignature.signAsList(settingsFiles);
 			this.formatterStepExt = formatterStepExt;
 		}

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3a.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3a.lockfile
@@ -17,10 +17,8 @@ org.eclipse.platform:org.eclipse.equinox.app:1.3.500
 org.eclipse.platform:org.eclipse.equinox.common:3.10.0
 org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
 org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
-#Spotless currently loads all transitive dependencies.
-#jface requires platform specific JARs (not used by formatter), which are not hosted via M2.
-#org.eclipse.platform:org.eclipse.jface.text:3.13.0
-#org.eclipse.platform:org.eclipse.jface:3.14.0
+org.eclipse.platform:org.eclipse.jface.text:3.13.0
+org.eclipse.platform:org.eclipse.jface:3.14.0
 org.eclipse.platform:org.eclipse.osgi.services:3.7.0
 org.eclipse.platform:org.eclipse.osgi:3.13.0
 org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.0.lockfile
@@ -12,9 +12,7 @@ org.eclipse.platform:org.eclipse.equinox.app:1.3.500
 org.eclipse.platform:org.eclipse.equinox.common:3.10.0
 org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
 org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
-#Spotless currently loads all transitive dependencies.
-#jface requires platform specific JARs (not used by formatter), which are not hosted via M2.
-#org.eclipse.platform:org.eclipse.jface.text:3.13.0
-#org.eclipse.platform:org.eclipse.jface:3.14.0
+org.eclipse.platform:org.eclipse.jface.text:3.13.0
+org.eclipse.platform:org.eclipse.jface:3.14.0
 org.eclipse.platform:org.eclipse.osgi:3.13.0
 org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.1.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.1.lockfile
@@ -12,9 +12,7 @@ org.eclipse.platform:org.eclipse.equinox.app:1.3.500
 org.eclipse.platform:org.eclipse.equinox.common:3.10.0
 org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
 org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
-#Spotless currently loads all transitive dependencies.
-#jface requires platform specific JARs (not used by formatter), which are not hosted via M2.
-#org.eclipse.platform:org.eclipse.jface.text:3.13.0
-#org.eclipse.platform:org.eclipse.jface:3.14.0
+org.eclipse.platform:org.eclipse.jface.text:3.13.0
+org.eclipse.platform:org.eclipse.jface:3.14.0
 org.eclipse.platform:org.eclipse.osgi:3.13.0
 org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -75,7 +75,7 @@ public final class JarState implements Serializable {
 	public static JarState from(Collection<String> mavenCoordinates, boolean resolveTransitives, Provisioner provisioner) throws IOException {
 		Objects.requireNonNull(provisioner, "provisioner");
 		Objects.requireNonNull(mavenCoordinates, "mavenCoordinates");
-		Set<File> jars = provisioner.provide(resolveTransitives, mavenCoordinates);
+		Set<File> jars = provisioner.provisionWithTransitives(resolveTransitives, mavenCoordinates);
 		if (jars.isEmpty()) {
 			throw new NoSuchElementException("Resolved to an empty result: " + mavenCoordinates.stream().collect(Collectors.joining(", ")));
 		}

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -69,9 +69,13 @@ public final class JarState implements Serializable {
 	}
 
 	public static JarState from(Collection<String> mavenCoordinates, Provisioner provisioner) throws IOException {
+		return from(mavenCoordinates, true, provisioner);
+	}
+
+	public static JarState from(Collection<String> mavenCoordinates, boolean resolveTransitives, Provisioner provisioner) throws IOException {
 		Objects.requireNonNull(provisioner, "provisioner");
 		Objects.requireNonNull(mavenCoordinates, "mavenCoordinates");
-		Set<File> jars = provisioner.provisionWithDependencies(mavenCoordinates);
+		Set<File> jars = provisioner.provide(resolveTransitives, mavenCoordinates);
 		if (jars.isEmpty()) {
 			throw new NoSuchElementException("Resolved to an empty result: " + mavenCoordinates.stream().collect(Collectors.joining(", ")));
 		}

--- a/lib/src/main/java/com/diffplug/spotless/Provisioner.java
+++ b/lib/src/main/java/com/diffplug/spotless/Provisioner.java
@@ -26,20 +26,20 @@ import java.util.Set;
  */
 public interface Provisioner {
 
-	/** Method interface has been extended to {@link Provisioner#provide}. */
+	/** Method interface has been extended to {@link Provisioner#provisionWithTransitives(boolean, Collection)}. */
 	@Deprecated
 	public default Set<File> provisionWithDependencies(Collection<String> mavenCoordinates) {
 		return provisionWithTransitives(true, mavenCoordinates);
 	}
 
-	/** Method interface has been extended to {@link Provisioner#provide}. */
+	/** Method interface has been extended to {@link Provisioner#provisionWithTransitives(boolean, String...)}. */
 	@Deprecated
 	public default Set<File> provisionWithDependencies(String... mavenCoordinates) {
 		return provisionWithDependencies(Arrays.asList(mavenCoordinates));
 	}
 
 	/**
-	 * Given a set of maven coordinates, returns a set of jars which include all
+	 * Given a set of Maven coordinates, returns a set of jars which include all
 	 * of the specified coordinates and optionally their transitive dependencies.
 	 */
 	public default Set<File> provisionWithTransitives(boolean withTransitives, String... mavenCoordinates) {
@@ -47,7 +47,7 @@ public interface Provisioner {
 	}
 
 	/**
-	 * Given a set of maven coordinates, returns a set of jars which include all
+	 * Given a set of Maven coordinates, returns a set of jars which include all
 	 * of the specified coordinates and optionally their transitive dependencies.
 	 */
 	public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates);

--- a/lib/src/main/java/com/diffplug/spotless/Provisioner.java
+++ b/lib/src/main/java/com/diffplug/spotless/Provisioner.java
@@ -28,7 +28,9 @@ public interface Provisioner {
 
 	/** Method interface has been extended to {@link Provisioner#provide}. */
 	@Deprecated
-	public Set<File> provisionWithDependencies(Collection<String> mavenCoordinates);
+	public default Set<File> provisionWithDependencies(Collection<String> mavenCoordinates) {
+		return provisionWithTransitives(true, mavenCoordinates);
+	}
 
 	/** Method interface has been extended to {@link Provisioner#provide}. */
 	@Deprecated
@@ -40,20 +42,13 @@ public interface Provisioner {
 	 * Given a set of maven coordinates, returns a set of jars which include all
 	 * of the specified coordinates and optionally their transitive dependencies.
 	 */
-	public default Set<File> provide(boolean resolveTransitives, String... mavenCoordinates) {
-		return provide(resolveTransitives, Arrays.asList(mavenCoordinates));
+	public default Set<File> provisionWithTransitives(boolean withTransitives, String... mavenCoordinates) {
+		return provisionWithTransitives(withTransitives, Arrays.asList(mavenCoordinates));
 	}
 
 	/**
 	 * Given a set of maven coordinates, returns a set of jars which include all
 	 * of the specified coordinates and optionally their transitive dependencies.
 	 */
-	public default Set<File> provide(boolean resolveTransitives, Collection<String> mavenCoordinates) {
-		if (resolveTransitives) {
-			//Support of previous implementation
-			return provisionWithDependencies(mavenCoordinates);
-		}
-		throw new UnsupportedOperationException("Provisioner: provide without transitives");
-	}
-
+	public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates);
 }

--- a/lib/src/main/java/com/diffplug/spotless/Provisioner.java
+++ b/lib/src/main/java/com/diffplug/spotless/Provisioner.java
@@ -25,17 +25,35 @@ import java.util.Set;
  * Spotless' dependencies minimal.
  */
 public interface Provisioner {
-	/**
-	 * Given a set of maven coordinates, returns a set of jars which
-	 * include all of the specified coordinates and their dependencies.
-	 */
+
+	/** Method interface has been extended to {@link Provisioner#provide}. */
+	@Deprecated
 	public Set<File> provisionWithDependencies(Collection<String> mavenCoordinates);
 
-	/**
-	 * Given a set of maven coordinates, returns a set of jars which
-	 * include all of the specified coordinates and their dependencies.
-	 */
+	/** Method interface has been extended to {@link Provisioner#provide}. */
+	@Deprecated
 	public default Set<File> provisionWithDependencies(String... mavenCoordinates) {
 		return provisionWithDependencies(Arrays.asList(mavenCoordinates));
 	}
+
+	/**
+	 * Given a set of maven coordinates, returns a set of jars which include all
+	 * of the specified coordinates and optionally their transitive dependencies.
+	 */
+	public default Set<File> provide(boolean resolveTransitives, String... mavenCoordinates) {
+		return provide(resolveTransitives, Arrays.asList(mavenCoordinates));
+	}
+
+	/**
+	 * Given a set of maven coordinates, returns a set of jars which include all
+	 * of the specified coordinates and optionally their transitive dependencies.
+	 */
+	public default Set<File> provide(boolean resolveTransitives, Collection<String> mavenCoordinates) {
+		if (resolveTransitives) {
+			//Support of previous implementation
+			return provisionWithDependencies(mavenCoordinates);
+		}
+		throw new UnsupportedOperationException("Provisioner: provide without transitives");
+	}
+
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -15,10 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.io.File;
-import java.util.Collection;
 import java.util.Objects;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,14 +32,14 @@ public class GradleProvisioner {
 
 	public static Provisioner fromProject(Project project) {
 		Objects.requireNonNull(project);
-		return (CompatibleProvisioner) (resolveTransitives, mavenCoords) -> {
+		return (withTransitives, mavenCoords) -> {
 			try {
 				Dependency[] deps = mavenCoords.stream()
 						.map(project.getBuildscript().getDependencies()::create)
 						.toArray(Dependency[]::new);
 				Configuration config = project.getRootProject().getBuildscript().getConfigurations().detachedConfiguration(deps);
 				config.setDescription(mavenCoords.toString());
-				config.setTransitive(resolveTransitives);
+				config.setTransitive(withTransitives);
 				return config.resolve();
 			} catch (Exception e) {
 				logger.log(Level.SEVERE,
@@ -58,19 +55,4 @@ public class GradleProvisioner {
 
 	private static final Logger logger = Logger.getLogger(GradleProvisioner.class.getName());
 
-	/**
-	 * Portable version of {@link Provisioner} interface. In next spotless-lib major version
-	 * deprecated methods can be removed together with this wrapper.
-	 */
-	private static interface CompatibleProvisioner extends Provisioner {
-
-		@Override
-		@Deprecated
-		default Set<File> provisionWithDependencies(Collection<String> mavenCoordinates) {
-			return provide(true, mavenCoordinates);
-		}
-
-		@Override
-		Set<File> provide(boolean resolveTransitives, Collection<String> mavenCoordinates);
-	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -67,14 +67,14 @@ public class ArtifactResolver {
 	 * Given a set of maven coordinates, returns a set of jars which include all
 	 * of the specified coordinates and optionally their transitive dependencies.
 	 */
-	public Set<File> resolve(boolean resolveTransitives, Collection<String> mavenCoordinates) {
+	public Set<File> resolve(boolean withTransitives, Collection<String> mavenCoordinates) {
 		List<Dependency> dependencies = mavenCoordinates.stream()
 				.map(coordinateString -> new DefaultArtifact(coordinateString))
 				.map(artifact -> new Dependency(artifact, null))
 				.collect(toList());
 		CollectRequest collectRequest = new CollectRequest(dependencies, null, repositories);
 		DependencyRequest dependencyRequest;
-		if (resolveTransitives) {
+		if (withTransitives) {
 			dependencyRequest = new DependencyRequest(collectRequest, ACCEPT_ALL);
 		} else {
 			dependencyRequest = new DependencyRequest(collectRequest, FILTER_TRANSITIVES);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -41,7 +41,8 @@ import org.eclipse.aether.resolution.DependencyResult;
 
 public class ArtifactResolver {
 
-	private static final DependencyFilter ACCEPT_ALL_FILTER = (node, parents) -> true;
+	private static final DependencyFilter ACCEPT_ALL = (node, parents) -> true;
+	private static final DependencyFilter FILTER_TRANSITIVES = (node, parents) -> parents.size() <= 1;
 
 	private final RepositorySystem repositorySystem;
 	private final RepositorySystemSession session;
@@ -56,19 +57,28 @@ public class ArtifactResolver {
 		this.log = Objects.requireNonNull(log);
 	}
 
-	/** Use {@link ArtifactResolver#resolve(Collection) instead.} */
+	/** Use {@link ArtifactResolver#resolve(boolean, Collection)) instead.} */
 	@Deprecated
 	public Set<File> resolve(String mavenCoordinate) {
-		return resolve(Arrays.asList(mavenCoordinate));
+		return resolve(true, Arrays.asList(mavenCoordinate));
 	}
 
-	public Set<File> resolve(Collection<String> mavenCoordinate) {
-		List<Dependency> dependencies = mavenCoordinate.stream()
+	/**
+	 * Given a set of maven coordinates, returns a set of jars which include all
+	 * of the specified coordinates and optionally their transitive dependencies.
+	 */
+	public Set<File> resolve(boolean resolveTransitives, Collection<String> mavenCoordinates) {
+		List<Dependency> dependencies = mavenCoordinates.stream()
 				.map(coordinateString -> new DefaultArtifact(coordinateString))
 				.map(artifact -> new Dependency(artifact, null))
 				.collect(toList());
-		CollectRequest collectRequest = new CollectRequest((Dependency) null, dependencies, repositories);
-		DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, ACCEPT_ALL_FILTER);
+		CollectRequest collectRequest = new CollectRequest(dependencies, null, repositories);
+		DependencyRequest dependencyRequest;
+		if (resolveTransitives) {
+			dependencyRequest = new DependencyRequest(collectRequest, ACCEPT_ALL);
+		} else {
+			dependencyRequest = new DependencyRequest(collectRequest, FILTER_TRANSITIVES);
+		}
 
 		DependencyResult dependencyResult = resolveDependencies(dependencyRequest);
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
@@ -15,10 +15,6 @@
  */
 package com.diffplug.spotless.maven;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.Set;
-
 import com.diffplug.spotless.Provisioner;
 
 /** Maven integration for Provisioner. */
@@ -26,21 +22,6 @@ public class MavenProvisioner {
 	private MavenProvisioner() {}
 
 	public static Provisioner create(ArtifactResolver artifactResolver) {
-		return (CompatibleProvisioner) artifactResolver::resolve;
-	}
-
-	/**
-	 * Portable version of {@link Provisioner} interface. In next spotless-lib major version
-	 * deprecated methods can be removed together with this wrapper.
-	 */
-	private static interface CompatibleProvisioner extends Provisioner {
-		@Override
-		@Deprecated
-		default Set<File> provisionWithDependencies(Collection<String> mavenCoordinates) {
-			return provide(true, mavenCoordinates);
-		}
-
-		@Override
-		Set<File> provide(boolean resolveTransitives, Collection<String> mavenCoordinates);
+		return artifactResolver::resolve;
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/MavenProvisioner.java
@@ -15,6 +15,10 @@
  */
 package com.diffplug.spotless.maven;
 
+import java.io.File;
+import java.util.Collection;
+import java.util.Set;
+
 import com.diffplug.spotless.Provisioner;
 
 /** Maven integration for Provisioner. */
@@ -22,7 +26,21 @@ public class MavenProvisioner {
 	private MavenProvisioner() {}
 
 	public static Provisioner create(ArtifactResolver artifactResolver) {
-		return artifactResolver::resolve;
+		return (CompatibleProvisioner) artifactResolver::resolve;
 	}
 
+	/**
+	 * Portable version of {@link Provisioner} interface. In next spotless-lib major version
+	 * deprecated methods can be removed together with this wrapper.
+	 */
+	private static interface CompatibleProvisioner extends Provisioner {
+		@Override
+		@Deprecated
+		default Set<File> provisionWithDependencies(Collection<String> mavenCoordinates) {
+			return provide(true, mavenCoordinates);
+		}
+
+		@Override
+		Set<File> provide(boolean resolveTransitives, Collection<String> mavenCoordinates);
+	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 public class MavenProvisionerTest extends MavenIntegrationTest {
 
 	@Test
-	public void testMultipleDependencies() throws Exception {
+	public void testMultipleDependenciesExcludingTransitives() throws Exception {
 		writePomWithJavaSteps(
 				"<eclipse>",
 				"  <version>4.8.0</version>",
@@ -30,7 +30,7 @@ public class MavenProvisionerTest extends MavenIntegrationTest {
 	}
 
 	@Test
-	public void testSingleDependency() throws Exception {
+	public void testSingleDependencyIncludingTransitives() throws Exception {
 		writePomWithJavaSteps(
 				"<googleJavaFormat>",
 				"  <version>1.2</version>",

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -19,10 +19,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -54,12 +52,12 @@ public class TestProvisioner {
 		return Suppliers.memoize(() -> {
 			Project project = ProjectBuilder.builder().build();
 			repoConfig.accept(project.getRepositories());
-			return (CompatibleProvisioner) (resolveTransitives, mavenCoords) -> {
+			return (withTransitives, mavenCoords) -> {
 				Dependency[] deps = mavenCoords.stream()
 						.map(project.getDependencies()::create)
 						.toArray(Dependency[]::new);
 				Configuration config = project.getConfigurations().detachedConfiguration(deps);
-				config.setTransitive(resolveTransitives);
+				config.setTransitive(withTransitives);
 				config.setDescription(mavenCoords.toString());
 				try {
 					return config.resolve();
@@ -88,11 +86,11 @@ public class TestProvisioner {
 		} else {
 			cached = new HashMap<>();
 		}
-		return (CompatibleProvisioner) (resolveTransitives, mavenCoords) -> {
+		return (withTransitives, mavenCoords) -> {
 			Box<Boolean> wasChanged = Box.of(false);
 			ImmutableSet<File> result = cached.computeIfAbsent(ImmutableSet.copyOf(mavenCoords), coords -> {
 				wasChanged.set(true);
-				return ImmutableSet.copyOf(input.get().provide(resolveTransitives, coords));
+				return ImmutableSet.copyOf(input.get().provisionWithTransitives(withTransitives, coords));
 			});
 			if (wasChanged.get()) {
 				try (ObjectOutputStream outputStream = new ObjectOutputStream(Files.asByteSink(cacheFile).openBufferedStream())) {
@@ -140,20 +138,4 @@ public class TestProvisioner {
 			setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots");
 		});
 	});
-
-	/**
-	 * Portable version of {@link Provisioner} interface. In next spotless-lib major version
-	 * deprecated methods can be removed together with this wrapper.
-	 */
-	private static interface CompatibleProvisioner extends Provisioner {
-
-		@Override
-		@Deprecated
-		default Set<File> provisionWithDependencies(Collection<String> mavenCoordinates) {
-			return provide(true, mavenCoordinates);
-		}
-
-		@Override
-		Set<File> provide(boolean resolveTransitives, Collection<String> mavenCoordinates);
-	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
@@ -24,13 +24,25 @@ import org.junit.Test;
 
 public class ProvisionerTest {
 	@Test
-	public void testManipulation() {
+	@Deprecated
+	public void testManipulationDeprecated() {
 		Provisioner provisioner = deps -> deps.stream().map(File::new).collect(Collectors.toSet());
 		Assertions.assertThat(provisioner.provisionWithDependencies("a"))
 				.containsExactlyInAnyOrder(new File("a"));
 		Assertions.assertThat(provisioner.provisionWithDependencies("a", "a"))
 				.containsExactlyInAnyOrder(new File("a"));
 		Assertions.assertThat(provisioner.provisionWithDependencies(Arrays.asList("a", "a")))
+				.containsExactlyInAnyOrder(new File("a"));
+	}
+
+	@Test
+	public void testManipulation() {
+		Provisioner provisioner = deps -> deps.stream().map(File::new).collect(Collectors.toSet());
+		Assertions.assertThat(provisioner.provide(true, "a"))
+				.containsExactlyInAnyOrder(new File("a"));
+		Assertions.assertThat(provisioner.provide(true, "a", "a"))
+				.containsExactlyInAnyOrder(new File("a"));
+		Assertions.assertThat(provisioner.provide(true, Arrays.asList("a", "a")))
 				.containsExactlyInAnyOrder(new File("a"));
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
@@ -26,7 +26,7 @@ public class ProvisionerTest {
 	@Test
 	@Deprecated
 	public void testManipulationDeprecated() {
-		Provisioner provisioner = deps -> deps.stream().map(File::new).collect(Collectors.toSet());
+		Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(File::new).collect(Collectors.toSet());
 		Assertions.assertThat(provisioner.provisionWithDependencies("a"))
 				.containsExactlyInAnyOrder(new File("a"));
 		Assertions.assertThat(provisioner.provisionWithDependencies("a", "a"))
@@ -37,12 +37,12 @@ public class ProvisionerTest {
 
 	@Test
 	public void testManipulation() {
-		Provisioner provisioner = deps -> deps.stream().map(File::new).collect(Collectors.toSet());
-		Assertions.assertThat(provisioner.provide(true, "a"))
+		Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(File::new).collect(Collectors.toSet());
+		Assertions.assertThat(provisioner.provisionWithTransitives(true, "a"))
 				.containsExactlyInAnyOrder(new File("a"));
-		Assertions.assertThat(provisioner.provide(true, "a", "a"))
+		Assertions.assertThat(provisioner.provisionWithTransitives(true, "a", "a"))
 				.containsExactlyInAnyOrder(new File("a"));
-		Assertions.assertThat(provisioner.provide(true, Arrays.asList("a", "a")))
+		Assertions.assertThat(provisioner.provisionWithTransitives(true, Arrays.asList("a", "a")))
 				.containsExactlyInAnyOrder(new File("a"));
 	}
 }


### PR DESCRIPTION
Extended Provisioner to provide dependencies either with or without their transitives.

Changed EclipseBasedStepBuilder to request dependencies only without transitives.
Removed work-around from Eclipse dependency lock-files.

The problem [had been spotted](https://github.com/diffplug/spotless/pull/264#issuecomment-406671944) when switching Groovy-Eclipse to new version supporting Eclipse-Base with the dependency lock.

Please consider this change as an implementation proposal. It is relatively verbose, since I tried to keep the public interfaces unchanged and backward compatible [as discussed previously](https://github.com/diffplug/spotless/pull/296#discussion_r216483917). Maybe this approach can be considered unnecessary for the `Provisioner`.