### PR TITLE
Changed CDT default versions to v4.11.

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -30,7 +30,7 @@ public final class EclipseCdtFormatterStep {
 
 	private static final String NAME = "eclipse cdt formatter";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.cdt.EclipseCdtFormatterStepImpl";
-	private static final String DEFAULT_VERSION = "4.7.3a";
+	private static final String DEFAULT_VERSION = "4.11.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.11.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.11.0.lockfile
@@ -1,0 +1,21 @@
+# Spotless formatter based on CDT version 9.7.0 (see https://www.eclipse.org/cdt/)
+com.diffplug.spotless:spotless-eclipse-cdt:9.7.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+com.ibm.icu:icu4j:61.1
+org.eclipse.platform:org.eclipse.core.commands:3.9.300
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.300
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.500
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.300
+org.eclipse.platform:org.eclipse.core.jobs:3.10.300
+org.eclipse.platform:org.eclipse.core.resources:3.13.300
+org.eclipse.platform:org.eclipse.core.runtime:3.15.200
+org.eclipse.platform:org.eclipse.equinox.app:1.4.100
+org.eclipse.platform:org.eclipse.equinox.common:3.10.300
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.300
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.300
+org.eclipse.platform:org.eclipse.jface.text:3.15.100
+org.eclipse.platform:org.eclipse.jface:3.15.100
+org.eclipse.platform:org.eclipse.osgi:3.13.300
+org.eclipse.platform:org.eclipse.text:3.8.100

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
@@ -24,7 +24,7 @@ public class EclipseCdtFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a"};
+		return new String[]{"4.7.3a", "4.11.0"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.22.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Updated default eclipse-cdt from 4.7.3a to 4.11.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
+
 ### Version 3.21.1 - March 29th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.21.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.21.1))
 
 * Fixes incorrect plugin and pom metadata in `3.21.0` ([#388](https://github.com/diffplug/spotless/issues/388)).

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.22.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
-* Updated default eclipse-cdt from 4.7.3a to 4.11.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
+* Updated default eclipse-cdt from 4.7.3a to 4.11.0 ([#390](https://github.com/diffplug/spotless/pull/390)).
 
 ### Version 3.21.1 - March 29th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.21.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.21.1))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.22.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Updated default eclipse-cdt from 4.7.3a to 4.11.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
+
 ### Version 1.21.1 - March 29th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.21.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.21.1))
 
 * Fixes incorrect plugin and pom metadata in `1.21.0` ([#388](https://github.com/diffplug/spotless/issues/388)).

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 1.22.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
-* Updated default eclipse-cdt from 4.7.3a to 4.11.0 ([#382](https://github.com/diffplug/spotless/pull/382)).
+* Updated default eclipse-cdt from 4.7.3a to 4.11.0 ([#390](https://github.com/diffplug/spotless/pull/390)).
 
 ### Version 1.21.1 - March 29th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.21.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.21.1))
 


### PR DESCRIPTION
spotless-eclipse-cdt changed to 4.11 which refers to CDT 7.9 for Eclipse 4.11 as provided by #389.