### PR TITLE
Eclipse updates for 4 12

### DIFF
--- a/_ext/eclipse-cdt/CHANGES.md
+++ b/_ext/eclipse-cdt/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 9.8.0 - July 24th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-cdt)))
 
-* Switch to Eclipse CDT release 9.8 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+* Switch to Eclipse CDT release 9.8 for Eclipse 4.12 ([#423](https://github.com/diffplug/spotless/pull/423)).
 
 ### Version 9.7.0 - March 31st 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-cdt)))
 

--- a/_ext/eclipse-cdt/CHANGES.md
+++ b/_ext/eclipse-cdt/CHANGES.md
@@ -1,5 +1,9 @@
 # spotless-eclipse-cdt
 
+### Version 9.8.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-cdt)))
+* Switch to Eclipse CTD release 9.8 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+
+
 ### Version 9.7.0 - March 31st 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-cdt)))
 
 * Switch to Eclipse CTD release 9.7 for Eclipse 4.11 ([#389](https://github.com/diffplug/spotless/pull/389)).

--- a/_ext/eclipse-cdt/CHANGES.md
+++ b/_ext/eclipse-cdt/CHANGES.md
@@ -1,8 +1,8 @@
 # spotless-eclipse-cdt
 
-### Version 9.8.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-cdt)))
-* Switch to Eclipse CTD release 9.8 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+### Version 9.8.0 - July 24th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-cdt)))
 
+* Switch to Eclipse CDT release 9.8 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
 
 ### Version 9.7.0 - March 31st 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-cdt)))
 

--- a/_ext/eclipse-cdt/gradle.properties
+++ b/_ext/eclipse-cdt/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Eclipse-CDT version used for the fat-JAR.
 # See https://www.eclipse.org/cdt/ for further information about Eclipse-CDT versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=9.7.0
+ext_version=9.8.0
 ext_artifactId=spotless-eclipse-cdt
 ext_description=Eclipse's CDT C/C++ formatter bundled for Spotless
 ext_org=diffplug
@@ -12,7 +12,7 @@ ext_VER_JAVA=1.8
 
 # Compile dependencies
 VER_ECLIPSE_CDT=9.7
-VER_SPOTLESS_ECLISPE_BASE=[3.1.0,4.0.0[
+VER_SPOTLESS_ECLISPE_BASE=[3.2.0,4.0.0[
 VER_ECLISPE_JFACE=[3.12.0,4.0.0[
 VER_ECLISPE_WORKBENCH=[3.11.0,4.0.0[
 VER_ECLISPE_PLATFORM=[3.6.0,4.0.0[

--- a/_ext/eclipse-cdt/src/test/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImplTest.java
+++ b/_ext/eclipse-cdt/src/test/java/com/diffplug/spotless/extra/eclipse/cdt/EclipseCdtFormatterStepImplTest.java
@@ -46,7 +46,7 @@ public class EclipseCdtFormatterStepImplTest {
 	private final static String ILLEGAL_CHAR = Character.toString((char) 254);
 
 	private final static String FUNCT_PTR_UNFORMATTED = "void  (*getFunc(void))  (int);";
-	private final static String FUNCT_PTR_FORMATTED = "void (*getFunc(void)) (int);";
+	private final static String FUNCT_PTR_FORMATTED = "void (* getFunc(void)) (int);";
 
 	@Test
 	public void defaultFormat() throws Throwable {

--- a/_ext/eclipse-groovy/CHANGES.md
+++ b/_ext/eclipse-groovy/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.4.0 - July 24th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-groovy)))
 
-* Switch to Groovy-Eclipse release 3.4.0 for Eclipse 4.12 using Groovy-Indy 3.0.0  ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+* Switch to Groovy-Eclipse release 3.4.0 for Eclipse 4.12 using Groovy-Indy 3.0.0  ([#423](https://github.com/diffplug/spotless/pull/423)).
 
 ### Version 3.2.0 - March 16th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-groovy)))
 

--- a/_ext/eclipse-groovy/CHANGES.md
+++ b/_ext/eclipse-groovy/CHANGES.md
@@ -1,5 +1,9 @@
 # spotless-eclipse-groovy
 
+### Version 3.4.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-groovy)))
+
+* Switch to Groovy-Eclipse release 3.4.0 for Eclipse 4.12 using Groovy-Indy 3.0.0  ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+
 ### Version 3.2.0 - March 16th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-groovy)))
 
 * Switch to Groovy-Eclipse release 3.2.0 for Eclipse 4.10 ([#375](https://github.com/diffplug/spotless/pull/375)).

--- a/_ext/eclipse-groovy/CHANGES.md
+++ b/_ext/eclipse-groovy/CHANGES.md
@@ -1,6 +1,6 @@
 # spotless-eclipse-groovy
 
-### Version 3.4.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-groovy)))
+### Version 3.4.0 - July 24th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-groovy)))
 
 * Switch to Groovy-Eclipse release 3.4.0 for Eclipse 4.12 using Groovy-Indy 3.0.0  ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
 

--- a/_ext/eclipse-groovy/gradle.properties
+++ b/_ext/eclipse-groovy/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Groovy-Eclipse version used for the fat-JAR.
 # See https://github.com/groovy/groovy-eclipse/releases for further information about Groovy-Eclipse versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=3.2.0
+ext_version=3.4.0
 ext_artifactId=spotless-eclipse-groovy
 ext_description=Groovy Eclipse's formatter bundled for Spotless
 
@@ -12,11 +12,11 @@ ext_group=com.diffplug.spotless
 ext_VER_JAVA=1.8
 
 # Compile
-VER_ECLIPSE=4.10
-VER_SPOTLESS_ECLISPE_BASE=[3.1.0,4.0.0[
+VER_ECLIPSE=4.12
+VER_SPOTLESS_ECLISPE_BASE=[3.2.0,4.0.0[
 VER_ECLISPE_JFACE=[3.12.0,4.0.0[
-VER_GRECLIPSE=3.2.0
-VER_GROOVY=2.6.0
+VER_GRECLIPSE=3.4.0
+VER_GROOVY=3.0.0
 
 # Provided dependencies
 VER_SLF4J=[1.6,2.0[

--- a/_ext/eclipse-groovy/src/test/java/com/diffplug/spotless/extra/eclipse/groovy/GrEclipseFormatterStepImplTest.java
+++ b/_ext/eclipse-groovy/src/test/java/com/diffplug/spotless/extra/eclipse/groovy/GrEclipseFormatterStepImplTest.java
@@ -31,7 +31,8 @@ public class GrEclipseFormatterStepImplTest {
 	private final static TestData TEST_DATA = TestData.getTestDataOnFileSystem();
 	private final static String PARSER_EXCEPTION = "class Test { void method() {} ";
 	private final static String SCANNER_EXCEPTION = "{";
-	private final static String BOUNDED_WILDCARDS = "foo(Map<String, ? extends  Object> e)\n{\ne.clear();\n}";
+	private final static String BOUNDED_WILDCARDS_UNFORMATTED = "foo(Map<String, ? extends  Object> e)\n{\ne.clear();\n}";
+	private final static String BOUNDED_WILDCARDS_FORMATTED = "foo(Map<String, ? extends  Object> e) {\n\te.clear();\n}";
 
 	@Test
 	public void defaultFormat() throws Throwable {
@@ -45,7 +46,7 @@ public class GrEclipseFormatterStepImplTest {
 		String output = format(TEST_DATA.input("nominal.test"), config -> {
 			config.put(GROOVY_FORMATTER_REMOVE_UNNECESSARY_SEMICOLONS, "true");
 		});
-		assertEquals("Unexpected formatting fro custom configuration.",
+		assertEquals("Unexpected formatting for custom configuration.",
 				TEST_DATA.expected("nominal.test").replace(";", ""), output);
 	}
 
@@ -74,12 +75,13 @@ public class GrEclipseFormatterStepImplTest {
 	/**
 	 * Test the handling bounded wildcards templates
 	 * No exception since Groovy-Eclipse 3.0.0.
+	 * Formatting fixed with Groovy-Eclipse 3.14 (org.codehaus.groovy:groovy[3.+]).
 	 */
 	@Test
 	public void boundedWildCards() throws Throwable {
-		String output = format(BOUNDED_WILDCARDS, config -> {});
-		assertEquals("Groovy formatter does  notformat after bounded wildcards correctly.",
-				BOUNDED_WILDCARDS.replace("\n", " "), output);
+		String output = format(BOUNDED_WILDCARDS_UNFORMATTED, config -> {});
+		assertEquals("Unexpected formatting after bounded wildcards.",
+				BOUNDED_WILDCARDS_FORMATTED, output);
 	}
 
 	@Test
@@ -89,7 +91,6 @@ public class GrEclipseFormatterStepImplTest {
 		};
 		format(PARSER_EXCEPTION, ignoreCompilerProblems);
 		format(SCANNER_EXCEPTION, ignoreCompilerProblems);
-		format(BOUNDED_WILDCARDS, ignoreCompilerProblems);
 		//Test is passed if it does not throw an exception. See issue 237.
 	}
 

--- a/_ext/eclipse-jdt/gradle.properties
+++ b/_ext/eclipse-jdt/gradle.properties
@@ -1,6 +1,6 @@
 # Mayor/Minor versions correspond to the minimum Eclipse version supported/tested.
 # Patch version is incremented for backward compatible patches of this library.
-ext_version=4.8.0
+ext_version=4.12.0
 ext_artifactId=spotless-eclipse-jdt
 ext_description=Eclipse's JDT formatter bundled for Spotless
 
@@ -12,4 +12,4 @@ ext_VER_JAVA=1.8
 
 # Compile
 VER_ECLIPSE_JDT_CORE=[3.12.0,4.0.0[
-VER_SPOTLESS_ECLISPE_BASE=[3.0.0,4.0.0[
+VER_SPOTLESS_ECLISPE_BASE=[3.2.0,4.0.0[

--- a/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
+++ b/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
@@ -53,13 +53,13 @@ public class EclipseJdtFormatterStepImplTest {
 				FORMATTED, output);
 	}
 
-	/** 
-     * The exception handling has changed sine about JDT 4.10.
-     * Before that version, JDT caught very internal parser error.
-     * The latest behavior is in line with Eclipse-Groovy.
-     * CDT however (still) catches parser exceptions in the formatter step.
-     * Spotless anyhow provides possibilities to change exception behavior.
-     * Furthermore it is assumed that Spotless runs on compile-able code. 
+	/**
+	 * The exception handling has changed sine about JDT 4.10.
+	 * Before that version, JDT caught very internal parser error.
+	 * The latest behavior is in line with Eclipse-Groovy.
+	 * CDT however (still) catches parser exceptions in the formatter step.
+	 * Spotless anyhow provides possibilities to change exception behavior.
+	 * Furthermore it is assumed that Spotless runs on compile-able code.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void invalidFormat() throws Throwable {

--- a/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
+++ b/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
@@ -53,10 +53,17 @@ public class EclipseJdtFormatterStepImplTest {
 				FORMATTED, output);
 	}
 
-	@Test
+	/** 
+     * The exception handling has changed sine about JDT 4.10.
+     * Before that version, JDT caught very internal parser error.
+     * The latest behavior is in line with Eclipse-Groovy.
+     * CDT however (still) catches parser exceptions in the formatter step.
+     * Spotless anyhow provides possibilities to change exception behavior.
+     * Furthermore it is assumed that Spotless runs on compile-able code. 
+	 */
+	@Test(expected = IndexOutOfBoundsException.class)
 	public void invalidFormat() throws Throwable {
-		String output = format(FORMATTED.replace("void hello() {", "void hello()  "), config -> {});
-		assertTrue("Incomplete Java not formatted on best effort basis.", output.contains("void hello()  " + LINE_DELIMITER));
+		format(FORMATTED.replace("void hello() {", "void hello()  "), config -> {});
 	}
 
 	@Test

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,6 +1,6 @@
 # spotless-eclipse-wtp
 
-### Version 3.14.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+### Version 3.14.0 - July 24th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * Switch to Eclipse WTP release 3.14.0 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
 

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,6 +1,6 @@
 # spotless-eclipse-wtp
 
-### Version 3.10.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+### Version 3.14.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * Switch to Eclipse WTP release 3.14.0 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
 

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,5 +1,9 @@
 # spotless-eclipse-wtp
 
+### Version 3.10.0 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+
+* Switch to Eclipse WTP release 3.14.0 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+
 ### Version 3.10.0 - March 17th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * Switch to Eclipse WTP release 3.10.0 for Eclipse 4.8 ([#378](https://github.com/diffplug/spotless/pull/378)).

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.14.0 - July 24th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
-* Switch to Eclipse WTP release 3.14.0 for Eclipse 4.12 ([#TBD](https://github.com/diffplug/spotless/pull/TBD)).
+* Switch to Eclipse WTP release 3.14.0 for Eclipse 4.12 ([#423](https://github.com/diffplug/spotless/pull/423)).
 
 ### Version 3.10.0 - March 17th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 

--- a/_ext/eclipse-wtp/gradle.properties
+++ b/_ext/eclipse-wtp/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Eclipse-WTP version used for the fat-JAR.
 # See https://www.eclipse.org/webtools/ for further information about Eclipse-WTP versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=3.10.0
+ext_version=3.14.0
 ext_artifactId=spotless-eclipse-wtp
 ext_description=Eclipse's WTP formatters bundled for Spotless
 
@@ -12,8 +12,8 @@ ext_group=com.diffplug.spotless
 ext_VER_JAVA=1.8
 
 # Compile
-VER_ECLIPSE_WTP=photon
-VER_SPOTLESS_ECLISPE_BASE=[3.1.0,4.0.0[
+VER_ECLIPSE_WTP=2019-06
+VER_SPOTLESS_ECLISPE_BASE=[3.2.0,4.0.0[
 VER_IBM_ICU=[61,62[
 VER_ECLISPE_EMF=[2.12.0,3.0.0[
 VER_ECLISPE_PLATFORM=[3.6.0,4.0.0[

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 buildscript {
-	repositories { maven { url 'https://plugins.gradle.org/m2/' } }
+	repositories {
+		maven {
+			url 'https://plugins.gradle.org/m2/'
+		}
+	}
 	dependencies {
 		classpath "com.diffplug.gradle:goomph:${VER_GOOMPH}"
 		classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${VER_BINTRAY}"

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -9,7 +9,8 @@ buildScan {
 	if (hasAccepted) {
 		termsOfServiceAgree = 'yes'
 	} else if (!hasRefused) {
-		gradle.buildFinished { println """
+		gradle.buildFinished {
+			println """
 This build uses Gradle Build Scans to gather statistics, share information about 
 failures, environmental issues, dependencies resolved during the build and more.
 Build scans will be published after each build, if you accept the terms of 
@@ -33,6 +34,7 @@ and then:
 
 And we'll not bother you again. Note that build scans are only made public if 
 you share the URL at the end of the build.
-""" }
+"""
+		}
 	}
 }

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -1,5 +1,9 @@
 buildscript {
-	repositories { maven { url 'https://plugins.gradle.org/m2/' } }
+	repositories {
+		maven {
+			url 'https://plugins.gradle.org/m2/'
+		}
+	}
 	dependencies { classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:${VER_SPOTBUGS_PLUGIN}" }
 }
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -30,7 +30,7 @@ public final class EclipseCdtFormatterStep {
 
 	private static final String NAME = "eclipse cdt formatter";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.cdt.EclipseCdtFormatterStepImpl";
-	private static final String DEFAULT_VERSION = "4.11.0";
+	private static final String DEFAULT_VERSION = "4.12.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
@@ -35,7 +35,7 @@ public final class GrEclipseFormatterStep {
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.groovy.eclipse.GrEclipseFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-groovy";
-	private static final String DEFAULT_VERSION = "4.10.0";
+	private static final String DEFAULT_VERSION = "4.12.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	/** Creates a formatter step using the default version for the given settings file. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -32,7 +32,7 @@ public final class EclipseJdtFormatterStep {
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.java.EclipseJdtFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-jdt";
-	private static final String DEFAULT_VERSION = "4.11.0";
+	private static final String DEFAULT_VERSION = "4.12.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -37,7 +37,7 @@ public enum EclipseWtpFormatterStep {
 
 	private static final String NAME = "eclipse wtp formatters";
 	private static final String FORMATTER_PACKAGE = "com.diffplug.spotless.extra.eclipse.wtp.";
-	private static final String DEFAULT_VERSION = "4.8.0";
+	private static final String DEFAULT_VERSION = "4.12.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	private final String implementationClassName;

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.12.0.lockfile
@@ -1,0 +1,22 @@
+# Spotless formatter based on CDT version 9.8.0 (see https://www.eclipse.org/cdt/)
+com.diffplug.spotless:spotless-eclipse-cdt:9.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.2.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+com.ibm.icu:icu4j:61.2
+org.eclipse.platform:org.eclipse.core.commands:3.9.400
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.300
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.600
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.400
+org.eclipse.platform:org.eclipse.core.jobs:3.10.400
+org.eclipse.platform:org.eclipse.core.resources:3.13.400
+org.eclipse.platform:org.eclipse.core.runtime:3.15.300
+org.eclipse.platform:org.eclipse.equinox.app:1.4.200
+org.eclipse.platform:org.eclipse.equinox.common:3.10.400
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.400
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.400
+org.eclipse.platform:org.eclipse.jface.text:3.15.200
+org.eclipse.platform:org.eclipse.jface:3.16.0
+org.eclipse.platform:org.eclipse.osgi:3.14.0
+org.eclipse.platform:org.eclipse.text:3.8.200
+org.slf4j:slf4j-api:1.8.0-beta4

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.12.0.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on JDT version 4.12.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tag/?h=R4_12 to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.2.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.18.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.400
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.300
+org.eclipse.platform:org.eclipse.core.jobs:3.10.400
+org.eclipse.platform:org.eclipse.core.resources:3.13.400
+org.eclipse.platform:org.eclipse.core.runtime:3.15.300
+org.eclipse.platform:org.eclipse.equinox.app:1.4.200
+org.eclipse.platform:org.eclipse.equinox.common:3.10.400
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.400
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.400
+org.eclipse.platform:org.eclipse.osgi:3.14.0
+org.eclipse.platform:org.eclipse.text:3.8.200

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.12.0.lockfile
@@ -1,9 +1,11 @@
-# Spotless formatter based on CDT version 9.8.0 (see https://www.eclipse.org/cdt/)
-com.diffplug.spotless:spotless-eclipse-cdt:9.8.0
+# Spotless formatter based on Eclipse-WTP version 3.14 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.14.0
 com.diffplug.spotless:spotless-eclipse-base:3.2.0
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.2
+org.eclipse.emf:org.eclipse.emf.common:2.16.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.18.0
 org.eclipse.platform:org.eclipse.core.commands:3.9.400
 org.eclipse.platform:org.eclipse.core.contenttype:3.7.300
 org.eclipse.platform:org.eclipse.core.filebuffers:3.6.600
@@ -17,5 +19,7 @@ org.eclipse.platform:org.eclipse.equinox.preferences:3.7.400
 org.eclipse.platform:org.eclipse.equinox.registry:3.8.400
 org.eclipse.platform:org.eclipse.jface.text:3.15.200
 org.eclipse.platform:org.eclipse.jface:3.16.0
+org.eclipse.platform:org.eclipse.osgi.services:3.8.0
 org.eclipse.platform:org.eclipse.osgi:3.14.0
 org.eclipse.platform:org.eclipse.text:3.8.200
+org.eclipse.xsd:org.eclipse.xsd:2.12.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.12.0.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on Groovy-Eclipse version 3.4.0 (see https://github.com/groovy/groovy-eclipse/releases)
+com.diffplug.spotless:spotless-eclipse-groovy:3.4.0
+com.diffplug.spotless:spotless-eclipse-base:3.2.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.400
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.300
+org.eclipse.platform:org.eclipse.core.jobs:3.10.400
+org.eclipse.platform:org.eclipse.core.resources:3.13.400
+org.eclipse.platform:org.eclipse.core.runtime:3.15.300
+org.eclipse.platform:org.eclipse.equinox.app:1.4.200
+org.eclipse.platform:org.eclipse.equinox.common:3.10.400
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.400
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.400
+org.eclipse.platform:org.eclipse.jface.text:3.15.200
+org.eclipse.platform:org.eclipse.jface:3.16.0
+org.eclipse.platform:org.eclipse.osgi:3.14.0
+org.eclipse.platform:org.eclipse.text:3.8.200

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
@@ -24,7 +24,7 @@ public class EclipseCdtFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a", "4.11.0"};
+		return new String[]{"4.7.3a", "4.11.0", "4.12.0"};
 	}
 
 	@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
@@ -23,7 +23,7 @@ import com.diffplug.spotless.extra.eclipse.EclipseCommonTests;
 public class GrEclipseFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"2.3.0", "4.6.3", "4.8.0", "4.8.1", "4.10.0"};
+		return new String[]{"2.3.0", "4.6.3", "4.8.0", "4.8.1", "4.10.0", "4.12.0"};
 	}
 
 	@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
@@ -25,7 +25,7 @@ public class EclipseJdtFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String[] getSupportedVersions() {
 		return new String[]{"4.6.1", "4.6.2", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.7.3a", "4.8.0", "4.9.0", "4.10.0",
-				"4.11.0"};
+				"4.11.0", "4.12.0"};
 	}
 
 	@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -76,7 +76,7 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a", "4.7.3b", "4.8.0"};
+		return new String[]{"4.7.3a", "4.7.3b", "4.8.0", "4.12.0"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Version 3.24.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Updated default eclipse-wtp from 4.8.0 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
+* Updated default eclipse-groovy from 4.10 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
+* Updated default eclipse-jdt from 4.11.0 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
+* Updated default eclipse-cdt from 4.11.0 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
 * Added new maven coordinates for scalafmt 2.0.0+, maintains backwards compatability ([#415](https://github.com/diffplug/spotless/issues/415))
 
 ### Version 3.23.1 - June 17th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.23.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.23.1))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Version 1.24.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Updated default eclipse-wtp from 4.8.0 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
+* Updated default eclipse-groovy from 4.10 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
+* Updated default eclipse-jdt from 4.11.0 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
+* Updated default eclipse-cdt from 4.11.0 to 4.12.0 ([#423](https://github.com/diffplug/spotless/pull/423)).
 * Added new maven coordinates for scalafmt 2.0.0+, maintains backwards compatability ([#415](https://github.com/diffplug/spotless/issues/415))
 
 ### Version 1.23.1 - June 17th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.23.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.23.1))

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -2,7 +2,8 @@ buildscript {
 	repositories { mavenCentral() }
 	dependencies { classpath "com.github.spullara.mustache.java:compiler:${VER_MUSTACHE}" }
 }
-plugins { id 'cz.malohlava' version '1.0.3' // https://github.com/mmalohlava/gradle-visteg
+plugins {
+	id 'cz.malohlava' version '1.0.3' // https://github.com/mmalohlava/gradle-visteg
 }
 
 // to generate taskGraph.pdf

--- a/spotlessSelf.gradle
+++ b/spotlessSelf.gradle
@@ -1,4 +1,8 @@
-buildscript { repositories { jcenter() } }
+buildscript {
+	repositories {
+		jcenter()
+	}
+}
 
 // applied by SelfTest
 plugins {


### PR DESCRIPTION
Provided updates for Eclipse based formatters as they were released for Eclipse 4.12 / 2019-06
Following updates are provided:
- JDT 4.12 (major fixes, should also cover most of the issues reported with #411)
- CDT 9.8 (better support of C11 and above)
-  WTP 3.14 (minor model change for HTML5)
-  GrEclipse 3.4 (Upgrade to Groovy-Indy 3.00 fixes some parser errors, for example bounded wildcards issue reported in  #237)
