### PR TITLE
Fix bug when `gradle clean spotlessCheck` was called on parallel build

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -2,7 +2,8 @@
 
 ### Version 3.27.0-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/spotless/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/spotless/spotless-plugin-gradle/))
 
-* Added method `FormatExtension.createIndependentTask(String taskName)` which allows creating a Spotless task outside of the `check`/`apply` lifecycle.  See [javadoc](https://github.com/diffplug/spotless/blob/91ed7203994e52058ea6c2e0f88d023ed290e433/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java#L613-L639) for details.
+* Added method `FormatExtension.createIndependentTask(String taskName)` which allows creating a Spotless task outside of the `check`/`apply` lifecycle.  See [javadoc](https://github.com/diffplug/spotless/blob/91ed7203994e52058ea6c2e0f88d023ed290e433/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java#L613-L639) for details. ([#500](https://github.com/diffplug/spotless/pull/500))
+* Running clean and spotlessCheck during a parallel build could cause exceptions, fixed by ([#501](https://github.com/diffplug/spotless/pull/501)).
 
 ### Version 3.26.1 - November 27th 2019 ([javadoc](https://diffplug.github.io/spotless/javadoc/spotless-plugin-gradle/3.26.1/), [jcenter](https://bintray.com/diffplug/opensource/spotless-plugin-gradle/3.26.1))
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -36,7 +36,17 @@ public class SpotlessPlugin implements Plugin<Project> {
 
 		// clear spotless' cache when the user does a clean
 		Task clean = project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME);
-		clean.doLast(unused -> SpotlessCache.clear());
+		clean.doLast(unused -> {
+			// resolution for: https://github.com/diffplug/spotless/issues/243#issuecomment-564323856
+			// project.getRootProject() is consistent across every project, so only of one the clears will
+			// actually happen (as desired)
+			SpotlessCache.clearOnce(project.getRootProject());
+			// if we hang onto the rootProject forever, that's a decent-size memory leak
+			// by setting to null, we force a second clear, but we prevent
+			project.getGradle().buildFinished(result -> {
+				SpotlessCache.clearOnce(null);
+			});
+		});
 
 		project.afterEvaluate(unused -> {
 			// Add our check task as a dependency on the global check task

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -40,12 +40,9 @@ public class SpotlessPlugin implements Plugin<Project> {
 			// resolution for: https://github.com/diffplug/spotless/issues/243#issuecomment-564323856
 			// project.getRootProject() is consistent across every project, so only of one the clears will
 			// actually happen (as desired)
-			SpotlessCache.clearOnce(project.getRootProject());
-			// if we hang onto the rootProject forever, that's a decent-size memory leak
-			// by setting to null, we force a second clear, but we prevent
-			project.getGradle().buildFinished(result -> {
-				SpotlessCache.clearOnce(null);
-			});
+			//
+			// we use System.identityHashCode() to avoid a memory leak by hanging on to the reference directly
+			SpotlessCache.clearOnce(System.identityHashCode(project.getRootProject()));
 		});
 
 		project.afterEvaluate(unused -> {


### PR DESCRIPTION
Fixes #243