### PR TITLE
Switch to Eclipse-WTP 3.10. Cleanup fix for #369. Add SLF4J support.

### DIFF
--- a/_ext/eclipse-jdt/src/main/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImpl.java
+++ b/_ext/eclipse-jdt/src/main/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImpl.java
@@ -33,6 +33,10 @@ public class EclipseJdtFormatterStepImpl {
 
 	public EclipseJdtFormatterStepImpl(Properties settings) throws Exception {
 		SpotlessEclipseFramework.setup(
+				config -> {
+					config.applyDefault();
+					config.useSlf4J(EclipseJdtFormatterStepImpl.class.getPackage().getName());
+				},
 				plugins -> {
 					plugins.applyDefault();
 					plugins.add(new JavaCore());

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.10.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
-* Switch to Eclipse WTP release 3.10.0 for Eclipse 4.8 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+* Switch to Eclipse WTP release 3.10.0 for Eclipse 4.8 ([#378](https://github.com/diffplug/spotless/pull/378)).
 * Include Eclipse logging allowing formatter warnings/errors to be logged via SLF4J ([#236](https://github.com/diffplug/spotless/issues/236)).
 
 ### Version 3.9.8 - March 10th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,6 +1,6 @@
 # spotless-eclipse-wtp
 
-### Version 3.10.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+### Version 3.10.0 - March 17th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * Switch to Eclipse WTP release 3.10.0 for Eclipse 4.8 ([#378](https://github.com/diffplug/spotless/pull/378)).
 * Include Eclipse logging allowing formatter warnings/errors to be logged via SLF4J ([#236](https://github.com/diffplug/spotless/issues/236)).

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,14 +1,19 @@
 # spotless-eclipse-wtp
 
-### Version 3.9.8 - March 10th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+### Version 3.10.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+
+* Switch to Eclipse WTP release 3.10.0 for Eclipse 4.8 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+* Include Eclipse logging allowing formatter warnings/errors to be logged via SLF4J ([#236](https://github.com/diffplug/spotless/issues/236)).
+
+### Version 3.9.8 - March 10th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * XML formatter ignores external URIs per default. ([#369](https://github.com/diffplug/spotless/issues/369)). Add `resolveExternalURI=true` property to switch to previous behavior.
 
-### Version 3.9.7 - February 25th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+### Version 3.9.7 - February 25th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * Replaced `http` update-site with `https` ([#360](https://github.com/diffplug/spotless/issues/360)).
 
-### Version 3.9.6 - February 10th 2018 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+### Version 3.9.6 - February 11th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * Fixed formatting of JSON arrays ([#344](https://github.com/diffplug/spotless/issues/344)).
 

--- a/_ext/eclipse-wtp/build.gradle
+++ b/_ext/eclipse-wtp/build.gradle
@@ -72,6 +72,8 @@ dependencies {
 	compile "org.eclipse.platform:org.eclipse.core.filesystem:${VER_ECLISPE_EFS}"
 	// Required by org.eclipse.wst.xsd.core
 	compile "org.eclipse.xsd:org.eclipse.xsd:${VER_ECLISPE_XSD}"
+
+	testCompile("org.slf4j:slf4j-simple:${VER_SLF4J}")
 }
 
 jar {

--- a/_ext/eclipse-wtp/gradle.properties
+++ b/_ext/eclipse-wtp/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Eclipse-WTP version used for the fat-JAR.
 # See https://www.eclipse.org/webtools/ for further information about Eclipse-WTP versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=3.9.8
+ext_version=3.10.0
 ext_artifactId=spotless-eclipse-wtp
 ext_description=Eclipse's WTP formatters bundled for Spotless
 
@@ -12,11 +12,14 @@ ext_group=com.diffplug.spotless
 ext_VER_JAVA=1.8
 
 # Compile
-VER_ECLIPSE_WTP=oxygen
-VER_SPOTLESS_ECLISPE_BASE=[3.0.0,4.0.0[
+VER_ECLIPSE_WTP=photon
+VER_SPOTLESS_ECLISPE_BASE=[3.1.0,4.0.0[
 VER_IBM_ICU=[61,62[
 VER_ECLISPE_EMF=[2.12.0,3.0.0[
 VER_ECLISPE_PLATFORM=[3.6.0,4.0.0[
 VER_ECLISPE_JFACE=[3.12.0,4.0.0[
 VER_ECLISPE_EFS=[1.6.0,2.0.0[
 VER_ECLISPE_XSD=[2.12.0,3.0.0[
+
+# Provided dependencies
+VER_SLF4J=[1.6,2.0[

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImpl.java
@@ -47,6 +47,7 @@ import org.eclipse.wst.xml.core.internal.preferences.XMLCorePreferenceInitialize
 import com.diffplug.spotless.extra.eclipse.wtp.html.JsRegionProcessor;
 import com.diffplug.spotless.extra.eclipse.wtp.html.StructuredDocumentProcessor;
 import com.diffplug.spotless.extra.eclipse.wtp.sse.CleanupStep;
+import com.diffplug.spotless.extra.eclipse.wtp.sse.PreventExternalURIResolverExtension;
 import com.diffplug.spotless.extra.eclipse.wtp.sse.SpotlessPreferences;
 
 /** Formatter step which calls out to the Eclipse HTML cleanup and formatter. */

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseJsFormatterStepImpl.java
@@ -84,7 +84,10 @@ public class EclipseJsFormatterStepImpl {
 	public EclipseJsFormatterStepImpl(Properties properties) throws Exception {
 		SpotlessEclipseFramework.setup(
 				JS_CORE_CONFIG,
-				config -> config.applyDefault(),
+				config -> {
+					config.applyDefault();
+					config.useSlf4J(this.getClass().getPackage().getName());
+				},
 				plugins -> {
 					plugins.applyDefault();
 					// The JS core uses EFS for determination of temporary storage location

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImpl.java
@@ -47,6 +47,7 @@ import org.eclipse.xsd.util.XSDSchemaBuildingTools;
 import org.osgi.framework.BundleException;
 
 import com.diffplug.spotless.extra.eclipse.base.SpotlessEclipseFramework;
+import com.diffplug.spotless.extra.eclipse.wtp.sse.PreventExternalURIResolverExtension;
 import com.diffplug.spotless.extra.eclipse.wtp.sse.SpotlessPreferences;
 
 /** Formatter step which calls out to the Eclipse XML formatter. */
@@ -58,7 +59,8 @@ public class EclipseXmlFormatterStepImpl {
 	private final INodeAdapterFactory xmlAdapterFactory;
 
 	public EclipseXmlFormatterStepImpl(Properties properties) throws Exception {
-		setupFramework(SpotlessPreferences.doResolveExternalURI(properties));
+		boolean resolveExternalURI = Boolean.parseBoolean(properties.getProperty(SpotlessPreferences.RESOLVE_EXTERNAL_URI, "false"));
+		setupFramework(resolveExternalURI);
 		preferences = PREFERENCE_FACTORY.create(properties);
 		formatter = new DefaultXMLPartitionFormatter();
 		//The adapter factory maintains the common CMDocumentCache
@@ -67,6 +69,10 @@ public class EclipseXmlFormatterStepImpl {
 
 	private static void setupFramework(boolean resolveExternalURI) throws BundleException {
 		if (SpotlessEclipseFramework.setup(
+				config -> {
+					config.applyDefault();
+					config.useSlf4J(EclipseXmlFormatterStepImpl.class.getPackage().getName());
+				},
 				plugins -> {
 					plugins.applyDefault();
 					//The WST XML formatter

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/CleanupStep.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/CleanupStep.java
@@ -92,6 +92,7 @@ public class CleanupStep<T extends AbstractStructuredCleanupProcessor & CleanupS
 					config.add(IContentTypeManager.class, new ContentTypeManager(processor));
 					//The preference lookup via the ContentTypeManager, requires a preference service
 					config.add(IPreferencesService.class, PreferencesService.getDefault());
+					config.useSlf4J(this.getClass().getPackage().getName());
 				},
 				plugins -> {
 					plugins.applyDefault();

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/PreventExternalURIResolverExtension.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/PreventExternalURIResolverExtension.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.diffplug.spotless.extra.eclipse.wtp;
+package com.diffplug.spotless.extra.eclipse.wtp.sse;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.emf.common.util.URI;

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/SpotlessPreferences.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/sse/SpotlessPreferences.java
@@ -65,19 +65,6 @@ public class SpotlessPreferences {
 		return oldValues;
 	}
 
-	public static boolean doResolveExternalURI(Properties properties) {
-		Object obj = properties.get(RESOLVE_EXTERNAL_URI);
-		if (null != obj) {
-			if (obj instanceof Boolean) {
-				return (Boolean) obj;
-			}
-			if (obj instanceof String) {
-				return ((String) obj).equalsIgnoreCase("true");
-			}
-		}
-		return false;
-	}
-
 	public static void configureCatalog(final Properties config) {
 		Optional<File> catalog = getCatalogConfig(config);
 		Catalog defaultCatalog = getDefaultCatalog();

--- a/_ext/eclipse-wtp/src/main/resources/plugin.xml
+++ b/_ext/eclipse-wtp/src/main/resources/plugin.xml
@@ -7,7 +7,7 @@
   <!-- "low priority' might be missleading. In fact the result of this extension overrules all other -->
   <!-- physical resolvers with higher priority. -->
   <extension point="org.eclipse.wst.common.uriresolver.resolverExtensions">
-    <resolverExtension stage="physical" priority="low" class="com.diffplug.spotless.extra.eclipse.wtp.PreventExternalURIResolverExtension">
+    <resolverExtension stage="physical" priority="low" class="com.diffplug.spotless.extra.eclipse.wtp.sse.PreventExternalURIResolverExtension">
     </resolverExtension>
   </extension>
 </plugin>


### PR DESCRIPTION
Switch to Eclipse-WTP 3.10 (latest version currently released).
Cleanup fix for #369 (minor refactoring).
Include Eclipse logging allowing formatter warnings/errors to be logged via SLF4J (see #236).
Fixed dates in change-log.