### PR TITLE
Wtp integration maven gradle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ You might be looking for:
 
 ### Version 1.18.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* CSS and XML extensions are discontinued ([#325](https://github.com/diffplug/spotless/pull/325)).
+
 ### Version 1.17.0 - October 30th 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.17.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.17.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Updated default eclipse-jdt from 4.7.3a to 4.9.0 ([#316](https://github.com/diffplug/spotless/pull/316)). New version addresses enum-tab formatting bug in 4.8 ([#314](https://github.com/diffplug/spotless/issues/314)).

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -15,14 +15,9 @@
  */
 package com.diffplug.spotless.extra.wtp;
 
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.joining;
-
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Locale;
-import java.util.Objects;
 import java.util.Properties;
 
 import com.diffplug.spotless.FormatterFunc;
@@ -51,20 +46,6 @@ public enum EclipseWtpFormatterStep {
 	EclipseWtpFormatterStep(String implementationClassName, ThrowingEx.BiFunction<String, EclipseBasedStepBuilder.State, FormatterFunc> formatterCall) {
 		this.implementationClassName = implementationClassName;
 		this.formatterCall = formatterCall;
-	}
-
-	/** Similar to {@link #valueOf(Class, String)}, ignores whitespace, case and adds helpful exception messages. */
-	public static EclipseWtpFormatterStep valueFrom(String name) {
-		Objects.requireNonNull(name);
-		name = name.trim().toUpperCase(Locale.ENGLISH);
-		try {
-			return valueOf(name);
-		} catch (IllegalArgumentException e) {
-			throw new IllegalArgumentException(e.getMessage() +
-					" (allowed values: " +
-					stream(values()).map(enumType -> enumType.toString()).collect(joining("; ")) +
-					")");
-		}
 	}
 
 	public EclipseBasedStepBuilder createBuilder(Provisioner provisioner) {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -65,22 +65,38 @@ public enum EclipseWtpFormatterStep {
 		return new EclipseBasedStepBuilder(NAME, " - css", provisioner, state -> applyWithoutFile("EclipseCssFormatterStepImpl", state));
 	}
 
-	/** Provides default configuration for HTML formatter */
+	/**
+	 * Provides default configuration for HTML formatter.
+	 * Method is deprecated. Use {@link EclipseWtpFormatterStep#createBuilder(Provisioner)} instead.
+	 */
+	@Deprecated
 	public static EclipseBasedStepBuilder createHtmlBuilder(Provisioner provisioner) {
 		return HTML.createBuilder(provisioner);
 	}
 
-	/** Provides default configuration for Java Script formatter */
+	/**
+	 * Provides default configuration for Java Script formatter.
+	 * Method is deprecated. Use {@link EclipseWtpFormatterStep#createBuilder(Provisioner)} instead.
+	 */
+	@Deprecated
 	public static EclipseBasedStepBuilder createJsBuilder(Provisioner provisioner) {
 		return JS.createBuilder(provisioner);
 	}
 
-	/** Provides default configuration for JSON formatter */
+	/**
+	 * Provides default configuration for JSON formatter.
+	 * Method is deprecated. Use {@link EclipseWtpFormatterStep#createBuilder(Provisioner)} instead.
+	 */
+	@Deprecated
 	public static EclipseBasedStepBuilder createJsonBuilder(Provisioner provisioner) {
 		return JSON.createBuilder(provisioner);
 	}
 
-	/** Provides default configuration for XML formatter */
+	/**
+	 * Provides default configuration for XML formatter.
+	 * Method is deprecated. Use {@link EclipseWtpFormatterStep#createBuilder(Provisioner)} instead.
+	 */
+	@Deprecated
 	public static EclipseBasedStepBuilder createXmlBuilder(Provisioner provisioner) {
 		return XML.createBuilder(provisioner);
 	}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -56,7 +56,11 @@ public enum EclipseWtpFormatterStep {
 		return DEFAULT_VERSION;
 	}
 
-	/** Provides default configuration for CSSformatter */
+	/**
+	 * Provides default configuration for CSSformatter.
+	 * Method is deprecated. Use {@link EclipseWtpFormatterStep#createBuilder(Provisioner)} instead.
+	 */
+	@Deprecated
 	public static EclipseBasedStepBuilder createCssBuilder(Provisioner provisioner) {
 		return new EclipseBasedStepBuilder(NAME, " - css", provisioner, state -> applyWithoutFile("EclipseCssFormatterStepImpl", state));
 	}

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -24,7 +24,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +32,6 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.eclipse.EclipseCommonTests;
@@ -44,29 +42,27 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 	private enum WTP {
 		// @formatter:off
 		CSS(	"body {\na: v;   b:   \nv;\n}  \n",
-				"body {\n\ta: v;\n\tb: v;\n}",
-				EclipseWtpFormatterStep::createCssBuilder),
+				"body {\n\ta: v;\n\tb: v;\n}"),
 		HTML(	"<!DOCTYPE html> <html>\t<head> <meta   charset=\"UTF-8\"></head>\n</html>  ",
-				"<!DOCTYPE html>\n<html>\n<head>\n<meta charset=\"UTF-8\">\n</head>\n</html>\n",
-				EclipseWtpFormatterStep::createHtmlBuilder),
+				"<!DOCTYPE html>\n<html>\n<head>\n<meta charset=\"UTF-8\">\n</head>\n</html>\n"),
 		JS(		"function f(  )   {\na.b(1,\n2);}",
-				"function f() {\n    a.b(1, 2);\n}",
-				EclipseWtpFormatterStep::createJsBuilder),
+				"function f() {\n    a.b(1, 2);\n}"),
 		JSON(	"{\"a\": \"b\",	\"c\":   { \"d\": \"e\",\"f\": \"g\"}}",
-				"{\n\t\"a\": \"b\",\n\t\"c\": {\n\t\t\"d\": \"e\",\n\t\t\"f\": \"g\"\n\t}\n}",
-				EclipseWtpFormatterStep::createJsonBuilder),
-		XML(	"<a><b>   c</b></a>", "<a>\n\t<b> c</b>\n</a>",
-				EclipseWtpFormatterStep::createXmlBuilder);
+				"{\n\t\"a\": \"b\",\n\t\"c\": {\n\t\t\"d\": \"e\",\n\t\t\"f\": \"g\"\n\t}\n}"),
+		XML(	"<a><b>   c</b></a>", "<a>\n\t<b> c</b>\n</a>");
 		// @formatter:on
 
 		public final String input;
 		public final String expectation;
-		public final Function<Provisioner, EclipseBasedStepBuilder> builderMethod;
 
-		private WTP(String input, final String expectation, Function<Provisioner, EclipseBasedStepBuilder> builderMethod) {
+		private WTP(String input, final String expectation) {
 			this.input = input;
 			this.expectation = expectation;
-			this.builderMethod = builderMethod;
+		}
+
+		public EclipseBasedStepBuilder createBuilder() {
+			EclipseWtpFormatterStep stepType = EclipseWtpFormatterStep.valueOf(this.toString());
+			return stepType.createBuilder(TestProvisioner.mavenCentral());
 		}
 	}
 
@@ -95,7 +91,7 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected FormatterStep createStep(String version) {
-		EclipseBasedStepBuilder builder = wtp.builderMethod.apply(TestProvisioner.mavenCentral());
+		EclipseBasedStepBuilder builder = wtp.createBuilder();
 		builder.setVersion(version);
 		return builder.build();
 	}
@@ -131,7 +127,7 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 		File tempFile = File.createTempFile("EclipseWtpFormatterStepTest-", ".properties");
 		OutputStream tempOut = new FileOutputStream(tempFile);
 		configProps.store(tempOut, "test properties");
-		EclipseBasedStepBuilder builder = wtp.builderMethod.apply(TestProvisioner.mavenCentral());
+		EclipseBasedStepBuilder builder = wtp.createBuilder();
 		builder.setVersion(EclipseWtpFormatterStep.defaultVersion());
 		builder.setPreferences(Arrays.asList(tempFile));
 		return builder.build();

--- a/lib/src/main/java/com/diffplug/spotless/css/CssDefaults.java
+++ b/lib/src/main/java/com/diffplug/spotless/css/CssDefaults.java
@@ -19,7 +19,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-/** Common utilities for CSS */
+/**
+ * Common utilities for CSS
+ * <br/>
+ * The CSS extension is discontinued.
+ */
+@Deprecated
 public class CssDefaults {
 	//Prevent instantiation
 	private CssDefaults() {};

--- a/lib/src/main/java/com/diffplug/spotless/xml/XmlDefaults.java
+++ b/lib/src/main/java/com/diffplug/spotless/xml/XmlDefaults.java
@@ -20,7 +20,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/** Common utilities for XML */
+/**
+ * Common utilities for XML
+ * <br/>
+ * The XML extension is discontinued.
+ */
+@Deprecated
 public class XmlDefaults {
 	//Prevent instantiation
 	private XmlDefaults() {};

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.18.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Provided eclipse-wtp formatters in generic formatter extension. ([#325](https://github.com/diffplug/spotless/pull/325)). This change obsoletes the CSS and XML extensions.
+
 ### Version 3.17.0 - December 13th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.17.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.17.0))
 
 * Updated default eclipse-jdt from 4.7.3a to 4.9.0 ([#316](https://github.com/diffplug/spotless/pull/316)). New version addresses enum-tab formatting bug in 4.8 ([#314](https://github.com/diffplug/spotless/issues/314)).

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -79,7 +79,7 @@ Spotless can check and apply formatting to any plain-text file, using simple rul
 
 * Eclipse's [CDT](#eclipse-cdt) C/C++ code formatter
 * Eclipse's java code formatter (including style and import ordering)
-* Eclipse's [WTP](#eclipse-wtp) WTP code formatters
+* Eclipse's [WTP](#eclipse-wtp) HTML, XML, ... code formatters
 * Google's [google-java-format](https://github.com/google/google-java-format)
 * [Groovy Eclipse](#groovy-eclipse)'s groovy code formatter
 * [FreshMark](https://github.com/diffplug/freshmark) (markdown with variables)
@@ -472,9 +472,9 @@ spotless {
     target fileTree('.') {
       include '**/*.xml', '**/*.xsd'
       exclude '**/build/**'
-	}
+    }
     // Use for example eclipseWtp('xml', '4.7.3a') to specify a specific version of Eclipse,
-    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters	
+    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters
     eclipseWtp('xml').configFile 'spotless.xml.prefs' 'spotless.common.properties'
   }
 }

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -79,8 +79,7 @@ Spotless can check and apply formatting to any plain-text file, using simple rul
 
 * Eclipse's [CDT](#eclipse-cdt) C/C++ code formatter
 * Eclipse's java code formatter (including style and import ordering)
-* Eclipse's [WTP-CSS](#eclipse-wtp-css) CSS code formatter
-* Eclipse's [WTP-XML](#eclipse-wtp-xml) XML code formatter
+* Eclipse's [WTP](#eclipse-wtp) WTP code formatters
 * Google's [google-java-format](https://github.com/google/google-java-format)
 * [Groovy Eclipse](#groovy-eclipse)'s groovy code formatter
 * [FreshMark](https://github.com/diffplug/freshmark) (markdown with variables)
@@ -321,55 +320,6 @@ spotless {
 
 Use the Eclipse to define the *Code Style preferences* (see [Eclipse documentation](https://www.eclipse.org/documentation/)). Within the preferences *Edit...* dialog, you can export your configuration as XML file, which can be used as a `configFile`. If no `configFile` is provided, the CDT default configuration is used.
 
-<a name="css-wtp"></a>
-
-## Applying to CSS sources
-
-```gradle
-spotless {
-  css {
-    target '**/*.css' '**/*.css2'// Change file filter. By default files with 'css' extension are supported
-    eclipse().configFile './css-formatter.prefs' // Properties file of the Eclipse WTP formatter
-    // Use for example eclipse('4.7.3a') to specify a specific version of Eclipse,
-    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters
-    // also supports license headers
-    licenseHeader '<!-- Licensed under Apache-2.0 -->'	// License header
-    licenseHeaderFile './license.txt'	// License header file
-  }
-}
-```
-
-<a name="eclipse-wtp-css"></a>
-
-### Eclipse [WTP](https://www.eclipse.org/webtools/) CSS formatter
-Use Eclipse to define the *CSS Files* editor preferences (see [Eclipse documentation](http://help.eclipse.org/photon/topic/org.eclipse.wst.sse.doc.user/topics/tsrcedt025.html)) and the *Cleanup* preferences available in the *Source* menu (when editing a CSS file). The preferences are stored below your Eclipse workspace directory in `.metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs`. Note that only the differences to the default configuration are stored within the file. Omit the 'configFile' entirely to use the default Eclipse configuration.
-
-<a name="xml-wtp"></a>
-
-## Applying to XML sources
-
-```gradle
-spotless {
-  xml {
-    target '**/*.xml' // Change file filter. By default files with 'xml', 'xsl', 'xslt', 'wsdl', 'xsd', 'exsd' and 'xmi' extension are supported
-    eclipse().configFile './xml-formatter.prefs' // Properties file of the Eclipse WTP formatter
-    // Use for example eclipse('4.7.3a') to specify a specific version of Eclipse,
-    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters
-    // also supports license headers
-    licenseHeader '<!-- Licensed under Apache-2.0 -->'	// License header
-    licenseHeaderFile './license.txt'	// License header file
-  }
-}
-```
-
-<a name="eclipse-wtp-xml"></a>
-
-### Eclipse [WTP](https://www.eclipse.org/webtools/) XML formatter
-Use Eclipse to define the *XML editor preferences* (see [Eclipse documentation](https://www.eclipse.org/documentation/)). The preferences are stored below your Eclipse workspace directory in `.metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.xml.core.prefs`. Note that only the differences to the default configuration are stored within the file. Omit the 'configFile' entirely to use the default Eclipse configuration.
-
-The Eclipse WTP formatter supports DTD/XSD restrictions on white spaces. For XSD/DTD lookup, relative and absolute XSD/DTD URIs are supported. Furthermore a user catalog can be configured using the `userCatalog` property key. Add the property to the preference file or add an additional preference or properties files as an additional argument to the `configFile`.
-
-
 <a name="typescript"></a>
 
 ## Applying to Typescript source
@@ -509,6 +459,41 @@ spotless {
 ```
 
 Spotless uses npm to install necessary packages locally. It runs prettier using [J2V8](https://github.com/eclipsesource/J2V8) internally after that.
+
+<a name="eclipse-wtp"></a>
+
+## Applying [Eclipse WTP](https://www.eclipse.org/webtools/) to css | html | etc.
+
+The Eclipse [WTP](https://www.eclipse.org/webtools/) formatter can be applied as follows:
+
+```gradle
+spotless {
+  format 'xml', {
+    target fileTree('.') {
+      include '**/*.xml', '**/*.xsd'
+      exclude '**/build/**'
+	}
+    // Use for example eclipseWtp('xml', '4.7.3a') to specify a specific version of Eclipse,
+    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters	
+    eclipseWtp('xml').configFile 'spotless.xml.prefs' 'spotless.common.properties'
+  }
+}
+```
+The WTP formatter accept multiple configuration files. All Eclipse configuration file formats are accepted as well as simple Java property files. Omit the `configFile` entirely to use the default Eclipse configuration. The following formatters and configurations are supported:
+
+| Type | Configuration       | File location
+| ---- | ------------------- | -------------
+| CSS  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+| HTML | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
+|      | embedded CSS        | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+|      | embedded JS         | Use the export in the Eclipse editor configuration dialog
+| JS   | editor preferences  | Use the export in the Eclipse editor configuration dialog
+| JSON | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.json.core.prefs
+| XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.xml.core.prefs
+
+Note that `HTML` should be used for `X-HTML` sources instead of `XML`.
 
 <a name="license-header"></a>
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CssExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CssExtension.java
@@ -23,6 +23,10 @@ import com.diffplug.spotless.css.CssDefaults;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 
+/**
+ * The CSS extension is deprecated. Use the generic {@link FormatExtension} instead.
+ */
+@Deprecated
 public class CssExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "css";
 
@@ -38,6 +42,10 @@ public class CssExtension extends FormatExtension implements HasBuiltinDelimiter
 		return new EclipseConfig(version);
 	}
 
+	/**
+	 * The CSS Eclipse configuration is deprecated. Use the {@link FormatExtension.EclipseWtpConfig} instead.
+	 */
+	@Deprecated
 	public class EclipseConfig {
 		private final EclipseBasedStepBuilder builder;
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -488,13 +488,9 @@ public class FormatExtension {
 	public class EclipseWtpConfig {
 		private final EclipseBasedStepBuilder builder;
 
-		EclipseWtpConfig(EclipseWtpFormatterStep type) {
-			this(type, EclipseWtpFormatterStep.defaultVersion());
-		}
-
 		EclipseWtpConfig(EclipseWtpFormatterStep type, String version) {
 			builder = type.createBuilder(GradleProvisioner.fromProject(getProject()));
-			builder.setVersion(EclipseWtpFormatterStep.defaultVersion());
+			builder.setVersion(version);
 			addStep(builder.build());
 		}
 
@@ -504,17 +500,14 @@ public class FormatExtension {
 			builder.setPreferences(project.files(configFiles).getFiles());
 			replaceStep(builder.build());
 		}
-
 	}
 
-	public EclipseWtpConfig eclipseWtp(String type) {
-		return new EclipseWtpConfig(EclipseWtpFormatterStep.valueFrom(type));
+	public EclipseWtpConfig eclipseWtp(EclipseWtpFormatterStep type) {
+		return eclipseWtp(type, EclipseWtpFormatterStep.defaultVersion());
 	}
 
-	public EclipseWtpConfig eclipseWtp(String type, String version) {
-		return new EclipseWtpConfig(
-				EclipseWtpFormatterStep.valueFrom(type),
-				version);
+	public EclipseWtpConfig eclipseWtp(EclipseWtpFormatterStep type, String version) {
+		return new EclipseWtpConfig(type, version);
 	}
 
 	/** Sets up a format task according to the values in this extension. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -35,6 +35,8 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LazyForwardingEquality;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.ThrowingEx;
+import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
+import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 import com.diffplug.spotless.generic.EndWithNewlineStep;
 import com.diffplug.spotless.generic.IndentStep;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
@@ -481,6 +483,38 @@ public class FormatExtension {
 		final PrettierConfig prettierConfig = new PrettierConfig();
 		addStep(prettierConfig.createStep());
 		return prettierConfig;
+	}
+
+	public class EclipseWtpConfig {
+		private final EclipseBasedStepBuilder builder;
+
+		EclipseWtpConfig(EclipseWtpFormatterStep type) {
+			this(type, EclipseWtpFormatterStep.defaultVersion());
+		}
+
+		EclipseWtpConfig(EclipseWtpFormatterStep type, String version) {
+			builder = type.createBuilder(GradleProvisioner.fromProject(getProject()));
+			builder.setVersion(EclipseWtpFormatterStep.defaultVersion());
+			addStep(builder.build());
+		}
+
+		public void configFile(Object... configFiles) {
+			requireElementsNonNull(configFiles);
+			Project project = getProject();
+			builder.setPreferences(project.files(configFiles).getFiles());
+			replaceStep(builder.build());
+		}
+
+	}
+
+	public EclipseWtpConfig eclipseWtp(String type) {
+		return new EclipseWtpConfig(EclipseWtpFormatterStep.valueFrom(type));
+	}
+
+	public EclipseWtpConfig eclipseWtp(String type, String version) {
+		return new EclipseWtpConfig(
+				EclipseWtpFormatterStep.valueFrom(type),
+				version);
 	}
 
 	/** Sets up a format task according to the values in this extension. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -118,12 +118,24 @@ public class SpotlessExtension {
 		configure(SqlExtension.NAME, SqlExtension.class, closure);
 	}
 
-	/** Configures the special css-specific extension for CSS files. */
+	/**
+	 * Configures the special css-specific extension for CSS files.
+	 * <br/>
+	 * The CSS extension is discontinued. CSS formatters are now part of
+	 * the generic {@link FormatExtension}.
+	 */
+	@Deprecated
 	public void css(Action<CssExtension> closure) {
 		configure(CssExtension.NAME, CssExtension.class, closure);
 	}
 
-	/** Configures the special xml-specific extension for XML/XSL/... files (XHTML is excluded). */
+	/**
+	 * Configures the special xml-specific extension for XML/XSL/... files (XHTML is excluded).
+	 * <br/>
+	 * The XML extension is discontinued. XML formatters are now part of
+	 * the generic {@link FormatExtension}.
+	 */
+	@Deprecated
 	public void xml(Action<XmlExtension> closure) {
 		configure(XmlExtension.NAME, XmlExtension.class, closure);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/XmlExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/XmlExtension.java
@@ -23,6 +23,10 @@ import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 import com.diffplug.spotless.xml.XmlDefaults;
 
+/**
+ * The XML extension is deprecated. Use the generic {@link FormatExtension} instead.
+ */
+@Deprecated
 public class XmlExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "xml";
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.18.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Provided eclipse-wtp formatters as part of custom source format element. ([#325](https://github.com/diffplug/spotless/pull/325)). This change obsoletes the CSS and XML source elements.
+
 ### Version 1.17.0 - December 13th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.17.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.17.0))
 
 * Updated default eclipse-jdt from 4.7.3a to 4.9.0 ([#316](https://github.com/diffplug/spotless/pull/316)). New version addresses enum-tab formatting bug in 4.8 ([#314](https://github.com/diffplug/spotless/issues/314)).

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -190,30 +190,6 @@ By default, all files matching `src/main/cpp/**/*.<ext>` and `src/test/cpp/**/*.
 ```
 Use the Eclipse to define the *Code Style preferences* (see [Eclipse documentation](https://www.eclipse.org/documentation/)). Within the preferences *Edit...* dialog, you can export your configuration as XML file, which can be used as a configuration `<file>`. If no `<file>` is provided, the CDT default configuration is used.
 
-<a name="xml"></a>
-
-## Applying to CSS source
-
-By default, all files matching `src/**/*.css` Ant style pattern will be formatted.  Each element under `<css>` is a step, and they will be applied in the order specified.  Every step is optional, and they will be applied in the order specified.
-
-```xml
-<configuration>
-  <css>
-     <licenseHeader>
-       <!-- Specify either content or file, but not both -->
-       <content>/* Licensed under Apache-2.0 */</content>
-       <file>${basedir}/license-header</file>
-     </licenseHeader>
-     <eclipse>
-       <file>${basedir}/eclipse-fmt.pref</file>
-       <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters -->
-       <version>4.7.3a</version>
-     </eclipse>
-  </css>
-</configuration>
-```
-Use Eclipse to define the *CSS Files* editor preferences (see [Eclipse documentation](http://help.eclipse.org/photon/topic/org.eclipse.wst.sse.doc.user/topics/tsrcedt025.html)) and the *Cleanup* preferences available in the *Source* menu (when editing a CSS file). The preferences are stored below your Eclipse workspace directory in `.metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs`. Note that only the differences to the default configuration are stored within the file. If no `<file>` is provided, the WTP default configuration is used.
-
 <a name="format"></a>
 
 ## Applying to custom sources

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -74,7 +74,7 @@ Spotless supports the following powerful formatters:
 
 * Eclipse's java code formatter (including style and import ordering)
 * Eclipse's [CDT](https://www.eclipse.org/cdt/) C/C++ code formatter
-* Eclipse's [WTP](https://www.eclipse.org/webtools/) CSS and XML code formatter
+* Eclipse's [WTP](https://www.eclipse.org/webtools/) Web-Tools code formatters
 * Google's [google-java-format](https://github.com/google/google-java-format)
 * User-defined license enforcement, regex replacement, etc.
 
@@ -214,32 +214,6 @@ By default, all files matching `src/**/*.css` Ant style pattern will be formatte
 ```
 Use Eclipse to define the *CSS Files* editor preferences (see [Eclipse documentation](http://help.eclipse.org/photon/topic/org.eclipse.wst.sse.doc.user/topics/tsrcedt025.html)) and the *Cleanup* preferences available in the *Source* menu (when editing a CSS file). The preferences are stored below your Eclipse workspace directory in `.metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs`. Note that only the differences to the default configuration are stored within the file. If no `<file>` is provided, the WTP default configuration is used.
 
-<a name="xml"></a>
-
-## Applying to XML source
-
-By default, all files matching `src/**/*.<ext>` Ant style pattern will be formatted, whereas the file extensions `xml`, `xsl`, `xslt`, `wsdl`, `xsd`, `exsd`, `xmi` are supported.  Each element under `<xml>` is a step, and they will be applied in the order specified.  Every step is optional, and they will be applied in the order specified.
-
-```xml
-<configuration>
-  <xml>
-     <licenseHeader>
-       <!-- Specify either content or file, but not both -->
-       <content>&lt;!-- Licensed under Apache-2.0 --&gt;</content>
-       <file>${basedir}/license-header</file>
-     </licenseHeader>
-     <eclipse>
-       <file>${basedir}/eclipse-fmt.pref</file>
-       <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters -->
-       <version>4.7.3a</version>
-     </eclipse>
-  </xml>
-</configuration>
-```
-Use Eclipse to define the *XML editor preferences* (see [Eclipse documentation](https://www.eclipse.org/documentation/)). The preferences are stored below your Eclipse workspace directory in `.metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.xml.core.prefs`. Note that only the differences to the default configuration are stored within the file. If no `<file>` is provided, the WTP default configuration is used.
-
-The Eclipse WTP formatter supports DTD/XSD restrictions on white spaces. For XSD/DTD lookup, relative and absolute XSD/DTD URIs are supported. Furthermore a user catalog can be configured using the `userCatalog` property key. Add the property to the preference `<file>`.
-
 <a name="format"></a>
 
 ## Applying to custom sources
@@ -300,6 +274,54 @@ By default, no Ant-Style include patterns are defined.  Each element under `<for
   </formats>
 </configuration>
 ```
+
+
+<a name="eclipse-wtp"></a>
+
+## Applying [Eclipse WTP](https://www.eclipse.org/webtools/) to css | html | etc.
+
+The Eclipse [WTP](https://www.eclipse.org/webtools/) formatter can be applied as follows:
+
+```xml
+<configuration>
+  <formats>
+
+    <format>
+      <includes>
+        <include>src/**/resources/**/*.xml</include>
+        <include>src/**/resources/**/*.xsd</include>
+      </includes>
+
+      <eclipseWtp>
+        <!-- Specify the WTP formatter type (XML, JS, ...) -->
+        <type>XML</type>
+        <!-- Specify the configuration for the selected type -->
+        <files>
+          <file>${basedir}/xml.prefs</file>
+          <file>${basedir}/additional.properties</file>
+        </files>
+        <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters -->
+        <version>4.7.3a</version>
+      </eclipseWtp>
+    </format>
+  </formats>
+</configuration>
+```
+The WTP formatter accept multiple configuration files. All Eclipse configuration file formats are accepted as well as simple Java property files. Omit the `<files>` entirely to use the default Eclipse configuration. The following formatters and configurations are supported:
+
+| Type | Configuration       | File location
+| ---- | ------------------- | -------------
+| CSS  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+| HTML | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
+|      | embedded CSS        | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+|      | embedded JS         | Use the export in the Eclipse editor configuration dialog
+| JS   | editor preferences  | Use the export in the Eclipse editor configuration dialog
+| JSON | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.json.core.prefs
+| XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.xml.core.prefs
+
+Note that `HTML` should be used for `X-HTML` sources instead of `XML`.
 
 <a name="invisible"></a>
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -37,13 +37,11 @@ import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.maven.cpp.Cpp;
-import com.diffplug.spotless.maven.css.Css;
 import com.diffplug.spotless.maven.generic.Format;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
 import com.diffplug.spotless.maven.java.Java;
 import com.diffplug.spotless.maven.kotlin.Kotlin;
 import com.diffplug.spotless.maven.scala.Scala;
-import com.diffplug.spotless.maven.xml.Xml;
 
 public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
@@ -89,14 +87,18 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter
 	private Kotlin kotlin;
 
+	/** The XML extension is discontinued. */
 	@Parameter
-	private Xml xml;
+	@Deprecated
+	private com.diffplug.spotless.maven.xml.Xml xml;
 
 	@Parameter
 	private Cpp cpp;
 
+	/** The CSS extension is discontinued. */
 	@Parameter
-	private Css css;
+	@Deprecated
+	private com.diffplug.spotless.maven.css.Css css;
 
 	protected abstract void process(List<File> files, Formatter formatter) throws MojoExecutionException;
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -107,6 +107,10 @@ public abstract class FormatterFactory {
 		addStepFactory(replaceRegex);
 	}
 
+	public final void addEclipseWtp(EclipseWtp eclipseWtp) {
+		addStepFactory(eclipseWtp);
+	}
+
 	protected final void addStepFactory(FormatterStepFactory stepFactory) {
 		Objects.requireNonNull(stepFactory);
 		stepFactories.add(stepFactory);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/css/Css.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/css/Css.java
@@ -24,10 +24,13 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
 
 /**
  * A {@link FormatterFactory} implementation that corresponds to {@code <css>...</css>} configuration element.
- * <p>
+ * <br/>
  * It defines a formatter for CSS source files that can execute both language agnostic (e.g. {@link LicenseHeader})
  * and css-specific (e.g. {@link Eclipse}) steps.
+ * <br/>
+ * The CSS extension is discontinued. CSS formatters are now part of the generic {@link FormatterFactory}.
  */
+@Deprecated
 public class Css extends FormatterFactory {
 
 	private static final Set<String> DEFAULT_INCLUDES = CssDefaults.FILE_FILTER

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/css/Eclipse.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/css/Eclipse.java
@@ -25,7 +25,10 @@ import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 import com.diffplug.spotless.maven.FormatterStepConfig;
 import com.diffplug.spotless.maven.FormatterStepFactory;
+import com.diffplug.spotless.maven.generic.EclipseWtp;
 
+/** CSS Eclipse is deprecated. Use {@link EclipseWtp} instead.*/
+@Deprecated
 public class Eclipse implements FormatterStepFactory {
 
 	@Parameter

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/EclipseWtp.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/EclipseWtp.java
@@ -28,7 +28,7 @@ import com.diffplug.spotless.maven.FormatterStepFactory;
 
 public class EclipseWtp implements FormatterStepFactory {
 	@Parameter
-	private String type;
+	private EclipseWtpFormatterStep type;
 
 	@Parameter
 	private String version;
@@ -38,7 +38,7 @@ public class EclipseWtp implements FormatterStepFactory {
 
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
-		EclipseBasedStepBuilder eclipseConfig = EclipseWtpFormatterStep.valueFrom(type).createBuilder(stepConfig.getProvisioner());
+		EclipseBasedStepBuilder eclipseConfig = type.createBuilder(stepConfig.getProvisioner());
 		eclipseConfig.setVersion(version == null ? EclipseWtpFormatterStep.defaultVersion() : version);
 		if (null != files) {
 			eclipseConfig.setPreferences(

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/EclipseWtp.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/EclipseWtp.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.generic;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
+import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+
+public class EclipseWtp implements FormatterStepFactory {
+	@Parameter
+	private String type;
+
+	@Parameter
+	private String version;
+
+	@Parameter
+	private String[] files;
+
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
+		EclipseBasedStepBuilder eclipseConfig = EclipseWtpFormatterStep.valueFrom(type).createBuilder(stepConfig.getProvisioner());
+		eclipseConfig.setVersion(version == null ? EclipseWtpFormatterStep.defaultVersion() : version);
+		if (null != files) {
+			eclipseConfig.setPreferences(
+					stream(files).map(file -> stepConfig.getFileLocator().locateFile(file)).collect(toList()));
+		}
+		return eclipseConfig.build();
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/xml/Eclipse.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/xml/Eclipse.java
@@ -25,7 +25,10 @@ import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 import com.diffplug.spotless.maven.FormatterStepConfig;
 import com.diffplug.spotless.maven.FormatterStepFactory;
+import com.diffplug.spotless.maven.generic.EclipseWtp;
 
+/** XML Eclipse is deprecated. Use {@link EclipseWtp} instead.*/
+@Deprecated
 public class Eclipse implements FormatterStepFactory {
 
 	@Parameter

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/xml/Xml.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/xml/Xml.java
@@ -24,10 +24,13 @@ import com.diffplug.spotless.xml.XmlDefaults;
 
 /**
  * A {@link FormatterFactory} implementation that corresponds to {@code <xml>...</xml>} configuration element.
- * <p>
+ * <br/>
  * It defines a formatter for XML/XSL/... source files that can execute both language agnostic (e.g. {@link LicenseHeader})
  * and xml-specific (e.g. {@link Eclipse}) steps.
- */
+ * <br/>
+ * The XML extension is discontinued. XML formatters are now part of the generic {@link FormatterFactory}.
+  */
+@Deprecated
 public class Xml extends FormatterFactory {
 
 	private static final Set<String> DEFAULT_INCLUDES = XmlDefaults.FILE_FILTER

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationTest.java
@@ -102,6 +102,8 @@ public class MavenIntegrationTest extends ResourceHarness {
 		writePom(groupWithSteps("kotlin", steps));
 	}
 
+	/** The XML extension is discontinued. */
+	@Deprecated
 	protected void writePomWithXmlSteps(String... steps) throws IOException {
 		writePom(groupWithSteps("xml", steps));
 	}
@@ -110,6 +112,8 @@ public class MavenIntegrationTest extends ResourceHarness {
 		writePom(groupWithSteps("cpp", steps));
 	}
 
+	/** The CSS extension is discontinued. */
+	@Deprecated
 	protected void writePomWithCssSteps(String... steps) throws IOException {
 		writePom(groupWithSteps("css", steps));
 	}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/EclipseWtpTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/EclipseWtpTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.generic;
+
+import org.junit.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationTest;
+
+public class EclipseWtpTest extends MavenIntegrationTest {
+
+	@Test
+	public void testType() throws Exception {
+		writePomWithFormatSteps(
+				"<eclipseWtp>",
+				"<type>XML</type>",
+				"</eclipseWtp>");
+		runTest();
+	}
+
+	private void runTest() throws Exception {
+		String notFormatted = "<a><b>   c</b></a>";
+		String formatted = "<a>\n\t<b> c</b>\n</a>";
+		//writePomWithFormatSteps includes java. WTP does not care about file extensions.
+		setFile("src/main/java/test.java").toContent(notFormatted);
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile("src/main/java/test.java").hasContent(formatted);
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
@@ -50,7 +50,9 @@ public class LicenseHeaderTest extends MavenIntegrationTest {
 		assertFile(path).hasContent(cppLicense + '\n' + cppContent);
 	}
 
+	/** The CSS extension is discontinued. */
 	@Test
+	@Deprecated
 	public void fromContentCss() throws Exception {
 		String license = "/* my license */";
 		writePomWithCssSteps(
@@ -131,7 +133,9 @@ public class LicenseHeaderTest extends MavenIntegrationTest {
 		assertFile(path).hasContent(KOTLIN_LICENSE_HEADER + '\n' + noLicenseHeader);
 	}
 
+	/** XML extension is discontinued. */
 	@Test
+	@Deprecated
 	public void fromContentXml() throws Exception {
 		String license = " Licensed under Apache-2.0 ";
 		writePomWithXmlSteps(

--- a/spotlessSelf.gradle
+++ b/spotlessSelf.gradle
@@ -43,13 +43,6 @@ spotless {
 		bumpThisNumberIfACustomStepChanges(3)
 		greclipse().configFile('spotless.eclipseformat.xml', 'spotless.groovyformat.prefs')
 	}
-	xml {
-		target fileTree('.') {
-			include com.diffplug.spotless.xml.XmlDefaults.FILE_FILTER
-			exclude '**/build/**'
-		}
-		eclipse().configFile 'spotless.xmlformat.prefs'
-	}
 	freshmark {
 		target '**/*.md'
 		propertiesFile('gradle.properties')
@@ -63,5 +56,12 @@ spotless {
 		indentWithSpaces(2)
 		trimTrailingWhitespace()
 		endWithNewline()
+	}
+	format 'xml', {
+		target fileTree('.') {
+			include '**/*.xml', '**/*.xsd'
+			exclude '**/build/**'
+		}
+		eclipseWtp('xml').configFile 'spotless.xmlformat.prefs'
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/css/CssDefaultsTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/css/CssDefaultsTest.java
@@ -26,6 +26,8 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
 
+/** The CSS extension is discontinued. */
+@Deprecated
 public class CssDefaultsTest extends ResourceHarness {
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/xml/XmlDefaultsTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/xml/XmlDefaultsTest.java
@@ -26,6 +26,8 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
 
+/** The XML extension is discontinued. */
+@Deprecated
 public class XmlDefaultsTest extends ResourceHarness {
 
 	@Test


### PR DESCRIPTION
As discussed in  #315, for WEB related development, no dedicated extensions for CSS, XML, ... shall be provided. The Eclipse WTP formatters shall no longer be configurable via these extensions, but become part of the generic formatter section.  