### PR TITLE
Use openjdk instead of oraclejdk on travis-ci because of license problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   - NODE_VERSION="6.10.2"
 before_install:


### PR DESCRIPTION
Use openjdk instead of oraclejdk on travis-ci because of license problem


