### PR TITLE
[Gradle Plugin] when reregistering a step, NoOp instead of Throw

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.24.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Updated FormatExtension to NoOp when double registering of the same step instead of throwing an exception to better support gradle multi-project builds ([#396](https://github.com/diffplug/spotless/pull/396))
+
 ### Version 3.23.0 - April 24th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.23.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.23.0))
 
 * Updated default ktlint from 0.21.0 to 0.32.0, and Maven coords to com.pinterest ([#394](https://github.com/diffplug/spotless/pull/394))

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -239,7 +239,7 @@ public class FormatExtension {
 		Objects.requireNonNull(newStep);
 		int existingIdx = getExistingStepIdx(newStep.getName());
 		if (existingIdx != -1) {
-			throw new GradleException("Multiple steps with name '" + newStep.getName() + "' for spotless format '" + formatName() + "'");
+			return;
 		}
 		steps.add(newStep);
 	}


### PR DESCRIPTION
We ran into a little bit of a problem trying to use Spotless and I narrowed
it down to `FormatExtension`'s handling of reregistering a plugin.

Below is my proposed solution, though I'm open to alternatives.

**Background**
A semi-common pattern in gradle multi-project builds is to provide some
sort of gradle script which can be sourced by multiple projects for
consistent configuration eg;

code-quality.gradle
```
// Code Formatting
// Spotless code formatting
apply plugin:"com.diffplug.gradle.spotless"

spotless {
  enforceCheck true
  java {
    target '**/*.java'
    googleJavaFormat()
    removeUnusedImports() // removes any unused imports
  }
}
```

consumer.gradle
```
apply from: "$rootDir/build-scripts/code-quality.gradle"
```

This works well for other gradle plugins (eg. Findbugs, pmd, Jacoco),
but breaks for Spotless:

```
* What went wrong:
A problem occurred evaluating project ':consumer'.
> Multiple steps with name 'google-java-format' for spotless format 'java'
```

**Change**
Instead of having the FormatExtension throw an exception when attempting
to reregister the same step, have it early return (NoOp)

**Test Plan**
 - [x] Unit tests pass
 - [x] Setup local repo and pass
