### PR TITLE
Added Gradle 4.9 Configuration Avoidance support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jul 31 18:08:12 CDT 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -19,15 +19,7 @@ import static com.diffplug.gradle.spotless.SpotlessTaskConstants.*;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.plugins.JavaBasePlugin;
-
-import com.diffplug.spotless.SpotlessCache;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import groovy.lang.Closure;
 
 public class SpotlessPlugin implements Plugin<Project> {
 	SpotlessExtension spotlessExtension;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -157,8 +157,8 @@ public class SpotlessTask extends DefaultTask {
 	/** Returns the name of this format. */
 	String formatName() {
 		String name = getName();
-		if (name.startsWith(SpotlessPlugin.EXTENSION)) {
-			return name.substring(SpotlessPlugin.EXTENSION.length()).toLowerCase(Locale.ROOT);
+		if (name.startsWith(SpotlessTaskConstants.EXTENSION)) {
+			return name.substring(SpotlessTaskConstants.EXTENSION.length()).toLowerCase(Locale.ROOT);
 		} else {
 			return name;
 		}
@@ -170,7 +170,7 @@ public class SpotlessTask extends DefaultTask {
 			throw new GradleException("You must specify 'Iterable<File> toFormat'");
 		}
 		if (!check && !apply) {
-			throw new GradleException("Don't call " + getName() + " directly, call " + getName() + SpotlessPlugin.CHECK + " or " + getName() + SpotlessPlugin.APPLY);
+			throw new GradleException("Don't call " + getName() + " directly, call " + getName() + SpotlessTaskConstants.CHECK + " or " + getName() + SpotlessTaskConstants.APPLY);
 		}
 
 		Predicate<File> shouldInclude;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskConstants.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskConstants.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.Objects;
+
+final class SpotlessTaskConstants {
+	static final String EXTENSION = "spotless";
+	static final String CHECK = "Check";
+	static final String APPLY = "Apply";
+
+	static final String TASK_GROUP = "Verification";
+	static final String CHECK_DESCRIPTION = "Checks that sourcecode satisfies formatting steps.";
+	static final String APPLY_DESCRIPTION = "Applies code formatting steps to sourcecode in-place.";
+
+	static final String FILES_PROPERTY = "spotlessFiles";
+
+	static String capitalize(String input) {
+		Objects.requireNonNull(input, "input");
+		return Character.toUpperCase(input.charAt(0)) + input.substring(1);
+	}
+
+	// prevent instantiation
+	private SpotlessTaskConstants() {}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskSetup.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskSetup.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.function.BiConsumer;
+
+import org.gradle.api.Project;
+import org.gradle.util.GradleVersion;
+
+interface SpotlessTaskSetup extends BiConsumer<Project, SpotlessExtension> {
+	static SpotlessTaskSetup getForVersion() {
+		if(GradleVersion.current().compareTo(GradleVersion.version("4.9")) >= 0) {
+			return new SpotlessTaskSetupConfigAvoidance();
+		} else {
+			return new SpotlessTaskSetupLegacy();
+		}
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskSetupConfigAvoidance.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskSetupConfigAvoidance.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.tasks.TaskProvider;
+
+import com.diffplug.spotless.SpotlessCache;
+
+import static com.diffplug.gradle.spotless.SpotlessTaskConstants.*;
+import static com.diffplug.gradle.spotless.SpotlessTaskConstants.FILES_PROPERTY;
+
+final class SpotlessTaskSetupConfigAvoidance implements SpotlessTaskSetup {
+	@Override
+	public void accept(Project project, SpotlessExtension spotlessExtension) {
+		TaskProvider<Task> rootCheckTaskProvider = project.getTasks().register(
+				EXTENSION + CHECK,
+				task -> {
+					task.setGroup(TASK_GROUP);
+					task.setDescription(CHECK_DESCRIPTION);
+				});
+		TaskProvider<Task> rootApplyTaskProvider = project.getTasks().register(
+				EXTENSION + APPLY,
+				task -> {
+					task.setGroup(TASK_GROUP);
+					task.setDescription(APPLY_DESCRIPTION);
+				});
+
+		String filePatterns;
+		if (project.hasProperty(FILES_PROPERTY) && project.property(FILES_PROPERTY) instanceof String) {
+			filePatterns = (String) project.property(FILES_PROPERTY);
+		} else {
+			// needs to be non-null since it is an @Input property of the task
+			filePatterns = "";
+		}
+
+		spotlessExtension.formats.forEach((key, value) -> {
+			// create the task that does the work
+			String taskName = EXTENSION + capitalize(key);
+			TaskProvider<SpotlessTask> spotlessTaskProvider = project.getTasks().register(taskName, SpotlessTask.class, task -> {
+				value.setupTask(task);
+				task.setFilePatterns(filePatterns);
+			});
+
+			// create the check and apply control tasks
+			TaskProvider<Task> checkTaskProvider = project.getTasks().register(taskName + CHECK);
+			TaskProvider<Task> applyTaskProvider = project.getTasks().register(taskName + APPLY);
+			// the root tasks depend on them
+			rootCheckTaskProvider.configure(rootCheckTask -> rootCheckTask.dependsOn(checkTaskProvider));
+			rootApplyTaskProvider.configure(rootApplyTask -> rootApplyTask.dependsOn(applyTaskProvider));
+			// and they depend on the work task
+			checkTaskProvider.configure(checkTask -> checkTask.dependsOn(spotlessTaskProvider));
+			applyTaskProvider.configure(applyTask -> applyTask.dependsOn(spotlessTaskProvider));
+
+			// when the task graph is ready, we'll configure the spotlessTask appropriately
+			project.getGradle().getTaskGraph().whenReady(graph -> {
+				if (checkTaskProvider.isPresent() && graph.hasTask(checkTaskProvider.get())) {
+					spotlessTaskProvider.configure(SpotlessTask::setCheck);
+				}
+				if (applyTaskProvider.isPresent() && graph.hasTask(applyTaskProvider.get())) {
+					spotlessTaskProvider.configure(SpotlessTask::setApply);
+				}
+			});
+		});
+
+		// Add our check task as a dependency on the global check task.
+		// getTasks() returns a "live" collection and configureEach() is lazy,
+		// so this works even if the task doesn't exist at the time this call
+		// is made.
+		if (spotlessExtension.enforceCheck) {
+			project.getTasks()
+					.matching(task -> task.getName().equals(JavaBasePlugin.CHECK_TASK_NAME))
+					.configureEach(task -> task.dependsOn(rootCheckTaskProvider));
+		}
+
+		// clear spotless' cache when the user does a clean, but only after any spotless tasks
+		TaskProvider<Task> cleanTaskProvider = project.getTasks().named(BasePlugin.CLEAN_TASK_NAME);
+		cleanTaskProvider.configure(task -> task.doLast(unused -> SpotlessCache.clear()));
+		project.getTasks()
+				.withType(SpotlessTask.class)
+				.configureEach(task -> task.mustRunAfter(cleanTaskProvider));
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskSetupLegacy.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskSetupLegacy.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import static com.diffplug.gradle.spotless.SpotlessTaskConstants.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import groovy.lang.Closure;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.execution.TaskExecutionGraph;
+import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaBasePlugin;
+
+import com.diffplug.spotless.SpotlessCache;
+
+final class SpotlessTaskSetupLegacy implements SpotlessTaskSetup {
+	@Override
+	@SuppressWarnings("rawtypes")
+	public void accept(Project project, SpotlessExtension spotlessExtension) {
+		Task rootCheckTask = project.task(EXTENSION + CHECK);
+		rootCheckTask.setGroup(SpotlessTaskConstants.TASK_GROUP);
+		rootCheckTask.setDescription(CHECK_DESCRIPTION);
+		Task rootApplyTask = project.task(EXTENSION + APPLY);
+		rootApplyTask.setGroup(TASK_GROUP);
+		rootApplyTask.setDescription(APPLY_DESCRIPTION);
+		String filePatterns;
+		if (project.hasProperty(FILES_PROPERTY) && project.property(FILES_PROPERTY) instanceof String) {
+			filePatterns = (String) project.property(FILES_PROPERTY);
+		} else {
+			// needs to be non-null since it is an @Input property of the task
+			filePatterns = "";
+		}
+
+		spotlessExtension.formats.forEach((key, value) -> {
+			// create the task that does the work
+			String taskName = EXTENSION + capitalize(key);
+			SpotlessTask spotlessTask = project.getTasks().create(taskName, SpotlessTask.class);
+			value.setupTask(spotlessTask);
+			spotlessTask.setFilePatterns(filePatterns);
+
+			// create the check and apply control tasks
+			Task checkTask = project.getTasks().create(taskName + CHECK);
+			Task applyTask = project.getTasks().create(taskName + APPLY);
+			// the root tasks depend on them
+			rootCheckTask.dependsOn(checkTask);
+			rootApplyTask.dependsOn(applyTask);
+			// and they depend on the work task
+			checkTask.dependsOn(spotlessTask);
+			applyTask.dependsOn(spotlessTask);
+
+			//this cannot be replaced with a lambda because the Action overload does not exist in 2.14
+			// when the task graph is ready, we'll configure the spotlessTask appropriately
+			project.getGradle().getTaskGraph().whenReady(new Closure(null) {
+				private static final long serialVersionUID = 1L;
+
+				// called by gradle
+				@SuppressFBWarnings("UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS")
+				public Object doCall(TaskExecutionGraph graph) {
+					if (graph.hasTask(checkTask)) {
+						spotlessTask.setCheck();
+					}
+					if (graph.hasTask(applyTask)) {
+						spotlessTask.setApply();
+					}
+					return Closure.DONE;
+				}
+			});
+		});
+
+		// Add our check task as a dependency on the global check task
+		// getTasks() returns a "live" collection, so this works even if the
+		// task doesn't exist at the time this call is made
+		if (spotlessExtension.enforceCheck) {
+			project.getTasks()
+				.matching(task -> task.getName().equals(JavaBasePlugin.CHECK_TASK_NAME))
+				.all(task -> task.dependsOn(rootCheckTask));
+		}
+
+		// clear spotless' cache when the user does a clean, but only after any spotless tasks
+		Task clean = project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME);
+		clean.doLast(unused -> SpotlessCache.clear());
+		project.getTasks()
+			.withType(SpotlessTask.class)
+			.all(task -> task.mustRunAfter(clean));
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle4_9IntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle4_9IntegrationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.diffplug.spotless.category.NpmTest;
+
+public class Gradle4_9IntegrationTest extends GradleIntegrationTest {
+	@Test
+	public void integration() throws IOException {
+		setFile("build.gradle").toLines(
+			"buildscript { repositories { mavenCentral() } }",
+			"plugins {",
+			"    id 'com.diffplug.gradle.spotless'",
+			"}",
+			"apply plugin: 'scala'",
+			"spotless {",
+			"    scala {",
+			"        scalafmt().configFile('scalafmt.conf')",
+			"    }",
+			"}");
+		setFile("scalafmt.conf").toResource("scala/scalafmt/scalafmt.conf");
+		setFile("src/main/scala/basic.scala").toResource("scala/scalafmt/basic.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/scala/basic.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf");
+	}
+
+	protected GradleRunner gradleRunner() throws IOException {
+		return GradleRunner.create()
+			.withGradleVersion("4.9")
+			.withProjectDir(rootFolder())
+			.withPluginClasspath();
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle4_9LazyTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle4_9LazyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class Gradle4_9LazyTest extends GradleIntegrationTest {
+	@Test
+	public void noConfigOnHelp() throws IOException {
+		setFile("build.gradle").toLines(
+				"buildscript { repositories { mavenCentral() } }",
+				"plugins {",
+				"    id 'com.diffplug.gradle.spotless'",
+				"}",
+				"apply plugin: 'scala'",
+				"spotless {",
+				"    scala {",
+				"        scalafmt().configFile('scalafmt.conf')",
+				"    }",
+				"}",
+				"project.tasks.matching { it.getName().startsWith(\"" + SpotlessTaskConstants.EXTENSION + "\") }",
+					".configureEach { task -> throw new AssertionError(\"Spotless task configured\") }"
+
+		);
+		gradleRunner().withArguments("help").build();
+	}
+
+	protected GradleRunner gradleRunner() throws IOException {
+		return GradleRunner.create()
+			.withGradleVersion("4.9")
+			.withProjectDir(rootFolder())
+			.withPluginClasspath();
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle5_4IntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle5_4IntegrationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class Gradle5_4IntegrationTest extends GradleIntegrationTest {
+	@Test
+	public void integration() throws IOException {
+		setFile("build.gradle").toLines(
+			"buildscript { repositories { mavenCentral() } }",
+			"plugins {",
+			"    id 'com.diffplug.gradle.spotless'",
+			"}",
+			"apply plugin: 'scala'",
+			"spotless {",
+			"    scala {",
+			"        scalafmt().configFile('scalafmt.conf')",
+			"    }",
+			"}");
+		setFile("scalafmt.conf").toResource("scala/scalafmt/scalafmt.conf");
+		setFile("src/main/scala/basic.scala").toResource("scala/scalafmt/basic.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/scala/basic.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf");
+	}
+
+	protected GradleRunner gradleRunner() throws IOException {
+		return GradleRunner.create()
+			.withGradleVersion("5.4")
+			.withProjectDir(rootFolder())
+			.withPluginClasspath();
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle5_4LazyTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/Gradle5_4LazyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class Gradle5_4LazyTest extends GradleIntegrationTest {
+	@Test
+	public void noConfigOnHelp() throws IOException {
+		setFile("build.gradle").toLines(
+				"buildscript { repositories { mavenCentral() } }",
+				"plugins {",
+				"    id 'com.diffplug.gradle.spotless'",
+				"}",
+				"apply plugin: 'scala'",
+				"spotless {",
+				"    scala {",
+				"        scalafmt().configFile('scalafmt.conf')",
+				"    }",
+				"}",
+				"project.tasks.matching { it.getName().startsWith(\"" + SpotlessTaskConstants.EXTENSION + "\") }",
+					".configureEach { task -> throw new AssertionError(\"Spotless task configured\") }"
+
+		);
+		gradleRunner().withArguments("help").build();
+	}
+
+	protected GradleRunner gradleRunner() throws IOException {
+		return GradleRunner.create()
+			.withGradleVersion("5.4")
+			.withProjectDir(rootFolder())
+			.withPluginClasspath();
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
@@ -56,7 +56,7 @@ public class GradleIntegrationTest extends ResourceHarness {
 		setFile(".gitattributes").toContent("* text eol=lf");
 	}
 
-	protected final GradleRunner gradleRunner() throws IOException {
+	protected GradleRunner gradleRunner() throws IOException {
 		return GradleRunner.create()
 				// Test against Gradle 2.14.1 in order to maintain backwards compatibility.
 				// https://github.com/diffplug/spotless/issues/161

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -66,7 +66,7 @@ public class PaddedCellTaskTest extends ResourceHarness {
 		}
 
 		private SpotlessTask createApplyTask(String name, FormatterStep step) {
-			SpotlessTask task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + SpotlessPlugin.APPLY, SpotlessTask.class);
+			SpotlessTask task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + SpotlessTaskConstants.APPLY, SpotlessTask.class);
 			task.setApply();
 			task.addStep(step);
 			task.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());


### PR DESCRIPTION
Work in progress for Gradle 4.9 Configuration Avoidance.

Once complete, this should close #269 as this as a continuation of #277 

All tests pass and a manual test on Gradle 5.4.1 shows that it does in fact lazily configure task.

Gradle has been bumped up to 4.9, as this is the first version with this new API.