### PR TITLE
Add checkGradleChecksum.sh to verify gradle wrapper jars on CI

### DIFF
--- a/.ci/checkGradleChecksum.sh
+++ b/.ci/checkGradleChecksum.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# First parse the gradle version from its gradle-wrapper.properties file
+GRADLE_WRAPPER_PROPERTIES_FILE=gradle/wrapper/gradle-wrapper.properties
+GRADLE_URL_PREFIX="https\://services.gradle.org/distributions/gradle-"
+GRADLE_URL_SUFFIX="-all.zip"
+
+function prop {
+    grep "${1}" ${GRADLE_WRAPPER_PROPERTIES_FILE}|cut -d'=' -f2
+}
+
+GRADLE_VERSION_URL=$(prop "distributionUrl")
+GRADLE_VERSION_STRIPPED_PREFIX=${GRADLE_VERSION_URL#"$GRADLE_URL_PREFIX"}
+GRADLE_VERSION=${GRADLE_VERSION_STRIPPED_PREFIX%"$GRADLE_URL_SUFFIX"}
+
+# Now compare against gradle's distribution upstream with sha256sum
+echo "Checking Gradle wrapper jar for version: ${GRADLE_VERSION}"
+cd gradle/wrapper
+curl --location --output gradle-wrapper.jar.sha256 \
+       https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-wrapper.jar.sha256
+echo "  gradle-wrapper.jar" >> gradle-wrapper.jar.sha256
+sha256sum --check gradle-wrapper.jar.sha256
+if [[ $? != 0 ]]; then
+    echo "Gradle wrapper failed checksum verification. Please investigate." >&2
+    exit $?
+fi
+rm gradle-wrapper.jar.sha256
+cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - NODE_VERSION="6.10.2"
 before_install:
   - nvm install $NODE_VERSION
+  - ./.ci/checkGradleChecksum.sh
 install: true
 script:
   - ./.ci/ci.sh


### PR DESCRIPTION
Followup from the discussion in #433 

This adds a CI check to verify the gradle wrapper jar checksum before running any gradle builds, using guidance from https://docs.gradle.org/current/userguide/gradle_wrapper.html#wrapper_checksum_verification

My bash-fu isn't amazing so I'm sure there's a cleaner way to parse the gradle version out of that property file

Successful pass looks like this:

```
$ ./.ci/checkGradleChecksum.sh    
Checking Gradle wrapper jar for version: 5.6
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100    64  100    64    0     0    127      0 --:--:-- --:--:-- --:--:--   127
gradle-wrapper.jar: OK
```

Failure looks like this and fails the build:

```
$ ./.ci/checkGradleChecksum.sh                                                                                                          
Checking Gradle wrapper jar for version: 5.6
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100    64  100    64    0     0    102      0 --:--:-- --:--:-- --:--:--   102
gradle-wrapper2.jar: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
Gradle wrapper failed checksum verification. Please investigate.
```