### PR TITLE
Changed default versions. WTP changed to v4.8. Groovy changed to v4.10.

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
@@ -35,7 +35,7 @@ public final class GrEclipseFormatterStep {
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.groovy.eclipse.GrEclipseFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-groovy";
-	private static final String DEFAULT_VERSION = "4.8.1";
+	private static final String DEFAULT_VERSION = "4.10.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	/** Creates a formatter step using the default version for the given settings file. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -37,7 +37,7 @@ public enum EclipseWtpFormatterStep {
 
 	private static final String NAME = "eclipse wtp formatters";
 	private static final String FORMATTER_PACKAGE = "com.diffplug.spotless.extra.eclipse.wtp.";
-	private static final String DEFAULT_VERSION = "4.7.3b";
+	private static final String DEFAULT_VERSION = "4.8.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	private final String implementationClassName;

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.8.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.8.0.lockfile
@@ -1,0 +1,25 @@
+# Spotless formatter based on Eclipse-WTP version 3.9.5 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.10.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+com.ibm.icu:icu4j:61.1
+org.eclipse.emf:org.eclipse.emf.common:2.15.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.15.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.300
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.300
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.500
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.300
+org.eclipse.platform:org.eclipse.core.jobs:3.10.300
+org.eclipse.platform:org.eclipse.core.resources:3.13.300
+org.eclipse.platform:org.eclipse.core.runtime:3.15.200
+org.eclipse.platform:org.eclipse.equinox.app:1.4.100
+org.eclipse.platform:org.eclipse.equinox.common:3.10.300
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.300
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.300
+org.eclipse.platform:org.eclipse.jface.text:3.15.100
+org.eclipse.platform:org.eclipse.jface:3.15.100
+org.eclipse.platform:org.eclipse.osgi.services:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.13.300
+org.eclipse.platform:org.eclipse.text:3.8.100
+org.eclipse.xsd:org.eclipse.xsd:2.12.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.10.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.10.0.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on Groovy-Eclipse version 3.0.0 (see https://github.com/groovy/groovy-eclipse/releases)
+com.diffplug.spotless:spotless-eclipse-groovy:3.2.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.300
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.300
+org.eclipse.platform:org.eclipse.core.jobs:3.10.300
+org.eclipse.platform:org.eclipse.core.resources:3.13.300
+org.eclipse.platform:org.eclipse.core.runtime:3.15.200
+org.eclipse.platform:org.eclipse.equinox.app:1.4.100
+org.eclipse.platform:org.eclipse.equinox.common:3.10.300
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.300
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.300
+org.eclipse.platform:org.eclipse.jface.text:3.15.100
+org.eclipse.platform:org.eclipse.jface:3.15.100
+org.eclipse.platform:org.eclipse.osgi:3.13.300
+org.eclipse.platform:org.eclipse.text:3.8.100

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
@@ -23,7 +23,7 @@ import com.diffplug.spotless.extra.eclipse.EclipseCommonTests;
 public class GrEclipseFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"2.3.0", "4.6.3", "4.8.0", "4.8.1"};
+		return new String[]{"2.3.0", "4.6.3", "4.8.0", "4.8.1", "4.10.0"};
 	}
 
 	@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -76,7 +76,7 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a", "4.7.3b"};
+		return new String[]{"4.7.3a", "4.7.3b", "4.8.0"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -1,6 +1,8 @@
 # spotless-plugin-gradle releases
 
 ### Version 3.21.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
+* Updated default eclipse-wtp from 4.7.3b to 4.8.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
+* Updated default eclipse-groovy from 4.8.1 to 4.10.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
 
 ### Version 3.20.0 - March 11th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.20.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.20.0))
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -1,8 +1,8 @@
 # spotless-plugin-gradle releases
 
 ### Version 3.21.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
-* Updated default eclipse-wtp from 4.7.3b to 4.8.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
-* Updated default eclipse-groovy from 4.8.1 to 4.10.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
+* Updated default eclipse-wtp from 4.7.3b to 4.8.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
+* Updated default eclipse-groovy from 4.8.1 to 4.10.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
 
 ### Version 3.20.0 - March 11th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.20.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.20.0))
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -491,7 +491,7 @@ spotless {
     }
     // Use for example eclipseWtp('xml', '4.7.3a') to specify a specific version of Eclipse,
     // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters
-    eclipseWtp('xml').configFile 'spotless.xml.prefs' 'spotless.common.properties'
+    eclipseWtp('xml').configFile 'spotless.xml.prefs', 'spotless.common.properties'
   }
 }
 ```

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -1,6 +1,8 @@
 # spotless-plugin-maven releases
 
 ### Version 1.21.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
+* Updated default eclipse-wtp from 4.7.3b to 4.8.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
+* Updated default eclipse-groovy from 4.8.1 to 4.10.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
 
 ### Version 1.20.0 - March 14th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.20.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.20.0))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -1,8 +1,8 @@
 # spotless-plugin-maven releases
 
 ### Version 1.21.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
-* Updated default eclipse-wtp from 4.7.3b to 4.8.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
-* Updated default eclipse-groovy from 4.8.1 to 4.10.0 ([#371](https://github.com/diffplug/spotless/pull/371)).
+* Updated default eclipse-wtp from 4.7.3b to 4.8.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
+* Updated default eclipse-groovy from 4.8.1 to 4.10.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
 
 ### Version 1.20.0 - March 14th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.20.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.20.0))
 


### PR DESCRIPTION
Changed default versions for WTP and Groovy formatters.

- spotless-eclipse-wtp changed to 4.8 which refers to WTP 3.10  for Eclipse 4.8 as provided by #378
- spotless-eclipse-groovy changed to 4.10 which refers to Groovy-Eclipse 3.2.0 for Eclipse 4.10 as provided by #375
