### PR TITLE
Using URI instead of URL for file lookup

### DIFF
--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -1,6 +1,7 @@
 # spotless-eclipse-base
 
-### Version 3.1.1 - TBD
+### Version 3.1.1 - June 4th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
+
 * Fixed problem handling URL escaped characters in JAR file location. ([#401](https://github.com/diffplug/spotless/issues/401))
 
 ### Version 3.1.0 - February 10th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))

--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -1,6 +1,7 @@
 # spotless-eclipse-base
 
-### Version 3.2.0 - TBD
+### Version 3.1.1 - TBD
+* Fixed problem handling URL escaped characters in JAR file location. ([#401](https://github.com/diffplug/spotless/issues/401))
 
 ### Version 3.1.0 - February 10th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
 

--- a/_ext/eclipse-base/gradle.properties
+++ b/_ext/eclipse-base/gradle.properties
@@ -1,7 +1,7 @@
 # Mayor versions correspond to the supported Eclipse core version.
 # Minor version is incremented for features or incompatible changes (including changes to supported dependency versions).
 # Patch version is incremented for backward compatible patches of this library.
-ext_version=3.2.0
+ext_version=3.1.1
 ext_artifactId=spotless-eclipse-base
 ext_description=Eclipse bundle controller and services for Spotless
 

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.11.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.11.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on CDT version 9.7.0 (see https://www.eclipse.org/cdt/)
 com.diffplug.spotless:spotless-eclipse-cdt:9.7.0
-com.diffplug.spotless:spotless-eclipse-base:3.1.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.7.3a.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.7.3a.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on CDT version 9.4.3 (see https://www.eclipse.org/cdt/)
 com.diffplug.spotless:spotless-eclipse-cdt:9.4.5
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.10.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.10.0.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.10.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tag/?h=R4_10 to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.jdt:org.eclipse.jdt.core:3.16.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.11.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.11.0.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.11.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tag/?h=R4_11 to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.jdt:org.eclipse.jdt.core:3.17.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.6.2.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.6.2.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.6.2 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_6_maintenance to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.jdt:org.eclipse.jdt.core:3.12.2

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.7.3a.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.7.3a.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.7.3a (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_7_maintenance to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.jdt:org.eclipse.jdt.core:3.13.101

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.8.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.8.0.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.8.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tag/?h=R4_8 to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.jdt:org.eclipse.jdt.core:3.14.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.9.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.9.0.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.9.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tag/?h=R4_9 to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.jdt:org.eclipse.jdt.core:3.15.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3a.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3a.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Eclipse-WTP version 3.9.5 (see https://www.eclipse.org/webtools/)
 com.diffplug.spotless:spotless-eclipse-wtp:3.9.7
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3b.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.7.3b.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Eclipse-WTP version 3.9.5 (see https://www.eclipse.org/webtools/)
 com.diffplug.spotless:spotless-eclipse-wtp:3.9.8
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.8.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.8.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Eclipse-WTP version 3.9.5 (see https://www.eclipse.org/webtools/)
 com.diffplug.spotless:spotless-eclipse-wtp:3.10.0
-com.diffplug.spotless:spotless-eclipse-base:3.1.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.10.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.10.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Groovy-Eclipse version 3.0.0 (see https://github.com/groovy/groovy-eclipse/releases)
 com.diffplug.spotless:spotless-eclipse-groovy:3.2.0
-com.diffplug.spotless:spotless-eclipse-base:3.1.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.platform:org.eclipse.core.commands:3.9.300

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Groovy-Eclipse version 2.9.2 (see https://github.com/groovy/groovy-eclipse/releases)
 com.diffplug.spotless:spotless-eclipse-groovy:2.9.2
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.platform:org.eclipse.core.commands:3.9.100

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.1.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.8.1.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Groovy-Eclipse version 3.0.0 (see https://github.com/groovy/groovy-eclipse/releases)
 com.diffplug.spotless:spotless-eclipse-groovy:3.0.1
-com.diffplug.spotless:spotless-eclipse-base:3.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.1.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.platform:org.eclipse.core.commands:3.9.100

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.24.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Fixes incorrect M2 cache directory path handling of Eclipse based formatters ([#401](https://github.com/diffplug/spotless/issues/401))
+
 ### Version 3.23.0 - April 24th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.23.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.23.0))
 
 * Updated default ktlint from 0.21.0 to 0.32.0, and Maven coords to com.pinterest ([#394](https://github.com/diffplug/spotless/pull/394))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.24.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Fixes incorrect M2 cache directory path handling of Eclipse based formatters ([#401](https://github.com/diffplug/spotless/issues/401))
+
 ### Version 1.23.0 - April 24th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.23.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.23.0))
 
 * Updated default ktlint from 0.21.0 to 0.32.0, and Maven coords to com.pinterest ([#394](https://github.com/diffplug/spotless/pull/394))


### PR DESCRIPTION
Using URI instead of URL for file lookup avoiding URL escape characters in path.

This change in eclipse-base fixes #401.
Since only a minor bug fix has been provided, only the patch version has been incremented.

All Spotless Eclipse based formatters are affected by #401. Hence their all dependency lock files require an update.

Note that the release date in the change log needs to be set.
Unit tests of the private static function are considered unnecessary.
Code change has been validated manually.