### PR TITLE
Fixes issue #344 by replacing spotless-eclipse-wtp version

### DIFF
--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3a.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3a.lockfile
@@ -1,5 +1,5 @@
 # Spotless formatter based on Eclipse-WTP version 3.9.5 (see https://www.eclipse.org/webtools/)
-com.diffplug.spotless:spotless-eclipse-wtp:3.9.5
+com.diffplug.spotless:spotless-eclipse-wtp:3.9.6
 com.diffplug.spotless:spotless-eclipse-base:3.0.0
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0


### PR DESCRIPTION
Fixes issue #344 by replacing spotless-eclipse-wtp version 3.9.5 by 3.9.6.
spotless-eclipse-wtp version 3.9.5 is identical to 3.9.6 except of changes introduced with #354.
Hence only the JSON behaviour has changed, which had not yet been part of a Spotless release. Therefore there is no need for any additions in the change log.