### PR TITLE
Slf4j support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ You might be looking for:
 ### Version 1.18.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
 * CSS and XML extensions are discontinued ([#325](https://github.com/diffplug/spotless/pull/325)).
+* Provided features with access to SLF4J interface of build tools. ([#236](https://github.com/diffplug/spotless/issues/236))
 
 ### Version 1.17.0 - October 30th 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.17.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.17.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 

--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -2,9 +2,9 @@
 
 ### Version 3.1.0 - TBD
 
-* Added logging service based on SLF4J.
+* Added logging service based on SLF4J. ([#236](https://github.com/diffplug/spotless/issues/236))
 * Updated internal interfaces to support `org.eclipse.osgi` version 3.13.
-* Corrected documentation of version number usage in `gradle.properties`.
+* Corrected documentation of version number usage in `gradle.properties`. 
 
 ### Version 3.0.0 - July 18th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
 

--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -1,8 +1,10 @@
 # spotless-eclipse-base
 
-### Version 3.1.0-SNAPSHOT - TBD
+### Version 3.1.0 - TBD
 
-* TBD.
+* Added logging service based on SLF4J.
+* Updated internal interfaces to support `org.eclipse.osgi` version 3.13.
+* Corrected documentation of version number usage in `gradle.properties`.
 
 ### Version 3.0.0 - July 18th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
 

--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Added logging service based on SLF4J. ([#236](https://github.com/diffplug/spotless/issues/236))
 * Updated internal interfaces to support `org.eclipse.osgi` version 3.13.
-* Corrected documentation of version number usage in `gradle.properties`. 
+* Corrected documentation of version number usage in `gradle.properties`.
 
 ### Version 3.0.0 - July 18th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
 

--- a/_ext/eclipse-base/build.gradle
+++ b/_ext/eclipse-base/build.gradle
@@ -13,6 +13,9 @@ dependencies {
 		exclude group: 'org.eclipse.platform', module: 'org.eclipse.core.expressions'
 		exclude group: 'org.eclipse.platform', module: 'org.eclipse.core.filesystem'
 	}
+	compile("org.slf4j:slf4j-api:${VER_SLF4J}")
+
+	testCompile("org.slf4j:slf4j-simple:${VER_SLF4J}")
 }
 
 jar {

--- a/_ext/eclipse-base/gradle.properties
+++ b/_ext/eclipse-base/gradle.properties
@@ -1,7 +1,7 @@
-# Mayor version correspond to the required Eclipse core version.
-# Minor version changes in case the minimum Eclipse core dependencies are raised due to incompatibilities of their internal interfaces.
-# Patch version is incremented in case of bug-fixes and evolutions.
-ext_version=3.0.0
+# Mayor versions correspond to the supported Eclipse core version.
+# Minor version is incremented for features or incompatible changes (including changes to supported dependency versions).
+# Patch version is incremented for backward compatible patches of this library.
+ext_version=3.1.0
 ext_artifactId=spotless-eclipse-base
 ext_description=Eclipse bundle controller and services for Spotless
 
@@ -12,4 +12,7 @@ ext_group=com.diffplug.spotless
 ext_VER_JAVA=1.8
 
 # Compile dependencies
-VER_ECLIPSE_CORE_RESOURCES=[3.11.0,4.0.0[
+VER_ECLIPSE_CORE_RESOURCES=[3.11.1,4.0.0[
+
+# Provided dependencies
+VER_SLF4J=[1.6,2.0[

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseServiceConfig.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseServiceConfig.java
@@ -18,12 +18,16 @@ package com.diffplug.spotless.extra.eclipse.base;
 import static com.diffplug.spotless.extra.eclipse.base.SpotlessEclipseFramework.LINE_DELIMITER;
 
 import java.util.Map;
+import java.util.function.BiFunction;
 
 import org.eclipse.core.runtime.content.IContentTypeManager;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.equinox.log.ExtendedLogReaderService;
+import org.eclipse.equinox.log.ExtendedLogService;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.environment.EnvironmentInfo;
+import org.osgi.service.log.LogLevel;
 
 import com.diffplug.spotless.extra.eclipse.base.service.*;
 
@@ -102,6 +106,19 @@ public interface SpotlessEclipseServiceConfig {
 	 */
 	default public void changeSystemLineSeparator() {
 		System.setProperty("line.separator", LINE_DELIMITER);
+	}
+
+	/** Adds Eclipse logging service Slf4J binding. */
+	default public void useSlf4J(String loggerName) {
+		useSlf4J(loggerName, (s, l) -> s);
+	}
+
+	/** Adds Eclipse logging service Slf4J binding with a message customizer function. */
+	default public void useSlf4J(String loggerName, BiFunction<String, LogLevel, String> messageCustomizer) {
+		SingleSlf4JService slf4jServce = new SingleSlf4JService(loggerName, messageCustomizer);
+		add(ExtendedLogService.class, slf4jServce);
+		add(ExtendedLogReaderService.class, slf4jServce);
+		slf4jServce.debug("Initialized Eclipse logging service.");
 	}
 
 	/** Applies the default configurations. */

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/EclipseBundleLookup.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/EclipseBundleLookup.java
@@ -16,12 +16,9 @@
 package com.diffplug.spotless.extra.eclipse.base.osgi;
 
 import org.osgi.framework.Bundle;
-import org.osgi.service.packageadmin.ExportedPackage;
-import org.osgi.service.packageadmin.PackageAdmin;
-import org.osgi.service.packageadmin.RequiredBundle;
 
 /**
- * {@link PackageAdmin} service for bundle look-up and bypassing wiring.
+ * {@link org.osgi.service.packageadmin.PackageAdmin} service for bundle look-up and bypassing wiring.
  * <p>
  * The wiring information will always claim that all required bundles are present.
  * Other functionality is not supported.
@@ -30,7 +27,7 @@ import org.osgi.service.packageadmin.RequiredBundle;
  * Interface is deprecated, but for example the InternalPlatform still uses PackageAdmin.
  */
 @SuppressWarnings("deprecation")
-class EclipseBundleLookup implements PackageAdmin {
+class EclipseBundleLookup implements org.osgi.service.packageadmin.PackageAdmin {
 
 	private final BundleSet bundles;
 
@@ -40,19 +37,19 @@ class EclipseBundleLookup implements PackageAdmin {
 
 	@Override
 	@Deprecated
-	public ExportedPackage[] getExportedPackages(Bundle bundle) {
+	public org.osgi.service.packageadmin.ExportedPackage[] getExportedPackages(Bundle bundle) {
 		return null;
 	}
 
 	@Override
 	@Deprecated
-	public ExportedPackage[] getExportedPackages(String name) {
+	public org.osgi.service.packageadmin.ExportedPackage[] getExportedPackages(String name) {
 		return null;
 	}
 
 	@Override
 	@Deprecated
-	public ExportedPackage getExportedPackage(String name) {
+	public org.osgi.service.packageadmin.ExportedPackage getExportedPackage(String name) {
 		return null;
 	}
 
@@ -66,7 +63,7 @@ class EclipseBundleLookup implements PackageAdmin {
 	}
 
 	@Override
-	public RequiredBundle[] getRequiredBundles(String symbolicName) {
+	public org.osgi.service.packageadmin.RequiredBundle[] getRequiredBundles(String symbolicName) {
 		return null; // No unresolved required bundles exist
 	}
 

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/EclipseBundleLookup.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/EclipseBundleLookup.java
@@ -16,9 +16,12 @@
 package com.diffplug.spotless.extra.eclipse.base.osgi;
 
 import org.osgi.framework.Bundle;
+import org.osgi.service.packageadmin.ExportedPackage;
+import org.osgi.service.packageadmin.PackageAdmin;
+import org.osgi.service.packageadmin.RequiredBundle;
 
 /**
- * {@link org.osgi.service.packageadmin.PackageAdmin} service for bundle look-up and bypassing wiring.
+ * {@link PackageAdmin} service for bundle look-up and bypassing wiring.
  * <p>
  * The wiring information will always claim that all required bundles are present.
  * Other functionality is not supported.
@@ -27,7 +30,7 @@ import org.osgi.framework.Bundle;
  * Interface is deprecated, but for example the InternalPlatform still uses PackageAdmin.
  */
 @SuppressWarnings("deprecation")
-class EclipseBundleLookup implements org.osgi.service.packageadmin.PackageAdmin {
+class EclipseBundleLookup implements PackageAdmin {
 
 	private final BundleSet bundles;
 
@@ -37,19 +40,19 @@ class EclipseBundleLookup implements org.osgi.service.packageadmin.PackageAdmin 
 
 	@Override
 	@Deprecated
-	public org.osgi.service.packageadmin.ExportedPackage[] getExportedPackages(Bundle bundle) {
+	public ExportedPackage[] getExportedPackages(Bundle bundle) {
 		return null;
 	}
 
 	@Override
 	@Deprecated
-	public org.osgi.service.packageadmin.ExportedPackage[] getExportedPackages(String name) {
+	public ExportedPackage[] getExportedPackages(String name) {
 		return null;
 	}
 
 	@Override
 	@Deprecated
-	public org.osgi.service.packageadmin.ExportedPackage getExportedPackage(String name) {
+	public ExportedPackage getExportedPackage(String name) {
 		return null;
 	}
 
@@ -63,7 +66,7 @@ class EclipseBundleLookup implements org.osgi.service.packageadmin.PackageAdmin 
 	}
 
 	@Override
-	public org.osgi.service.packageadmin.RequiredBundle[] getRequiredBundles(String symbolicName) {
+	public RequiredBundle[] getRequiredBundles(String symbolicName) {
 		return null; // No unresolved required bundles exist
 	}
 

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/SingleSlf4JService.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/SingleSlf4JService.java
@@ -176,7 +176,7 @@ public class SingleSlf4JService implements ExtendedLogService, ExtendedLogReader
 		}
 	}
 
-	public void log(LogEntry entry) {
+	private void log(LogEntry entry) {
 		synchronized (listener) {
 			listener.stream().forEach(l -> l.logged(entry));
 		}
@@ -390,7 +390,8 @@ public class SingleSlf4JService implements ExtendedLogService, ExtendedLogReader
 		audit(String.format(format, arguments));
 	}
 
-	public static class SimpleLogEntry implements LogEntry {
+	/** Internal wrapper for Eclipse OSGI 3.12 based logs and new log services. */
+	private static class SimpleLogEntry implements LogEntry {
 
 		private final LogLevel level;
 		private final String message;
@@ -491,7 +492,7 @@ public class SingleSlf4JService implements ExtendedLogService, ExtendedLogReader
 
 		@Override
 		public StackTraceElement getLocation() {
-			return null;
+			return null; // Not used by SingleSlf4JService
 		}
 
 	}

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/SingleSlf4JService.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/SingleSlf4JService.java
@@ -1,0 +1,532 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.extra.eclipse.base.service;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.core.internal.runtime.InternalPlatform;
+import org.eclipse.equinox.log.ExtendedLogReaderService;
+import org.eclipse.equinox.log.ExtendedLogService;
+import org.eclipse.equinox.log.LogFilter;
+import org.eclipse.equinox.log.Logger;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogEntry;
+import org.osgi.service.log.LogLevel;
+import org.osgi.service.log.LogListener;
+import org.osgi.service.log.LoggerConsumer;
+
+/**
+ * Eclipse log service facade that delegates to a Slf4J logger.
+ * The service does not provide historical log entries (empty history reported).
+ * No factory service is provided for OSGI logger extensions (method are marked
+ * as deprecated and raise UnsupportedOperationException).
+ * All Eclipse logger are delegated to a single Slf4J logger instance.
+ * The log messages can be formatted by customizer.
+ */
+public class SingleSlf4JService implements ExtendedLogService, ExtendedLogReaderService {
+
+	private final org.slf4j.Logger delegate;
+	private final Map<LogLevel, LogMethods> logLevel2methods;
+	private final Set<LogListener> listener;
+	private final BiFunction<String, LogLevel, String> messageCustomizer;
+
+	/** Create facade for named logger with customized messages. */
+	public SingleSlf4JService(String name, BiFunction<String, LogLevel, String> messageCustomizer) {
+		delegate = org.slf4j.LoggerFactory.getLogger(name);
+		logLevel2methods = new HashMap<LogLevel, LogMethods>();
+		/*
+		 * Audit message are treated as normal info-messages and might not get logged.
+		 * Logging of Eclipse messages in Spotless formatter is meant for debugging purposes and
+		 * detection of erroneous usage/override of internal Eclipse methods.
+		 * Hence the concept of Audit is not required.
+		 */
+		logLevel2methods.put(LogLevel.AUDIT,
+				create(() -> true, m -> delegate.info(m), (m, e) -> delegate.info(m, e)));
+		logLevel2methods.put(LogLevel.DEBUG,
+				create(() -> delegate.isDebugEnabled(), m -> delegate.debug(m), (m, e) -> delegate.debug(m, e)));
+		logLevel2methods.put(LogLevel.ERROR,
+				create(() -> delegate.isErrorEnabled(), m -> delegate.error(m), (m, e) -> delegate.error(m, e)));
+		logLevel2methods.put(LogLevel.INFO,
+				create(() -> delegate.isInfoEnabled(), m -> delegate.info(m), (m, e) -> delegate.info(m, e)));
+		logLevel2methods.put(LogLevel.TRACE,
+				create(() -> delegate.isTraceEnabled(), m -> delegate.trace(m), (m, e) -> delegate.trace(m, e)));
+		logLevel2methods.put(LogLevel.WARN,
+				create(() -> delegate.isWarnEnabled(), m -> delegate.warn(m), (m, e) -> delegate.warn(m, e)));
+		listener = new HashSet<LogListener>();
+		this.messageCustomizer = messageCustomizer;
+	}
+
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(int level, String message) {
+		log(this, level, message);
+	}
+
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(int level, String message, @Nullable Throwable exception) {
+		log(this, level, message, exception);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(ServiceReference sr, int level, String message) {
+		log(this, level, message);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public void log(ServiceReference sr, int level, String message, Throwable exception) {
+		log(this, level, message, exception);
+	}
+
+	@Override
+	public void log(Object context, int level, String message) {
+		log(context, level, message, null);
+	}
+
+	@Override
+	public void log(Object context, int level, String message, @Nullable Throwable exception) {
+		LogLevel logLevel = convertDeprectatedOsgiLevel(level);
+		log(new SimpleLogEntry(logLevel, message, exception));
+	}
+
+	@Override
+	public boolean isLoggable(int level) {
+		LogLevel logLevel = convertDeprectatedOsgiLevel(level);
+		return logLevel2methods.get(logLevel).isEnabled();
+	}
+
+	@SuppressWarnings("deprecation") ////Backward compatibility with Eclipse OSGI 3.12
+	private static LogLevel convertDeprectatedOsgiLevel(int level) {
+		switch (level) {
+		case SingleSlf4JService.LOG_DEBUG:
+			return LogLevel.DEBUG;
+		case SingleSlf4JService.LOG_INFO:
+			return LogLevel.INFO;
+		case SingleSlf4JService.LOG_ERROR:
+			return LogLevel.ERROR;
+		case SingleSlf4JService.LOG_WARNING:
+			return LogLevel.WARN;
+		default:
+			return LogLevel.AUDIT;
+		}
+	}
+
+	@Override
+	public String getName() {
+		return delegate.getName();
+	}
+
+	@Override
+	public Logger getLogger(String loggerName) {
+		return this;
+	}
+
+	@Override
+	public Logger getLogger(Bundle bundle, String loggerName) {
+		return this;
+	}
+
+	@Override
+	public void addLogListener(LogListener listener) {
+		synchronized (this.listener) {
+			this.listener.add(listener);
+		}
+	}
+
+	@Override
+	public void removeLogListener(LogListener listener) {
+		synchronized (this.listener) {
+			this.listener.remove(listener);
+		}
+	}
+
+	public void log(LogEntry entry) {
+		synchronized (listener) {
+			listener.stream().forEach(l -> l.logged(entry));
+		}
+		String customMessage = messageCustomizer.apply(entry.getMessage(), entry.getLogLevel());
+		logLevel2methods.get(entry.getLogLevel()).log(customMessage, entry.getException());
+	}
+
+	@Override
+	@Deprecated
+	//Backward compatibility with Eclipse OSGI 3.12
+	public Enumeration<LogEntry> getLog() {
+		return Collections.emptyEnumeration(); //We do not provide historical information
+	}
+
+	@Override
+	public void addLogListener(LogListener listener, LogFilter filter) {
+		addLogListener(listener); //Listener must filter if required
+
+	}
+
+	@Override
+	public org.osgi.service.log.Logger getLogger(Class<?> clazz) {
+		return this;
+	}
+
+	@Override
+	@Deprecated
+	public <L extends org.osgi.service.log.Logger> L getLogger(String name, Class<L> loggerType) {
+		throw new UnsupportedOperationException("Logger factory for indifivaul types currently not supported.");
+	}
+
+	@Override
+	@Deprecated
+	public <L extends org.osgi.service.log.Logger> L getLogger(Class<?> clazz, Class<L> loggerType) {
+		return getLogger(getName(), loggerType);
+	}
+
+	@Override
+	@Deprecated
+	public <L extends org.osgi.service.log.Logger> L getLogger(Bundle bundle, String name, Class<L> loggerType) {
+		return getLogger(getName(), loggerType);
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return delegate.isTraceEnabled();
+	}
+
+	@Override
+	public void trace(String message) {
+		log(new SimpleLogEntry(LogLevel.TRACE, message));
+	}
+
+	@Override
+	public void trace(String format, Object arg) {
+		trace(String.format(format, arg));
+	}
+
+	@Override
+	public void trace(String format, Object arg1, Object arg2) {
+		trace(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void trace(String format, Object... arguments) {
+		trace(String.format(format, arguments));
+	}
+
+	@Override
+	public <E extends Exception> void trace(LoggerConsumer<E> consumer) throws E {
+		consumer.accept(this);
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return delegate.isDebugEnabled();
+	}
+
+	@Override
+	public void debug(String message) {
+		log(new SimpleLogEntry(LogLevel.DEBUG, message));
+	}
+
+	@Override
+	public void debug(String format, Object arg) {
+		debug(String.format(format, arg));
+	}
+
+	@Override
+	public void debug(String format, Object arg1, Object arg2) {
+		debug(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void debug(String format, Object... arguments) {
+		debug(String.format(format, arguments));
+	}
+
+	@Override
+	public <E extends Exception> void debug(LoggerConsumer<E> consumer) throws E {
+		consumer.accept(this);
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return delegate.isInfoEnabled();
+	}
+
+	@Override
+	public void info(String message) {
+		log(new SimpleLogEntry(LogLevel.INFO, message));
+	}
+
+	@Override
+	public void info(String format, Object arg) {
+		info(String.format(format, arg));
+	}
+
+	@Override
+	public void info(String format, Object arg1, Object arg2) {
+		info(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void info(String format, Object... arguments) {
+		info(String.format(format, arguments));
+	}
+
+	@Override
+	public <E extends Exception> void info(LoggerConsumer<E> consumer) throws E {
+		consumer.accept(this);
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return delegate.isWarnEnabled();
+	}
+
+	@Override
+	public void warn(String message) {
+		log(new SimpleLogEntry(LogLevel.WARN, message));
+	}
+
+	@Override
+	public void warn(String format, Object arg) {
+		warn(String.format(format, arg));
+	}
+
+	@Override
+	public void warn(String format, Object arg1, Object arg2) {
+		warn(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void warn(String format, Object... arguments) {
+		warn(String.format(format, arguments));
+	}
+
+	@Override
+	public <E extends Exception> void warn(LoggerConsumer<E> consumer) throws E {
+		consumer.accept(this);
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return delegate.isErrorEnabled();
+	}
+
+	@Override
+	public void error(String message) {
+		log(new SimpleLogEntry(LogLevel.ERROR, message));
+	}
+
+	@Override
+	public void error(String format, Object arg) {
+		error(String.format(format, arg));
+	}
+
+	@Override
+	public void error(String format, Object arg1, Object arg2) {
+		error(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void error(String format, Object... arguments) {
+		error(String.format(format, arguments));
+	}
+
+	@Override
+	public <E extends Exception> void error(LoggerConsumer<E> consumer) throws E {
+		consumer.accept(this);
+	}
+
+	@Override
+	public void audit(String message) {
+		log(new SimpleLogEntry(LogLevel.AUDIT, message));
+	}
+
+	@Override
+	public void audit(String format, Object arg) {
+		audit(String.format(format, arg));
+	}
+
+	@Override
+	public void audit(String format, Object arg1, Object arg2) {
+		audit(String.format(format, arg1, arg2));
+	}
+
+	@Override
+	public void audit(String format, Object... arguments) {
+		audit(String.format(format, arguments));
+	}
+
+	public static class SimpleLogEntry implements LogEntry {
+
+		private final LogLevel level;
+		private final String message;
+		private final Optional<Throwable> execption;
+
+		public SimpleLogEntry(LogLevel level, String message) {
+			this(level, message, Optional.empty());
+		}
+
+		public SimpleLogEntry(LogLevel level, String message, @Nullable Throwable execption) {
+			this(level, message, Optional.ofNullable(execption));
+		}
+
+		private SimpleLogEntry(LogLevel level, String message, Optional<Throwable> execption) {
+			this.level = level;
+			this.message = message;
+			this.execption = execption;
+		}
+
+		@Override
+		public Bundle getBundle() {
+			//Return the spotless framework bundle
+			return InternalPlatform.getDefault().getBundleContext().getBundle();
+		}
+
+		@SuppressWarnings({"rawtypes", "unchecked"})
+		@Override
+		public ServiceReference getServiceReference() {
+			return null;
+		}
+
+		@Override
+		@Deprecated
+		//Backward compatibility with Eclipse OSGI 3.12
+		public int getLevel() {
+			switch (level) {
+			case DEBUG:
+			case TRACE:
+				return SingleSlf4JService.LOG_DEBUG;
+			case AUDIT:
+			case INFO:
+				return SingleSlf4JService.LOG_INFO;
+			case ERROR:
+				return SingleSlf4JService.LOG_ERROR;
+			case WARN:
+				return SingleSlf4JService.LOG_WARNING;
+			}
+			return SingleSlf4JService.LOG_ERROR; //Don't fail here. Just log it as error. This is anyway just for debugging internal problems.
+		}
+
+		@Override
+		public String getMessage() {
+			return message;
+		}
+
+		@Override
+		public Throwable getException() {
+			return execption.orElse(null);
+		}
+
+		@Override
+		public long getTime() {
+			return 0;
+		}
+
+		@Override
+		public String toString() {
+			StringWriter result = new StringWriter();
+			result.write(message);
+			if (execption.isPresent()) {
+				result.write('\n');
+				result.write(execption.get().toString());
+				result.write('\n');
+				execption.get().printStackTrace(new PrintWriter(result));
+			}
+			return result.toString();
+		}
+
+		@Override
+		public LogLevel getLogLevel() {
+			return level;
+		}
+
+		@Override
+		public String getLoggerName() {
+			return this.getClass().getSimpleName();
+		}
+
+		@Override
+		public long getSequence() {
+			return 0;
+		}
+
+		@Override
+		public String getThreadInfo() {
+			return null;
+		}
+
+		@Override
+		public StackTraceElement getLocation() {
+			return null;
+		}
+
+	}
+
+	private static LogMethods create(Supplier<Boolean> enabled, Consumer<String> log, BiConsumer<String, Throwable> logException) {
+		return new LogMethods(enabled, log, logException);
+	}
+
+	private static class LogMethods {
+		private final Supplier<Boolean> enabled;
+		private final Consumer<String> log;
+		private final BiConsumer<String, Throwable> logException;
+
+		private LogMethods(Supplier<Boolean> enabled, Consumer<String> log, BiConsumer<String, Throwable> logException) {
+			this.enabled = enabled;
+			this.log = log;
+			this.logException = logException;
+		}
+
+		public boolean isEnabled() {
+			return enabled.get();
+		}
+
+		public void log(String message) {
+			log.accept(message);
+		}
+
+		public void log(String message, @Nullable Throwable exception) {
+			if (null == exception) {
+				log(message);
+			} else {
+				logException.accept(message, exception);
+			}
+		}
+
+	};
+
+}

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/TemporaryLocation.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/TemporaryLocation.java
@@ -81,6 +81,7 @@ public class TemporaryLocation implements Location {
 	}
 
 	@Override
+	@Deprecated
 	public boolean setURL(URL value, boolean lock) throws IllegalStateException {
 		throw new IllegalStateException("URL not modifyable.");
 	}

--- a/_ext/eclipse-base/src/test/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseFrameworkTest.java
+++ b/_ext/eclipse-base/src/test/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseFrameworkTest.java
@@ -15,15 +15,317 @@
  */
 package com.diffplug.spotless.extra.eclipse.base;
 
-import org.junit.Test;
-import org.osgi.framework.BundleException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-/** Smoke tests */
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.StringAssert;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.equinox.log.ExtendedLogReaderService;
+import org.eclipse.equinox.log.ExtendedLogService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogEntry;
+import org.osgi.service.log.LogLevel;
+import org.osgi.service.log.LogListener;
+import org.slf4j.simple.SimpleLogger;
+
+import com.diffplug.spotless.extra.eclipse.base.service.SingleSlf4JService;
+
+/** Integration tests */
 public class SpotlessEclipseFrameworkTest {
 
-	@Test
-	public void testSetup() throws BundleException {
-		SpotlessEclipseFramework.setup();
+	private final static String TEST_LOGGER_NAME = SpotlessEclipseFrameworkTest.class.getSimpleName();
+	private final static String CUSTOM_PREFIX = "prefix\t";
+	private final static String CUSTOM_POSTFIX = "\tpostfix";
+	private final static String TEST_EXCEPTION_MESSAGE = "MY TEST-EXCEPTION";
+	private static Slf4JMesssageListener SLF4J_RECEIVER = null;
+
+	private static boolean TREAT_ERROR_AS_EXCEPTION = false;
+
+	@BeforeClass
+	public static void frameworkTestSetup() throws BundleException {
+		//Prepare interception of SLF4J messages to System.out
+		SLF4J_RECEIVER = new Slf4JMesssageListener();
+
+		//Configure SLF4J-Simple
+		System.setProperty(SimpleLogger.LOG_FILE_KEY, "System.out");
+		System.setProperty(SimpleLogger.SHOW_SHORT_LOG_NAME_KEY, "true");
+		System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "warn");
+
+		//Instantiate default framework + SLF4J logger
+		SpotlessEclipseFramework.setup(
+				config -> {
+					config.applyDefault();
+					config.useSlf4J(TEST_LOGGER_NAME, (s, l) -> {
+						if (TREAT_ERROR_AS_EXCEPTION && (LogLevel.ERROR == l)) {
+							throw new IllegalArgumentException(TEST_EXCEPTION_MESSAGE);
+						}
+						return CUSTOM_PREFIX + s + CUSTOM_POSTFIX;
+					});
+				},
+				plugins -> {
+					plugins.applyDefault();
+				});
 	}
 
+	@AfterClass
+	public static void deregisterSlf4JReceiver() {
+		SLF4J_RECEIVER.deregister();
+	}
+
+	private EclipseMessageListener eclipseMessageListener;
+
+	@Before
+	public void eclipseReceiverSetup() {
+		ExtendedLogReaderService service = getService(ExtendedLogReaderService.class);
+		eclipseMessageListener = new EclipseMessageListener();
+		service.addLogListener(eclipseMessageListener);
+		SLF4J_RECEIVER.clear();
+	}
+
+	@After
+	public void logReceiverTearDown() {
+		ExtendedLogReaderService service = getService(ExtendedLogReaderService.class);
+		service.removeLogListener(eclipseMessageListener);
+	}
+
+	@Test
+	public void testCustomizedLogMessage() {
+		ResourcesPlugin.getPlugin().getLog().log(new Status(IStatus.ERROR, "Some plugin", "Hello World!"));
+		assertSlf4J()
+				.as("Error message logged.").received("Hello World!").contains(TEST_LOGGER_NAME)
+				.as("Customization method has been applied.").contains(CUSTOM_PREFIX, CUSTOM_POSTFIX)
+				.as("Status level has been converted to simple SLF4J level").contains("ERROR");
+		assertEclipse()
+				.as("Warning message received.").received("Hello World!")
+				.as("Customization method is only for SLF4J").doesNotContain(CUSTOM_PREFIX);
+	}
+
+	@Test
+	public void testCustomizedLogException() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> {
+					try {
+						TREAT_ERROR_AS_EXCEPTION = true;
+						ResourcesPlugin.getPlugin().getLog().log(new Status(IStatus.ERROR, "Some plugin", "Hello World!"));
+					} finally {
+						TREAT_ERROR_AS_EXCEPTION = false;
+					}
+				})
+				.withMessage(TEST_EXCEPTION_MESSAGE);
+	}
+
+	@Test
+	public void testPluginLog() {
+		List<Integer> logLevels = Arrays.asList(IStatus.CANCEL, IStatus.ERROR, IStatus.INFO, IStatus.OK, IStatus.WARNING);
+		List<Integer> enabledLogLevels = Arrays.asList(IStatus.ERROR, IStatus.WARNING);
+		List<Integer> disabledLogLevels = logLevels.stream().filter(level -> !enabledLogLevels.contains(level)).collect(Collectors.toList());
+		ILog logger = ResourcesPlugin.getPlugin().getLog();
+		logLevels.forEach(logLevel -> logger.log(new Status(logLevel, "Some plugin", logLevel.toString())));
+		assertSlf4J()
+				.as("Messages for all enabled levels are logged.").received(
+						enabledLogLevels.stream().map(i -> i.toString()).collect(Collectors.toList()));
+		assertSlf4J()
+				.as("Messages all disabled levels are not logged.").notReceived(
+						disabledLogLevels.stream().map(i -> i.toString()).collect(Collectors.toList()));
+		assertEclipse()
+				.as("All messages received.").received(
+						logLevels.stream().map(i -> i.toString()).collect(Collectors.toList()));
+	}
+
+	@Test
+	public void testLogServiceLevel() {
+		ExtendedLogService service = getService(ExtendedLogService.class);
+		assertThat(service.isErrorEnabled()).as("Error log level is enabled").isTrue();
+		assertThat(service.isWarnEnabled()).as("Warning log level is enabled").isTrue();
+		assertThat(service.isInfoEnabled()).as("Info log level is disabled").isFalse();
+		assertThat(service.isDebugEnabled()).as("Debug log level is disabled").isFalse();
+		assertThat(service.isTraceEnabled()).as("Trace log level is disabled").isFalse();
+	}
+
+	@Test
+	public void testLogServiceLog() {
+		ExtendedLogService service = getService(ExtendedLogService.class);
+		service.info("Log Info");
+		service.warn("Log Warn");
+		assertSlf4J().received("Log Warn");
+		assertSlf4J().notReceived("Log Info");
+		assertEclipse().received(Arrays.asList("Log Warn", "Log Info"));
+	}
+
+	@Test
+	@Deprecated
+	public void testLogServiceLog_3_12() {
+		ExtendedLogService service = getService(ExtendedLogService.class);
+		service.log(SingleSlf4JService.LOG_INFO, "Log Info");
+		try {
+			throw new IllegalArgumentException(TEST_EXCEPTION_MESSAGE);
+		} catch (Exception e) {
+			service.log(SingleSlf4JService.LOG_WARNING, "Log Warn", e);
+		}
+		assertSlf4J().received(Arrays.asList("Log Warn", TEST_EXCEPTION_MESSAGE));
+		assertSlf4J().notReceived("Log Info");
+		assertEclipse().received(Arrays.asList("Log Warn", TEST_EXCEPTION_MESSAGE, "Log Info"));
+	}
+
+	private static <T> T getService(Class<T> serviceClass) {
+		ResourcesPlugin plugin = ResourcesPlugin.getPlugin();
+		assertThat(plugin).as("ResourcesPlugin instantiated as part of framework defaults").isNotNull();
+		Bundle bundle = plugin.getBundle();
+		assertThat(bundle).as("ResourcesPlugin has been started.").isNotNull();
+		BundleContext context = bundle.getBundleContext();
+		assertThat(context).as("ResourcesPlugin has been started.").isNotNull();
+		ServiceReference<T> reference = context.getServiceReference(serviceClass);
+		assertThat(reference).as(serviceClass.getSimpleName() + " has been registered.").isNotNull();
+		T service = context.getService(reference);
+		assertThat(service).as(serviceClass.getSimpleName() + " can be resolved.").isNotNull();
+		return service;
+	}
+
+	private static interface IMessageListener {
+		Collection<String> getMessages();
+	}
+
+	private static class EclipseMessageListener implements LogListener, IMessageListener {
+
+		private final List<String> messages;
+
+		public EclipseMessageListener() {
+			messages = new ArrayList<String>();
+		}
+
+		@Override
+		public Collection<String> getMessages() {
+			return Collections.unmodifiableList(messages);
+		}
+
+		@Override
+		public void logged(LogEntry entry) {
+			messages.add(entry.getMessage());
+			if (null != entry.getException()) {
+				messages.add(entry.getException().getMessage());
+			}
+		}
+	}
+
+	private final static class Slf4JMesssageListener extends PrintStream implements IMessageListener {
+
+		private final List<String> messages;
+		private final PrintStream originalStream;
+
+		public Slf4JMesssageListener() {
+			super(System.out);
+			messages = new ArrayList<String>();
+			originalStream = System.out;
+			System.setOut(this);
+		}
+
+		@Override
+		public void println(String x) {
+			if (x.contains(TEST_LOGGER_NAME)) {
+				messages.add(x);
+			} else {
+				super.println(x);
+			}
+		}
+
+		@Override
+		public void println(Object x) {
+			if (x instanceof Exception) {
+				Exception e = (Exception) x;
+				if (TEST_EXCEPTION_MESSAGE == e.getMessage()) {
+					messages.add(TEST_EXCEPTION_MESSAGE);
+				}
+			}
+			super.println(x);
+		}
+
+		public void deregister() {
+			System.setOut(originalStream);
+		}
+
+		public void clear() {
+			messages.clear();
+		}
+
+		@Override
+		public Collection<String> getMessages() {
+			return Collections.unmodifiableList(messages);
+		}
+	}
+
+	private static class MessageListenerAssert<T extends IMessageListener> extends AbstractAssert<MessageListenerAssert<T>, T> {
+
+		public MessageListenerAssert(T actual) {
+			super(actual, MessageListenerAssert.class);
+		}
+
+		public ObjectArrayAssert<String> received(Collection<String> unformattedMessages) {
+			List<String> formattedMessages = unformattedMessages.stream()
+					.map(unformattedMessage -> getReceivedMessage(unformattedMessage, false))
+					.collect(Collectors.toList());
+			return new ObjectArrayAssert<String>(formattedMessages.toArray(new String[0]));
+		}
+
+		public StringAssert received(String unformattedMessage) {
+			return new StringAssert(getReceivedMessage(unformattedMessage, false));
+		}
+
+		public MessageListenerAssert<T> notReceived(String unformattedMessage) {
+			getReceivedMessage(unformattedMessage, true);
+			return this;
+		}
+
+		public MessageListenerAssert<T> notReceived(Collection<String> unformattedMessages) {
+			unformattedMessages.forEach(unformattedMessage -> getReceivedMessage(unformattedMessage, true));
+			return this;
+		}
+
+		private String getReceivedMessage(String unformattedMessage, boolean negate) {
+			isNotNull();
+			String receivedMessage = null;
+			for (String formattedMessage : actual.getMessages()) {
+				if (formattedMessage.contains(unformattedMessage)) {
+					receivedMessage = formattedMessage;
+					break;
+				}
+			}
+			if ((!negate) && (null == receivedMessage)) {
+				failWithMessage("Message <%s> not received.", unformattedMessage);
+			}
+			if (negate && (null != receivedMessage)) {
+				failWithMessage("Message <%s> has been received. Formatted message is: %s", unformattedMessage, receivedMessage);
+			}
+			return receivedMessage;
+		}
+
+	}
+
+	private static MessageListenerAssert<Slf4JMesssageListener> assertSlf4J() {
+		return new MessageListenerAssert<Slf4JMesssageListener>(SLF4J_RECEIVER).as("SLF4J");
+	}
+
+	private MessageListenerAssert<EclipseMessageListener> assertEclipse() {
+		return new MessageListenerAssert<EclipseMessageListener>(eclipseMessageListener).as("Eclipse");
+	}
 }

--- a/_ext/eclipse-base/src/test/java/com/diffplug/spotless/extra/eclipse/base/osgi/TestBundle.java
+++ b/_ext/eclipse-base/src/test/java/com/diffplug/spotless/extra/eclipse/base/osgi/TestBundle.java
@@ -45,6 +45,7 @@ public class TestBundle implements StaticBundle, TemporaryBundle {
 	}
 
 	@Override
+	@Deprecated
 	public Dictionary<String, String> getHeaders() {
 		return null;
 	}
@@ -70,6 +71,7 @@ public class TestBundle implements StaticBundle, TemporaryBundle {
 	}
 
 	@Override
+	@Deprecated
 	public Dictionary<String, String> getHeaders(String locale) {
 		return null;
 	}
@@ -100,6 +102,7 @@ public class TestBundle implements StaticBundle, TemporaryBundle {
 	}
 
 	@Override
+	@Deprecated
 	public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
 		return null;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
+++ b/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
@@ -40,7 +40,7 @@ public class FeatureClassLoader extends URLClassLoader {
 	}
 
 	/** Packages which must be provided by the build tool or the corresponding Spotless plugin. */
-	private static List<String> BUILD_TOOLS_PACKAGES = Arrays.asList("org.slf4j");
+	private static List<String> BUILD_TOOLS_PACKAGES = Arrays.asList("org.slf4j.");
 
 	private final ClassLoader buildToolClassLoader;
 

--- a/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
+++ b/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This class loader is used to load classes of Spotless features from a search
+ * path of URLs.<br/>
+ * Features shall be independent from build tools. Hence the class loader of the
+ * underlying build tool is e.g. skipped during the the search for classes.<br/>
+ * Only {@link #BUILD_TOOLS_PACKAGES } are explicitly looked up from the class loader of
+ * the build tool and the provided URLs are ignored. This allows the feature to use
+ * distinct functionality of the build tool.
+ */
+public class FeatureClassLoader extends URLClassLoader {
+	static {
+		try {
+			ClassLoader.registerAsParallelCapable();
+		} catch (NoSuchMethodError ignore) {
+			// Not supported on Java 6
+		}
+	}
+
+	/** Packages which must be provided by the build tool or the corresponding Spotless plugin. */
+	private static List<String> BUILD_TOOLS_PACKAGES = Arrays.asList("org.slf4j");
+
+	private final ClassLoader buildToolClassLoader;
+
+	/**
+	 * Constructs a new FeatureClassLoader for the given URLs, based on an {@code URLClassLoader},
+	 * using the system class loader as parent. For {@link #BUILD_TOOLS_PACKAGES }, the build
+	 * tool class loader is used.
+	 *
+	 * @param urls the URLs from which to load classes and resources
+	 * @param buildToolClassLoader The build tool class loader
+	 * @exception  SecurityException  If a security manager exists and prevents the creation of a class loader.
+	 * @exception  NullPointerException if {@code urls} is {@code null}.
+	 */
+
+	public FeatureClassLoader(URL[] urls, ClassLoader buildToolClassLoader) {
+		super(urls, null);
+		Objects.requireNonNull(buildToolClassLoader);
+		this.buildToolClassLoader = buildToolClassLoader;
+	}
+
+	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException {
+		for (String buildToolPackage : BUILD_TOOLS_PACKAGES) {
+			if (name.startsWith(buildToolPackage)) {
+				return buildToolClassLoader.loadClass(name);
+			}
+		}
+		return super.findClass(name);
+	}
+
+}

--- a/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
+++ b/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
@@ -18,6 +18,7 @@ package com.diffplug.spotless;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,17 +31,18 @@ import java.util.Objects;
  * the build tool and the provided URLs are ignored. This allows the feature to use
  * distinct functionality of the build tool.
  */
-public class FeatureClassLoader extends URLClassLoader {
+class FeatureClassLoader extends URLClassLoader {
 	static {
-		try {
-			ClassLoader.registerAsParallelCapable();
-		} catch (NoSuchMethodError ignore) {
-			// Not supported on Java 6
-		}
+		ClassLoader.registerAsParallelCapable();
 	}
 
-	/** Packages which must be provided by the build tool or the corresponding Spotless plugin. */
-	private static List<String> BUILD_TOOLS_PACKAGES = Arrays.asList("org.slf4j.");
+	/**
+	 * The following packages must be provided by the build tool or the corresponding Spotless plugin:
+	 * <ul>
+	 *   <li>org.slf4j - SLF4J API must be provided. If no SLF4J binding is provided, log messages are dropped.</li>
+	 * </ul>
+	 */
+	static final List<String> BUILD_TOOLS_PACKAGES = Collections.unmodifiableList(Arrays.asList("org.slf4j."));
 
 	private final ClassLoader buildToolClassLoader;
 
@@ -55,7 +57,7 @@ public class FeatureClassLoader extends URLClassLoader {
 	 * @exception  NullPointerException if {@code urls} is {@code null}.
 	 */
 
-	public FeatureClassLoader(URL[] urls, ClassLoader buildToolClassLoader) {
+	FeatureClassLoader(URL[] urls, ClassLoader buildToolClassLoader) {
 		super(urls, null);
 		Objects.requireNonNull(buildToolClassLoader);
 		this.buildToolClassLoader = buildToolClassLoader;

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -97,8 +97,10 @@ public final class JarState implements Serializable {
 	}
 
 	/**
-	 * Returns a classloader containing only the jars in this JarState.
-	 *
+	 * Returns a classloader containing the only jars in this JarState.
+	 * Look-up of classes in {@link FeatureClassLoader#BUILD_TOOLS_PACKAGES build tool packages}
+	 * are not taken from the JarState, but redirected to the class loader of this class.
+	 * <br/>
 	 * The lifetime of the underlying cacheloader is controlled by {@link SpotlessCache}.
 	 */
 	public ClassLoader getClassLoader() {
@@ -106,8 +108,10 @@ public final class JarState implements Serializable {
 	}
 
 	/**
-	 * Returns a classloader containing only the jars in this JarState.
-	 *
+	 * Returns a classloader containing the only jars in this JarState.
+	 * Look-up of classes in {@link FeatureClassLoader#BUILD_TOOLS_PACKAGES build tool packages}
+	 * are not taken from the JarState, but redirected to the class loader of this class.
+	 * <br/>
 	 * The lifetime of the underlying cacheloader is controlled by {@link SpotlessCache}.
 	 */
 	public ClassLoader getClassLoader(Serializable key) {

--- a/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
+++ b/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
@@ -66,7 +66,7 @@ public final class SpotlessCache {
 	synchronized ClassLoader classloader(Serializable key, JarState state) {
 		SerializedKey serializedKey = new SerializedKey(key);
 		return cache
-				.computeIfAbsent(serializedKey, k -> new URLClassLoader(state.jarUrls(), null));
+				.computeIfAbsent(serializedKey, k -> new FeatureClassLoader(state.jarUrls(), this.getClass().getClassLoader()));
 	}
 
 	static SpotlessCache instance() {


### PR DESCRIPTION
The PR provides the Spotless features with access to the SLF4J interface of the underlying build tool.

In case the build tools associated to a Spotless plugin does not provide SLF4J, the Spotless plugin must provide an implementation mapping to the logging feature of the build tool.

The changes fixing #236 and are the result of the discussion and POC provided for that issue.

For the new Eclipse-Base service, UTs have been provided. The Maven and Gradle plugin have been tested with a patched Spotless Eclipse-JDT. Since the changes to the Spotless LIB are quite simple, UTs are currently not foreseen.

@nedtwigg Please provide a new release of Eclipse-Base. It's change log still contains a TDB for the release date.