### PR TITLE
Fix scala and kotlin maven config documentation

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Fix scala and kotlin maven config documentation.
 
 ## [1.27.0] - 2020-01-01
 * Should be no changes whatsoever!  Released only for consistency with lib and plugin-gradle.

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -134,7 +134,7 @@ By default, all files matching `src/main/scala/**/*.scala`, `src/test/scala/**/*
        <content>/* Licensed under Apache-2.0 */</content>
        <file>${basedir}/license-header</file>
      </licenseHeader>
-     <endWithNewLine/>
+     <endWithNewline/>
      <trimTrailingWhitespace/>
      <scalafmt>
        <file>${basedir}/scalafmt.conf</file>
@@ -159,7 +159,7 @@ By default, all files matching `src/main/kotlin/**/*.kt` and `src/test/kotlin/**
        <content>/* Licensed under Apache-2.0 */</content>
        <file>${basedir}/license-header</file>
      </licenseHeader>
-     <endWithNewLine/>
+     <endWithNewline/>
      <trimTrailingWhitespace/>
      <ktlint>
        <!-- Optional, available versions: https://github.com/pinterest/ktlint/releases -->


### PR DESCRIPTION
This documentation allows for the maven plugin for kotlin and scala to work as expected. The case was mixed up for the maven plugin `endWithNewLine` instead of `endWithNewline`.
