### PR TITLE
Fix Spotless Eclipse workspace cleanup and OSGI lock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ You might be looking for:
 
 ### Version 1.25.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Eclipse-based formatters used to leave temporary files around ([#447](https://github.com/diffplug/spotless/issues/447)). This is now fixed, but only for eclipse 4.12+, no back-port to older Eclipse formatter versions is planned. ([#451](https://github.com/diffplug/spotless/issues/451))
+
 ### Version 1.24.1 - August 12th 2018 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.24.1/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.24.1/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Fixes class loading issue with Java 9+ ([#426](https://github.com/diffplug/spotless/pull/426)).

--- a/_ext/BUILD_INSTRUCTIONS.md
+++ b/_ext/BUILD_INSTRUCTIONS.md
@@ -1,0 +1,9 @@
+
+The `_ext` builds are currently tested only with gradle `4.4.1`.  They are known not to work for the current wrapper version.
+
+To install the correct version using [sdkman](https://sdkman.io/install):
+
+- `sdk install gradle 4.4.1`
+- `sdk default gradle 4.4.1`
+
+Then you can do `gradle -b _ext/{DIR}/build.gradle publish`.  `gradlew` will not work.

--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -1,6 +1,6 @@
 # spotless-eclipse-base
 
-### Version 3.2.1 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
+### Version 3.2.1 - September 3rd 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
 
 * Fixed deletion of temporary workspace. ([#447](https://github.com/diffplug/spotless/issues/447))
 

--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -1,5 +1,9 @@
 # spotless-eclipse-base
 
+### Version 3.2.1 - TBD ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
+
+* Fixed deletion of temporary workspace. ([#447](https://github.com/diffplug/spotless/issues/447))
+
 ### Version 3.2.0 - June 30th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-base)))
 
 * Added support of Eclipse 4.12 framework wiring. ([#413](https://github.com/diffplug/spotless/issues/413))

--- a/_ext/eclipse-base/README.md
+++ b/_ext/eclipse-base/README.md
@@ -53,13 +53,9 @@ is included in your formatter fat JAR, the directory structure should be:
 
 ```
 
-
 ## Build
 
-```
-gradlew -b _ext/eclipse-base/build.gradle publish
-```
-
+To publish a new version, update the `_ext/eclipse-base/gradle.properties` appropriately and see [BUILD_INSTRUCTIONS.md](../BUILD_INSTRUCTIONS).
 
 ## License
 

--- a/_ext/eclipse-base/gradle.properties
+++ b/_ext/eclipse-base/gradle.properties
@@ -1,7 +1,7 @@
 # Mayor versions correspond to the supported Eclipse core version.
 # Minor version is incremented for features or incompatible changes (including changes to supported dependency versions).
 # Patch version is incremented for backward compatible patches of this library.
-ext_version=3.2.0
+ext_version=3.2.1
 ext_artifactId=spotless-eclipse-base
 ext_description=Eclipse bundle controller and services for Spotless
 

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/BundleController.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/BundleController.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.eclipse.osgi.internal.location.LocationHelper;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -48,9 +49,13 @@ public final class BundleController implements StaticBundleContext {
 
 	@SuppressWarnings("deprecation")
 	public BundleController() throws BundleException {
+		//OSGI locks are not required, since this framework does not allow changes after initialization.
+		System.setProperty(LocationHelper.PROP_OSGI_LOCKING, LocationHelper.LOCKING_NONE);
+
 		this.properties = new HashMap<String, String>();
 		//Don't activate all plugin bundles. Activation is triggered by this controller where needed.
 		properties.put(org.eclipse.core.internal.runtime.InternalPlatform.PROP_ACTIVATE_PLUGINS, Boolean.toString(false));
+
 		/*
 		 * Used to set-up an internal member of the Eclipse runtime FindSupport,
 		 * which is used during resources look-up from different version of bundles.

--- a/_ext/eclipse-cdt/README.md
+++ b/_ext/eclipse-cdt/README.md
@@ -2,10 +2,8 @@
 
 Eclipse CDT is not available in a form which can be easily consumed by maven or gradle.  To fix this, we publish Eclipse's formatter and all its dependencies, along with a small amount of glue code, into the `com.diffplug.gradle.spotless:spotless-eclipse-cdt` artifact.
 
-To publish a new version, update the `_ext/eclipse-cdt/gradle.properties` appropriately and run this from the root directory:
+To publish a new version, update the `_ext/eclipse-cdt/gradle.properties` appropriately and see [BUILD_INSTRUCTIONS.md](../BUILD_INSTRUCTIONS).
 
-```
-gradlew -b _ext/eclipse-cdt/build.gradle publish
-```
+## License
 
 Spotless at large is under the Apache 2.0 license, but this jar is under the EPL v1.

--- a/_ext/eclipse-groovy/README.md
+++ b/_ext/eclipse-groovy/README.md
@@ -5,10 +5,8 @@ To fix this, we publish Groovy-Eclipse's formatter and all its dependencies, alo
 
 ## Build
 
-To publish a new version, update the `_ext/eclipse-groovy/gradle.properties` appropriately and run this from the root directory:
+To publish a new version, update the `_ext/eclipse-groovy/gradle.properties` appropriately and and see [BUILD_INSTRUCTIONS.md](../BUILD_INSTRUCTIONS).
 
-```
-gradlew -b _ext/eclipse-groovy/build.gradle publish
-```
+## License
 
 Spotless at large is under the Apache 2.0 license, but this jar is under the EPL v1.

--- a/_ext/eclipse-jdt/README.md
+++ b/_ext/eclipse-jdt/README.md
@@ -4,10 +4,8 @@ Eclipse JDT and its dependencies require a large amount of byte code.
 Hence they should not be directly be required by the Spotless, but only be requested in case
 they are configured by the Spotless configuration. Hence we publish Eclipse's formatter and all its dependencies, along with a small amount of glue code, into the `com.diffplug.gradle.spotless:spotless-eclipse-jdt` artifact.
 
-To publish a new version, update the `_ext/eclipse-jdt/gradle.properties` appropriately and run this from the root directory:
+To publish a new version, update the `_ext/eclipse-jdt/gradle.properties` appropriately and and see [BUILD_INSTRUCTIONS.md](../BUILD_INSTRUCTIONS).
 
-```
-gradlew -b _ext/eclipse-jdt/build.gradle publish
-```
+## License
 
 Spotless at large is under the Apache 2.0 license, but this jar is under the EPL v1.

--- a/_ext/eclipse-wtp/README.md
+++ b/_ext/eclipse-wtp/README.md
@@ -2,10 +2,8 @@
 
 Eclipse WTP is not available in a form which can be easily consumed by maven or gradle. To fix this, we publish Eclipse's WTP formatters, along with a small amount of glue code, into the `com.diffplug.spotless.extra:spotless-eclipse-wtp` artifact.
 
-To publish a new version, update the `_ext/eclipse-wtp/gradle.properties` appropriately and run this from the root directory:
+To publish a new version, update the `_ext/eclipse-wtp/gradle.properties` appropriately and and see [BUILD_INSTRUCTIONS.md](../BUILD_INSTRUCTIONS).
 
-```
-gradlew -b _ext/eclipse-wtp/build.gradle publish
-```
+## License
 
 Spotless at large is under the Apache 2.0 license, but this jar is under the EPL v1.

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.12.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on CDT version 9.8.0 (see https://www.eclipse.org/cdt/)
 com.diffplug.spotless:spotless-eclipse-cdt:9.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.2.0
+com.diffplug.spotless:spotless-eclipse-base:3.2.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.2

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.12.0.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.12.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tag/?h=R4_12 to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
-com.diffplug.spotless:spotless-eclipse-base:3.2.0
+com.diffplug.spotless:spotless-eclipse-base:3.2.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.jdt:org.eclipse.jdt.core:3.18.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.12.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Eclipse-WTP version 3.14 (see https://www.eclipse.org/webtools/)
 com.diffplug.spotless:spotless-eclipse-wtp:3.14.0
-com.diffplug.spotless:spotless-eclipse-base:3.2.0
+com.diffplug.spotless:spotless-eclipse-base:3.2.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.2

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.12.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.12.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Groovy-Eclipse version 3.4.0 (see https://github.com/groovy/groovy-eclipse/releases)
 com.diffplug.spotless:spotless-eclipse-groovy:3.4.0
-com.diffplug.spotless:spotless-eclipse-base:3.2.0
+com.diffplug.spotless:spotless-eclipse-base:3.2.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 org.eclipse.platform:org.eclipse.core.commands:3.9.400

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.25.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
+* Fixed deletion of Eclipse based formatters temporary workspaces. ([#447](https://github.com/diffplug/spotless/issues/447))
+
 ### Version 3.24.2 - August 19th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.24.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.24.1))
 
 * Fixed `Warning deprecated usage found: Using the incremental task API without declaring any outputs has been deprecated.` that started appearing in Gradle 5.5 ([#434](https://github.com/diffplug/spotless/pull/434)).

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.25.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
-* Fixed deletion of Eclipse 4.12 based formatters temporary workspaces. No back-port to older Eclipse formatter versions is planed. ([#447](https://github.com/diffplug/spotless/issues/447))
+* Eclipse-based formatters used to leave temporary files around ([#447](https://github.com/diffplug/spotless/issues/447)). This is now fixed, but only for eclipse 4.12+, no back-port to older Eclipse formatter versions is planned. ([#451](https://github.com/diffplug/spotless/issues/451))
 
 ### Version 3.24.2 - August 19th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.24.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.24.1))
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.25.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
-* Fixed deletion of Eclipse based formatters temporary workspaces. ([#447](https://github.com/diffplug/spotless/issues/447))
+* Fixed deletion of Eclipse 4.12 based formatters temporary workspaces. No back-port to older Eclipse formatter versions is planed. ([#447](https://github.com/diffplug/spotless/issues/447))
 
 ### Version 3.24.2 - August 19th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.24.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.24.1))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 1.25.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
-* Fixed deletion of Eclipse based formatters temporary workspaces. ([#447](https://github.com/diffplug/spotless/issues/447))
+* Fixed deletion of Eclipse 4.12 based formatters temporary workspaces. No back-port to older Eclipse formatter versions is planed. ([#447](https://github.com/diffplug/spotless/issues/447))
 
 ### Version 1.24.1 - August 12th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.24.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.24.1))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 1.25.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
-* Fixed deletion of Eclipse 4.12 based formatters temporary workspaces. No back-port to older Eclipse formatter versions is planed. ([#447](https://github.com/diffplug/spotless/issues/447))
+* Eclipse-based formatters used to leave temporary files around ([#447](https://github.com/diffplug/spotless/issues/447)). This is now fixed, but only for eclipse 4.12+, no back-port to older Eclipse formatter versions is planned. ([#451](https://github.com/diffplug/spotless/issues/451))
 
 ### Version 1.24.1 - August 12th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.24.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.24.1))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.25.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Fixed deletion of Eclipse based formatters temporary workspaces. ([#447](https://github.com/diffplug/spotless/issues/447))
+
 ### Version 1.24.1 - August 12th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.24.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.24.1))
 
 * Fixes class loading issue with Java 9+ ([#426](https://github.com/diffplug/spotless/pull/426)).


### PR DESCRIPTION
Fixes #447

* Eclipse workspace cleanup uses shut-down hook for recursive file/directory removal
* Unnecessary OSGI lock removed

Change log has been updated. Fix is back-ward compatible. Hence a re-build of the Eclipse formatters is not required. 
