### PR TITLE
Applied latest eclipse-wtp in Eclipse version 4.13.0

### DIFF
--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Eclipse-WTP version 3.15 (see https://www.eclipse.org/webtools/)
-com.diffplug.spotless:spotless-eclipse-wtp:3.15.1
-com.diffplug.spotless:spotless-eclipse-base:3.2.1
+com.diffplug.spotless:spotless-eclipse-wtp:3.15.2
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0
 com.ibm.icu:icu4j:61.2
@@ -9,7 +9,7 @@ org.eclipse.emf:org.eclipse.emf.ecore:2.19.0
 org.eclipse.platform:org.eclipse.core.commands:3.9.500
 org.eclipse.platform:org.eclipse.core.contenttype:3.7.400
 org.eclipse.platform:org.eclipse.core.filebuffers:3.6.700
-org.eclipse.platform:org.eclipse.core.filesystem:1.7.500
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.600
 org.eclipse.platform:org.eclipse.core.jobs:3.10.500
 org.eclipse.platform:org.eclipse.core.resources:3.13.500
 org.eclipse.platform:org.eclipse.core.runtime:3.16.0

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Eclipse-WTP formatter (web tools platform, not java) could encounter errors in parallel multiproject builds [#492](https://github.com/diffplug/spotless/issues/492). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).
 
 ## [3.27.2] - 2020-03-05
 * Add tests to `SpecificFilesTest` to fix [#529](https://github.com/diffplug/spotless/issues/529)

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,7 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
 * Fix scala and kotlin maven config documentation.
+* Eclipse-WTP formatter (web tools platform, not java) could encounter errors in parallel multiproject builds [#492](https://github.com/diffplug/spotless/issues/492). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).
 
 ## [1.27.0] - 2020-01-01
 * Should be no changes whatsoever!  Released only for consistency with lib and plugin-gradle.


### PR DESCRIPTION
Modified WTP Eclipse version 4.13.0 to use eclipse-wtp 3.15.2 as provided with  #533. 
Fixes #492.