### PR TITLE
Modify `FileSignature` so that it can be relocated based on content

### DIFF
--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -46,6 +46,9 @@ tasks.named('spotbugsTest') {
 tasks.named('spotbugsMain') {
 	// only run on Java 8 (no benefit to running twice)
 	enabled = org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8
+	reports {
+		html.enabled = true
+	}
 }
 dependencies {
 	compileOnly 'net.jcip:jcip-annotations:1.0'

--- a/lib/src/main/java/com/diffplug/spotless/FileSignatureRelocatable.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignatureRelocatable.java
@@ -25,6 +25,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 /**
  * You give it a root directory and an object which contains FileSignatures - this class will now implement `Serializable`
  * and `equalsTo` in terms of content hashes and relative path names, which makes it possible to relocate up-to-date checks
@@ -56,7 +58,7 @@ public class FileSignatureRelocatable extends LazyForwardingEquality<byte[]> imp
 
 	private static final ThreadLocal<FileSignatureRelocatableApi> api = new ThreadLocal<FileSignatureRelocatableApi>();
 
-	static FileSignatureRelocatableApi api() {
+	static @Nullable FileSignatureRelocatableApi api() {
 		return api.get();
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/FileSignatureRelocatable.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignatureRelocatable.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+/**
+ * You give it a root directory and an object which contains FileSignatures - this class will now implement `Serializable`
+ * and `equalsTo` in terms of content hashes and relative path names, which makes it possible to relocate up-to-date checks
+ * between machines.  If you pass a file which is not a subfile of `rootDir`, it will use the file's name as its full path (likely
+ * to be jar files resolved as dependencies).
+ */
+public class FileSignatureRelocatable extends LazyForwardingEquality<byte[]> implements FileSignatureRelocatableApi {
+	private static final long serialVersionUID = 7134847654770187954L;
+
+	private transient final String rootDir;
+	private transient final Object containsFileSignatures;
+
+	public FileSignatureRelocatable(File rootDir, Object containsFileSignatures) throws IOException {
+		this.rootDir = rootDir.getCanonicalPath().replace('\\', '/') + "/";
+		this.containsFileSignatures = Objects.requireNonNull(containsFileSignatures);
+	}
+
+	@Override
+	protected byte[] calculateState() throws Exception {
+		api.set(this);
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+			objectOutput.writeObject(containsFileSignatures);
+		} finally {
+			api.set(null);
+		}
+		return output.toByteArray();
+	}
+
+	private static final ThreadLocal<FileSignatureRelocatableApi> api = new ThreadLocal<FileSignatureRelocatableApi>();
+
+	static FileSignatureRelocatableApi api() {
+		return api.get();
+	}
+
+	@Override
+	public void writeRelocatable(ObjectOutputStream outputStream, String[] unixPaths) throws IOException {
+		try {
+			for (String unixPath : unixPaths) {
+				String pathToWrite;
+				if (unixPath.startsWith(rootDir)) {
+					// relocate files in the root dir
+					pathToWrite = unixPath.substring(rootDir.length());
+				} else {
+					// files outside the root dir are referenced based only on their name, not path
+					int lastSlash = unixPath.lastIndexOf('/');
+					pathToWrite = lastSlash == -1 ? unixPath : unixPath.substring(lastSlash + 1);
+				}
+				outputStream.writeBytes(pathToWrite);
+
+				MessageDigest md = MessageDigest.getInstance("SHA-256");
+				byte[] hash = md.digest(Files.readAllBytes(Paths.get(unixPath)));
+				outputStream.write(hash);
+			}
+		} catch (NoSuchAlgorithmException e) {
+			throw ThrowingEx.asRuntime(e);
+		}
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/FileSignatureRelocatableApi.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignatureRelocatableApi.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+interface FileSignatureRelocatableApi {
+	void writeRelocatable(ObjectOutputStream outputStream, String[] unixPaths) throws IOException;
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -16,6 +16,7 @@
 package com.diffplug.gradle.spotless;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class SpotlessTask extends DefaultTask {
 	}
 
 	@Input
-	public Object getLineEndingsPolicyRelocatable() {
+	public Object getLineEndingsPolicyRelocatable() throws IOException {
 		// allows gradle buildcache to relocate between machines
 		return new FileSignatureRelocatable(getProject().getRootProject().getRootDir(), getLineEndingsPolicy());
 	}
@@ -153,7 +154,7 @@ public class SpotlessTask extends DefaultTask {
 	}
 
 	@Input
-	public Object getStepsRelocatable() {
+	public Object getStepsRelocatable() throws IOException {
 		// allows gradle buildcache to relocate between machines
 		return new FileSignatureRelocatable(getProject().getRootProject().getRootDir(), getSteps());
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 
 import com.diffplug.common.collect.ImmutableList;
 import com.diffplug.common.collect.Iterables;
+import com.diffplug.spotless.FileSignatureRelocatable;
 import com.diffplug.spotless.FormatExceptionPolicy;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.Formatter;
@@ -62,9 +63,15 @@ public class SpotlessTask extends DefaultTask {
 
 	protected LineEnding.Policy lineEndingsPolicy = LineEnding.UNIX.createPolicy();
 
-	@Input
+	@Internal
 	public LineEnding.Policy getLineEndingsPolicy() {
 		return lineEndingsPolicy;
+	}
+
+	@Input
+	public Object getLineEndingsPolicyRelocatable() {
+		// allows gradle buildcache to relocate between machines
+		return new FileSignatureRelocatable(getProject().getRootProject().getRootDir(), getLineEndingsPolicy());
 	}
 
 	public void setLineEndingsPolicy(LineEnding.Policy lineEndingsPolicy) {
@@ -140,9 +147,15 @@ public class SpotlessTask extends DefaultTask {
 
 	protected List<FormatterStep> steps = new ArrayList<>();
 
-	@Input
+	@Internal
 	public List<FormatterStep> getSteps() {
 		return Collections.unmodifiableList(steps);
+	}
+
+	@Input
+	public Object getStepsRelocatable() {
+		// allows gradle buildcache to relocate between machines
+		return new FileSignatureRelocatable(getProject().getRootProject().getRootDir(), getSteps());
 	}
 
 	public void setSteps(List<FormatterStep> steps) {

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureRelocatableTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureRelocatableTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class FileSignatureRelocatableTest extends ResourceHarness {
+	@Test
+	public void relocateWorks() throws IOException {
+		// paths much match
+		FileSignature local = FileSignature.signAsSet(setFile("local/test").toContent("123"));
+		FileSignature remote = FileSignature.signAsSet(setFile("remote/test").toContent("123"));
+		assertNotEqual(local, remote);
+
+		// but can be relocated
+		FileSignatureRelocatable localRelocatable = new FileSignatureRelocatable(newFile("local"), local);
+		FileSignatureRelocatable remoteRelocatable = new FileSignatureRelocatable(newFile("remote"), remote);
+		assertAreEqual(localRelocatable, remoteRelocatable);
+
+		// root directory matters
+		FileSignatureRelocatable localFromRoot = new FileSignatureRelocatable(this.rootFolder(), local);
+		assertNotEqual(localFromRoot, localRelocatable);
+		assertNotEqual(localFromRoot, remoteRelocatable);
+
+		// and so does content
+		FileSignature content = FileSignature.signAsSet(setFile("content/test").toContent("abc"));
+		FileSignatureRelocatable contentRelocatable = new FileSignatureRelocatable(newFile("content"), content);
+		assertNotEqual(localRelocatable, contentRelocatable);
+	}
+
+	private void assertNotEqual(Object a, Object b) {
+		Assertions.assertThat(serialize(a)).isNotEqualTo(serialize(b));
+	}
+
+	private void assertAreEqual(Object a, Object b) {
+		Assertions.assertThat(serialize(a)).isEqualTo(serialize(b));
+	}
+
+	private byte[] serialize(Object in) {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		try (ObjectOutputStream outputObj = new ObjectOutputStream(output)) {
+			outputObj.writeObject(in);
+		} catch (IOException e) {
+			throw new AssertionError(e);
+		}
+		return output.toByteArray();
+	}
+}


### PR DESCRIPTION
This attempts to resolve #566 by using `ThreadLocal` to serialize `FileSignature` differently when it is being used by Gradle than by other consumers.  This allows `SpotlessCache` to use the fastpath, and only Gradle up-to-date checking uses the slow path.

Ideally, we could use the fast path for Gradle up-to-date checking too, and we'd somehow have a way to alter/canonicalize the cache key only for the remote buildcache.  @bigdaz am I correct that no such API exists?