### PR TITLE
Support google-java-format 1.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,28 @@
 language: java
-jdk:
-  - openjdk8
-env:
-  - NODE_VERSION="6.10.2"
-before_install:
-  - nvm install $NODE_VERSION
-  - bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZacSweers/check-gradle-checksums/c8dc2ae0756a8041e240cdc6fa6c38c256dfeab0/check-gradle-checksums.sh)"
-install: true
-script:
-  - ./gradlew build --build-cache && ./gradlew npmTest --build-cache
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr plugin-maven/build/localMavenRepository/com/diffplug/spotless/
 cache:
   directories:
   - $HOME/.gradle/caches/modules-2/
   - $HOME/.gradle/wrapper/
   - $HOME/.m2/
   - plugin-maven/build/localMavenRepository/
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr plugin-maven/build/localMavenRepository/com/diffplug/spotless/  
+env:
+  - NODE_VERSION="6.10.2"
+before_install:
+  - nvm install $NODE_VERSION
+install: true
+jdk:
+  - openjdk8
+  - openjdk11
+
+jobs:
+  include:
+    - stage: test
+      jdk: openjdk8
+      script: ./gradlew build --build-cache && ./gradlew npmTest --build-cache
+
+    - stage: test
+      jdk: openjdk11
+      script: ./gradlew build --build-cache && ./gradlew npmTest --build-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,21 @@
 language: java
+jdk:
+  - openjdk8
+  - openjdk11
+env:
+  - NODE_VERSION="6.10.2"
+before_install:
+  - nvm install $NODE_VERSION
+  - bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZacSweers/check-gradle-checksums/c8dc2ae0756a8041e240cdc6fa6c38c256dfeab0/check-gradle-checksums.sh)"
+install: true
+script:
+  - ./gradlew build --build-cache && ./gradlew npmTest --build-cache
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr plugin-maven/build/localMavenRepository/com/diffplug/spotless/
 cache:
   directories:
   - $HOME/.gradle/caches/modules-2/
   - $HOME/.gradle/wrapper/
   - $HOME/.m2/
   - plugin-maven/build/localMavenRepository/
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr plugin-maven/build/localMavenRepository/com/diffplug/spotless/  
-env:
-  - NODE_VERSION="6.10.2"
-before_install:
-  - nvm install $NODE_VERSION
-install: true
-jdk:
-  - openjdk8
-  - openjdk11
-
-jobs:
-  include:
-    - stage: test
-      jdk: openjdk8
-      script: ./gradlew build --build-cache && ./gradlew npmTest --build-cache
-
-    - stage: test
-      jdk: openjdk11
-      script: ./gradlew build --build-cache && ./gradlew npmTest --build-cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Support for google-java-format 1.8. ([#562](https://github.com/diffplug/spotless/issues/562))
+* Support for google-java-format 1.8 (including test infrastructure for Java 11). ([#562](https://github.com/diffplug/spotless/issues/562))
 
 ## [1.28.1] - 2020-04-02
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for google-java-format 1.8. ([#562](https://github.com/diffplug/spotless/issues/562))
 
 ## [1.28.1] - 2020-04-02
 ### Fixed

--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -15,6 +15,10 @@ task sourcesJar(type: Jar) {
 // Thus, no javadoc warnings.
 javadoc {
 	options.addStringOption('Xdoclint:none', '-quiet')
+	// disable javadoc on 11
+	if (org.gradle.api.JavaVersion.current().compareTo(org.gradle.api.JavaVersion.VERSION_1_9) >= 0) {
+		enabled = false
+	}
 }
 
 // use markdown in javadoc

--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -15,10 +15,7 @@ task sourcesJar(type: Jar) {
 // Thus, no javadoc warnings.
 javadoc {
 	options.addStringOption('Xdoclint:none', '-quiet')
-	// disable javadoc on 11
-	if (org.gradle.api.JavaVersion.current().compareTo(org.gradle.api.JavaVersion.VERSION_1_9) >= 0) {
-		enabled = false
-	}
+	enabled = org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8
 }
 
 // use markdown in javadoc

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -47,7 +47,7 @@ spotbugs {
 // HTML instead of XML
 tasks.withType(spotBugsTaskType()) {
 	// only run on Java 8 (no benefit to running twice)
-	enabled = System.getProperty("java.version").startsWith('1.8.')
+	enabled = org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8
 	reports {
 		xml.enabled = false
 		html.enabled = true

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -46,6 +46,8 @@ spotbugs {
 }
 // HTML instead of XML
 tasks.withType(spotBugsTaskType()) {
+	// only run on Java 8 (no benefit to running twice)
+	enabled = System.getProperty("java.version").startsWith('1.8.')
 	reports {
 		xml.enabled = false
 		html.enabled = true

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -25,6 +25,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.ThrowingEx.Function;
 
 /** Wraps up [google-java-format](https://github.com/google/google-java-format) as a FormatterStep. */
 public class GoogleJavaFormatStep {
@@ -124,17 +125,14 @@ public class GoogleJavaFormatStep {
 			Object formatter = formatterClazz.getConstructor(optionsClass).newInstance(options);
 			Method formatterMethod = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
 
-			Class<?> removeUnusedClass = classLoader.loadClass(REMOVE_UNUSED_CLASS);
-			Class<?> removeJavadocOnlyClass = classLoader.loadClass(REMOVE_UNUSED_IMPORT_JavadocOnlyImports);
-			Object removeJavadocConstant = Enum.valueOf((Class<Enum>) removeJavadocOnlyClass, REMOVE_UNUSED_IMPORT_JavadocOnlyImports_Keep);
-			Method removeUnusedMethod = removeUnusedClass.getMethod(REMOVE_UNUSED_METHOD, String.class, removeJavadocOnlyClass);
+			Function<String, String> removeUnused = constructRemoveUnusedFunction(classLoader);
 
 			Class<?> importOrdererClass = classLoader.loadClass(IMPORT_ORDERER_CLASS);
 			Method importOrdererMethod = importOrdererClass.getMethod(IMPORT_ORDERER_METHOD, String.class);
 
 			return input -> {
 				String formatted = (String) formatterMethod.invoke(formatter, input);
-				String removedUnused = (String) removeUnusedMethod.invoke(null, formatted, removeJavadocConstant);
+				String removedUnused = removeUnused.apply(formatted);
 				String sortedImports = (String) importOrdererMethod.invoke(null, removedUnused);
 				return fixWindowsBug(sortedImports, version);
 			};
@@ -144,15 +142,33 @@ public class GoogleJavaFormatStep {
 		FormatterFunc createRemoveUnusedImportsOnly() throws Exception {
 			ClassLoader classLoader = jarState.getClassLoader();
 
-			Class<?> removeUnusedClass = classLoader.loadClass(REMOVE_UNUSED_CLASS);
-			Class<?> removeJavadocOnlyClass = classLoader.loadClass(REMOVE_UNUSED_IMPORT_JavadocOnlyImports);
-			Object removeJavadocConstant = Enum.valueOf((Class<Enum>) removeJavadocOnlyClass, REMOVE_UNUSED_IMPORT_JavadocOnlyImports_Keep);
-			Method removeUnusedMethod = removeUnusedClass.getMethod(REMOVE_UNUSED_METHOD, String.class, removeJavadocOnlyClass);
+			Function<String, String> removeUnused = constructRemoveUnusedFunction(classLoader);
 
-			return input -> {
-				String removeUnused = (String) removeUnusedMethod.invoke(null, input, removeJavadocConstant);
-				return fixWindowsBug(removeUnused, version);
-			};
+			return input -> fixWindowsBug(removeUnused.apply(input), version);
+		}
+
+		private static Function<String, String> constructRemoveUnusedFunction(ClassLoader classLoader)
+				throws NoSuchMethodException, ClassNotFoundException {
+			Class<?> removeUnusedClass = classLoader.loadClass(REMOVE_UNUSED_CLASS);
+			Class<?> removeJavadocOnlyClass;
+			try {
+				// google-java-format 1.7 or lower
+				removeJavadocOnlyClass = classLoader.loadClass(REMOVE_UNUSED_IMPORT_JavadocOnlyImports);
+			} catch (ClassNotFoundException e) {
+				// google-java-format 1.8+
+				removeJavadocOnlyClass = null;
+			}
+
+			Function<String, String> removeUnused;
+			if (removeJavadocOnlyClass != null) {
+				Object removeJavadocConstant = Enum.valueOf((Class<Enum>) removeJavadocOnlyClass, REMOVE_UNUSED_IMPORT_JavadocOnlyImports_Keep);
+				Method removeUnusedMethod = removeUnusedClass.getMethod(REMOVE_UNUSED_METHOD, String.class, removeJavadocOnlyClass);
+				removeUnused = (x) -> (String) removeUnusedMethod.invoke(null, x, removeJavadocConstant);
+			} else {
+				Method removeUnusedMethod = removeUnusedClass.getMethod(REMOVE_UNUSED_METHOD, String.class);
+				removeUnused = (x) -> (String) removeUnusedMethod.invoke(null, x);
+			}
+			return removeUnused;
 		}
 	}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,7 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [3.28.1] - 2020-04-02
 ### Added
-* Support for google-java-format 1.8. ([#562](https://github.com/diffplug/spotless/issues/562))
+* Support for google-java-format 1.8 (requires you to run build on Java 11) ([#562](https://github.com/diffplug/spotless/issues/562))
 ### Fixed
 * Eclipse-WTP formatter (web tools platform, not java) handles some character encodings incorrectly on OS with non-unicode default file encoding [#545](https://github.com/diffplug/spotless/issues/545). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ## [3.28.1] - 2020-04-02
+### Added
+* Support for google-java-format 1.8. ([#562](https://github.com/diffplug/spotless/issues/562))
 ### Fixed
 * Eclipse-WTP formatter (web tools platform, not java) handles some character encodings incorrectly on OS with non-unicode default file encoding [#545](https://github.com/diffplug/spotless/issues/545). Fixed for Eclipse-WTP formatter Eclipse version 4.13.0 (default version).
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre11.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre11.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.Test;
+
+import com.diffplug.common.base.CharMatcher;
+import com.diffplug.common.base.Splitter;
+import com.diffplug.common.base.StringPrinter;
+import com.diffplug.spotless.JreVersion;
+import com.diffplug.spotless.LineEnding;
+
+/** Tests the desired behavior from https://github.com/diffplug/spotless/issues/46. */
+public class ErrorShouldRethrowJre11 extends GradleIntegrationTest {
+	private void writeBuild(String... toInsert) throws IOException {
+		List<String> lines = new ArrayList<>();
+		lines.add("plugins {");
+		lines.add("    id 'com.diffplug.gradle.spotless'");
+		lines.add("    id 'java'");
+		lines.add("}");
+		lines.add("spotless {");
+		lines.add("    format 'misc', {");
+		lines.add("        lineEndings 'UNIX'");
+		lines.add("        target file('README.md')");
+		lines.add("        custom 'no swearing', {");
+		lines.add("             if (it.toLowerCase(Locale.ROOT).contains('fubar')) {");
+		lines.add("                 throw new RuntimeException('No swearing!');");
+		lines.add("             }");
+		lines.add("        }");
+		lines.addAll(Arrays.asList(toInsert));
+		setFile("build.gradle").toContent(String.join("\n", lines));
+	}
+
+	@Test
+	public void passesIfNoException() throws Exception {
+		writeBuild(
+				"    } // format",
+				"}     // spotless");
+		setFile("README.md").toContent("This code is fun.");
+		runWithSuccess(":spotlessMisc");
+	}
+
+	@Test
+	public void anyExceptionShouldFail() throws Exception {
+		writeBuild(
+				"    } // format",
+				"}     // spotless");
+		setFile("README.md").toContent("This code is fubar.");
+		runWithFailure(
+				":spotlessMiscStep 'no swearing' found problem in 'README.md':",
+				"No swearing!",
+				"java.lang.RuntimeException: No swearing!");
+	}
+
+	@Test
+	public void unlessEnforceCheckIsFalse() throws Exception {
+		writeBuild(
+				"    } // format",
+				"    enforceCheck false",
+				"}     // spotless");
+		setFile("README.md").toContent("This code is fubar.");
+		runWithSuccess(":compileJava UP-TO-DATE");
+	}
+
+	@Test
+	public void unlessExemptedByStep() throws Exception {
+		writeBuild(
+				"        ignoreErrorForStep 'no swearing'",
+				"    } // format",
+				"}     // spotless");
+		setFile("README.md").toContent("This code is fubar.");
+		runWithSuccess(":spotlessMisc",
+				"Unable to apply step 'no swearing' to 'README.md'");
+	}
+
+	@Test
+	public void unlessExemptedByPath() throws Exception {
+		writeBuild(
+				"        ignoreErrorForPath 'README.md'",
+				"    } // format",
+				"}     // spotless");
+		setFile("README.md").toContent("This code is fubar.");
+		runWithSuccess(":spotlessMisc",
+				"Unable to apply step 'no swearing' to 'README.md'");
+	}
+
+	@Test
+	public void failsIfNeitherStepNorFileExempted() throws Exception {
+		writeBuild(
+				"        ignoreErrorForStep 'nope'",
+				"        ignoreErrorForPath 'nope'",
+				"    } // format",
+				"}     // spotless");
+		setFile("README.md").toContent("This code is fubar.");
+		runWithFailure(
+				":spotlessMiscStep 'no swearing' found problem in 'README.md':",
+				"No swearing!",
+				"java.lang.RuntimeException: No swearing!");
+	}
+
+	private void runWithSuccess(String... messages) throws Exception {
+		if (JreVersion.thisVm() != JreVersion._11) {
+			return;
+		}
+		BuildResult result = gradleRunner().withGradleVersion("5.0").withArguments("check").build();
+		assertResultAndMessages(result, TaskOutcome.SUCCESS, messages);
+	}
+
+	private void runWithFailure(String... messages) throws Exception {
+		if (JreVersion.thisVm() != JreVersion._11) {
+			return;
+		}
+		BuildResult result = gradleRunner().withGradleVersion("5.0").withArguments("check").buildAndFail();
+		assertResultAndMessages(result, TaskOutcome.FAILED, messages);
+	}
+
+	private void assertResultAndMessages(BuildResult result, TaskOutcome outcome, String... messages) {
+		String expectedToStartWith = StringPrinter.buildStringFromLines(messages).trim();
+		int numNewlines = CharMatcher.is('\n').countIn(expectedToStartWith);
+		List<String> actualLines = Splitter.on('\n').splitToList(LineEnding.toUnix(result.getOutput()));
+		String actualStart = String.join("\n", actualLines.subList(0, numNewlines + 1));
+		Assertions.assertThat(actualStart).isEqualTo(expectedToStartWith);
+		Assertions.assertThat(result.tasks(outcome).size() + result.tasks(TaskOutcome.UP_TO_DATE).size())
+				.isEqualTo(result.getTasks().size());
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre11.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre11.java
@@ -140,7 +140,6 @@ public class ErrorShouldRethrowJre11 extends GradleIntegrationTest {
 		String expectedToStartWith = StringPrinter.buildStringFromLines(messages).trim();
 		int numNewlines = CharMatcher.is('\n').countIn(expectedToStartWith);
 		List<String> actualLines = Splitter.on('\n').splitToList(LineEnding.toUnix(result.getOutput().trim()));
-		System.out.println("out=" + result.getOutput());
 		String actualStart = String.join("\n", actualLines.subList(0, numNewlines + 1));
 		Assertions.assertThat(actualStart).isEqualTo(expectedToStartWith);
 		Assertions.assertThat(result.tasks(outcome).size() + result.tasks(TaskOutcome.UP_TO_DATE).size() + result.tasks(TaskOutcome.NO_SOURCE).size())

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre8.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre8.java
@@ -28,10 +28,11 @@ import org.junit.Test;
 import com.diffplug.common.base.CharMatcher;
 import com.diffplug.common.base.Splitter;
 import com.diffplug.common.base.StringPrinter;
+import com.diffplug.spotless.JreVersion;
 import com.diffplug.spotless.LineEnding;
 
 /** Tests the desired behavior from https://github.com/diffplug/spotless/issues/46. */
-public class ErrorShouldRethrow extends GradleIntegrationTest {
+public class ErrorShouldRethrowJre8 extends GradleIntegrationTest {
 	private void writeBuild(String... toInsert) throws IOException {
 		List<String> lines = new ArrayList<>();
 		lines.add("plugins {");
@@ -119,11 +120,17 @@ public class ErrorShouldRethrow extends GradleIntegrationTest {
 	}
 
 	private void runWithSuccess(String... messages) throws Exception {
+		if (JreVersion.thisVm() != JreVersion._8) {
+			return;
+		}
 		BuildResult result = gradleRunner().withArguments("check").build();
 		assertResultAndMessages(result, TaskOutcome.SUCCESS, messages);
 	}
 
 	private void runWithFailure(String... messages) throws Exception {
+		if (JreVersion.thisVm() != JreVersion._8) {
+			return;
+		}
 		BuildResult result = gradleRunner().withArguments("check").buildAndFail();
 		assertResultAndMessages(result, TaskOutcome.FAILED, messages);
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
@@ -75,8 +75,7 @@ public class GradleIntegrationTest extends ResourceHarness {
 
 	protected final GradleRunner gradleRunner() throws IOException {
 		return GradleRunner.create()
-				//.withGradleVersion(requestGradleForJre8and11("2.14"))
-				.withGradleVersion(requestGradleForJre8and11("5.0"))
+				.withGradleVersion(requestGradleForJre8and11("2.14"))
 				.withProjectDir(rootFolder())
 				.withPluginClasspath();
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationTest.java
@@ -33,6 +33,7 @@ import com.diffplug.common.base.Errors;
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.common.tree.TreeDef;
 import com.diffplug.common.tree.TreeStream;
+import com.diffplug.spotless.JreVersion;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.ResourceHarness;
 
@@ -56,11 +57,26 @@ public class GradleIntegrationTest extends ResourceHarness {
 		setFile(".gitattributes").toContent("* text eol=lf");
 	}
 
+	/**
+	 * For Java 11+, Gradle 5 is the minimum.
+	 * So if you ask for less than Gradle 5, you get it on Java 8, but on Java 11 you get promoted to Gradle 5.
+	 * If you ask for more than Gradle 5, you'll definitely get it.
+	 */
+	protected static String requestGradleForJre8and11(String ver) {
+		JreVersion jre = JreVersion.thisVm();
+		// @formatter:off
+		switch (jre) {
+		case _8:  return ver;
+		case _11: return Double.parseDouble(ver) < 5.0 ? "5.0" : ver;
+		default:  throw new IllegalStateException("Spotless build is only supported on Java 8 and Java 11");
+		}
+		// @formatter:on
+	}
+
 	protected final GradleRunner gradleRunner() throws IOException {
 		return GradleRunner.create()
-				// Test against Gradle 2.14.1 in order to maintain backwards compatibility.
-				// https://github.com/diffplug/spotless/issues/161
-				.withGradleVersion("2.14.1")
+				//.withGradleVersion(requestGradleForJre8and11("2.14"))
+				.withGradleVersion(requestGradleForJre8and11("5.0"))
 				.withProjectDir(rootFolder())
 				.withPluginClasspath();
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/HasBuiltinDelimiterForLicenseTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/HasBuiltinDelimiterForLicenseTest.java
@@ -49,7 +49,7 @@ public class HasBuiltinDelimiterForLicenseTest extends GradleIntegrationTest {
 				"    }",
 				"}");
 		gradleRunner()
-				.withGradleVersion("4.6")
+				.withGradleVersion(requestGradleForJre8and11("4.6")) // 4.6 is the min
 				.withArguments("spotlessApply")
 				.forwardOutput()
 				.build();

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
+import com.diffplug.spotless.JreVersion;
+
 public class RegisterDependenciesTaskTest extends GradleIntegrationTest {
 	@Test
 	public void registerDependencies() throws IOException {
@@ -38,16 +40,18 @@ public class RegisterDependenciesTaskTest extends GradleIntegrationTest {
 				"  }",
 				"}");
 
-		String oldestSupported = gradleRunner()
-				.withArguments("spotlessCheck").build().getOutput();
-		Assertions.assertThat(oldestSupported.replace("\r", "")).startsWith(
-				":spotlessCheck UP-TO-DATE\n" +
-						":spotlessInternalRegisterDependencies\n" +
-						":sub:spotlessJava\n" +
-						":sub:spotlessJavaCheck\n" +
-						":sub:spotlessCheck\n" +
-						"\n" +
-						"BUILD SUCCESSFUL");
+		if (JreVersion.thisVm() == JreVersion._8) {
+			String oldestSupported = gradleRunner()
+					.withArguments("spotlessCheck").build().getOutput();
+			Assertions.assertThat(oldestSupported.replace("\r", "")).startsWith(
+					":spotlessCheck UP-TO-DATE\n" +
+							":spotlessInternalRegisterDependencies\n" +
+							":sub:spotlessJava\n" +
+							":sub:spotlessJavaCheck\n" +
+							":sub:spotlessCheck\n" +
+							"\n" +
+							"BUILD SUCCESSFUL");
+		}
 
 		setFile("gradle.properties").toLines();
 		String newestSupported = gradleRunner().withGradleVersion("6.0")

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
@@ -103,7 +103,7 @@ public class SpecificFilesTest extends GradleIntegrationTest {
 		GradleRunner runner = gradleRunner()
 				.withArguments("spotlessApply", "-PspotlessFiles=" + patterns);
 		if (isKotlin) {
-			runner.withGradleVersion("4.0");
+			runner.withGradleVersion(requestGradleForJre8and11("4.0"));
 		}
 		runner.build();
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,7 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [1.30.0] - 2020-04-10
 ### Added
 * Support for prettier ([#555](https://github.com/diffplug/spotless/pull/555)).
-* Support for google-java-format 1.8. ([#562](https://github.com/diffplug/spotless/issues/562))
+* Support for google-java-format 1.8 (requires you to run build on Java 11) ([#562](https://github.com/diffplug/spotless/issues/562))
 
 ## [1.29.0] - 2020-04-02
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [1.30.0] - 2020-04-10
 ### Added
 * Support for prettier ([#555](https://github.com/diffplug/spotless/pull/555)).
+* Support for google-java-format 1.8. ([#562](https://github.com/diffplug/spotless/issues/562))
 
 ## [1.29.0] - 2020-04-02
 ### Added

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,9 +42,11 @@ include 'testlib'	// library for sharing test infrastructure between the project
 include 'lib-extra'	// reusable library with lots of dependencies
 include 'plugin-gradle'	// gradle-specific glue code
 
-// excludes maven from JitCI builds,
-if (System.getenv('SPOTLESS_EXCLUDE_MAVEN') != 'true' && System.getenv('JITPACK') != 'true') {
-	include 'plugin-maven'	// maven-specific glue code
+if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
+	// only build Java 8
+	if (System.getenv('SPOTLESS_EXCLUDE_MAVEN') != 'true' && System.getenv('JITPACK') != 'true') {
+		include 'plugin-maven'	// maven-specific glue code
+	}
 }
 
 def getStartProperty(java.lang.String name) {

--- a/testlib/src/main/java/com/diffplug/spotless/JreVersion.java
+++ b/testlib/src/main/java/com/diffplug/spotless/JreVersion.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import com.diffplug.common.base.StandardSystemProperty;
+
+public enum JreVersion {
+	_8, _11;
+
+	public static JreVersion thisVm() {
+		String jvmVersion = StandardSystemProperty.JAVA_VERSION.value();
+		if (jvmVersion.startsWith("1.8.")) {
+			return _8;
+		} else if (jvmVersion.startsWith("11.")) {
+			return _11;
+		} else {
+			throw new IllegalStateException("Spotless build is only supported on Java 8 and Java 11");
+		}
+	}
+}

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormatted18.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormatted18.test
@@ -1,0 +1,10 @@
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+  public static void main(String[] args) {
+    System.out.println("hello");
+    UsedB.someMethod();
+    UsedA.someMethod();
+  }
+}

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -20,12 +20,27 @@ import org.junit.Test;
 
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.JreVersion;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
 public class GoogleJavaFormatStepTest extends ResourceHarness {
+	@Test
+	public void behavior18() throws Exception {
+		if (JreVersion.thisVm() == JreVersion._8) {
+			// google-java-format requires JRE 11+
+			return;
+		}
+		FormatterStep step = GoogleJavaFormatStep.create("1.8", TestProvisioner.mavenCentral());
+		StepHarness.forStep(step)
+				.testResource("java/googlejavaformat/JavaCodeUnformatted.test", "java/googlejavaformat/JavaCodeFormatted.test")
+				.testResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test", "java/googlejavaformat/JavaCodeWithLicenseFormatted.test")
+				.testResource("java/googlejavaformat/JavaCodeWithLicensePackageUnformatted.test", "java/googlejavaformat/JavaCodeWithLicensePackageFormatted.test")
+				.testResource("java/googlejavaformat/JavaCodeWithPackageUnformatted.test", "java/googlejavaformat/JavaCodeWithPackageFormatted.test");
+	}
+
 	@Test
 	public void behavior() throws Exception {
 		FormatterStep step = GoogleJavaFormatStep.create("1.2", TestProvisioner.mavenCentral());

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -35,7 +35,7 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 		}
 		FormatterStep step = GoogleJavaFormatStep.create("1.8", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
-				.testResource("java/googlejavaformat/JavaCodeUnformatted.test", "java/googlejavaformat/JavaCodeFormatted.test")
+				.testResource("java/googlejavaformat/JavaCodeUnformatted.test", "java/googlejavaformat/JavaCodeFormatted18.test")
 				.testResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test", "java/googlejavaformat/JavaCodeWithLicenseFormatted.test")
 				.testResource("java/googlejavaformat/JavaCodeWithLicensePackageUnformatted.test", "java/googlejavaformat/JavaCodeWithLicensePackageFormatted.test")
 				.testResource("java/googlejavaformat/JavaCodeWithPackageUnformatted.test", "java/googlejavaformat/JavaCodeWithPackageFormatted.test");


### PR DESCRIPTION
In google-java-format 1.8, the signature of
`RemoveUnusedImports#removeUnusedImports` changed and the
`RemoveUnusedImports$JavadocOnlyImports` class was removed entirely.
With this patch, GoogleJavaFormatStep detects which version of the
method is available and calls the right one.

Fixes #562.