### PR TITLE
Fix Eclipse WTP encoding handling

### DIFF
--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -3,6 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.15.1`).
 
 ## [Unreleased]
+### Fixed
+* Handling of character encodings which require more than 1 byte. Previously the WTP
+decoded input twice, once using the encoding configured by the user, and
+once again using the default platform character set ([#545](https://github.com/diffplug/spotless/issues/545)).
 
 ## [3.15.2] - 2020-03-04
 ### Fixed

--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -4,9 +4,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* Handling of character encodings which require more than 1 byte. Previously the WTP
-decoded input twice, once using the encoding configured by the user, and
-once again using the default platform character set ([#545](https://github.com/diffplug/spotless/issues/545)).
+* Handling of character encodings on OS with non UTF-8 default file encoding format. 
+CSS, HTML and JSON formatter steps encoded intermediately the input
+to UTF-8 and used the default file encoding format for decoding. This process failed
+if the input contained characters not bit-equivalent in UTF-8 and OS default file encoding format ([#545](https://github.com/diffplug/spotless/issues/545)).
 
 ## [3.15.2] - 2020-03-04
 ### Fixed

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImplTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImplTest.java
@@ -89,6 +89,28 @@ public class EclipseHtmlFormatterStepImplTest {
 				testData.expected("css.html"), output);
 	}
 
+	@Test
+	public void checkNoDoubleEndoding() throws Exception {
+		String osEncoding = System.getProperty("file.encoding");
+		//Assure that file.encoding is not used during the clean-up.
+		System.setProperty("file.encoding", "ISO-8859-1");
+		//Check that WTP does not try to do UTF-8 conversion again (since done by Spotless framework)
+		String[] input = testData.input("utf-8.html");
+		String output = formatter.format(input[0]);
+		System.setProperty("file.encoding", osEncoding);
+		assertEquals("Unexpected formatting of UTF-8", testData.expected("utf-8.html"), output);
+	}
+
+	@Test
+	public void checkBOMisStripped() throws Exception {
+		String[] input = testData.input("bom.html");
+		String[] inputWithoutBom = testData.input("utf-8.html");
+		//The UTF-8 BOM is interpreted as on UTF-16 character.
+		assertEquals("BOM input invalid", input[0].length() - 1, inputWithoutBom[0].length());
+		String output = formatter.format(input[0]);
+		assertEquals("BOM is not stripped", testData.expected("utf-8.html"), output);
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void configurationChange() throws Exception {
 		new EclipseHtmlFormatterStepImpl(new Properties());

--- a/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImplTest.java
+++ b/_ext/eclipse-wtp/src/test/java/com/diffplug/spotless/extra/eclipse/wtp/EclipseHtmlFormatterStepImplTest.java
@@ -90,11 +90,9 @@ public class EclipseHtmlFormatterStepImplTest {
 	}
 
 	@Test
-	public void checkNoDoubleEndoding() throws Exception {
+	public void checkCleanupForNonUtf8() throws Exception {
 		String osEncoding = System.getProperty("file.encoding");
-		//Assure that file.encoding is not used during the clean-up.
-		System.setProperty("file.encoding", "ISO-8859-1");
-		//Check that WTP does not try to do UTF-8 conversion again (since done by Spotless framework)
+		System.setProperty("file.encoding", "ISO-8859-1"); //Simulate a non UTF-8 OS
 		String[] input = testData.input("utf-8.html");
 		String output = formatter.format(input[0]);
 		System.setProperty("file.encoding", osEncoding);

--- a/_ext/eclipse-wtp/src/test/resources/html/expected/utf-8.html
+++ b/_ext/eclipse-wtp/src/test/resources/html/expected/utf-8.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<HTML>
+<HEAD>
+<META charset="UTF-8">
+<TITLE>ÄÜ€</TITLE>
+</HEAD>
+</HTML>

--- a/_ext/eclipse-wtp/src/test/resources/html/input/bom.html
+++ b/_ext/eclipse-wtp/src/test/resources/html/input/bom.html
@@ -1,0 +1,2 @@
+﻿<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>ÄÜ€</title></head></html>

--- a/_ext/eclipse-wtp/src/test/resources/html/input/utf-8.html
+++ b/_ext/eclipse-wtp/src/test/resources/html/input/utf-8.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>ÄÜ€</title></head></html>


### PR DESCRIPTION
Fixes the WTP encoding handling.
Spotless always provides decoded string to WTP.
The original implementation did not provide any coding descriptions. Hence for HTML, the platform specific one were used. E.g. this affects all WTP clean-up tasks, not only HTML, but whether the others do a second decoding in the first place, has not been checked thoroughly. 
Probably they do not.
Anyhow, the changed implementation assures that this part of the code common to all WTP formatters, behaves like that original WTP, though the input files are not directly accessed.
