### PR TITLE
Add `pull_request` to Wrapper Validation Triggers

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,5 @@
 name: "Validate Gradle Wrapper"
-on: [push]
+on: [push, pull_request]
 
 jobs:
   validation:


### PR DESCRIPTION
Someone let me know that `push` only works for maintainers. You need `pull_request` for it to trigger for non-maintainers.