### PR TITLE
Be proactive about encoding mismatch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* `PaddedCell.calculateDirtyState` is now defensive about misconfigured character encoding. ([#575](https://github.com/diffplug/spotless/pull/575))
+
 ### Fixed
 * `PaddedCell.DirtyState::writeCanonicalTo(File)` can now create a new file if necessary (previously required to overwrite an existing file) ([#576](https://github.com/diffplug/spotless/pull/576)).
 

--- a/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
+++ b/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
@@ -18,89 +18,108 @@ package com.diffplug.spotless;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
-import java.util.Locale;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 
 import javax.annotation.Nullable;
 
 class EncodingErrorMsg {
 	private static final char UNREPRESENTABLE = '�';
 
-	static @Nullable String msg(String chars, byte[] bytes, Charset encoding) {
+	static @Nullable String msg(String chars, byte[] bytes, Charset charset) {
 		int unrepresentable = chars.indexOf(UNREPRESENTABLE);
 		if (unrepresentable == -1) {
 			return null;
 		}
 
-		CharsetEncoder encoder = encoding.newEncoder();
-		CharBuffer charBuf = CharBuffer.allocate(2);
-		ByteBuffer byteBuf = ByteBuffer.allocate(4);
-		int cIdx = 0;
-		int bIdx = 0;
+		StringBuilder message = new StringBuilder("Encoding error! ");
+		if (charset.equals(StandardCharsets.UTF_8)) {
+			message.append("Spotless uses UTF-8 by default.");
+		} else {
+			message.append("You configured Spotless to use " + charset.name() + ".");
+		}
+
 		int line = 1;
-		int col = 0;
-		while (cIdx < chars.length()) {
-			charBuf.clear();
-			byteBuf.clear();
-			++col;
-			char c = chars.charAt(cIdx++);
-			charBuf.put(c);
-			int codePoint;
-			if (Character.isBmpCodePoint(c)) {
-				codePoint = c;
-				if (c == '\n') {
-					++line;
-					col = 0;
-				} else if (c < ' ' && c != '\t' && c != '\r') {
-					return lineColCodepointMsg(line, col, codePoint, encoding, ByteBuffer.wrap(bytes, bIdx, 1), "is a control character");
-				}
-			} else {
-				// since we just decoded String, we can assume that all of its UTF-16 are correctly paired
-				char c2 = chars.charAt(cIdx++);
-				codePoint = Character.toCodePoint(c, c2);
-				charBuf.put(c2);
+		int col = 1;
+		for (int i = 0; i < unrepresentable; ++i) {
+			char c = chars.charAt(i);
+			if (c == '\n') {
+				++line;
+				col = 1;
+			} else if (c != '\r') {
+				++col;
 			}
-			charBuf.flip();
-			boolean endOfInput = true;
-			CoderResult result = encoder.encode(charBuf, byteBuf, endOfInput);
-			if (result.isUnmappable()) {
-				return lineColMsg(line, col, "unmappable character for " + encoding);
-			} else if (result.isMalformed()) {
-				return lineColMsg(line, col, "malformed character for " + encoding);
-			}
-			for (int i = 0; i < byteBuf.position(); ++i) {
-				if (byteBuf.get(i) != bytes[bIdx + i]) {
-					byteBuf.flip();
-					return lineColCodepointMsg(line, col, codePoint, encoding, ByteBuffer.wrap(bytes, bIdx, i + 1),
-							"should have been 0x" + hex(byteBuf));
-				}
-			}
-			bIdx += byteBuf.position();
 		}
-		throw new IllegalArgumentException();
-	}
+		message.append("  At line " + line + " col " + col + ":");
 
-	private static String lineColMsg(int line, int col, String msg) {
-		return "Line " + line + " col " + col + ": " + msg;
-	}
+		// https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html
+		LinkedHashSet<Charset> encodings = new LinkedHashSet<>();
+		encodings.add(charset); // the encoding we are using
+		encodings.add(StandardCharsets.UTF_8);  // followed by likely encodings
+		addIfAvailable(encodings, "windows-1252");
+		encodings.add(StandardCharsets.ISO_8859_1);
+		addIfAvailable(encodings, "Shift_JIS");
+		addIfAvailable(encodings, "Big5");
+		addIfAvailable(encodings, "Big5-HKSCS");
+		addIfAvailable(encodings, "GBK");
+		addIfAvailable(encodings, "GB2312");
+		addIfAvailable(encodings, "GB18030");
+		Iterator<Charset> iterator = encodings.iterator();
 
-	private static String lineColCodepointMsg(int line, int col, int codepoint, Charset charset, ByteBuffer decodedFrom, String msg) {
-		return lineColMsg(line, col, "the codepoint '" + new String(Character.toChars(codepoint)) + "' (U+" + Integer.toHexString(codepoint).toUpperCase(Locale.ROOT) + ") " +
-				"decoded via " + charset + " from 0x" + hex(decodedFrom) + " " +
-				msg);
-	}
+		ByteBuffer byteByf = ByteBuffer.wrap(bytes);
+		CharBuffer charBuf = CharBuffer.allocate(Math.min(unrepresentable + 6, chars.length()));
 
-	private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
-
-	private static String hex(ByteBuffer bytes) {
-		int len = bytes.limit() - bytes.position();
-		char[] hexChars = new char[2 * len];
-		for (int j = 0; j < len; j++) {
-			int v = bytes.get() & 0xFF;
-			hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-			hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+		appendExample(message, iterator.next(), byteByf, charBuf, unrepresentable, true);
+		while (iterator.hasNext()) {
+			appendExample(message, iterator.next(), byteByf, charBuf, unrepresentable, false);
 		}
-		return new String(hexChars);
+		return message.toString();
+	}
+
+	private static void addIfAvailable(Collection<Charset> charsets, String name) {
+		try {
+			charsets.add(Charset.forName(name));
+		} catch (UnsupportedCharsetException e) {
+			// no worries
+		}
+	}
+
+	private static void appendExample(StringBuilder message, Charset charset, ByteBuffer byteBuf, CharBuffer charBuf, int startPoint, boolean must) {
+		byteBuf.clear();
+		charBuf.clear();
+
+		CharsetDecoder decoder = charset.newDecoder();
+		if (!must) {
+			// bail early if we can
+			CoderResult r = decoder
+					.onMalformedInput(CodingErrorAction.REPORT)
+					.onUnmappableCharacter(CodingErrorAction.REPORT)
+					.decode(byteBuf, charBuf, true);
+			if (r.isError()) {
+				return;
+			}
+		} else {
+			decoder
+					.onMalformedInput(CodingErrorAction.REPLACE)
+					.onUnmappableCharacter(CodingErrorAction.REPLACE)
+					.decode(byteBuf, charBuf, true);
+		}
+		charBuf.flip();
+
+		int start = Math.max(startPoint - 3, 0);
+		int end = Math.min(charBuf.limit(), startPoint + 4);
+		message.append('\n');
+		message.append(charBuf.subSequence(start, end).toString()
+				.replace('\n', '␤')
+				.replace('\r', '␍')
+				.replace('\t', '⇥'));
+		message.append(" <- ");
+		message.append(charset.name());
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
+++ b/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.util.Locale;
+
+import javax.annotation.Nullable;
+
+class EncodingErrorMsg {
+	static @Nullable String msg(String chars, byte[] bytes, Charset encoding) {
+		CharsetEncoder encoder = encoding.newEncoder();
+		CharBuffer charBuf = CharBuffer.allocate(2);
+		ByteBuffer byteBuf = ByteBuffer.allocate(4);
+		int cIdx = 0;
+		int bIdx = 0;
+		int line = 1;
+		int col = 0;
+		while (cIdx < chars.length()) {
+			charBuf.rewind();
+			byteBuf.rewind();
+			++col;
+			char c = chars.charAt(cIdx++);
+			charBuf.put(c);
+			if (c == '\n') {
+				++line;
+				col = 0;
+			} else if (!Character.isBmpCodePoint(c)) {
+				// since we just decoded String, we can assume that all of its UTF-16 are correctly paired
+				charBuf.put(chars.charAt(cIdx++));
+			}
+			charBuf.limit(charBuf.position());
+			charBuf.position(0);
+			boolean endOfInput = true;
+			encoder.encode(charBuf, byteBuf, endOfInput);
+			for (int i = 0; i < byteBuf.position(); ++i) {
+				if (byteBuf.get(i) != bytes[bIdx + i]) {
+					byteBuf.limit(byteBuf.position());
+					byteBuf.position(0);
+					charBuf.position(0);
+					return "Line " + line + " col " + col + ": the codepoint '" + charBuf.toString() + "' (U+" + Integer.toHexString(charBuf.toString().codePointAt(0)).toUpperCase(Locale.ROOT) +
+							") encoded via " + encoding +
+							" to 0x" + hex(byteBuf) + " but was decoded from 0x" + hex(ByteBuffer.wrap(bytes, bIdx, 1));
+				}
+			}
+			bIdx += byteBuf.position();
+		}
+		return null;
+	}
+
+	private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+
+	private static String hex(ByteBuffer bytes) {
+		char[] hexChars = new char[bytes.remaining() * 2];
+		for (int j = 0; j < bytes.limit(); j++) {
+			int v = bytes.get() & 0xFF;
+			hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+			hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+		}
+		return new String(hexChars);
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
+++ b/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
@@ -25,7 +25,14 @@ import java.util.Locale;
 import javax.annotation.Nullable;
 
 class EncodingErrorMsg {
+	private static final char UNREPRESENTABLE = '�';
+
 	static @Nullable String msg(String chars, byte[] bytes, Charset encoding) {
+		int unrepresentable = chars.indexOf(UNREPRESENTABLE);
+		if (unrepresentable == -1) {
+			return null;
+		}
+
 		CharsetEncoder encoder = encoding.newEncoder();
 		CharBuffer charBuf = CharBuffer.allocate(2);
 		ByteBuffer byteBuf = ByteBuffer.allocate(4);
@@ -71,7 +78,7 @@ class EncodingErrorMsg {
 			}
 			bIdx += byteBuf.position();
 		}
-		return null;
+		throw new IllegalArgumentException();
 	}
 
 	private static String lineColMsg(int line, int col, String msg) {

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -191,9 +191,9 @@ public final class PaddedCell {
 	public static DirtyState calculateDirtyState(Formatter formatter, File file, byte[] rawBytes) throws IOException {
 		String raw = new String(rawBytes, formatter.getEncoding());
 		// check that all characters were encodable
-		byte[] roundtrippedBytes = raw.getBytes(formatter.getEncoding());
-		if (!Arrays.equals(rawBytes, roundtrippedBytes)) {
-			throw new IllegalArgumentException("Check Spotless encoding, not all characters are encodable");
+		String encodingError = EncodingErrorMsg.msg(raw, rawBytes, formatter.getEncoding());
+		if (encodingError != null) {
+			throw new IllegalArgumentException(encodingError);
 		}
 		String rawUnix = LineEnding.toUnix(raw);
 

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -191,6 +191,11 @@ public final class PaddedCell {
 
 	public static DirtyState calculateDirtyState(Formatter formatter, File file, byte[] rawBytes) throws IOException {
 		String raw = new String(rawBytes, formatter.getEncoding());
+		// check that all characters were encodable
+		byte[] roundtrippedBytes = raw.getBytes(formatter.getEncoding());
+		if (!Arrays.equals(rawBytes, roundtrippedBytes)) {
+			throw new IllegalArgumentException("Check Spotless encoding, not all characters are encodable");
+		}
 		String rawUnix = LineEnding.toUnix(raw);
 
 		// enforce the format

--- a/lib/src/main/java/com/diffplug/spotless/generic/ReplaceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/ReplaceStep.java
@@ -37,12 +37,12 @@ public final class ReplaceStep {
 	private static final class State implements Serializable {
 		private static final long serialVersionUID = 1L;
 
-		private final CharSequence target;
-		private final CharSequence replacement;
+		private final String target;
+		private final String replacement;
 
 		State(CharSequence target, CharSequence replacement) {
-			this.target = target;
-			this.replacement = replacement;
+			this.target = target.toString();
+			this.replacement = replacement.toString();
 		}
 
 		FormatterFunc toFormatter() {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* If the encoding was set incorrectly, `spotlessApply` could clobber special characters.  Spotless now prevents this, and helps to suggest the correct encoding. ([#575](https://github.com/diffplug/spotless/pull/575))
 
 ## [4.0.0] - 2020-05-17
 **TLDR: This version improves performance and adds support for the local Gradle Build Cache.  You will not need to make any changes in your buildscript.**  It is a breaking change only for a few users who have built *other* plugins on top of this one.
@@ -16,8 +18,6 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * (Power users only) **BREAKING** `SpotlessTask FormatExtension::createIndependentTask` has been removed, and replaced with `SpotlessApply::createIndependentApplyTask`. ([#576](https://github.com/diffplug/spotless/pull/576))
 * Improve suggested gradle invocation for running `spotlessApply`. ([#578](https://github.com/diffplug/spotless/pull/578))
-### Fixed
-* If the encoding was set incorrectly, `spotless:apply` could clobber special characters.  Spotless now prevents this, and helps to suggest the correct encoding. ([#575](https://github.com/diffplug/spotless/pull/575))
 
 ## [3.30.0] - 2020-05-11
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -14,6 +14,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * (Power users only) **BREAKING** `SpotlessTask FormatExtension::createIndependentTask` has been removed, and replaced with `SpotlessApply::createIndependentApplyTask`. ([#576](https://github.com/diffplug/spotless/pull/576))
 * Improve suggested gradle invocation for running `spotlessApply`. ([#578](https://github.com/diffplug/spotless/pull/578))
+### Fixed
+* If the encoding was set incorrectly, `spotless:apply` could clobber special characters.  Spotless now prevents this, and helps to suggest the correct encoding. ([#575](https://github.com/diffplug/spotless/pull/575))
 
 ## [3.30.0] - 2020-05-11
 ### Added

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java
@@ -51,8 +51,8 @@ public class EncodingTest extends GradleIntegrationTest {
 				"    encoding 'US-ASCII'",
 				"}");
 		setFile("test.java").toContent("µ");
-		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("test.java").hasContent("??");
+		gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");
+		assertFile("test.java").hasContent("µ");
 	}
 
 	@Test
@@ -75,8 +75,8 @@ public class EncodingTest extends GradleIntegrationTest {
 				"}");
 		setFile("test.java").toContent("µ");
 		setFile("utf32.encoded").toContent("µ", Charset.forName("UTF-32"));
-		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("test.java").hasContent("??");
-		assertFile("utf32.encoded").hasContent("A", Charset.forName("UTF-32"));
+		gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");
+		assertFile("test.java").hasContent("µ");
+		assertFile("utf32.encoded").hasContent("µ", Charset.forName("UTF-32"));
 	}
 }

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* If the encoding was set incorrectly, `spotless:apply` could clobber special characters.  Spotless now prevents this, and helps to suggest the correct encoding. ([#575](https://github.com/diffplug/spotless/pull/575))
 
 ## [1.31.0] - 2020-05-05
 ### Added

--- a/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
@@ -31,12 +31,18 @@ public class EncodingErrorMsgTest {
 		cp1252asUtf8("", null);
 		// single char
 		cp1252asUtf8("a", null);
-		cp1252asUtf8("\u00B0",
-				"Line 1 col 1: the codepoint '�' (U+FFFD) decoded via UTF-8 from 0xB0 should have been 0xEFBFBD");
+		cp1252asUtf8("°", "Encoding error! Spotless uses UTF-8 by default.  At line 1 col 1:\n" +
+				"� <- UTF-8\n" +
+				"° <- windows-1252\n" +
+				"° <- ISO-8859-1\n" +
+				"ｰ <- Shift_JIS");
 		// multiline
 		cp1252asUtf8("\n123\nabc\n", null);
-		cp1252asUtf8("\n123\nabc\u00B0\nABC",
-				"Line 3 col 4: the codepoint '�' (U+FFFD) decoded via UTF-8 from 0xB0 should have been 0xEFBFBD");
+		cp1252asUtf8("\n123\nabc°\nABC", "Encoding error! Spotless uses UTF-8 by default.  At line 3 col 4:\n" +
+				"abc�␤AB <- UTF-8\n" +
+				"abc°␤AB <- windows-1252\n" +
+				"abc°␤AB <- ISO-8859-1\n" +
+				"abcｰ␤AB <- Shift_JIS");
 	}
 
 	private void cp1252asUtf8(String test, @Nullable String expectedMessage) throws UnsupportedEncodingException {
@@ -55,16 +61,24 @@ public class EncodingErrorMsgTest {
 		utf8asCP1252("", null);
 		// single char
 		utf8asCP1252("a", null);
-		utf8asCP1252("\u00B0", null);
+		utf8asCP1252("°", null);
 		// multibyte UTF-8 can hide too
-		utf8asCP1252("\u1F602", null);
+		utf8asCP1252("😂", null);
 		// but some will trigger problems we can detect
-		utf8asCP1252("\u237B", "Line 1 col 2: unmappable character for windows-1252"); // there are some codepoints where it doesn't
+		utf8asCP1252("⍻", "Encoding error! You configured Spotless to use windows-1252.  At line 1 col 2:\n" +
+				"â�» <- windows-1252\n" +
+				"⍻ <- UTF-8\n" +
+				"â» <- ISO-8859-1\n" +
+				"竝ｻ <- Shift_JIS"); // there are some codepoints where it doesn't
 		// multiline
 		utf8asCP1252("\n123\nabc\n", null);
-		utf8asCP1252("\n123\nabc\u00B0\nABC", null);
-		utf8asCP1252("\n123\nabc\u1F602\nABC", null);
-		utf8asCP1252("\n123\nabc\u237B\nABC", "Line 3 col 5: unmappable character for windows-1252");
+		utf8asCP1252("\n123\nabc°\nABC", null);
+		utf8asCP1252("\n123\nabc😂\nABC", null);
+		utf8asCP1252("\n123\nabc⍻\nABC", "Encoding error! You configured Spotless to use windows-1252.  At line 3 col 5:\n" +
+				"bcâ�»␤A <- windows-1252\n" +
+				"bc⍻␤ABC <- UTF-8\n" +
+				"bcâ»␤A <- ISO-8859-1\n" +
+				"bc竝ｻ␤AB <- Shift_JIS");
 	}
 
 	private void utf8asCP1252(String test, @Nullable String expectedMessage) throws UnsupportedEncodingException {

--- a/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
@@ -87,4 +87,12 @@ public class EncodingErrorMsgTest {
 		String actualMessage = EncodingErrorMsg.msg(asCp1252, utf8, Charset.forName("cp1252"));
 		Assertions.assertThat(actualMessage).isEqualTo(expectedMessage);
 	}
+
+	@Test
+	public void canUseUnrepresentableOnPurpose() throws UnsupportedEncodingException {
+		String pathologic = new String(new char[]{EncodingErrorMsg.UNREPRESENTABLE});
+		byte[] pathologicBytes = pathologic.getBytes(StandardCharsets.UTF_8);
+		String pathologicMsg = EncodingErrorMsg.msg(pathologic, pathologicBytes, StandardCharsets.UTF_8);
+		Assertions.assertThat(pathologicMsg).isNull();
+	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nullable;
@@ -26,20 +27,50 @@ import org.junit.Test;
 public class EncodingErrorMsgTest {
 	@Test
 	public void cp1252asUtf8() throws UnsupportedEncodingException {
-		// dummy case
+		// empty case
 		cp1252asUtf8("", null);
+		// single char
 		cp1252asUtf8("a", null);
 		cp1252asUtf8("\u00B0",
-				"Line 1 col 1: the codepoint '�' (U+FFFD) encoded via UTF-8 to 0xEFBFBD but was decoded from 0xB0");
+				"Line 1 col 1: the codepoint '�' (U+FFFD) decoded via UTF-8 from 0xB0 should have been 0xEFBFBD");
+		// multiline
 		cp1252asUtf8("\n123\nabc\n", null);
-		//		cp1252asUtf8("\n123\nabc" + "\u00B0" + "\nABC",
-		//				"Line 3 col 4: the codepoint '�' (U+FFFD) encoded via UTF-8 to 0xEFBFBD but was decoded from 0xB0");
+		cp1252asUtf8("\n123\nabc\u00B0\nABC",
+				"Line 3 col 4: the codepoint '�' (U+FFFD) decoded via UTF-8 from 0xB0 should have been 0xEFBFBD");
 	}
 
 	private void cp1252asUtf8(String test, @Nullable String expectedMessage) throws UnsupportedEncodingException {
 		byte[] cp1252 = test.getBytes("cp1252");
 		String asUTF = new String(cp1252, StandardCharsets.UTF_8);
 		String actualMessage = EncodingErrorMsg.msg(asUTF, cp1252, StandardCharsets.UTF_8);
+		Assertions.assertThat(actualMessage).isEqualTo(expectedMessage);
+	}
+
+	@Test
+	public void utf8asCP1252() throws UnsupportedEncodingException {
+		// unfortunately, if you treat UTF8 as Cp1252, it looks weird, but it usually roundtrips faithfully
+		// which makes it hard to detect
+
+		// empty case
+		utf8asCP1252("", null);
+		// single char
+		utf8asCP1252("a", null);
+		utf8asCP1252("\u00B0", null);
+		// multibyte UTF-8 can hide too
+		utf8asCP1252("\u1F602", null);
+		// but some will trigger problems we can detect
+		utf8asCP1252("\u237B", "Line 1 col 2: unmappable character for windows-1252"); // there are some codepoints where it doesn't
+		// multiline
+		utf8asCP1252("\n123\nabc\n", null);
+		utf8asCP1252("\n123\nabc\u00B0\nABC", null);
+		utf8asCP1252("\n123\nabc\u1F602\nABC", null);
+		utf8asCP1252("\n123\nabc\u237B\nABC", "Line 3 col 5: unmappable character for windows-1252");
+	}
+
+	private void utf8asCP1252(String test, @Nullable String expectedMessage) throws UnsupportedEncodingException {
+		byte[] utf8 = test.getBytes(StandardCharsets.UTF_8);
+		String asCp1252 = new String(utf8, "cp1252");
+		String actualMessage = EncodingErrorMsg.msg(asCp1252, utf8, Charset.forName("cp1252"));
 		Assertions.assertThat(actualMessage).isEqualTo(expectedMessage);
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nullable;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class EncodingErrorMsgTest {
+	@Test
+	public void cp1252asUtf8() throws UnsupportedEncodingException {
+		// dummy case
+		cp1252asUtf8("", null);
+		cp1252asUtf8("a", null);
+		cp1252asUtf8("\u00B0",
+				"Line 1 col 1: the codepoint '�' (U+FFFD) encoded via UTF-8 to 0xEFBFBD but was decoded from 0xB0");
+		cp1252asUtf8("\n123\nabc\n", null);
+		//		cp1252asUtf8("\n123\nabc" + "\u00B0" + "\nABC",
+		//				"Line 3 col 4: the codepoint '�' (U+FFFD) encoded via UTF-8 to 0xEFBFBD but was decoded from 0xB0");
+	}
+
+	private void cp1252asUtf8(String test, @Nullable String expectedMessage) throws UnsupportedEncodingException {
+		byte[] cp1252 = test.getBytes("cp1252");
+		String asUTF = new String(cp1252, StandardCharsets.UTF_8);
+		String actualMessage = EncodingErrorMsg.msg(asUTF, cp1252, StandardCharsets.UTF_8);
+		Assertions.assertThat(actualMessage).isEqualTo(expectedMessage);
+	}
+}


### PR DESCRIPTION
As noted [here](https://github.com/openhab/openhab-addons/pull/7449#issuecomment-627162470), it is very destructive for Spotless to run an `apply` operation with an incorrect encoding set.  If the encoding was incorrect, we should error loudly to prevent special characters from being changed.

This PR is just a draft - We can make the error message a lot better, and we can probably go faster by never re-encoding to an entire `byte[]`, and instead just check against the existing `byte[]` as we go.  That also makes it easier to create a good error message, especially for multibyte encodings like UTF-8.