### PR TITLE
WTP - Ignore external URIs by default

### DIFF
--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,6 +1,8 @@
 # spotless-eclipse-wtp
 
-### Versioni 3.10.0 - TBD
+### Version 3.9.8 - TBD
+
+* XML formatter ignores external URIs per default. ([#369](https://github.com/diffplug/spotless/issues/369)). Add `resolveExternalURI=true` property to switch to previous behavior.
 
 ### Version 3.9.7 - February 25th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 

--- a/_ext/eclipse-wtp/build.gradle
+++ b/_ext/eclipse-wtp/build.gradle
@@ -74,6 +74,12 @@ dependencies {
 	compile "org.eclipse.xsd:org.eclipse.xsd:${VER_ECLISPE_XSD}"
 }
 
+jar {
+	manifest {
+		from 'src/main/resources/META-INF/MANIFEST.MF'
+	}
+}
+
 //////////
 // Test //
 //////////

--- a/_ext/eclipse-wtp/gradle.properties
+++ b/_ext/eclipse-wtp/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Eclipse-WTP version used for the fat-JAR.
 # See https://www.eclipse.org/webtools/ for further information about Eclipse-WTP versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=3.9.7
+ext_version=3.9.8
 ext_artifactId=spotless-eclipse-wtp
 ext_description=Eclipse's WTP formatters bundled for Spotless
 

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImpl.java
@@ -67,6 +67,8 @@ public class EclipseHtmlFormatterStepImpl extends CleanupStep<EclipseHtmlFormatt
 			additionalPlugins.add(new org.eclipse.core.internal.filesystem.Activator());
 			additionalPlugins.add(new JavaScriptCore());
 			additionalPlugins.add(new HTMLCorePlugin());
+			//The HTML formatter only uses the DOCTYPE/SCHEMA for content model selection.  
+			additionalPlugins.add(new PreventExternalURIResolverExtension());
 		});
 		/*
 		 * The cleanup processor tries to load DTDs into the cache (which we have not setup).

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImpl.java
@@ -67,7 +67,7 @@ public class EclipseHtmlFormatterStepImpl extends CleanupStep<EclipseHtmlFormatt
 			additionalPlugins.add(new org.eclipse.core.internal.filesystem.Activator());
 			additionalPlugins.add(new JavaScriptCore());
 			additionalPlugins.add(new HTMLCorePlugin());
-			//The HTML formatter only uses the DOCTYPE/SCHEMA for content model selection.  
+			//The HTML formatter only uses the DOCTYPE/SCHEMA for content model selection.
 			additionalPlugins.add(new PreventExternalURIResolverExtension());
 		});
 		/*

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImpl.java
@@ -51,17 +51,6 @@ import com.diffplug.spotless.extra.eclipse.wtp.sse.SpotlessPreferences;
 
 /** Formatter step which calls out to the Eclipse XML formatter. */
 public class EclipseXmlFormatterStepImpl {
-	/**
-	 * Indicates if external URIs (location hints) should be resolved
-	 * and the referenced DTD/XSD shall be applied. Per default
-	 * external URIs are ignored.
-	 * <p>
-	 * Value is of type <code>Boolean</code>.
-	 * </p>
-	 */
-	public static final String RESOLVE_EXTERNAL_URI = "resolveExternalURI";
-	
-	
 	private static XmlFormattingPreferencesFactory PREFERENCE_FACTORY = null;
 
 	private final DefaultXMLPartitionFormatter formatter;
@@ -69,25 +58,12 @@ public class EclipseXmlFormatterStepImpl {
 	private final INodeAdapterFactory xmlAdapterFactory;
 
 	public EclipseXmlFormatterStepImpl(Properties properties) throws Exception {
-		setupFramework(doResolveExternalURI(properties));
+		setupFramework(SpotlessPreferences.doResolveExternalURI(properties));
 		preferences = PREFERENCE_FACTORY.create(properties);
 		formatter = new DefaultXMLPartitionFormatter();
 		//The adapter factory maintains the common CMDocumentCache
 		xmlAdapterFactory = new ModelQueryAdapterFactoryForXML();
 	}
-	
-	private static boolean doResolveExternalURI(Properties properties) {
-		Object obj = properties.get(RESOLVE_EXTERNAL_URI);
-		if(null != obj) {
-			if(obj instanceof Boolean) {
-				return (Boolean)obj;
-			}
-			if(obj instanceof String) {
-				return ((String)obj).equalsIgnoreCase("true");
-			}
-		}
-		return false;
-	} 
 
 	private static void setupFramework(boolean resolveExternalURI) throws BundleException {
 		if (SpotlessEclipseFramework.setup(
@@ -101,7 +77,7 @@ public class EclipseXmlFormatterStepImpl {
 					plugins.add(new DTDCorePlugin());
 					//Support formatting based on XSD restrictions
 					plugins.add(new XSDCorePlugin());
-					if(!resolveExternalURI) {
+					if (!resolveExternalURI) {
 						plugins.add(new PreventExternalURIResolverExtension());
 					}
 				})) {

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/PreventExternalURIResolverExtension.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/PreventExternalURIResolverExtension.java
@@ -1,40 +1,54 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.diffplug.spotless.extra.eclipse.wtp;
 
-import org.eclipse.emf.common.util.URI;
-
 import org.eclipse.core.resources.IFile;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.wst.common.uriresolver.internal.provisional.URIResolverExtension;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
 /**
- * The URI resolver extension  
+ * The URI resolver extension
  */
 public class PreventExternalURIResolverExtension implements URIResolverExtension, BundleActivator {
 
-	private final String REFUSE_EXTERNAL_URI="file://refused.external.uri";
-	
+	private final String REFUSE_EXTERNAL_URI = "file://refused.external.uri";
+
 	/**
 	 * @param file the in-workspace base resource, if one exists
 	 * @param baseLocation - the location of the resource that contains the uri
 	 * @param publicId - an optional public identifier (i.e. namespace name), or null if none
-	 * @param systemId - an absolute or relative URI, or null if none 
-	 * 
+	 * @param systemId - an absolute or relative URI, or null if none
+	 *
 	 * @return an absolute URI or null if this extension can not resolve this reference
-	 */	@Override
+	 */
+	@Override
 	public String resolve(IFile file, String baseLocation, String publicId, String systemId) {
-		if(null != systemId) {
+		if (null != systemId) {
 			try {
 				URI proposalByPreviousResolver = org.eclipse.emf.common.util.URI.createURI(systemId);
 				String host = proposalByPreviousResolver.host();
 				/*
-				 * The host is empty (not null) 
+				 * The host is empty (not null)
 				 */
-				if(!(null == host || host.isEmpty()) ) {
+				if (!(null == host || host.isEmpty())) {
 					return REFUSE_EXTERNAL_URI;
 				}
-			}
-			catch(IllegalArgumentException ignore) {
+			} catch (IllegalArgumentException ignore) {
 				//If it is no a valid URI, there is nothing to do here.
 			}
 		}

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/PreventExternalURIResolverExtension.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/PreventExternalURIResolverExtension.java
@@ -1,0 +1,54 @@
+package com.diffplug.spotless.extra.eclipse.wtp;
+
+import org.eclipse.emf.common.util.URI;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.wst.common.uriresolver.internal.provisional.URIResolverExtension;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The URI resolver extension  
+ */
+public class PreventExternalURIResolverExtension implements URIResolverExtension, BundleActivator {
+
+	private final String REFUSE_EXTERNAL_URI="file://refused.external.uri";
+	
+	/**
+	 * @param file the in-workspace base resource, if one exists
+	 * @param baseLocation - the location of the resource that contains the uri
+	 * @param publicId - an optional public identifier (i.e. namespace name), or null if none
+	 * @param systemId - an absolute or relative URI, or null if none 
+	 * 
+	 * @return an absolute URI or null if this extension can not resolve this reference
+	 */	@Override
+	public String resolve(IFile file, String baseLocation, String publicId, String systemId) {
+		if(null != systemId) {
+			try {
+				URI proposalByPreviousResolver = org.eclipse.emf.common.util.URI.createURI(systemId);
+				String host = proposalByPreviousResolver.host();
+				/*
+				 * The host is empty (not null) 
+				 */
+				if(!(null == host || host.isEmpty()) ) {
+					return REFUSE_EXTERNAL_URI;
+				}
+			}
+			catch(IllegalArgumentException ignore) {
+				//If it is no a valid URI, there is nothing to do here.
+			}
+		}
+		return null; //Don't alter the proposal of previous resolver extensions by proposing something else
+	}
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		//Nothing to do. The bundle-activator interface only allows to load this extension as a stand-alone plugin.
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		//Nothing to do. The bundle-activator interface only allows to load this extension as a stand-alone plugin.
+	}
+
+}

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/PreventExternalURIResolverExtension.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/PreventExternalURIResolverExtension.java
@@ -26,7 +26,7 @@ import org.osgi.framework.BundleContext;
  */
 public class PreventExternalURIResolverExtension implements URIResolverExtension, BundleActivator {
 
-	private final String REFUSE_EXTERNAL_URI = "file://refused.external.uri";
+	private static final String REFUSE_EXTERNAL_URI = "file://refused.external.uri";
 
 	/**
 	 * @param file the in-workspace base resource, if one exists

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/SpotlessPreferences.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/SpotlessPreferences.java
@@ -41,6 +41,16 @@ public class SpotlessPreferences {
 	 */
 	public static final String USER_CATALOG = "userCatalog";
 
+	/**
+	 * Indicates if external URIs (location hints) should be resolved
+	 * and the referenced DTD/XSD shall be applied. Per default
+	 * external URIs are ignored.
+	 * <p>
+	 * Value is of type <code>Boolean</code>.
+	 * </p>
+	 */
+	public static final String RESOLVE_EXTERNAL_URI = "resolveExternalURI";
+
 	/** Configures the Eclipse properties for a Plugin and returns its previous values. */
 	public static Properties configurePluginPreferences(Plugin plugin, Properties newValues) {
 		IEclipsePreferences globalPreferences = DefaultScope.INSTANCE.getNode(plugin.getBundle().getSymbolicName());
@@ -53,6 +63,19 @@ public class SpotlessPreferences {
 			globalPreferences.put((String) key, (String) value);
 		});
 		return oldValues;
+	}
+
+	public static boolean doResolveExternalURI(Properties properties) {
+		Object obj = properties.get(RESOLVE_EXTERNAL_URI);
+		if (null != obj) {
+			if (obj instanceof Boolean) {
+				return (Boolean) obj;
+			}
+			if (obj instanceof String) {
+				return ((String) obj).equalsIgnoreCase("true");
+			}
+		}
+		return false;
 	}
 
 	public static void configureCatalog(final Properties config) {

--- a/_ext/eclipse-wtp/src/main/resources/META-INF/MANIFEST.MF
+++ b/_ext/eclipse-wtp/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: com.diffplug.gradle.spotless.eclipse.wtp; singleton:=true

--- a/_ext/eclipse-wtp/src/main/resources/plugin.xml
+++ b/_ext/eclipse-wtp/src/main/resources/plugin.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>
+	<!-- Prevents resolution of external URIs by redirecting them to invalid external URI.
+	     The low priority assures that the org.eclipse.wst.common.uriresolver.internal.ExtensibleURIResolver
+	     ask this resolver extension at the end and let it override all previous results. Hence the term
+	     "low priority' might be missleading. In fact the result of this extension overrules all other physical
+	     resolvers with higher priority. -->
+	<extension point="org.eclipse.wst.common.uriresolver.resolverExtensions">
+		<resolverExtension
+			stage="physical"
+			priority="low"
+			class="com.diffplug.spotless.extra.eclipse.wtp.PreventExternalURIResolverExtension">
+		</resolverExtension>
+	</extension>
+</plugin>

--- a/_ext/eclipse-wtp/src/main/resources/plugin.xml
+++ b/_ext/eclipse-wtp/src/main/resources/plugin.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
-	<!-- Prevents resolution of external URIs by redirecting them to invalid external URI.
-	     The low priority assures that the org.eclipse.wst.common.uriresolver.internal.ExtensibleURIResolver
-	     ask this resolver extension at the end and let it override all previous results. Hence the term
-	     "low priority' might be missleading. In fact the result of this extension overrules all other physical
-	     resolvers with higher priority. -->
-	<extension point="org.eclipse.wst.common.uriresolver.resolverExtensions">
-		<resolverExtension
-			stage="physical"
-			priority="low"
-			class="com.diffplug.spotless.extra.eclipse.wtp.PreventExternalURIResolverExtension">
-		</resolverExtension>
-	</extension>
+  <!-- Prevents resolution of external URIs by redirecting them to invalid external URI. -->
+  <!-- The low priority assures that the org.eclipse.wst.common.uriresolver.internal.ExtensibleURIResolver -->
+  <!-- ask this resolver extension at the end and let it override all previous results. Hence the term -->
+  <!-- "low priority' might be missleading. In fact the result of this extension overrules all other -->
+  <!-- physical resolvers with higher priority. -->
+  <extension point="org.eclipse.wst.common.uriresolver.resolverExtensions">
+    <resolverExtension stage="physical" priority="low" class="com.diffplug.spotless.extra.eclipse.wtp.PreventExternalURIResolverExtension">
+    </resolverExtension>
+  </extension>
 </plugin>

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplAllowExternalURIsTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplAllowExternalURIsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.extra.eclipse.wtp;
+
+import static org.junit.Assert.*;
+
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Test configuration allowExternalURI=false */
+public class EclipseXmlFormatterStepImplAllowExternalURIsTest {
+	private static TestData TEST_DATA = null;
+
+	@BeforeClass
+	public static void initializeStatic() throws Exception {
+		TEST_DATA = TestData.getTestDataOnFileSystem("xml");
+	}
+	
+	@Test
+	public void dtdExternalPath() throws Throwable {
+		String output = format(TEST_DATA.input("dtd_external.test"));
+		assertEquals("External DTD not resolved. Restrictions are not applied by formatter.",
+				TEST_DATA.expected("dtd_external.test"), output);
+	}
+	
+	@Test
+	public void xsdExternalPath() throws Throwable {
+		String output = format(TEST_DATA.input("xsd_external.test"));
+		assertEquals("External XSD not resolved. Restrictions are not applied by formatter.",
+				TEST_DATA.expected("xsd_external.test"), output);
+	}
+	
+	private static String format(final String[] input) throws Exception {
+		return format(input[0], input[1]);
+	}
+	
+	private static String format(final String input, final String location) throws Exception {
+		Properties properties = new Properties();
+		properties.put(EclipseXmlFormatterStepImpl.RESOLVE_EXTERNAL_URI, "TRUE");
+		EclipseXmlFormatterStepImpl formatter = new EclipseXmlFormatterStepImpl(properties);
+		return formatter.format(input, location);
+	}
+}

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplAllowExternalURIsTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplAllowExternalURIsTest.java
@@ -22,6 +22,8 @@ import java.util.Properties;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.diffplug.spotless.extra.eclipse.wtp.sse.SpotlessPreferences;
+
 /** Test configuration allowExternalURI=false */
 public class EclipseXmlFormatterStepImplAllowExternalURIsTest {
 	private static TestData TEST_DATA = null;
@@ -30,28 +32,28 @@ public class EclipseXmlFormatterStepImplAllowExternalURIsTest {
 	public static void initializeStatic() throws Exception {
 		TEST_DATA = TestData.getTestDataOnFileSystem("xml");
 	}
-	
+
 	@Test
 	public void dtdExternalPath() throws Throwable {
 		String output = format(TEST_DATA.input("dtd_external.test"));
 		assertEquals("External DTD not resolved. Restrictions are not applied by formatter.",
 				TEST_DATA.expected("dtd_external.test"), output);
 	}
-	
+
 	@Test
 	public void xsdExternalPath() throws Throwable {
 		String output = format(TEST_DATA.input("xsd_external.test"));
 		assertEquals("External XSD not resolved. Restrictions are not applied by formatter.",
 				TEST_DATA.expected("xsd_external.test"), output);
 	}
-	
+
 	private static String format(final String[] input) throws Exception {
 		return format(input[0], input[1]);
 	}
-	
+
 	private static String format(final String input, final String location) throws Exception {
 		Properties properties = new Properties();
-		properties.put(EclipseXmlFormatterStepImpl.RESOLVE_EXTERNAL_URI, "TRUE");
+		properties.put(SpotlessPreferences.RESOLVE_EXTERNAL_URI, "TRUE");
 		EclipseXmlFormatterStepImpl formatter = new EclipseXmlFormatterStepImpl(properties);
 		return formatter.format(input, location);
 	}

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplTest.java
@@ -101,10 +101,24 @@ public class EclipseXmlFormatterStepImplTest {
 	}
 
 	@Test
+	public void dtdExternalPath() throws Throwable {
+		String output = format(TEST_DATA.input("dtd_external.test"), config -> {});
+		assertNotEquals("External DTD resolved by default. Restrictions are applied by formatter.",
+				TEST_DATA.expected("dtd_external.test"), output);
+	}
+	
+	@Test
 	public void xsdRelativePath() throws Throwable {
 		String output = format(TEST_DATA.input("xsd_relative.test"), config -> {});
 		assertEquals("Relative XSD not resolved. Restrictions are not applied by formatter.",
 				TEST_DATA.expected("xsd_relative.test"), output);
+	}
+
+	@Test
+	public void xsdExternalPath() throws Throwable {
+		String output = format(TEST_DATA.input("xsd_external.test"), config -> {});
+		assertNotEquals("External XSD resolved per default. Restrictions are applied by formatter.",
+				TEST_DATA.expected("xsd_external.test"), output);
 	}
 
 	@Test

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImplTest.java
@@ -106,7 +106,7 @@ public class EclipseXmlFormatterStepImplTest {
 		assertNotEquals("External DTD resolved by default. Restrictions are applied by formatter.",
 				TEST_DATA.expected("dtd_external.test"), output);
 	}
-	
+
 	@Test
 	public void xsdRelativePath() throws Throwable {
 		String output = format(TEST_DATA.input("xsd_relative.test"), config -> {});

--- a/_ext/eclipse-wtp/src/test/resources/xml/expected/dtd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/expected/dtd_external.test
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE r SYSTEM "https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.dtd">
+<r>
+	<x>indent
+		this text</x>
+	<y>preserve 
+  spaces</y>
+</r>

--- a/_ext/eclipse-wtp/src/test/resources/xml/expected/xsd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/expected/xsd_external.test
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:r xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:t="http://foo.bar/test"
+	xsi:schemaLocation="http://foo.bar/test https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.xsd">
+	<t:x>remove spaces</t:x>
+	<t:y> preserve spaces </t:y>
+</t:r>

--- a/_ext/eclipse-wtp/src/test/resources/xml/input/dtd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/input/dtd_external.test
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE r SYSTEM "https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.dtd">
+<r>
+	<x>indent
+  this text</x>
+	<y>preserve 
+  spaces</y>
+</r>

--- a/_ext/eclipse-wtp/src/test/resources/xml/input/xsd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/input/xsd_external.test
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<t:r xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://foo.bar/test" xsi:schemaLocation="http://foo.bar/test https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.xsd">
+<t:x> remove spaces </t:x><t:y> preserve spaces </t:y>
+</t:r>

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -3,7 +3,7 @@
 <!---freshmark shields
 output = [
   link(shield('Gradle plugin', 'plugins.gradle.org', 'com.diffplug.gradle.spotless', 'blue'), 'https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless'),
-  link(shield('Maven central', 'mavencentral', 'com.diffplug.gradle.spotless:spotless', 'blue'), 'https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22'),
+  link(shield('Maven central', 'mavencentral', 'com.diffplug.gradle.spotless:spotless', 'blue'), 'http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22'),
   link(shield('Javadoc', 'javadoc', '{{stableGradle}}', 'blue'), 'https://{{org}}.github.io/{{name}}/javadoc/spotless-plugin-gradle/{{stableGradle}}/'),
   '',
   link(shield('Changelog', 'changelog', '{{versionGradle}}', 'brightgreen'), 'CHANGES.md'),
@@ -13,7 +13,7 @@ output = [
   ].join('\n');
 -->
 [![Gradle plugin](https://img.shields.io/badge/plugins.gradle.org-com.diffplug.gradle.spotless-blue.svg)](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless)
-[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.gradle.spotless%3Aspotless-blue.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22)
+[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.gradle.spotless%3Aspotless-blue.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22)
 [![Javadoc](https://img.shields.io/badge/javadoc-3.18.0-blue.svg)](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.18.0/)
 
 [![Changelog](https://img.shields.io/badge/changelog-3.19.0--SNAPSHOT-brightgreen.svg)](CHANGES.md)
@@ -506,6 +506,14 @@ The WTP formatter accept multiple configuration files. All Eclipse configuration
 | XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.xml.core.prefs
 
 Note that `HTML` should be used for `X-HTML` sources instead of `XML`.
+
+The Eclipse XML catalog cannot be configured for the Spotless WTP formatter, instead a
+user defined catalog file can be specified using the property `userCatalog`. Catalog versions
+1.0 and 1.1 are supported by Spotless.
+
+Unlike Eclipse, Spotless WTP ignores per default external URIs in schema location hints and
+external entities. To allow the access of external URIs, set the property `resolveExternalURI`
+to true.
 
 <a name="license-header"></a>
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -495,15 +495,15 @@ The WTP formatter accept multiple configuration files. All Eclipse configuration
 
 | Type | Configuration       | File location
 | ---- | ------------------- | -------------
-| CSS  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
-|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
-| HTML | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
-|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
-|      | embedded CSS        | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+| CSS  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.css.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.css.core.prefs
+| HTML | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.html.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.html.core.prefs
+|      | embedded CSS        | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.css.core.prefs
 |      | embedded JS         | Use the export in the Eclipse editor configuration dialog
 | JS   | editor preferences  | Use the export in the Eclipse editor configuration dialog
 | JSON | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.json.core.prefs
-| XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.xml.core.prefs
+| XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.xml.core.prefs
 
 Note that `HTML` should be used for `X-HTML` sources instead of `XML`.
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -3,7 +3,7 @@
 <!---freshmark shields
 output = [
   link(shield('Gradle plugin', 'plugins.gradle.org', 'com.diffplug.gradle.spotless', 'blue'), 'https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless'),
-  link(shield('Maven central', 'mavencentral', 'com.diffplug.gradle.spotless:spotless', 'blue'), 'http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22'),
+  link(shield('Maven central', 'mavencentral', 'com.diffplug.gradle.spotless:spotless', 'blue'), 'https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22'),
   link(shield('Javadoc', 'javadoc', '{{stableGradle}}', 'blue'), 'https://{{org}}.github.io/{{name}}/javadoc/spotless-plugin-gradle/{{stableGradle}}/'),
   '',
   link(shield('Changelog', 'changelog', '{{versionGradle}}', 'brightgreen'), 'CHANGES.md'),
@@ -13,7 +13,7 @@ output = [
   ].join('\n');
 -->
 [![Gradle plugin](https://img.shields.io/badge/plugins.gradle.org-com.diffplug.gradle.spotless-blue.svg)](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless)
-[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.gradle.spotless%3Aspotless-blue.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22)
+[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.gradle.spotless%3Aspotless-blue.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-plugin-gradle%22)
 [![Javadoc](https://img.shields.io/badge/javadoc-3.18.0-blue.svg)](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.18.0/)
 
 [![Changelog](https://img.shields.io/badge/changelog-3.19.0--SNAPSHOT-brightgreen.svg)](CHANGES.md)

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -287,15 +287,15 @@ The WTP formatter accept multiple configuration files. All Eclipse configuration
 
 | Type | Configuration       | File location
 | ---- | ------------------- | -------------
-| CSS  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
-|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
-| HTML | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
-|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.html.core.prefs
-|      | embedded CSS        | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.css.core.prefs
+| CSS  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.css.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.css.core.prefs
+| HTML | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.html.core.prefs
+|      | cleanup preferences | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.html.core.prefs
+|      | embedded CSS        | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.css.core.prefs
 |      | embedded JS         | Use the export in the Eclipse editor configuration dialog
 | JS   | editor preferences  | Use the export in the Eclipse editor configuration dialog
 | JSON | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.json.core.prefs
-| XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/org.eclipse.wst.xml.core.prefs
+| XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.xml.core.prefs
 
 Note that `HTML` should be used for `X-HTML` sources instead of `XML`.
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -2,7 +2,7 @@
 
 <!---freshmark shields
 output = [
-  link(shield('Maven central', 'mavencentral', '{{group}}:{{artifactIdMaven}}', 'blue'), 'https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22{{group}}%22%20AND%20a%3A%22{{artifactIdMaven}}%22'),
+  link(shield('Maven central', 'mavencentral', '{{group}}:{{artifactIdMaven}}', 'blue'), 'http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22{{group}}%22%20AND%20a%3A%22{{artifactIdMaven}}%22'),
   link(shield('Javadoc', 'javadoc', '{{stableMaven}}', 'blue'), 'https://{{org}}.github.io/{{name}}/javadoc/{{artifactIdMaven}}/{{stableMaven}}/'),
   '',
   link(shield('Changelog', 'changelog', '{{stableMaven}}', 'brightgreen'), 'CHANGES.md'),
@@ -11,7 +11,7 @@ output = [
   link(shield('License Apache', 'license', 'apache', 'brightgreen'), 'https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)')
   ].join('\n');
 -->
-[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.spotless%3Aspotless--maven--plugin-blue.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-maven-plugin%22)
+[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.spotless%3Aspotless--maven--plugin-blue.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-maven-plugin%22)
 [![Javadoc](https://img.shields.io/badge/javadoc-1.18.0-blue.svg)](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.18.0/)
 
 [![Changelog](https://img.shields.io/badge/changelog-1.18.0-brightgreen.svg)](CHANGES.md)
@@ -298,6 +298,14 @@ The WTP formatter accept multiple configuration files. All Eclipse configuration
 | XML  | editor preferences  | .metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.wst.xml.core.prefs
 
 Note that `HTML` should be used for `X-HTML` sources instead of `XML`.
+
+The Eclipse XML catalog cannot be configured for the Spotless WTP formatter, instead a
+user defined catalog file can be specified using the property `userCatalog`. Catalog versions
+1.0 and 1.1 are supported by Spotless.
+
+Unlike Eclipse, Spotless WTP ignores per default external URIs in schema location hints and
+external entities. To allow the access of external URIs, set the property `resolveExternalURI`
+to true.
 
 <a name="invisible"></a>
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -2,7 +2,7 @@
 
 <!---freshmark shields
 output = [
-  link(shield('Maven central', 'mavencentral', '{{group}}:{{artifactIdMaven}}', 'blue'), 'http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22{{group}}%22%20AND%20a%3A%22{{artifactIdMaven}}%22'),
+  link(shield('Maven central', 'mavencentral', '{{group}}:{{artifactIdMaven}}', 'blue'), 'https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22{{group}}%22%20AND%20a%3A%22{{artifactIdMaven}}%22'),
   link(shield('Javadoc', 'javadoc', '{{stableMaven}}', 'blue'), 'https://{{org}}.github.io/{{name}}/javadoc/{{artifactIdMaven}}/{{stableMaven}}/'),
   '',
   link(shield('Changelog', 'changelog', '{{stableMaven}}', 'brightgreen'), 'CHANGES.md'),
@@ -11,7 +11,7 @@ output = [
   link(shield('License Apache', 'license', 'apache', 'brightgreen'), 'https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)')
   ].join('\n');
 -->
-[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.spotless%3Aspotless--maven--plugin-blue.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-maven-plugin%22)
+[![Maven central](https://img.shields.io/badge/mavencentral-com.diffplug.spotless%3Aspotless--maven--plugin-blue.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-maven-plugin%22)
 [![Javadoc](https://img.shields.io/badge/javadoc-1.18.0-blue.svg)](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.18.0/)
 
 [![Changelog](https://img.shields.io/badge/changelog-1.18.0-brightgreen.svg)](CHANGES.md)


### PR DESCRIPTION
Eclipse WTP XML formatter resolves automatically external URIs. URIs that cannot be accessed are ignored. If the referenced external DTD/XSD contains formatting instructions, the formatter results differs depending whether the URI is reachable or not.
This is not appropriate behaviour for Spotless, since it is e.g. used for continuous integration testing.  
Normally all external URIs shall be included in a XML catalog during build.
But many users may not be aware that the XML formatter uses the DTDs and XSDs specified in an XML in the first place.
To prevent an spotlessCheck error due failure accessing an external DTD/XSD, the Spotless default behaviour has been changed, to ignore external URIs per default.
