### PR TITLE
Replaced spotless-eclipse-wtp 3.15.2 by 3.15.3. Fixes #545.

### DIFF
--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.13.0.lockfile
@@ -1,5 +1,5 @@
 # Spotless formatter based on Eclipse-WTP version 3.15 (see https://www.eclipse.org/webtools/)
-com.diffplug.spotless:spotless-eclipse-wtp:3.15.2
+com.diffplug.spotless:spotless-eclipse-wtp:3.15.3
 com.diffplug.spotless:spotless-eclipse-base:3.3.0
 com.google.code.findbugs:annotations:3.0.0
 com.google.code.findbugs:jsr305:3.0.0

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Eclipse-WTP formatter (web tools platform, not java) handles some character encodings incorrectly on OS with non-unicode default file encoding [#545](https://github.com/diffplug/spotless/issues/545). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).
 
 ## [3.28.0] - 2020-03-20
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Eclipse-WTP formatter (web tools platform, not java) handles some character encodings incorrectly on OS with non-unicode default file encoding [#545](https://github.com/diffplug/spotless/issues/545). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).
 
 ## [1.28.0] - 2020-03-20
 ### Added


### PR DESCRIPTION
Replaced spotless-eclipse-wtp 3.15.2 by 3.15.3. Fixes #545.

See #546 for details on v3.15.3.