### PR TITLE
Fix broken link in gradle README, remove unnecessary tabsize param.

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -580,7 +580,7 @@ spotless {
 
 If you use `custom` or `customLazy`, you might want to take a look at [this javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.17.0/com/diffplug/gradle/spotless/FormatExtension.html#bumpThisNumberIfACustomStepChanges-int-) for a big performance win.
 
-See [`JavaExtension.java`](src/main/java/com/diffplug/gradle/spotless/java/JavaExtension.java?ts=4) if you'd like to see how a language-specific set of custom rules is implemented.  We'd love PR's which add support for other languages.
+See [`JavaExtension.java`](src/main/java/com/diffplug/gradle/spotless/JavaExtension.java) if you'd like to see how a language-specific set of custom rules is implemented.  We'd love PR's which add support for other languages.
 
 <a name="invisible"></a>
 


### PR DESCRIPTION
This PR:

- Fixes broken link to JavaExtension.java from gradle-plugin/README.md.
- Removes unnecessary tabsize query string param, as 4 is now the default tabsize on GitHub.

Fixes #331