### PR TITLE
Fix NPE in EclipseXmlFormatterStepImpl (#489)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ You might be looking for:
 ### Version 1.27.0-SNAPSHOT - TBD (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/snapshot/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/snapshot/), [snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/))
 
 * Revert the change in console display of errors from 1.26.0 ([#485](https://github.com/diffplug/spotless/pull/485)) because [of these problems](https://github.com/diffplug/spotless/pull/485#issuecomment-552925932).
+* Bugfix: Fix NPE in EclipseXmlFormatterStepImpl ([#489](https://github.com/diffplug/spotless/pull/489))
 
 ### Version 1.26.0 - November 11th 2019 (javadoc [lib](https://diffplug.github.io/spotless/javadoc/spotless-lib/1.26.0/) [lib-extra](https://diffplug.github.io/spotless/javadoc/spotless-lib-extra/1.26.0/), artifact [lib]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib), [lib-extra]([jcenter](https://bintray.com/diffplug/opensource/spotless-lib-extra)))
 

--- a/_ext/eclipse-groovy/src/main/java/com/diffplug/spotless/extra/eclipse/groovy/GrEclipseFormatterStepImpl.java
+++ b/_ext/eclipse-groovy/src/main/java/com/diffplug/spotless/extra/eclipse/groovy/GrEclipseFormatterStepImpl.java
@@ -55,14 +55,14 @@ public class GrEclipseFormatterStepImpl {
 	private final boolean ignoreFormatterProblems;
 
 	public GrEclipseFormatterStepImpl(final Properties properties) throws Exception {
-		if (SpotlessEclipseFramework.setup(
+		SpotlessEclipseFramework.setup(
 				config -> {
 					config.applyDefault();
 					config.useSlf4J(GrEclipseFormatterStepImpl.class.getPackage().getName());
 				},
 				plugins -> {
 					plugins.add(new GroovyCoreActivator());
-				})) {}
+				});
 		PreferenceStore preferences = createPreferences(properties);
 		preferencesStore = new FormatterPreferencesOnStore(preferences);
 		ignoreFormatterProblems = Boolean.parseBoolean(properties.getProperty(IGNORE_FORMATTER_PROBLEMS, "false"));

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -1,5 +1,9 @@
 # spotless-eclipse-wtp
 
+### Version 3.15.1 - November 27th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
+
+* Bugfix: Fix NPE in EclipseXmlFormatterStepImpl ([#490](https://github.com/diffplug/spotless/pull/490)).
+
 ### Version 3.15.0 - November 6th 2019 ([artifact]([jcenter](https://bintray.com/diffplug/opensource/spotless-eclipse-wtp)))
 
 * Switch to Eclipse WTP release 3.15.0 for Eclipse 4.13 ([#480](https://github.com/diffplug/spotless/issues/480)).

--- a/_ext/eclipse-wtp/gradle.properties
+++ b/_ext/eclipse-wtp/gradle.properties
@@ -1,7 +1,7 @@
 # Versions correspond to the Eclipse-WTP version used for the fat-JAR.
 # See https://www.eclipse.org/webtools/ for further information about Eclipse-WTP versions.
 # Patch version can be incremented independently for backward compatible patches of this library. 
-ext_version=3.15.0
+ext_version=3.15.1
 ext_artifactId=spotless-eclipse-wtp
 ext_description=Eclipse's WTP formatters bundled for Spotless
 

--- a/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImpl.java
+++ b/_ext/eclipse-wtp/src/main/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseXmlFormatterStepImpl.java
@@ -67,7 +67,7 @@ public class EclipseXmlFormatterStepImpl {
 		xmlAdapterFactory = new ModelQueryAdapterFactoryForXML();
 	}
 
-	private static void setupFramework(boolean resolveExternalURI) throws BundleException {
+	private synchronized static void setupFramework(boolean resolveExternalURI) throws BundleException {
 		if (SpotlessEclipseFramework.setup(
 				config -> {
 					config.applyDefault();

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.0.lockfile
@@ -1,5 +1,5 @@
 # Spotless formatter based on Eclipse-WTP version 3.15 (see https://www.eclipse.org/webtools/)
-com.diffplug.spotless:spotless-eclipse-wtp:3.15.0
+com.diffplug.spotless:spotless-eclipse-wtp:3.15.1
 com.diffplug.spotless:spotless-eclipse-base:3.2.1
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 ### Version 3.27.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
 * Revert the change in console display of errors from 3.26.0 ([#485](https://github.com/diffplug/spotless/pull/485)) because [of these problems](https://github.com/diffplug/spotless/pull/485#issuecomment-552925932).
+* Bugfix: Fix NPE in EclipseXmlFormatterStepImpl ([#489](https://github.com/diffplug/spotless/pull/489))
 
 ### Version 3.26.0 - November 11th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.26.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.26.0))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 ### Version 1.27.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-maven-plugin/))
 
 * Revert the change in console display of errors from 1.26.0 ([#485](https://github.com/diffplug/spotless/pull/485)) because [of these problems](https://github.com/diffplug/spotless/pull/485#issuecomment-552925932).
+* Bugfix: Fix NPE in EclipseXmlFormatterStepImpl ([#489](https://github.com/diffplug/spotless/pull/489))
 
 ### Version 1.26.0 - November 11th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-maven-plugin/1.26.0/), [jcenter](https://bintray.com/diffplug/opensource/spotless-maven-plugin/1.26.0))
 


### PR DESCRIPTION
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/master/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
