### PR TITLE
Simple spike at separating the core `SpotlessTask` from check and apply

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -203,33 +203,6 @@ public final class Formatter implements Serializable, AutoCloseable {
 		}
 	}
 
-	/**
-	 * Applies formatting to the given file, writing to the output file if the result is different.
-	 * If the result of formatting is the same as the input, the output file is deleted.
-	 */
-	public void applyToAndWriteResultIfDirty(File input, File output) throws IOException {
-		Objects.requireNonNull(input);
-		Objects.requireNonNull(output);
-
-		byte[] rawBytes = Files.readAllBytes(input.toPath());
-		String raw = new String(rawBytes, encoding);
-		String rawUnix = LineEnding.toUnix(raw);
-
-		// enforce the format
-		String formattedUnix = compute(rawUnix, input);
-		// enforce the line endings
-		String formatted = computeLineEndings(formattedUnix, input);
-
-		// write out the file iff it has changed
-		byte[] formattedBytes = formatted.getBytes(encoding);
-		if (!Arrays.equals(rawBytes, formattedBytes)) {
-			Files.createDirectories(output.getParentFile().toPath());
-			Files.write(output.toPath(), formattedBytes);
-		} else {
-			Files.deleteIfExists(output.toPath());
-		}
-	}
-
 	/** Applies the appropriate line endings to the given unix content. */
 	public String computeLineEndings(String unix, File file) {
 		Objects.requireNonNull(unix, "unix");

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -203,6 +203,33 @@ public final class Formatter implements Serializable, AutoCloseable {
 		}
 	}
 
+	/**
+	 * Applies formatting to the given file, writing to the output file if the result is different.
+	 * If the result of formatting is the same as the input, the output file is deleted.
+	 */
+	public void applyToAndWriteResultIfDirty(File input, File output) throws IOException {
+		Objects.requireNonNull(input);
+		Objects.requireNonNull(output);
+
+		byte[] rawBytes = Files.readAllBytes(input.toPath());
+		String raw = new String(rawBytes, encoding);
+		String rawUnix = LineEnding.toUnix(raw);
+
+		// enforce the format
+		String formattedUnix = compute(rawUnix, input);
+		// enforce the line endings
+		String formatted = computeLineEndings(formattedUnix, input);
+
+		// write out the file iff it has changed
+		byte[] formattedBytes = formatted.getBytes(encoding);
+		if (!Arrays.equals(rawBytes, formattedBytes)) {
+			Files.createDirectories(output.getParentFile().toPath());
+			Files.write(output.toPath(), formattedBytes);
+		} else {
+			Files.deleteIfExists(output.toPath());
+		}
+	}
+
 	/** Applies the appropriate line endings to the given unix content. */
 	public String computeLineEndings(String unix, File file) {
 		Objects.requireNonNull(unix, "unix");

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCellBulk.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCellBulk.java
@@ -228,6 +228,12 @@ public final class PaddedCellBulk {
 		}
 
 		// F(input) != input, so we'll do a padded check
+		String doubleFormattedUnix = formatter.compute(formattedUnix, file);
+		if (doubleFormattedUnix.equals(formattedUnix)) {
+			// most dirty files are idempotent-dirty, so this is a quick-short circuit for that common case
+			return formattedBytes;
+		}
+
 		PaddedCell cell = PaddedCell.check(formatter, file, rawUnix);
 		if (!cell.isResolvable()) {
 			// nothing we can do, but check will warn and dump out the divergence path

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PaddedCellGradle.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PaddedCellGradle.java
@@ -16,7 +16,6 @@
 package com.diffplug.gradle.spotless;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -24,9 +23,6 @@ import org.gradle.api.GradleException;
 
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.Formatter;
-import com.diffplug.spotless.PaddedCellBulk;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Incorporates the PaddedCell machinery into SpotlessTask.apply() and SpotlessTask.check().
@@ -81,23 +77,5 @@ class PaddedCellGradle {
 
 	private static File diagnoseDir(SpotlessTask task) {
 		return new File(task.getProject().getBuildDir(), "spotless-diagnose-" + task.formatName());
-	}
-
-	@SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-	static void check(SpotlessTask task, Formatter formatter, List<File> problemFiles) throws IOException {
-		if (problemFiles.isEmpty()) {
-			// if the first pass was successful, then paddedCell() mode is unnecessary
-			task.getLogger().info(StringPrinter.buildStringFromLines(
-					task.getName() + " is in paddedCell() mode, but it doesn't need to be.",
-					"If you remove that option, spotless will run ~2x faster.",
-					"For details see " + URL));
-		}
-
-		File diagnoseDir = diagnoseDir(task);
-		File rootDir = task.getProject().getRootDir();
-		List<File> stillFailing = PaddedCellBulk.check(rootDir, diagnoseDir, formatter, problemFiles);
-		if (!stillFailing.isEmpty()) {
-			throw task.formatViolationsFor(formatter, problemFiles);
-		}
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.FileVisitor;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+public class SpotlessApply extends DefaultTask {
+	private File spotlessOutDirectory;
+
+	@InputDirectory
+	@SkipWhenEmpty
+	public File getSpotlessOutDirectory() {
+		return spotlessOutDirectory;
+	}
+
+	public void setSpotlessOutDirectory(File spotlessOutDirectory) {
+		this.spotlessOutDirectory = spotlessOutDirectory;
+	}
+
+	@TaskAction
+	public void performAction() {
+		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
+		if (files.isEmpty()) {
+			System.out.println("NOTHING TO DO");
+		} else {
+			files.visit(new FileVisitor() {
+				@Override
+				public void visitDir(FileVisitDetails fileVisitDetails) {
+
+				}
+
+				@Override
+				public void visitFile(FileVisitDetails fileVisitDetails) {
+					String path = fileVisitDetails.getPath();
+					File originalSource = new File(getProject().getProjectDir(), path);
+					try {
+						System.out.println("Copying " + fileVisitDetails.getFile() + " to " + originalSource);
+						Files.copy(fileVisitDetails.getFile().toPath(), originalSource.toPath(), StandardCopyOption.REPLACE_EXISTING);
+					} catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				}
+			});
+		}
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -15,6 +15,11 @@
  */
 package com.diffplug.gradle.spotless;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileVisitDetails;
@@ -22,11 +27,6 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 public class SpotlessApply extends DefaultTask {
 	private File spotlessOutDirectory;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -18,12 +18,11 @@ package com.diffplug.gradle.spotless;
 import java.io.File;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
-
-import com.diffplug.common.collect.Lists;
 
 public class SpotlessCheck extends DefaultTask {
 	public SpotlessTask formatTask;
@@ -44,7 +43,18 @@ public class SpotlessCheck extends DefaultTask {
 	public void performAction() throws Exception {
 		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
 		if (!files.isEmpty()) {
-			throw formatTask.formatViolationsFor(Lists.newArrayList(files.getFiles()));
+			throw new GradleException("Run 'gradlew spotlessApply' to fix these violations.");
+			/*
+			 * TODO: problemFiles is expected to be the "real files"
+			 * This error message should now take the "real files" and "error files" as the inputs, rather than
+			 * the "real files" and the formatter.
+			DiffMessageFormatter.builder()
+					.runToFix("Run 'gradlew spotlessApply' to fix these violations.")
+					.isPaddedCell(paddedCell)
+					.formatter(formatter)
+					.problemFiles(problemFiles)
+					.getMessage());
+					*/
 		}
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -15,14 +15,15 @@
  */
 package com.diffplug.gradle.spotless;
 
-import com.diffplug.common.collect.Lists;
+import java.io.File;
+
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 
-import java.io.File;
+import com.diffplug.common.collect.Lists;
 
 public class SpotlessCheck extends DefaultTask {
 	public SpotlessTask formatTask;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import com.diffplug.common.collect.Lists;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+
+public class SpotlessCheck extends DefaultTask {
+	public SpotlessTask formatTask;
+
+	private File spotlessOutDirectory;
+
+	@InputDirectory
+	@SkipWhenEmpty
+	public File getSpotlessOutDirectory() {
+		return spotlessOutDirectory;
+	}
+
+	public void setSpotlessOutDirectory(File spotlessOutDirectory) {
+		this.spotlessOutDirectory = spotlessOutDirectory;
+	}
+
+	@TaskAction
+	public void performAction() throws Exception {
+		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
+		if (!files.isEmpty()) {
+			throw formatTask.formatViolationsFor(Lists.newArrayList(files.getFiles()));
+		}
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -27,14 +27,10 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.plugins.BasePlugin;
 
 import com.diffplug.common.base.Errors;
 import com.diffplug.spotless.LineEnding;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import groovy.lang.Closure;
 
 public class SpotlessExtension {
 	final Project project;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -114,6 +114,7 @@ public class SpotlessTask extends DefaultTask {
 	}
 
 	private File outputDirectory = new File(getProject().getBuildDir(), "spotless/" + getName());
+
 	@OutputDirectory
 	public File getOutputDirectory() {
 		return outputDirectory;


### PR DESCRIPTION
- SpotlessTask runs the formatter for each source file, and generates an
  output file with the formatted results (if different)
   - If the task is not incremental, all prior outputs are removed
   - For each added file, the formatter is run, and the output is
     written if different from the original
   - For each removed file, the previous output is removed, if present
- SpotlessCheck will fail if there are any outputs from SpotlessTask
- SpotlessApply will copy any formatted outputs back over the original source

This mechanism has a number of benefits and makes things a lot simpler:
- The spotless cache is not required
- SpotlessTask is now a simple incremental task and benefits from the
  usual up-to-date checking. It should also support being made cacheable.

Note that a number of things were ignored for this spike:
- Anything to do with `PaddedCell`
- Check does not print out the actual formatting issues
- I didn't run any of the tests


