### PR TITLE
New maven coordinates for 2.0.0 release of Scalafmt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ You might be looking for:
 
 ### Version 1.24.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Added new maven coordinates for scalafmt 2.0.0+, maintains backwards compatability ([#415](https://github.com/diffplug/spotless/issues/415))
+
 ### Version 1.23.1 - June 17th 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.23.1/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.23.1/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Fixes incorrect M2 cache directory path handling of Eclipse based formatters ([#401](https://github.com/diffplug/spotless/issues/401))

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ extra('wtp.EclipseWtpFormatterStep')             +'{{yes}}       | {{yes}}      
 - Thanks to [Frank Vennemeyer](https://github.com/fvgh) for [Groovy support via greclipse](https://github.com/diffplug/spotless/issues/13), [C++ support via CDT](https://github.com/diffplug/spotless/issues/232), [XML support via WTP](https://github.com/diffplug/spotless/pull/241) and a huge body of work with other eclipse-based formatters.
 - Thanks to [Konstantin Lutovich](https://github.com/lutovich) for [implementing the maven plugin](https://github.com/diffplug/spotless/pull/188).
 - Thanks to [Joan Goyeau](https://github.com/joan38) for [fixing scalafmt integration](https://github.com/diffplug/spotless/pull/260).
+- Thanks to [Nick Sutcliffe](https://github.com/nsutcliffe) for [fixing scalafmt post-2.0](https://github.com/diffplug/spotless/pull/416).
 - Thanks to [Baptiste Mesta](https://github.com/baptistemesta) for
   - porting the DBeaver formatter to Spotless, and thanks to [DBeaver](https://dbeaver.jkiss.org/) and [its authors](https://github.com/serge-rider/dbeaver/graphs/contributors) for their excellent SQL formatter.
   - making license headers date-aware [#179](https://github.com/diffplug/spotless/pull/179)

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -39,7 +39,8 @@ public class ScalaFmtStep {
 
 	private static final String DEFAULT_VERSION = "1.1.0";
 	static final String NAME = "scalafmt";
-	static final String MAVEN_COORDINATE = "com.geirsson:scalafmt-core_2.11:";
+	static final String MAVEN_COORDINATE_PRE_2 = "com.geirsson:scalafmt-core_2.11:";
+	static final String MAVEN_COORDINATE = "org.scalameta:scalafmt-core_2.11:";
 
 	public static FormatterStep create(Provisioner provisioner) {
 		return create(defaultVersion(), provisioner, null);
@@ -64,7 +65,11 @@ public class ScalaFmtStep {
 		final FileSignature configSignature;
 
 		State(String version, Provisioner provisioner, @Nullable File configFile) throws IOException {
-			this.jarState = JarState.from(MAVEN_COORDINATE + version, provisioner);
+			String MAVEN_COORDINATE_FOR_VERSION;
+			if (Integer.parseInt(version.substring(0,1)) < 2) MAVEN_COORDINATE_FOR_VERSION = MAVEN_COORDINATE_PRE_2;
+			else MAVEN_COORDINATE_FOR_VERSION = MAVEN_COORDINATE;
+
+			this.jarState = JarState.from(MAVEN_COORDINATE_FOR_VERSION + version, provisioner);
 			this.configSignature = FileSignature.signAsList(configFile == null ? Collections.emptySet() : Collections.singleton(configFile));
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -23,6 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
@@ -37,9 +39,10 @@ public class ScalaFmtStep {
 	// prevent direct instantiation
 	private ScalaFmtStep() {}
 
+	private static final Pattern VERSION_PRE_2_0 = Pattern.compile("[10]\\.(\\d+)\\.\\d+");
 	private static final String DEFAULT_VERSION = "1.1.0";
 	static final String NAME = "scalafmt";
-	static final String MAVEN_COORDINATE_PRE_2 = "com.geirsson:scalafmt-core_2.11:";
+	static final String MAVEN_COORDINATE_PRE_2_0 = "com.geirsson:scalafmt-core_2.11:";
 	static final String MAVEN_COORDINATE = "org.scalameta:scalafmt-core_2.11:";
 
 	public static FormatterStep create(Provisioner provisioner) {
@@ -65,11 +68,15 @@ public class ScalaFmtStep {
 		final FileSignature configSignature;
 
 		State(String version, Provisioner provisioner, @Nullable File configFile) throws IOException {
-			String MAVEN_COORDINATE_FOR_VERSION;
-			if (Integer.parseInt(version.substring(0,1)) < 2) MAVEN_COORDINATE_FOR_VERSION = MAVEN_COORDINATE_PRE_2;
-			else MAVEN_COORDINATE_FOR_VERSION = MAVEN_COORDINATE;
+			String mavenCoordinate;
+			Matcher versionMatcher = VERSION_PRE_2_0.matcher(version);
+			if (versionMatcher.matches()) {
+				mavenCoordinate = MAVEN_COORDINATE_PRE_2_0;
+			} else {
+				mavenCoordinate = MAVEN_COORDINATE;
+			}
 
-			this.jarState = JarState.from(MAVEN_COORDINATE_FOR_VERSION + version, provisioner);
+			this.jarState = JarState.from(mavenCoordinate + version, provisioner);
 			this.configSignature = FileSignature.signAsList(configFile == null ? Collections.emptySet() : Collections.singleton(configFile));
 		}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.24.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Added new maven coordinates for scalafmt 2.0.0+, maintains backwards compatability ([#415](https://github.com/diffplug/spotless/issues/415))
+
 ### Version 3.23.1 - June 17th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.23.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.23.1))
 
 * Fixes incorrect M2 cache directory path handling of Eclipse based formatters ([#401](https://github.com/diffplug/spotless/issues/401))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.24.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Added new maven coordinates for scalafmt 2.0.0+, maintains backwards compatability ([#415](https://github.com/diffplug/spotless/issues/415))
+
 ### Version 1.23.1 - June 17th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.23.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.23.1))
 
 * Fixes incorrect M2 cache directory path handling of Eclipse based formatters ([#401](https://github.com/diffplug/spotless/issues/401))

--- a/testlib/src/main/resources/scala/scalafmt/basicPost2.0.0.clean
+++ b/testlib/src/main/resources/scala/scalafmt/basicPost2.0.0.clean
@@ -1,0 +1,18 @@
+@foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+object a extends b with c {
+  def foo[T: Int#Double#Triple, R <% String](
+      @annot1
+      x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 =>
+        3
+      case <A>2</A> => 2
+    }
+  }
+}

--- a/testlib/src/main/resources/scala/scalafmt/basicPost2.0.0.cleanWithCustomConf
+++ b/testlib/src/main/resources/scala/scalafmt/basicPost2.0.0.cleanWithCustomConf
@@ -1,0 +1,25 @@
+@foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+object a
+    extends b
+    with c {
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1
+      x: Int @annot2 =
+        2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 =>
+        3
+      case <A>2</A> =>
+        2
+    }
+  }
+}

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -42,6 +42,20 @@ public class ScalaFmtStepTest extends ResourceHarness {
 	}
 
 	@Test
+	public void behaviorDefaultConfigVersion_2_0_0() throws Exception {
+		FormatterStep step = ScalaFmtStep.create("2.0.0", TestProvisioner.mavenCentral(), null);
+		StepHarness.forStep(step)
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.clean");
+	}
+
+	@Test
+	public void behaviorCustomConfigVersion_2_0_0() throws Exception {
+		FormatterStep step = ScalaFmtStep.create("2.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf"));
+		StepHarness.forStep(step)
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.cleanWithCustomConf");
+	}
+
+	@Test
 	public void equality() throws Exception {
 		new SerializableEqualityTester() {
 			String version = "0.5.1";

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -45,14 +45,14 @@ public class ScalaFmtStepTest extends ResourceHarness {
 	public void behaviorDefaultConfigVersion_2_0_0() throws Exception {
 		FormatterStep step = ScalaFmtStep.create("2.0.0", TestProvisioner.mavenCentral(), null);
 		StepHarness.forStep(step)
-				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.clean");
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basicPost2.0.0.clean");
 	}
 
 	@Test
 	public void behaviorCustomConfigVersion_2_0_0() throws Exception {
 		FormatterStep step = ScalaFmtStep.create("2.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf"));
 		StepHarness.forStep(step)
-				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.cleanWithCustomConf");
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basicPost2.0.0.cleanWithCustomConf");
 	}
 
 	@Test


### PR DESCRIPTION
Scalafmt now releases under org.scalameta rather than com.geirsson as of 2.0.0. Updating so that spotless will work with scalafmt 2.0.0+ (maintains backwards compatability of scalafmt prior to 2.0.0).