### PR TITLE
EclipseCommonTests are no longer sensitive to line-ending problems.

### DIFF
--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/eclipse/EclipseCommonTests.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/eclipse/EclipseCommonTests.java
@@ -22,6 +22,7 @@ import java.io.File;
 import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.ResourceHarness;
 
 /**
@@ -78,7 +79,7 @@ public abstract class EclipseCommonTests extends ResourceHarness {
 			}
 			String output = null;
 			try {
-				output = step.format(input, inputFile);
+				output = LineEnding.toUnix(step.format(input, inputFile));
 			} catch (Exception e) {
 				fail("Exception occured when formatting input with version: " + version, e);
 			}


### PR DESCRIPTION
FormatterStep are supposed to return unix line endings, but `Formatter` silently corrects for the case that they don't.  To keep the windows build durable, we can resolve #298 by just making the tests ignore line ending problems.