### PR TITLE
Issue 344

### DIFF
--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,0 +1,9 @@
+# spotless-eclipse-wtp
+
+### Version 3.9.6 - TBD
+
+* Fixed formatting of JSON arrays ([#344](https://github.com/diffplug/spotless/issues/344)).
+
+### Version 3.9.5 - August 8th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+
+* Initial release!

--- a/_ext/eclipse-wtp/gradle.properties
+++ b/_ext/eclipse-wtp/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Eclipse-WTP version used for the fat-JAR.
 # See https://www.eclipse.org/webtools/ for further information about Eclipse-WTP versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=3.9.5
+ext_version=3.9.6
 ext_artifactId=spotless-eclipse-wtp
 ext_description=Eclipse's WTP formatters bundled for Spotless
 

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImpl.java
@@ -15,16 +15,22 @@
  */
 package com.diffplug.spotless.extra.eclipse.wtp;
 
+import java.io.IOException;
 import java.util.Properties;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.json.core.JSONCorePlugin;
 import org.eclipse.wst.json.core.cleanup.CleanupProcessorJSON;
+import org.eclipse.wst.json.core.format.FormatProcessorJSON;
 import org.eclipse.wst.json.core.internal.preferences.JSONCorePreferenceInitializer;
 import org.eclipse.wst.sse.core.internal.format.IStructuredFormatProcessor;
 
 import com.diffplug.spotless.extra.eclipse.wtp.sse.CleanupStep;
 
-/** Formatter step which calls out to the Eclipse JSON cleanup processor and formatter. */
+/**
+ * Formatter step which calls out to the Eclipse JSON cleanup processor and formatter.
+ * Note that the cleanup is escaped, since it has known bugs and is currently not used by Eclipse. 
+ */
 public class EclipseJsonFormatterStepImpl extends CleanupStep<EclipseJsonFormatterStepImpl.SpotlessJsonCleanup> {
 
 	public EclipseJsonFormatterStepImpl(Properties properties) throws Exception {
@@ -48,6 +54,12 @@ public class EclipseJsonFormatterStepImpl extends CleanupStep<EclipseJsonFormatt
 	 *  See {@code org.eclipse.wst.json.core.internal.format.AbstractJSONSourceFormatter} for details.
 	 */
 	public static class SpotlessJsonCleanup extends CleanupProcessorJSON implements CleanupStep.ProcessorAccessor {
+		private final FormatProcessorJSON formatter;
+
+		public SpotlessJsonCleanup() {
+			formatter = new FormatProcessorJSON();
+		}
+
 		@Override
 		public String getThisContentType() {
 			return getContentType();
@@ -61,6 +73,19 @@ public class EclipseJsonFormatterStepImpl extends CleanupStep<EclipseJsonFormatt
 		@Override
 		public void refreshThisCleanupPreferences() {
 			refreshCleanupPreferences();
+		}
+
+		@Override
+		public String cleanupContent(String input) throws IOException, CoreException {
+			/*
+			 * The CleanupProcessorJSON.cleanupContent is erroneous and disabled in IDE.
+			 * Hence the clean-up itself is replaced by a format processor.
+			 * The SpotlessJsonCleanup still derives from the CleanupStep base class
+			 * to use the common Spotless WTP configuration.
+			 *
+			 * See Spotless issue #344 for details.
+			 */
+			return formatter.formatContent(input);
 		}
 
 	}

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImpl.java
@@ -29,7 +29,7 @@ import com.diffplug.spotless.extra.eclipse.wtp.sse.CleanupStep;
 
 /**
  * Formatter step which calls out to the Eclipse JSON cleanup processor and formatter.
- * Note that the cleanup is escaped, since it has known bugs and is currently not used by Eclipse. 
+ * Note that the cleanup is escaped, since it has known bugs and is currently not used by Eclipse.
  */
 public class EclipseJsonFormatterStepImpl extends CleanupStep<EclipseJsonFormatterStepImpl.SpotlessJsonCleanup> {
 

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImplTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImplTest.java
@@ -28,8 +28,8 @@ public class EclipseJsonFormatterStepImplTest {
 	private final static String ILLEGAL_CHAR = Character.toString((char) 254);
 	private final static String UNFORMATTED_OBJECT = "{\n \"x\": { \"a\" : \"v\",\"properties\" : \"v\" }}".replaceAll("\n", LINE_DELIMITER);
 	private final static String FORMATTED_OBJECT = "{\n   \"x\": {\n      \"a\": \"v\",\n      \"properties\": \"v\"\n   }\n}".replaceAll("\n", LINE_DELIMITER);
-	private final static String UNFORMATTED_ARRAY = "[\n { \"a\" : \"v\",\"properties\" : \"v\" }}".replaceAll("\n", LINE_DELIMITER);
-	private final static String FORMATTED_ARRAY = "[\n   {\n      \"a\": \"v\",\n      \"properties\": \"v\"\n   }\n}".replaceAll("\n", LINE_DELIMITER);
+	private final static String UNFORMATTED_ARRAY = "[\n { \"a\" : \"v\",\"properties\" : \"v\" }]".replaceAll("\n", LINE_DELIMITER);
+	private final static String FORMATTED_ARRAY = "[\n   {\n      \"a\": \"v\",\n      \"properties\": \"v\"\n   }\n]".replaceAll("\n", LINE_DELIMITER);
 
 	private static EclipseJsonFormatterStepImpl formatter;
 
@@ -49,14 +49,14 @@ public class EclipseJsonFormatterStepImplTest {
 	}
 
 	@Test
-	public void format_object() throws Exception {
+	public void formatObject() throws Exception {
 		String output = formatter.format(UNFORMATTED_OBJECT);
 		assertEquals("Unexpected formatting with default preferences.",
 				FORMATTED_OBJECT, output);
 	}
 
 	@Test
-	public void format_array() throws Exception {
+	public void formatArray() throws Exception {
 		String output = formatter.format(UNFORMATTED_ARRAY);
 		assertEquals("Unexpected formatting with default preferences.",
 				FORMATTED_ARRAY, output);

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImplTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsonFormatterStepImplTest.java
@@ -26,8 +26,10 @@ import org.junit.Test;
 
 public class EclipseJsonFormatterStepImplTest {
 	private final static String ILLEGAL_CHAR = Character.toString((char) 254);
-	private final static String UNFORMATTED = "{\n \"x\": { \"a\" : \"v\",\"properties\" : \"v\" }}".replaceAll("\n", LINE_DELIMITER);
-	private final static String FORMATTED = "{\n   \"x\": {\n      \"a\": \"v\",\n      \"properties\": \"v\"\n   }\n}".replaceAll("\n", LINE_DELIMITER);
+	private final static String UNFORMATTED_OBJECT = "{\n \"x\": { \"a\" : \"v\",\"properties\" : \"v\" }}".replaceAll("\n", LINE_DELIMITER);
+	private final static String FORMATTED_OBJECT = "{\n   \"x\": {\n      \"a\": \"v\",\n      \"properties\": \"v\"\n   }\n}".replaceAll("\n", LINE_DELIMITER);
+	private final static String UNFORMATTED_ARRAY = "[\n { \"a\" : \"v\",\"properties\" : \"v\" }}".replaceAll("\n", LINE_DELIMITER);
+	private final static String FORMATTED_ARRAY = "[\n   {\n      \"a\": \"v\",\n      \"properties\": \"v\"\n   }\n}".replaceAll("\n", LINE_DELIMITER);
 
 	private static EclipseJsonFormatterStepImpl formatter;
 
@@ -47,23 +49,30 @@ public class EclipseJsonFormatterStepImplTest {
 	}
 
 	@Test
-	public void format() throws Exception {
-		String output = formatter.format(UNFORMATTED);
+	public void format_object() throws Exception {
+		String output = formatter.format(UNFORMATTED_OBJECT);
 		assertEquals("Unexpected formatting with default preferences.",
-				FORMATTED, output);
+				FORMATTED_OBJECT, output);
+	}
+
+	@Test
+	public void format_array() throws Exception {
+		String output = formatter.format(UNFORMATTED_ARRAY);
+		assertEquals("Unexpected formatting with default preferences.",
+				FORMATTED_ARRAY, output);
 	}
 
 	@Test
 	public void illegalCharacter() throws Exception {
-		String output = formatter.format(ILLEGAL_CHAR + UNFORMATTED);
+		String output = formatter.format(ILLEGAL_CHAR + UNFORMATTED_OBJECT);
 		assertEquals("Illeagl characteds are not ignored.",
-				ILLEGAL_CHAR + FORMATTED, output);
+				ILLEGAL_CHAR + FORMATTED_OBJECT, output);
 	}
 
 	@Test
 	public void illegalSyntax() throws Exception {
-		String output = formatter.format("{" + UNFORMATTED);
+		String output = formatter.format("{" + UNFORMATTED_OBJECT);
 		assertEquals("Illeagl syntax is not handled on best effort basis.",
-				FORMATTED, output);
+				FORMATTED_OBJECT, output);
 	}
 }


### PR DESCRIPTION
Excluded JSON model cleanup from WTP JSON formatter step implementation.
Eclipse WTP 3.12 code inspection shows that the cleanup is no used by IDE (the only calls are made by unit tests).
#344 proves that the cleanup is not working properly for all JSON content.
Unit-test added checking problem described in #344.
Updated version to 3.9.6 (release date is still TBD).
Added change record.