### PR TITLE
Fix #219 - Replacing a step no longer triggers early evaluation

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@
 * Provided eclipse-wtp formatters in generic formatter extension. ([#325](https://github.com/diffplug/spotless/pull/325)). This change obsoletes the CSS and XML extensions.
 * Improved configuration times for large projects (thanks to @oehme for finding [#348](https://github.com/diffplug/spotless/pull/348)).
 * Updated default google-java-format from 1.5 to 1.7 ([#335](https://github.com/diffplug/spotless/issues/335)).
+* Replacing a step no longer triggers early evaluation ([#219](https://github.com/diffplug/spotless/issues/219)).
 
 ### Version 3.17.0 - December 13th 2018 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.17.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.17.0))
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -209,14 +209,15 @@ public class FormatExtension {
 	/** Adds a new step. */
 	public void addStep(FormatterStep newStep) {
 		Objects.requireNonNull(newStep);
-		FormatterStep existing = getExistingStep(newStep.getName());
-		if (existing != null) {
+		int existingIdx = getExistingStepIdx(newStep.getName());
+		if (existingIdx == -1) {
 			throw new GradleException("Multiple steps with name '" + newStep.getName() + "' for spotless format '" + formatName() + "'");
 		}
 		steps.add(newStep);
 	}
 
 	/** Returns the existing step with the given name, if any. */
+	@Deprecated
 	protected @Nullable FormatterStep getExistingStep(String stepName) {
 		return steps.stream() //
 				.filter(step -> stepName.equals(step.getName())) //
@@ -224,14 +225,23 @@ public class FormatExtension {
 				.orElse(null);
 	}
 
+	/** Returns the index of the existing step with the given name, or -1 if no such step exists. */
+	protected int getExistingStepIdx(String stepName) {
+		for (int i = 0; i < steps.size(); ++i) {
+			if (steps.get(i).getName().equals(stepName)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
 	/** Replaces the given step. */
 	protected void replaceStep(FormatterStep replacementStep) {
-		FormatterStep existing = getExistingStep(replacementStep.getName());
-		if (existing == null) {
+		int existingIdx = getExistingStepIdx(replacementStep.getName());
+		if (existingIdx == -1) {
 			throw new GradleException("Cannot replace step '" + replacementStep.getName() + "' for spotless format '" + formatName() + "' because it hasn't been added yet.");
 		}
-		int index = steps.indexOf(existing);
-		steps.set(index, replacementStep);
+		steps.set(existingIdx, replacementStep);
 	}
 
 	/** Clears all of the existing steps. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -210,7 +210,7 @@ public class FormatExtension {
 	public void addStep(FormatterStep newStep) {
 		Objects.requireNonNull(newStep);
 		int existingIdx = getExistingStepIdx(newStep.getName());
-		if (existingIdx == -1) {
+		if (existingIdx != -1) {
 			throw new GradleException("Multiple steps with name '" + newStep.getName() + "' for spotless format '" + formatName() + "'");
 		}
 		steps.add(newStep);


### PR DESCRIPTION
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/master/CHANGES.md) and [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [x] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
