### PR TITLE
Add Apache Avro to the example configurations

### DIFF
--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -379,6 +379,7 @@ By default, `spotless:check` is bound to the `verify` phase.  You might want to 
 
 ## Example configurations (from real-world projects)
 
+- [Apache Avro](https://github.com/apache/avro/blob/8026c8ffe4ef67ab419dba73910636bf2c1a691c/lang/java/pom.xml#L307-L334)
 - [JUNG: Java Universal Network/Graph Framework](https://github.com/jrtom/jung/blob/b3a2461b97bb3ab40acc631e21feef74976489e4/pom.xml#L187-L208)
 
 <!---freshmark /javadoc -->


### PR DESCRIPTION
Notice that it uses the Eclipse formatter, a particular formatter (with Sun conventions but 2 spaces) and the configuration of spotless:check is attached to the compile phase to fail fast.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.
