### PR TITLE
fix project URLs in maven poms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ You might be looking for:
 - [plugin-maven/CHANGES.md](plugin-maven/CHANGES.md)
 
 ### Version 1.26.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
+* Fix project URLs in poms. ([#478](https://github.com/diffplug/spotless/pull/478))
 
 ### Version 1.25.0 - October 6th 2019 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.25.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.25.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 

--- a/_ext/gradle/java-publish.gradle
+++ b/_ext/gradle/java-publish.gradle
@@ -50,11 +50,11 @@ publishing {
 					resolveStrategy = Closure.DELEGATE_FIRST
 					name project.ext_artifactId
 					description project.ext_description
-					url "https://github.com/${project.ext_org}/${project.name}"
+					url "https://github.com/${project.ext_org}/${rootProject.name}"
 					scm {
-						url "https://github.com/${project.ext_org}/${project.name}"
-						connection "scm:git:git://github.com/${project.ext_org}/${project.name}"
-						developerConnection "scm:git:ssh:git@github.com/${project.ext_org}/${project.name}"
+						url "https://github.com/${project.ext_org}/${rootProject.name}"
+						connection "scm:git:https://github.com/${project.ext_org}/${rootProject.name}.git"
+						developerConnection "scm:git:ssh:git@github.com/${project.ext_org}/${rootProject.name}.git"
 					}
 					licenses {
 						license {

--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -86,11 +86,11 @@ model {
 						resolveStrategy = Closure.DELEGATE_FIRST
 						name project.ext.artifactId
 						description project.description
-						url "https://github.com/${project.org}/${project.name}"
+						url "https://github.com/${project.org}/${rootProject.name}"
 						scm {
-							url "https://github.com/${project.org}/${project.name}"
-							connection "scm:git:git://github.com/${project.org}/${project.name}"
-							developerConnection "scm:git:ssh:git@github.com/${project.org}/${project.name}"
+							url "https://github.com/${project.org}/${rootProject.name}"
+							connection "scm:git:https://github.com/${project.org}/${rootProject.name}.git"
+							developerConnection "scm:git:ssh:git@github.com/${project.org}/${rootProject.name}.git"
 						}
 						licenses {
 							license {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -1,6 +1,7 @@
 # spotless-plugin-gradle releases
 
 ### Version 3.26.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
+* Fix project URLs in poms. ([#478](https://github.com/diffplug/spotless/pull/478))
 
 ### Version 3.25.0 - October 6th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.25.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.25.0))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -1,6 +1,7 @@
 # spotless-plugin-maven releases
 
 ### Version 1.26.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
+* Fix project URLs in poms. ([#478](https://github.com/diffplug/spotless/pull/478))
 
 ### Version 1.25.1 - October 7th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.25.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.25.1))
 


### PR DESCRIPTION
When dependabot sent me a PR to update my spotless version it presented a hyperlink to this repository that didn't work because it became:
https://github.com/diffplug/plugin-gradle instead of https://github.com/diffplug/spotless