### PR TITLE
Support KtLint 0.34+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ You might be looking for:
 
 ### Version 1.25.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
+* Add support for ktlint `0.34+`, and bump default version from `0.32.0` to `0.34.2`. ([#469](https://github.com/diffplug/spotless/pull/469))
+
 ### Version 1.24.3 - September 23rd 2019 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.24.3/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.24.3/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Update jgit from `5.3.2.201906051522-r` to `5.5.0.201909110433-r`. ([#445](https://github.com/diffplug/spotless/pull/445))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -200,7 +200,7 @@ You might be looking for:
 ### Version 1.1.0 - February 27th 2017 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.1.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.1.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 
 * Added support for Scala via [scalafmt](https://github.com/olafurpg/scalafmt).
-* Added support for Kotlin via [ktlint](https://github.com/shyiko/ktlint).
+* Added support for Kotlin via [ktlint](https://github.com/pinterest/ktlint).
 * Better error messages for JarState.
 * Improved test harnessing.
 * Formatter now has pluggable exception policies,

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Once someone has filled in one square of the formatter/build system matrix, it's
 - Thanks to [Oliver Horn](https://github.com/ohorn) for adding AOSP support for Spotless' google-java-format integration.
 - Formatting by Eclipse
   - Special thanks to [Mateusz Matela](https://waynebeaton.wordpress.com/2015/03/15/great-fixes-for-mars-winners-part-i/) for huge improvements to the eclipse code formatter!
-- Thanks to [Zac Sweers](https://github.com/ZacSweers) for multiple build updates and fixing a gradle deprecation warning ([#434](https://github.com/diffplug/spotless/pull/434) and others).
+- Thanks to [Zac Sweers](https://github.com/ZacSweers) for fixing the highly requested ktlint 0.34+ support ([#469](https://github.com/diffplug/spotless/pull/469)), multiple build updates and fixing a gradle deprecation warning ([#434](https://github.com/diffplug/spotless/pull/434) and others).
 - Thanks to [Nelson Osacky](https://github.com/runningcode) for android doc improvements, versions bump, and a build improvement.
 - Thanks to [Stanley Shyiko](https://github.com/shyiko) for his help integrating [ktlint](https://github.com/shyiko/ktlint).
 - Thanks to [Jonathan Leitschuh](https://github.com/JLLeitschuh) for adding [ktlint](https://github.com/shyiko/ktlint) support for [Gradle Kotlin DSL](https://github.com/gradle/kotlin-dsl) files.

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -33,7 +33,7 @@ import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.ThrowingEx;
 
-/** Wraps up [ktlint](https://github.com/shyiko/ktlint) as a FormatterStep. */
+/** Wraps up [ktlint](https://github.com/pinterest/ktlint) as a FormatterStep. */
 public class KtLintStep {
 	// prevent direct instantiation
 	private KtLintStep() {}

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -15,8 +15,14 @@
  */
 package com.diffplug.spotless.kotlin;
 
+import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.JarState;
+import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.ThrowingEx;
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -27,19 +33,13 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.diffplug.spotless.FormatterFunc;
-import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.JarState;
-import com.diffplug.spotless.Provisioner;
-import com.diffplug.spotless.ThrowingEx;
-
 /** Wraps up [ktlint](https://github.com/pinterest/ktlint) as a FormatterStep. */
 public class KtLintStep {
 	// prevent direct instantiation
 	private KtLintStep() {}
 
-	private static final Pattern VERSION_PRE_0_32 = Pattern.compile("0\\.(\\d+)\\.\\d+");
-	private static final String DEFAULT_VERSION = "0.32.0";
+	private static final Pattern VERSION_MATCHER = Pattern.compile("0\\.(\\d+)\\.\\d+");
+	private static final String DEFAULT_VERSION = "0.34.2";
 	static final String NAME = "ktlint";
 	static final String PACKAGE_PRE_0_32 = "com.github.shyiko";
 	static final String PACKAGE = "com.pinterest";
@@ -87,18 +87,21 @@ public class KtLintStep {
 		/** The jar that contains the eclipse formatter. */
 		final JarState jarState;
 		private final TreeMap<String, String> userData;
+		private final boolean useParams;
 
 		State(String version, Provisioner provisioner, boolean isScript, Map<String, String> userData) throws IOException {
 			this.userData = new TreeMap<>(userData);
 			String coordinate;
-			Matcher matcher = VERSION_PRE_0_32.matcher(version);
-			if (matcher.matches() && Integer.parseInt(matcher.group(1)) < 32) {
+			Matcher matcher = VERSION_MATCHER.matcher(version);
+			boolean matches = matcher.matches();
+			if (matches && Integer.parseInt(matcher.group(1)) < 32) {
 				coordinate = MAVEN_COORDINATE_PRE_0_32;
 				this.pkg = PACKAGE_PRE_0_32;
 			} else {
 				coordinate = MAVEN_COORDINATE;
 				this.pkg = PACKAGE;
 			}
+			this.useParams = matches && Integer.parseInt(matcher.group(1)) >= 34;
 			this.jarState = JarState.from(coordinate + version, provisioner);
 			this.isScript = isScript;
 		}
@@ -135,18 +138,58 @@ public class KtLintStep {
 			// grab the KtLint singleton
 			Class<?> ktlintClass = classLoader.loadClass(pkg + ".ktlint.core.KtLint");
 			Object ktlint = ktlintClass.getDeclaredField("INSTANCE").get(null);
-			// and its format method
-			String formatterMethodName = isScript ? "formatScript" : "format";
-			Method formatterMethod = ktlintClass.getMethod(formatterMethodName, String.class, Iterable.class, Map.class, function2Interface);
+			FormatterFunc formatterFunc;
+			if (useParams) {
+				//
+				// In KtLint 0.34+ there is a new "format(params: Params)" function. We create an
+				// instance of the Params class with our configuration and call it here.
+				//
 
-			return input -> {
-				try {
-					String formatted = (String) formatterMethod.invoke(ktlint, input, ruleSets, userData, formatterCallback);
-					return formatted;
-				} catch (InvocationTargetException e) {
-					throw ThrowingEx.unwrapCause(e);
-				}
-			};
+				// grab the Params class
+				Class<?> paramsClass = classLoader.loadClass(pkg + ".ktlint.core.KtLint.Params");
+				// and its format method
+				Constructor<?> constructor = paramsClass.getConstructor(
+					/* fileName, nullable */ String.class,
+					/* text */ String.class,
+					/* ruleSets */ Iterable.class,
+					/* userData */ Map.class,
+					/* callback */ function2Interface,
+					/* script */ boolean.class,
+					/* editorConfigPath, nullable */ String.class,
+					/* debug */ boolean.class
+				);
+				Method formatterMethod = ktlintClass.getMethod("format", paramsClass);
+				formatterFunc = input -> {
+					try {
+						Object params = constructor.newInstance(
+							/* fileName, nullable */ null,
+							/* text */ input,
+							/* ruleSets */ ruleSets,
+							/* userData */ userData,
+							/* callback */ formatterCallback,
+							/* script */ isScript,
+							/* editorConfigPath, nullable */ null,
+							/* debug */ false
+						);
+						return (String) formatterMethod.invoke(ktlint, params);
+					} catch (InvocationTargetException e) {
+						throw ThrowingEx.unwrapCause(e);
+					}
+				};
+			} else {
+				// and its format method
+				String formatterMethodName = isScript ? "formatScript" : "format";
+				Method formatterMethod = ktlintClass.getMethod(formatterMethodName, String.class, Iterable.class, Map.class, function2Interface);
+				formatterFunc = input -> {
+					try {
+						return (String) formatterMethod.invoke(ktlint, input, ruleSets, userData, formatterCallback);
+					} catch (InvocationTargetException e) {
+						throw ThrowingEx.unwrapCause(e);
+					}
+				};
+			}
+
+			return formatterFunc;
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -143,12 +143,12 @@ public class KtLintStep {
 			if (useParams) {
 				//
 				// In KtLint 0.34+ there is a new "format(params: Params)" function. We create an
-				// instance of the Params class with our configuration and call it here.
+				// instance of the Params class with our configuration and invoke it here.
 				//
 
 				// grab the Params class
 				Class<?> paramsClass = classLoader.loadClass(pkg + ".ktlint.core.KtLint$Params");
-				// and its format method
+				// and its constructor
 				Constructor<?> constructor = paramsClass.getConstructor(
 						/* fileName, nullable */ String.class,
 						/* text */ String.class,

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -15,11 +15,6 @@
  */
 package com.diffplug.spotless.kotlin;
 
-import com.diffplug.spotless.FormatterFunc;
-import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.JarState;
-import com.diffplug.spotless.Provisioner;
-import com.diffplug.spotless.ThrowingEx;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
@@ -32,6 +27,12 @@ import java.util.Objects;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.JarState;
+import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.ThrowingEx;
 
 /** Wraps up [ktlint](https://github.com/pinterest/ktlint) as a FormatterStep. */
 public class KtLintStep {
@@ -149,28 +150,26 @@ public class KtLintStep {
 				Class<?> paramsClass = classLoader.loadClass(pkg + ".ktlint.core.KtLint$Params");
 				// and its format method
 				Constructor<?> constructor = paramsClass.getConstructor(
-					/* fileName, nullable */ String.class,
-					/* text */ String.class,
-					/* ruleSets */ Iterable.class,
-					/* userData */ Map.class,
-					/* callback */ function2Interface,
-					/* script */ boolean.class,
-					/* editorConfigPath, nullable */ String.class,
-					/* debug */ boolean.class
-				);
+						/* fileName, nullable */ String.class,
+						/* text */ String.class,
+						/* ruleSets */ Iterable.class,
+						/* userData */ Map.class,
+						/* callback */ function2Interface,
+						/* script */ boolean.class,
+						/* editorConfigPath, nullable */ String.class,
+						/* debug */ boolean.class);
 				Method formatterMethod = ktlintClass.getMethod("format", paramsClass);
 				formatterFunc = input -> {
 					try {
 						Object params = constructor.newInstance(
-							/* fileName, nullable */ null,
-							/* text */ input,
-							/* ruleSets */ ruleSets,
-							/* userData */ userData,
-							/* callback */ formatterCallback,
-							/* script */ isScript,
-							/* editorConfigPath, nullable */ null,
-							/* debug */ false
-						);
+								/* fileName, nullable */ null,
+								/* text */ input,
+								/* ruleSets */ ruleSets,
+								/* userData */ userData,
+								/* callback */ formatterCallback,
+								/* script */ isScript,
+								/* editorConfigPath, nullable */ null,
+								/* debug */ false);
 						return (String) formatterMethod.invoke(ktlint, params);
 					} catch (InvocationTargetException e) {
 						throw ThrowingEx.unwrapCause(e);

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -146,7 +146,7 @@ public class KtLintStep {
 				//
 
 				// grab the Params class
-				Class<?> paramsClass = classLoader.loadClass(pkg + ".ktlint.core.KtLint.Params");
+				Class<?> paramsClass = classLoader.loadClass(pkg + ".ktlint.core.KtLint$Params");
 				// and its format method
 				Constructor<?> constructor = paramsClass.getConstructor(
 					/* fileName, nullable */ String.class,

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Spotless no longer breaks configuration avoidance for other tasks (specifically the `check` task and all of its dependees) ([#463](https://github.com/diffplug/spotless/pull/463)).
   * Important change: **Formerly, Spotless did not create its tasks until the `afterEvaluate` phase.  Spotless now creates them as soon as the plugin is applied**, and it creates the format-specific tasks as soon as the formats are defined.  There is no performance degradation associated with this change, and it makes configuring Spotless easier.
+* Add support for ktlint `0.34+`, and bump default version from `0.32.0` to `0.34.2`. ([#469](https://github.com/diffplug/spotless/pull/469))
 
 ### Version 3.24.3 - September 23rd 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.24.3/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.24.3))
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -215,7 +215,7 @@
 ### Version 3.1.0 - February 27th 2017 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.1.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.1.0))
 
 * Added support for Scala via [scalafmt](https://github.com/olafurpg/scalafmt).
-* Added support for Kotlin via [ktlint](https://github.com/shyiko/ktlint).
+* Added support for Kotlin via [ktlint](https://github.com/pinterest/ktlint).
 * Added `FormatExtension::replaceStep`.
 * `paddedCell()` is no longer required if a misbehaving rule converges.
 * Any errors in a step will now fail the build - previously they were only warned.

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -83,7 +83,7 @@ Spotless can check and apply formatting to any plain-text file, using simple rul
 * Google's [google-java-format](https://github.com/google/google-java-format)
 * [Groovy Eclipse](#groovy-eclipse)'s groovy code formatter
 * [FreshMark](https://github.com/diffplug/freshmark) (markdown with variables)
-* [ktlint](https://github.com/shyiko/ktlint)
+* [ktlint](https://github.com/pinterest/ktlint)
 * [scalafmt](https://github.com/olafurpg/scalafmt)
 * [DBeaver sql format](https://dbeaver.jkiss.org/)
 * [Prettier: An opinionated code formatter](https://prettier.io)
@@ -252,7 +252,7 @@ spotless {
 
 <a name="ktlint"></a>
 
-## Applying [ktlint](https://github.com/shyiko/ktlint) to Kotlin files
+## Applying [ktlint](https://github.com/pinterest/ktlint) to Kotlin files
 
 ```gradle
 spotless {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -15,19 +15,17 @@
  */
 package com.diffplug.gradle.spotless;
 
-import static com.diffplug.spotless.kotlin.KotlinConstants.LICENSE_HEADER_DELIMITER;
-
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.kotlin.KtLintStep;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 
-import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.kotlin.KtLintStep;
+import static com.diffplug.spotless.kotlin.KotlinConstants.LICENSE_HEADER_DELIMITER;
 
 public class KotlinExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "kotlin";
@@ -46,7 +44,7 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 		return licenseHeaderFile(licenseHeaderFile, LICENSE_HEADER_DELIMITER);
 	}
 
-	/** Adds the specified version of [ktlint](https://github.com/shyiko/ktlint). */
+	/** Adds the specified version of [ktlint](https://github.com/pinterest/ktlint). */
 	public KotlinFormatExtension ktlint(String version) {
 		Objects.requireNonNull(version);
 		return new KotlinFormatExtension(version, Collections.emptyMap());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -15,17 +15,19 @@
  */
 package com.diffplug.gradle.spotless;
 
-import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.kotlin.KtLintStep;
+import static com.diffplug.spotless.kotlin.KotlinConstants.LICENSE_HEADER_DELIMITER;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 
-import static com.diffplug.spotless.kotlin.KotlinConstants.LICENSE_HEADER_DELIMITER;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.kotlin.KtLintStep;
 
 public class KotlinExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "kotlin";

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -32,7 +32,7 @@ public class KotlinGradleExtension extends FormatExtension {
 		super(rootExtension);
 	}
 
-	/** Adds the specified version of [ktlint](https://github.com/shyiko/ktlint). */
+	/** Adds the specified version of [ktlint](https://github.com/pinterest/ktlint). */
 	public KotlinFormatExtension ktlint(String version) {
 		Objects.requireNonNull(version, "version");
 		return new KotlinFormatExtension(version, Collections.emptyMap());

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -74,7 +74,7 @@ public class KotlinGradleExtensionTest extends GradleIntegrationTest {
 	}
 
 	@Test
-	public void integration_shyiko() throws IOException {
+	public void integration_pinterest() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
 				"    id 'nebula.kotlin' version '1.0.6'",

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 1.25.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
+* Add support for ktlint `0.34+`, and bump default version from `0.32.0` to `0.34.2`. ([#469](https://github.com/diffplug/spotless/pull/469))
+
 ### Version 1.24.3 - September 23rd 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.24.3/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.24.3))
 
 * Update jgit from `5.3.2.201906051522-r` to `5.5.0.201909110433-r`. ([#445](https://github.com/diffplug/spotless/pull/445))

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -162,7 +162,7 @@ By default, all files matching `src/main/kotlin/**/*.kt` and `src/test/kotlin/**
      <endWithNewLine/>
      <trimTrailingWhitespace/>
      <ktlint>
-       <!-- Optional, available versions: https://github.com/shyiko/ktlint/releases -->
+       <!-- Optional, available versions: https://github.com/pinterest/ktlint/releases -->
        <version>0.14.0</version>
      </ktlint>
   </kotlin>

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -37,7 +37,7 @@ public class KtlintTest extends MavenIntegrationTest {
 	}
 
 	@Test
-	public void testKtlintPinterest() throws Exception {
+	public void testKtlintShyiko() throws Exception {
 		writePomWithKotlinSteps("<ktlint><version>0.21.0</version></ktlint>");
 
 		String path1 = "src/main/kotlin/main1.kt";

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -37,7 +37,7 @@ public class KtlintTest extends MavenIntegrationTest {
 	}
 
 	@Test
-	public void testKtlintShyiko() throws Exception {
+	public void testKtlintPinterest() throws Exception {
 		writePomWithKotlinSteps("<ktlint><version>0.21.0</version></ktlint>");
 
 		String path1 = "src/main/kotlin/main1.kt";

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -15,13 +15,12 @@
  */
 package com.diffplug.spotless.kotlin;
 
-import org.junit.Test;
-
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
+import org.junit.Test;
 
 public class KtLintStepTest extends ResourceHarness {
 	@Test
@@ -52,8 +51,11 @@ public class KtLintStepTest extends ResourceHarness {
 				});
 	}
 
+	// Regression test to ensure it works on the version it switched to Pinterest (version 0.32.0)
+	// but before 0.34.
+	// https://github.com/diffplug/spotless/issues/419
 	@Test
-	public void worksPinterest() throws Exception {
+	public void worksPinterestAndPre034() throws Exception {
 		// Must use jcenter because `com.andreapivetta.kolor:kolor:0.0.2` isn't available on mavenCentral.
 		// It is a dependency of ktlint.
 		FormatterStep step = KtLintStep.create("0.32.0", TestProvisioner.jcenter());

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -39,7 +39,7 @@ public class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
-	public void worksShyiko() throws Exception {
+	public void worksPinterest() throws Exception {
 		// Must use jcenter because `com.andreapivetta.kolor:kolor:0.0.2` isn't available on mavenCentral.
 		// It is a dependency of ktlint.
 		FormatterStep step = KtLintStep.create("0.31.0", TestProvisioner.jcenter());

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -39,7 +39,7 @@ public class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
-	public void worksPinterest() throws Exception {
+	public void worksShyiko() throws Exception {
 		// Must use jcenter because `com.andreapivetta.kolor:kolor:0.0.2` isn't available on mavenCentral.
 		// It is a dependency of ktlint.
 		FormatterStep step = KtLintStep.create("0.31.0", TestProvisioner.jcenter());

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.kotlin;
 
+import org.junit.Test;
+
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
-import org.junit.Test;
 
 public class KtLintStepTest extends ResourceHarness {
 	@Test


### PR DESCRIPTION
This resolves #419 by invoking the new `format(Params)` API in KtLint 0.34+. This API also lays groundwork for adding editorconfig in the future since the new `Params` API allows specifying one. Opportunistically also fixed some stale names in 3812713.

Starting this now for early review, will add a test next.