### PR TITLE
Upgrade WTP eclipse to version 3.9.8.

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -37,7 +37,7 @@ public enum EclipseWtpFormatterStep {
 
 	private static final String NAME = "eclipse wtp formatters";
 	private static final String FORMATTER_PACKAGE = "com.diffplug.spotless.extra.eclipse.wtp.";
-	private static final String DEFAULT_VERSION = "4.7.3a";
+	private static final String DEFAULT_VERSION = "4.7.3b";
 	private static final String FORMATTER_METHOD = "format";
 
 	private final String implementationClassName;

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3b.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3b.lockfile
@@ -1,0 +1,25 @@
+# Spotless formatter based on Eclipse-WTP version 3.9.5 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.9.8
+com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+com.ibm.icu:icu4j:61.1
+org.eclipse.emf:org.eclipse.emf.common:2.12.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.12.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.100
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.0
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.200
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.100
+org.eclipse.platform:org.eclipse.core.jobs:3.10.0
+org.eclipse.platform:org.eclipse.core.resources:3.13.0
+org.eclipse.platform:org.eclipse.core.runtime:3.14.0
+org.eclipse.platform:org.eclipse.equinox.app:1.3.500
+org.eclipse.platform:org.eclipse.equinox.common:3.10.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.100
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.0
+org.eclipse.platform:org.eclipse.jface.text:3.13.0
+org.eclipse.platform:org.eclipse.jface:3.14.0
+org.eclipse.platform:org.eclipse.osgi.services:3.7.0
+org.eclipse.platform:org.eclipse.osgi:3.13.0
+org.eclipse.platform:org.eclipse.text:3.6.300
+org.eclipse.xsd:org.eclipse.xsd:2.12.0

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -76,7 +76,7 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a"};
+		return new String[]{"4.7.3a", "4.7.3b"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,7 @@
 
 **WARNING: xml formatter in this version may be vulnerable to XXE attacks (see [#358](https://github.com/diffplug/spotless/issues/358)).**
 
+* Updated default eclipse-wtp from 4.7.3a to 4.7.3b ([#371](https://github.com/diffplug/spotless/pull/371)). Default behavior of XML formatter changed to ignore  external URIs ([#369](https://github.com/diffplug/spotless/issues/369).
 * Security fix: Updated groovy, c/c++, and eclipse WTP formatters so that they download their source jars securely using `https` rather than `http` ([#360](https://github.com/diffplug/spotless/issues/360)).
 * Updated default eclipse-jdt from 4.9.0 to 4.10.0 ([#368](https://github.com/diffplug/spotless/pull/368))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,7 @@
 
 **WARNING: xml formatter in this version may be vulnerable to XXE attacks (see [#358](https://github.com/diffplug/spotless/issues/358)).**
 
+* Updated default eclipse-wtp from 4.7.3a to 4.7.3b ([#371](https://github.com/diffplug/spotless/pull/371)). Default behavior of XML formatter changed to ignore  external URIs ([#369](https://github.com/diffplug/spotless/issues/369).
 * Security fix: Updated groovy, c/c++, and eclipse WTP formatters so that they download their source jars securely using `https` rather than `http` ([#360](https://github.com/diffplug/spotless/issues/360)).
 * Updated default eclipse-jdt from 4.9.0 to 4.10.0 ([#368](https://github.com/diffplug/spotless/pull/368))
 * Add a skip parameter to apply mojo to enable to bypass it if desired. ([#367](https://github.com/diffplug/spotless/pull/367)).


### PR DESCRIPTION
Upgraded to WTP Eclipse version 3.9.8. The related Eclipse version is named 4.7.3b, since it is still based on Oxygen.