### PR TITLE
Provides Eclipse 4.9 JDT.

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -32,7 +32,7 @@ public final class EclipseJdtFormatterStep {
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.java.EclipseJdtFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-jdt";
-	private static final String DEFAULT_VERSION = "4.7.3a";
+	private static final String DEFAULT_VERSION = "4.9.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.9.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.9.0.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on JDT version 4.9.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_9_maintenance to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.15.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.100
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.0
+org.eclipse.platform:org.eclipse.core.jobs:3.10.0
+org.eclipse.platform:org.eclipse.core.resources:3.13.0
+org.eclipse.platform:org.eclipse.core.runtime:3.14.0
+org.eclipse.platform:org.eclipse.equinox.app:1.3.500
+org.eclipse.platform:org.eclipse.equinox.common:3.10.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.13.0
+org.eclipse.platform:org.eclipse.text:3.6.300

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
@@ -24,7 +24,7 @@ public class EclipseJdtFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.6.1", "4.6.2", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.7.3a", "4.8.0"};
+		return new String[]{"4.6.1", "4.6.2", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.7.3a", "4.8.0", "4.9.0"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.17.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Updated default eclipse-jdt from 4.7.3a to 4.9.0 ([#316](https://github.com/diffplug/spotless/pull/316)). New version addresses enum-tab formatting bug in 4.8 ([#314](https://github.com/diffplug/spotless/issues/314)).
+
 ### Version 3.16.0 - October 30th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.16.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.16.0))
 
 * Added support for Eclipse's CSS formatter from WTP ([#311](https://github.com/diffplug/spotless/pull/311)).

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.17.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Updated default eclipse-jdt from 4.7.3a to 4.9.0 ([#316](https://github.com/diffplug/spotless/pull/316)). New version addresses enum-tab formatting bug in 4.8 ([#314](https://github.com/diffplug/spotless/issues/314)).
+
 ### Version 1.16.0 - October 30th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.16.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.16.0))
 
 * Added support for Eclipse's CSS formatter from WTP ([#311](https://github.com/diffplug/spotless/pull/311)).


### PR DESCRIPTION
Provides Eclipse 4.9 JDT and makes it default.

Tested with an [older version of JUnit5](https://github.com/fvgh/junit5/commit/3d70d90bfde049008d918774e0c781d76e03b12f). Found no changes in comparison to 4.7.3.

Fixes #314.