### PR TITLE
Add Tests

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Add tests to `SpecificFilesTest` to fix [#529](https://github.com/diffplug/spotless/issues/529)
 
 ## [3.27.1] - 2020-01-14
 ### Fixed

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
@@ -57,10 +57,14 @@ public class GradleIntegrationTest extends ResourceHarness {
 	}
 
 	protected final GradleRunner gradleRunner() throws IOException {
+		return gradleRunner(false);
+	}
+
+	protected final GradleRunner gradleRunner(boolean isKotlin) throws IOException {
 		return GradleRunner.create()
 				// Test against Gradle 2.14.1 in order to maintain backwards compatibility.
 				// https://github.com/diffplug/spotless/issues/161
-				.withGradleVersion("2.14.1")
+				.withGradleVersion(isKotlin ? "4.0" : "2.14.1")
 				.withProjectDir(rootFolder())
 				.withPluginClasspath();
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
@@ -57,14 +57,10 @@ public class GradleIntegrationTest extends ResourceHarness {
 	}
 
 	protected final GradleRunner gradleRunner() throws IOException {
-		return gradleRunner(false);
-	}
-
-	protected final GradleRunner gradleRunner(boolean isKotlin) throws IOException {
 		return GradleRunner.create()
 				// Test against Gradle 2.14.1 in order to maintain backwards compatibility.
 				// https://github.com/diffplug/spotless/issues/161
-				.withGradleVersion(isKotlin ? "4.0" : "2.14.1")
+				.withGradleVersion("2.14.1")
 				.withProjectDir(rootFolder())
 				.withPluginClasspath();
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
@@ -17,28 +17,59 @@ package com.diffplug.gradle.spotless;
 
 import java.io.IOException;
 
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SpecificFilesTest extends GradleIntegrationTest {
-	private String testFile(int number, boolean absolute) throws IOException {
-		String rel = "src/main/java/test" + number + ".java";
+	private String testFilePath(int number) {
+		return testFilePath(number, true);
+	}
+
+	private String testFilePath(int number, boolean absolute) {
+		String relPath = "src/main/java/test" + number + ".java";
 		if (absolute) {
-			return rootFolder() + "/" + rel;
+			return rootFolder() + "/" + relPath;
 		} else {
-			return rel;
+			return relPath;
 		}
 	}
 
-	private String testFile(int number) throws IOException {
-		return testFile(number, false);
+	private String fixture() {
+		return fixture(false);
 	}
 
 	private String fixture(boolean formatted) {
 		return "java/googlejavaformat/JavaCode" + (formatted ? "F" : "Unf") + "ormatted.test";
 	}
 
-	private void integration(String patterns, boolean firstFormatted, boolean secondFormatted, boolean thirdFormatted)
-			throws IOException {
+	private void createBuildScript() throws IOException {
+		createBuildScript(false);
+	}
+
+	private void createBuildScript(boolean isKotlin) throws IOException {
+		if (isKotlin) {
+			setFile("build.gradle.kts").toLines(
+					"import com.diffplug.gradle.spotless.SpotlessExtension",
+					"buildscript {",
+					"    repositories {",
+					"        mavenCentral()",
+					"    }",
+					"    dependencies {",
+					"        classpath(\"com.diffplug.spotless:spotless-plugin-gradle:3.27.1\")",
+					"    }",
+					"}",
+					"plugins {",
+					"    java",
+					"    id(\"com.diffplug.gradle.spotless\")",
+					"}",
+					"configure<SpotlessExtension> {",
+					"    java {",
+					"        googleJavaFormat(\"1.2\")",
+					"    }",
+					"}");
+			return;
+		}
 
 		setFile("build.gradle").toLines(
 				"buildscript { repositories { mavenCentral() } }",
@@ -51,32 +82,74 @@ public class SpecificFilesTest extends GradleIntegrationTest {
 				"        googleJavaFormat('1.2')",
 				"    }",
 				"}");
+	}
 
-		setFile(testFile(1)).toResource(fixture(false));
-		setFile(testFile(2)).toResource(fixture(false));
-		setFile(testFile(3)).toResource(fixture(false));
+	private void integration(String patterns,
+			boolean firstFormatted, boolean secondFormatted, boolean thirdFormatted) throws IOException {
+		integration(patterns, firstFormatted, secondFormatted, thirdFormatted, false);
+	}
 
-		gradleRunner()
+	private void integration(String patterns,
+			boolean firstFormatted, boolean secondFormatted, boolean thirdFormatted,
+			boolean isKotlin) throws IOException {
+		String testFileOne = testFilePath(1, false);
+		String testFileTwo = testFilePath(2, false);
+		String testFileThree = testFilePath(3, false);
+
+		setFile(testFileOne).toResource(fixture());
+		setFile(testFileTwo).toResource(fixture());
+		setFile(testFileThree).toResource(fixture());
+
+		gradleRunner(isKotlin)
 				.withArguments("spotlessApply", "-PspotlessFiles=" + patterns)
 				.build();
 
-		assertFile(testFile(1)).sameAsResource(fixture(firstFormatted));
-		assertFile(testFile(2)).sameAsResource(fixture(secondFormatted));
-		assertFile(testFile(3)).sameAsResource(fixture(thirdFormatted));
+		assertFile(testFileOne).sameAsResource(fixture(firstFormatted));
+		assertFile(testFileTwo).sameAsResource(fixture(secondFormatted));
+		assertFile(testFileThree).sameAsResource(fixture(thirdFormatted));
 	}
 
 	@Test
 	public void singleFile() throws IOException {
-		integration(testFile(2, true), false, true, false);
+		createBuildScript(false);
+		integration(testFilePath(2), false, true, false);
 	}
 
 	@Test
 	public void multiFile() throws IOException {
-		integration(testFile(1, true) + "," + testFile(3, true), true, false, true);
+		createBuildScript();
+		integration(testFilePath(1) + "," + testFilePath(3),
+				true, false, true);
+	}
+
+	@Test
+	@Ignore("When spotlessFiles is specified without a value, Spotless runs on all files. It should run on none.")
+	public void emptyPattern_formatsNoFiles() throws IOException {
+		createBuildScript();
+		integration("", false, false, false);
+	}
+
+	@Test
+	public void matchesNoFiles_formatsNoFilesButDoesNotExitInError() throws IOException {
+		createBuildScript();
+		integration(testFilePath(4), false, false, false);
 	}
 
 	@Test
 	public void regexp() throws IOException {
+		createBuildScript();
 		integration(".*/src/main/java/test(1|3).java", true, false, true);
+	}
+
+	@Test(expected = UnexpectedBuildFailure.class)
+	public void invalidRegexp_exitsInError() throws IOException {
+		createBuildScript(false);
+		integration("./[?)!\\", false, false, false);
+	}
+
+	@Test
+	public void kotlinBuildScript() throws IOException {
+		createBuildScript(true);
+		integration(testFilePath(2), false, true, false, true);
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
@@ -17,7 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import java.io.IOException;
 
-import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.gradle.testkit.runner.*;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -100,9 +100,12 @@ public class SpecificFilesTest extends GradleIntegrationTest {
 		setFile(testFileTwo).toResource(fixture());
 		setFile(testFileThree).toResource(fixture());
 
-		gradleRunner(isKotlin)
-				.withArguments("spotlessApply", "-PspotlessFiles=" + patterns)
-				.build();
+		GradleRunner runner = gradleRunner()
+				.withArguments("spotlessApply", "-PspotlessFiles=" + patterns);
+		if (isKotlin) {
+			runner.withGradleVersion("4.0");
+		}
+		runner.build();
 
 		assertFile(testFileOne).sameAsResource(fixture(firstFormatted));
 		assertFile(testFileTwo).sameAsResource(fixture(secondFormatted));


### PR DESCRIPTION
fixes #529 

## Changes

Add tests for the following cases:

* Empty pattern passed to spotlessFiles
* A pattern that matches no files passed to spotlessFiles
* Invalid regexp passed to spotlessFiles
* Spotless is configured with a Kotlin build script

Also a little reorganization, and a change required to support Kotlin
build script was added to GradleIntegrationTest.java so that other tests
can make use of it.

I'd be more than willing to also fix the IntelliJ warnings (unused method, unnecessary ```throws```, and access modifiers that can be more restrictive) in ```GradleIntegrationTest.java``` if you'd like. As a rule of thumb, I generally do incremental style fixes when making other changes to a file (in a separate commit, but the same PR. Happy to break this convention if you prefer).

## Suggestion

Perhaps consider renaming ```GradleIntegrationTest```. Maybe something like  ```GradleIntegrationTestHarness```  would be a better name. In my experience, it's best practice for the names only of test classes to end in ```Test```, rather than also doing so for testing infrastructure. For example, I sometimes will search the test source directory with the intent of only looking at testing infrastructure, rather than tests. I actually did so in writing this change. Sometimes people get around this by putting their test classes in a separate directory from testing infrastructure, though this does not appear to be the case for Spotless. This makes proper naming of testing infrastructure especially important. Even in other cases, I still see it as the cleaner naming convention. I'd be happy to make this change, if you'd like.

## Question

When an empty pattern is passed to ```spotlessFiles```, what should be the behavior? The test I've written currently assumes that the correct behavior is for Spotless not to format any files. Note that this is not the way Spotless currently behaves: It currently acts as though ```spotlessFiles``` is unspecified and formats all files matched by ```target```. I have added an ```@Ignore``` annotation to that test case.
