### PR TITLE
Enable support for intelliJ placeholder for year in license header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,13 +10,14 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Enable IntelliJ-compatible token `$today.year` for specifying the year in license header files. ([#542](https://github.com/diffplug/spotless/pull/542))
 ### Build
 * All `CHANGES.md` are now in keepachangelog format. ([#507](https://github.com/diffplug/spotless/pull/507))
 * We now use [javadoc.io](https://javadoc.io/) instead of github pages. ([#508](https://github.com/diffplug/spotless/pull/508))
 * We no longer publish `-SNAPSHOT` for every build to `master`, since we have good [JitPack integration](https://github.com/diffplug/spotless/blob/master/CONTRIBUTING.md#gradle---any-commit-in-a-public-github-repo-this-one-or-any-fork). ([#508](https://github.com/diffplug/spotless/pull/508))
 * Improved how we use Spotless on itself. ([#509](https://github.com/diffplug/spotless/pull/509))
 * Fix build warnings when building on Gradle 6+, bump build gradle to 6.2.2, and fix javadoc links. ([#536](https://github.com/diffplug/spotless/pull/536))
-* Enable IntelliJ compatible tokens for specifying the year in license header files ([#542](https://github.com/diffplug/spotless/pull/542))
 
 ## [1.27.0] - 2020-01-01
 * Ignored `KtLintStepTest`, because [gradle/gradle#11752](https://github.com/gradle/gradle/issues/11752) is causing too many CI failures. ([#499](https://github.com/diffplug/spotless/pull/499))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * We no longer publish `-SNAPSHOT` for every build to `master`, since we have good [JitPack integration](https://github.com/diffplug/spotless/blob/master/CONTRIBUTING.md#gradle---any-commit-in-a-public-github-repo-this-one-or-any-fork). ([#508](https://github.com/diffplug/spotless/pull/508))
 * Improved how we use Spotless on itself. ([#509](https://github.com/diffplug/spotless/pull/509))
 * Fix build warnings when building on Gradle 6+, bump build gradle to 6.2.2, and fix javadoc links. ([#536](https://github.com/diffplug/spotless/pull/536))
+* Enable IntelliJ compatible tokens for specifying the year in license header files ([#542](https://github.com/diffplug/spotless/pull/542))
 
 ## [1.27.0] - 2020-01-01
 * Ignored `KtLintStepTest`, because [gradle/gradle#11752](https://github.com/gradle/gradle/issues/11752) is causing too many CI failures. ([#499](https://github.com/diffplug/spotless/pull/499))

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -21,7 +21,10 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.time.YearMonth;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,6 +38,7 @@ public final class LicenseHeaderStep implements Serializable {
 
 	private static final String NAME = "licenseHeader";
 	private static final String DEFAULT_YEAR_DELIMITER = "-";
+	private static final List<String> YEAR_TOKENS = Arrays.asList("$YEAR", "$today.year");
 
 	private static final SerializableFileFilter UNSUPPORTED_JVM_FILES_FILTER = SerializableFileFilter.skipFilesNamed(
 			"package-info.java", "package-info.groovy", "module-info.java");
@@ -107,14 +111,27 @@ public final class LicenseHeaderStep implements Serializable {
 		}
 		this.licenseHeader = licenseHeader;
 		this.delimiterPattern = Pattern.compile('^' + delimiter, Pattern.UNIX_LINES | Pattern.MULTILINE);
-		this.hasYearToken = licenseHeader.contains("$YEAR");
-		if (this.hasYearToken) {
-			int yearTokenIndex = licenseHeader.indexOf("$YEAR");
+
+		if (getToken(licenseHeader).isPresent()) {
+			String token = getToken(licenseHeader).get();
+			this.hasYearToken = true;
+			int yearTokenIndex = licenseHeader.indexOf(token);
 			this.licenseHeaderBeforeYearToken = licenseHeader.substring(0, yearTokenIndex);
-			this.licenseHeaderAfterYearToken = licenseHeader.substring(yearTokenIndex + 5, licenseHeader.length());
-			this.licenseHeaderWithYearTokenReplaced = licenseHeader.replace("$YEAR", String.valueOf(YearMonth.now().getYear()));
+			this.licenseHeaderAfterYearToken = licenseHeader.substring(yearTokenIndex + 5);
+			this.licenseHeaderWithYearTokenReplaced = licenseHeader.replace(token, String.valueOf(YearMonth.now().getYear()));
 			this.yearMatcherPattern = Pattern.compile("[0-9]{4}(" + Pattern.quote(yearSeparator) + "[0-9]{4})?");
 		}
+	}
+
+	/**
+	 * Get the first place holder token being used in the
+	 * license header for specifying the year
+	 *
+	 * @param licenseHeader String representation of the license header
+	 * @return Matching value from YEAR_TOKENS or null if none exist
+	 */
+	private Optional<String> getToken(String licenseHeader) {
+		return YEAR_TOKENS.stream().filter(licenseHeader::contains).findFirst();
 	}
 
 	/** Reads the license file from the given file. */

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,10 +3,13 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Enable IntelliJ-compatible token `$today.year` for specifying the year in license header files. ([#542](https://github.com/diffplug/spotless/pull/542))
 ### Fixed
 * Eclipse-WTP formatter (web tools platform, not java) could encounter errors in parallel multiproject builds [#492](https://github.com/diffplug/spotless/issues/492). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).
 
 ## [3.27.2] - 2020-03-05
+### Fixed
 * Add tests to `SpecificFilesTest` to fix [#529](https://github.com/diffplug/spotless/issues/529)
 * If you applied spotless to a subproject, but not to the root project, then on Gradle 6+ you would get the deprecation warning `Using method Project#afterEvaluate(Action) when the project is already evaluated has been deprecated.`  This has now been fixed. ([#506](https://github.com/diffplug/spotless/issues/506))
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -523,8 +523,8 @@ to true.
 
 ## License header options
 
-If the string contents of a licenseHeader step or the file contents of a licenseHeaderFile step contains a $YEAR token,
-then in the end-result generated license headers which use this license header as a template, $YEAR will be replaced with the current year.
+If the string contents of a licenseHeader step or the file contents of a licenseHeaderFile step contains a $YEAR OR $today.year token,
+then in the end-result generated license headers which use this license header as a template, $YEAR or $today.year will be replaced with the current year.
 
 
 For example:

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -523,9 +523,7 @@ to true.
 
 ## License header options
 
-If the string contents of a licenseHeader step or the file contents of a licenseHeaderFile step contains a $YEAR OR $today.year token,
-then in the end-result generated license headers which use this license header as a template, $YEAR or $today.year will be replaced with the current year.
-
+If the license header (specified with `licenseHeader` or `licenseHeaderFile`) contains `$YEAR` or `$today.year`, then that token will be replaced with the current 4-digit year.
 
 For example:
 ```

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Enable IntelliJ-compatible token `$today.year` for specifying the year in license header files. ([#542](https://github.com/diffplug/spotless/pull/542))
 ### Fixed
 * Fix scala and kotlin maven config documentation.
 * Eclipse-WTP formatter (web tools platform, not java) could encounter errors in parallel multiproject builds [#492](https://github.com/diffplug/spotless/issues/492). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -39,6 +39,8 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	private static final String KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER = "license/FileWithLicenseHeaderAndPlaceholder.test";
 	// Licenses to test $YEAR token replacement
 	private static final String LICENSE_HEADER_YEAR = "This is a fake license, $YEAR. ACME corp.";
+	// License to test $today.year token replacement
+	private static final String LICENSE_HEADER_YEAR_INTELLIJ_TOKEN = "This is a fake license, $today.year. ACME corp.";
 	// Special case where the characters immediately before and after the year token are the same,
 	// start position of the second part might overlap the end position of the first part.
 	private static final String LICENSE_HEADER_YEAR_VARIANT = "This is a fake license. Copyright $YEAR ACME corp.";
@@ -82,6 +84,12 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				.test(fileWithLicenseContaining(" ACME corp."), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()))
 				.test(fileWithLicenseContaining("This is a fake license. Copyright ACME corp."), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()))
 				.test(fileWithLicenseContaining("This is a fake license. CopyrightACME corp."), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()));
+
+		//Check when token is of the format $today.year
+		step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR_INTELLIJ_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
+
+		StepHarness.forStep(step)
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR_INTELLIJ_TOKEN), fileWithLicenseContaining(LICENSE_HEADER_YEAR_INTELLIJ_TOKEN, currentYear(), "$today.year"));
 	}
 
 	@Test
@@ -124,6 +132,10 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 	private String fileWithLicenseContaining(String license, String yearContent) throws IOException {
 		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__LICENSE_PLACEHOLDER__", license).replace("$YEAR", yearContent);
+	}
+
+	private String fileWithLicenseContaining(String license, String yearContent, String token) throws IOException {
+		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__LICENSE_PLACEHOLDER__", license).replace(token, yearContent);
 	}
 
 	private String currentYear() {


### PR DESCRIPTION
# Change log
- Enable support for IntelliJ style year tokens of the format `$year.today` 
- I raised an issue earlier https://github.com/diffplug/spotless/issues/541

