### PR TITLE
Added eclipse-wtp 3.15.2 to Eclipse (as pseudo Eclipse version 4.13.1).

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -37,7 +37,7 @@ public enum EclipseWtpFormatterStep {
 
 	private static final String NAME = "eclipse wtp formatters";
 	private static final String FORMATTER_PACKAGE = "com.diffplug.spotless.extra.eclipse.wtp.";
-	private static final String DEFAULT_VERSION = "4.13.0";
+	private static final String DEFAULT_VERSION = "4.13.1";
 	private static final String FORMATTER_METHOD = "format";
 
 	private final String implementationClassName;

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.1.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.1.lockfile
@@ -1,0 +1,25 @@
+# Spotless formatter based on Eclipse-WTP version 3.15 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.15.2
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.google.code.findbugs:annotations:3.0.0
+com.google.code.findbugs:jsr305:3.0.0
+com.ibm.icu:icu4j:61.2
+org.eclipse.emf:org.eclipse.emf.common:2.16.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.19.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.500
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.400
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.700
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.500
+org.eclipse.platform:org.eclipse.core.jobs:3.10.500
+org.eclipse.platform:org.eclipse.core.resources:3.13.500
+org.eclipse.platform:org.eclipse.core.runtime:3.16.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.300
+org.eclipse.platform:org.eclipse.equinox.common:3.10.500
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.500
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.500
+org.eclipse.platform:org.eclipse.jface.text:3.15.300
+org.eclipse.platform:org.eclipse.jface:3.17.0
+org.eclipse.platform:org.eclipse.osgi.services:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.15.0
+org.eclipse.platform:org.eclipse.text:3.9.0
+org.eclipse.xsd:org.eclipse.xsd:2.12.0

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -76,7 +76,7 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a", "4.7.3b", "4.8.0", "4.12.0", "4.13.0"};
+		return new String[]{"4.7.3a", "4.7.3b", "4.8.0", "4.12.0", "4.13.0", "4.13.1"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* WTP based formatter do not apply configuration in parallel builds [#492](https://github.com/diffplug/spotless/issues/492). Fixed with WTP version 4.13.1. Note that this version no longer supports multiple configurations as explained in the [documentation](https://github.com/diffplug/spotless/blob/master/plugin-gradle/README.md).
 
 ## [3.27.2] - 2020-03-05
 * Add tests to `SpecificFilesTest` to fix [#529](https://github.com/diffplug/spotless/issues/529)

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -519,6 +519,9 @@ Unlike Eclipse, Spotless WTP ignores per default external URIs in schema locatio
 external entities. To allow the access of external URIs, set the property `resolveExternalURI`
 to true.
 
+Unlike other Eclipse based formatters, Spotless WTP does not support multiple configurations
+per formatter type. For example running `eclipseWtp('xml')` in the same project (or subprojects) with different configurations will raise an error.
+
 <a name="license-header"></a>
 
 ## License header options

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,7 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
 * Fix scala and kotlin maven config documentation.
+* WTP based formatter do not apply configuration in parallel builds [#492](https://github.com/diffplug/spotless/issues/492). Fixed with WTP version 4.13.1. Note that this version no longer supports multiple configurations as explained in the [documentation](https://github.com/diffplug/spotless/blob/master/plugin-maven/README.md).
+
 
 ## [1.27.0] - 2020-01-01
 * Should be no changes whatsoever!  Released only for consistency with lib and plugin-gradle.

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -310,6 +310,9 @@ Unlike Eclipse, Spotless WTP ignores per default external URIs in schema locatio
 external entities. To allow the access of external URIs, set the property `resolveExternalURI`
 to true.
 
+Unlike other Eclipse based formatters, Spotless WTP does not support multiple configurations
+per formatter type. For example running `<eclipseWtp><type>XML` in the same module (or submodule) with different configurations will raise an error.
+
 <a name="invisible"></a>
 
 ## Line endings and encodings (invisible stuff)


### PR DESCRIPTION
Fix #492.
Introduced pseudo Eclipse version 4.13.1 since the new approach does not support multiple WTP configurations (for the same WTP type). So the user still has the possibility to use 4.13.0.

If any user needs multiple WTP configurations, please raise an issue.