### PR TITLE
Fix resource leak in Maven plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * `prettier` will now autodetect the parser (and formatter) to use based on the filename, unless you override this using `config` or `configFile` with the option `parser` or `filepath`. ([#620](https://github.com/diffplug/spotless/pull/620))
+### Changed
+* **BREAKING** `FileSignature` can no longer sign folders, only files.  Signatures are now based only on filename (not path), size, and a content hash.  It throws an error if a signature is attempted on a folder or on multiple files with different paths but the same filename - it never breaks silently.  This change does not break any of Spotless' internal logic, so it is unlikely to affect any of Spotless' consumers either. ([#571](https://github.com/diffplug/spotless/pull/571))
+  * This change allows the maven plugin to cache classloaders across subprojects when loading config resources from the classpath (fixes [#559](https://github.com/diffplug/spotless/issues/559)).
+  * This change also allows the gradle plugin to work with the remote buildcache (fixes [#280](https://github.com/diffplug/spotless/issues/280)).
 
 ## [1.34.1] - 2020-06-17
 ### Changed
@@ -160,7 +164,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   * Updated default npm package version of `prettier` from 1.13.4 to 1.16.4
   * Updated default npm package version of internally used typescript package from 2.9.2 to 3.3.3 and tslint package from 5.1.0 to 5.12.0 (both used by `tsfmt`)
 * Updated default eclipse-wtp from 4.7.3a to 4.7.3b ([#371](https://github.com/diffplug/spotless/pull/371)).
-* Configured `buìld-scan` plugin in build ([#356](https://github.com/diffplug/spotless/pull/356)).
+* Configured `build-scan` plugin in build ([#356](https://github.com/diffplug/spotless/pull/356)).
   * Runs on every CI build automatically.
   * Users need to opt-in on their local machine.
 * Default behavior of XML formatter changed to ignore external URIs ([#369](https://github.com/diffplug/spotless/issues/369)).

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -83,7 +83,21 @@ public final class FileSignature implements Serializable {
 
 	/** Creates file signature insensitive to the order of the files. */
 	public static FileSignature signAsSet(Iterable<File> files) throws IOException {
-		return new FileSignature(toSortedSet(files, comparing(File::getName)));
+		List<File> natural = toSortedSet(files);
+		List<File> onNameOnly = toSortedSet(files, comparing(File::getName));
+		if (natural.size() != onNameOnly.size()) {
+			StringBuilder builder = new StringBuilder();
+			builder.append("For these files:\n");
+			for (File file : files) {
+				builder.append("  " + file.getAbsolutePath() + "\n");
+			}
+			builder.append("a caching signature is being generated, which will be based only on their\n");
+			builder.append("names, not their full path (foo.txt, not C:\folder\foo.txt). Unexpectedly,\n");
+			builder.append("you have two files with different paths, but the same names.  You must\n");
+			builder.append("rename one of them so that all files have unique names.");
+			throw new IllegalArgumentException(builder.toString());
+		}
+		return new FileSignature(onNameOnly);
 	}
 
 	private FileSignature(final List<File> files) throws IOException {

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -186,8 +186,11 @@ public final class FileSignature implements Serializable {
 	private static final class Sig implements Serializable {
 		private static final long serialVersionUID = 6727302747168655222L;
 
+		@SuppressWarnings("unused")
 		final String name;
+		@SuppressWarnings("unused")
 		final long size;
+		@SuppressWarnings("unused")
 		final byte[] hash;
 		/** transient because state should be transferable from machine to machine. */
 		final transient long lastModified;

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -150,7 +150,7 @@ public final class FileSignature implements Serializable {
 	 */
 	static final Cache cache = new Cache();
 
-	static class Cache {
+	private static final class Cache {
 		Map<String, Sig> cache = new HashMap<>();
 
 		synchronized Sig sign(File fileInput) throws IOException {
@@ -183,7 +183,7 @@ public final class FileSignature implements Serializable {
 	}
 
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	static class Sig implements Serializable {
+	private static final class Sig implements Serializable {
 		private static final long serialVersionUID = 6727302747168655222L;
 
 		final String name;

--- a/lib/src/main/java/com/diffplug/spotless/MoreIterables.java
+++ b/lib/src/main/java/com/diffplug/spotless/MoreIterables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static com.diffplug.spotless.LibPreconditions.requireElementsNonNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -37,18 +38,23 @@ final class MoreIterables {
 		return shallowCopy;
 	}
 
-	/** Sorts "raw" and removes duplicates, throwing on null elements. */
+	/** Sorts "raw" using {@link Comparator#naturalOrder()} and removes duplicates, throwing on null elements. */
 	static <T extends Comparable<T>> List<T> toSortedSet(Iterable<T> raw) {
+		return toSortedSet(raw, Comparator.naturalOrder());
+	}
+
+	/** Sorts "raw" and removes duplicates, throwing on null elements. */
+	static <T> List<T> toSortedSet(Iterable<T> raw, Comparator<T> comparator) {
 		List<T> toBeSorted = toNullHostileList(raw);
 		// sort it
-		Collections.sort(toBeSorted);
+		Collections.sort(toBeSorted, comparator);
 		// remove any duplicates (normally there won't be any)
 		if (toBeSorted.size() > 1) {
 			Iterator<T> iter = toBeSorted.iterator();
 			T last = iter.next();
 			while (iter.hasNext()) {
 				T next = iter.next();
-				if (next.compareTo(last) == 0) {
+				if (comparator.compare(next, last) == 0) {
 					iter.remove();
 				} else {
 					last = next;

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.npm;
+
+import java.io.File;
+
+class NodeServerLayout {
+
+	private final File nodeModulesDir;
+	private final File packageJsonFile;
+	private final File serveJsFile;
+
+	NodeServerLayout(File buildDir, String stepName) {
+		this.nodeModulesDir = new File(buildDir, "spotless-node-modules-" + stepName);
+		this.packageJsonFile = new File(nodeModulesDir, "package.json");
+		this.serveJsFile = new File(nodeModulesDir, "serve.js");
+	}
+
+	File nodeModulesDir() {
+		return nodeModulesDir;
+	}
+
+	File packageJsonFile() {
+		return packageJsonFile;
+	}
+
+	File serveJsFile() {
+		return serveJsFile;
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -44,7 +44,7 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 	private static final long serialVersionUID = 1460749955865959948L;
 
 	@SuppressWarnings("unused")
-	private final FileSignature nodeModulesSignature;
+	private final FileSignature packageJsonSignature;
 
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 	public final transient File nodeModulesDir;
@@ -56,22 +56,26 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 
 	private final String stepName;
 
-	protected NpmFormatterStepStateBase(String stepName, NpmConfig npmConfig, File buildDir, @Nullable File npm) throws IOException {
+	protected NpmFormatterStepStateBase(String stepName, NpmConfig npmConfig, File buildDir,
+			@Nullable File npm) throws IOException {
 		this.stepName = requireNonNull(stepName);
 		this.npmConfig = requireNonNull(npmConfig);
 		this.npmExecutable = resolveNpm(npm);
 
-		this.nodeModulesDir = prepareNodeServer(buildDir);
-		this.nodeModulesSignature = FileSignature.signAsList(this.nodeModulesDir);
+		NodeServerLayout layout = prepareNodeServer(buildDir);
+		this.nodeModulesDir = layout.nodeModulesDir();
+		this.packageJsonSignature = FileSignature.signAsList(layout.packageJsonFile());
 	}
 
-	private File prepareNodeServer(File buildDir) throws IOException {
-		File targetDir = new File(buildDir, "spotless-node-modules-" + stepName);
-		NpmResourceHelper.assertDirectoryExists(targetDir);
-		NpmResourceHelper.writeUtf8StringToFile(targetDir, "package.json", this.npmConfig.getPackageJsonContent());
-		NpmResourceHelper.writeUtf8StringToFile(targetDir, "serve.js", this.npmConfig.getServeScriptContent());
-		runNpmInstall(targetDir);
-		return targetDir;
+	private NodeServerLayout prepareNodeServer(File buildDir) throws IOException {
+		NodeServerLayout layout = new NodeServerLayout(buildDir, stepName);
+		NpmResourceHelper.assertDirectoryExists(layout.nodeModulesDir());
+		NpmResourceHelper.writeUtf8StringToFile(layout.packageJsonFile(),
+				this.npmConfig.getPackageJsonContent());
+		NpmResourceHelper
+				.writeUtf8StringToFile(layout.serveJsFile(), this.npmConfig.getServeScriptContent());
+		runNpmInstall(layout.nodeModulesDir());
+		return layout;
 	}
 
 	private void runNpmInstall(File npmProjectDir) throws IOException {

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmResourceHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmResourceHelper.java
@@ -28,9 +28,8 @@ final class NpmResourceHelper {
 		// no instance required
 	}
 
-	static void writeUtf8StringToFile(File targetDir, String fileName, String stringToWrite) throws IOException {
-		File packageJsonFile = new File(targetDir, fileName);
-		Files.write(packageJsonFile.toPath(), stringToWrite.getBytes(StandardCharsets.UTF_8));
+	static void writeUtf8StringToFile(File file, String stringToWrite) throws IOException {
+		Files.write(file.toPath(), stringToWrite.getBytes(StandardCharsets.UTF_8));
 	}
 
 	static void writeUtf8StringToOutputStream(String stringToWrite, OutputStream outputStream) throws IOException {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
+* Full support for the Gradle buildcache - previously only supported local, now supports remote too. Fixes [#566](https://github.com/diffplug/spotless/issues/566) and [#280](https://github.com/diffplug/spotless/issues/280), via changes in [#621](https://github.com/diffplug/spotless/pull/621) and [#571](https://github.com/diffplug/spotless/pull/571).
 * `prettier` will now autodetect the parser (and formatter) to use based on the filename, unless you override this using `config()` or `configFile()` with the option `parser` or `filepath`. ([#620](https://github.com/diffplug/spotless/pull/620))
 ### Fixed
 * LineEndings.GIT_ATTRIBUTES is now a bit more efficient, and paves the way for remote build cache support in Gradle. ([#621](https://github.com/diffplug/spotless/pull/621))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,7 +4,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* `prettier` will now autodetect the parser (and formatter) to use based on the filename, unless you override this using `config` or `configFile` with the option `parser` or `filepath`. ([#620](https://github.com/diffplug/spotless/pull/620))
+* `prettier` will now autodetect the parser (and formatter) to use based on the filename, unless you override this using `config` or `configFile` with the option `parser` or `filepath` ([#620](https://github.com/diffplug/spotless/pull/620)).
+* Huge speed improvement for multi-module projects thanks to improved cross-project classloader caching ([#571](https://github.com/diffplug/spotless/pull/571), fixes [#559](https://github.com/diffplug/spotless/issues/559)).
 
 ## [1.31.3] - 2020-06-17
 ### Changed

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 package com.diffplug.spotless;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -46,6 +48,23 @@ public class FileSignatureTest extends ResourceHarness {
 		Collection<File> expectedFiles = getTestFiles(expectedPathSet);
 		Collection<File> outputFiles = signature.files();
 		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
+	}
+
+	@Test
+	public void testFromDirectory() {
+		File dir = new File(rootFolder(), "dir");
+		assertThatThrownBy(() -> FileSignature.signAsList(dir))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void testFromFilesAndDirectory() throws IOException {
+		File dir = new File(rootFolder(), "dir");
+		List<File> files = getTestFiles(inputPaths);
+		files.add(dir);
+		Collections.shuffle(files);
+		assertThatThrownBy(() -> FileSignature.signAsList(files))
+				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	private List<File> getTestFiles(final String[] paths) throws IOException {


### PR DESCRIPTION
The resource leak increased the number of threads with every execution of Exclipse-based formatter step in a Maven module. It happened because the `SpotlessCache` wasn't properly utilized. Every cache key was based on randomized file names because Maven plugin relocates config files into the target directory with a random file name. This resulted in all cache accesses being cache misses.

This PR fixes the problem by:

 * making the Maven plugin use non-random file names for output files. `FileLocator` is changed to construct names based on a hash of the input path. Input path can be a URL, file in a JAR, or a regular local file

 * changing `FileSignature` (used for `SpotlessCache` keys) to use filenames instead of paths and file hashes instead of last modified timestamps

These two changes allow `FileSignature` to uniquely identify a set of files by their content and not take file paths into account. As a result, created keys for `SpotlessCache` are properly comparable which results in lots of cache hits and decreased number of created threads.

Changed `FileCignature` only accepts files, not directories. NPM formatters changed to have their signatures based on package.json file instead of the whole node_modules directory.

Fixes #559 