### PR TITLE
Improve gradle spotless apply suggestion

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -18,6 +18,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [3.30.0] - 2020-05-11
 ### Added
 * `-PspotlessIdeHook` which makes the VS Code extension faster and more reliable.  See [`IDE_INTEGRATION.md`](IDE_INTEGRATION.md) for more details. ([#568](https://github.com/diffplug/spotless/pull/568))
+* Improve suggested gradle invocation for running `spotlessApply`. ([#578](https://github.com/diffplug/spotless/pull/578))
 
 ## [3.29.0] - 2020-05-05
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -13,12 +13,11 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   * Previously, the `check` and `apply` tasks were just marker tasks, and they called `setCheck` and `setApply` on the "worker" task.  Now `check` and `apply` are real tasks in their own right, so the marker-task kludge is no longer necessary.
 ### Changed
 * (Power users only) **BREAKING** `SpotlessTask FormatExtension::createIndependentTask` has been removed, and replaced with `SpotlessApply::createIndependentApplyTask`. ([#576](https://github.com/diffplug/spotless/pull/576))
-
+* Improve suggested gradle invocation for running `spotlessApply`. ([#578](https://github.com/diffplug/spotless/pull/578))
 
 ## [3.30.0] - 2020-05-11
 ### Added
 * `-PspotlessIdeHook` which makes the VS Code extension faster and more reliable.  See [`IDE_INTEGRATION.md`](IDE_INTEGRATION.md) for more details. ([#568](https://github.com/diffplug/spotless/pull/568))
-* Improve suggested gradle invocation for running `spotlessApply`. ([#578](https://github.com/diffplug/spotless/pull/578))
 
 ## [3.29.0] - 2020-05-05
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -46,7 +46,7 @@ cmd> gradlew build
     -\t\t····if·(targets.length·==·0)·{
     +\t\tif·(targets.length·==·0)·{
     ...
-  Run './gradlew :spotlessApply' to fix these violations.
+  Run 'gradlew spotlessApply' to fix these violations.
 
 cmd> gradlew spotlessApply
 :spotlessApply

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -46,7 +46,7 @@ cmd> gradlew build
     -\t\t····if·(targets.length·==·0)·{
     +\t\tif·(targets.length·==·0)·{
     ...
-  Run 'gradlew spotlessApply' to fix these violations.
+  Run './gradlew :spotlessApply' to fix these violations.
 
 cmd> gradlew spotlessApply
 :spotlessApply

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -19,8 +19,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
-import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileTree;
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+import com.diffplug.common.base.StandardSystemProperty;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 
@@ -93,7 +94,7 @@ public class SpotlessCheck extends DefaultTask {
 	}
 
 	private static String calculateGradleCommand() {
-		return Os.isFamily(Os.FAMILY_WINDOWS)
+		return StandardSystemProperty.OS_NAME.value().toLowerCase(Locale.US).contains("win")
 				? "gradlew.bat"
 				: "./gradlew";
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileTree;
@@ -77,12 +78,23 @@ public class SpotlessCheck extends DefaultTask {
 	}
 
 	/** Returns an exception which indicates problem files nicely. */
-	private static GradleException formatViolationsFor(Formatter formatter, List<File> problemFiles) {
+	private GradleException formatViolationsFor(Formatter formatter, List<File> problemFiles) {
 		return new GradleException(DiffMessageFormatter.builder()
-				.runToFix("Run 'gradlew spotlessApply' to fix these violations.")
+				.runToFix("Run '" + calculateGradleCommand() + " " + getTaskPathPrefix() + "spotlessApply' to fix these violations.")
 				.formatter(formatter)
 				.problemFiles(problemFiles)
 				.getMessage());
 	}
 
+	private String getTaskPathPrefix() {
+		return getProject().getPath().equals(":")
+			? ":"
+			: getProject().getPath() + ":";
+	}
+
+	private static String calculateGradleCommand() {
+		return Os.isFamily(Os.FAMILY_WINDOWS)
+			? "gradlew.bat"
+			: "./gradlew";
+	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -88,13 +88,13 @@ public class SpotlessCheck extends DefaultTask {
 
 	private String getTaskPathPrefix() {
 		return getProject().getPath().equals(":")
-			? ":"
-			: getProject().getPath() + ":";
+				? ":"
+				: getProject().getPath() + ":";
 	}
 
 	private static String calculateGradleCommand() {
 		return Os.isFamily(Os.FAMILY_WINDOWS)
-			? "gradlew.bat"
-			: "./gradlew";
+				? "gradlew.bat"
+				: "./gradlew";
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -122,7 +122,7 @@ public class DiffMessageFormatterTest extends ResourceHarness {
 		String msg = spotless.checkFailureMsg();
 
 		String firstLine = "The following files had format violations:\n";
-		String lastLine = "\nRun 'gradlew spotlessApply' to fix these violations.";
+		String lastLine = "\n" + TestFixtures.EXPECTED_RUN_SPOTLESS_APPLY_SUGGESTION;
 		Assertions.assertThat(msg).startsWith(firstLine).endsWith(lastLine);
 
 		String middle = msg.substring(firstLine.length(), msg.length() - lastLine.length());

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -22,13 +22,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Locale;
 
 import org.gradle.api.Project;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.diffplug.common.base.StandardSystemProperty;
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -37,10 +35,9 @@ import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.TestProvisioner;
 
 public class PaddedCellTaskTest extends ResourceHarness {
-	private static final boolean IS_WIN = StandardSystemProperty.OS_NAME.value().toLowerCase(Locale.US).contains("win");
 
 	private static String slashify(String input) {
-		return IS_WIN ? input.replace('/', '\\') : input;
+		return TestFixtures.IS_WIN ? input.replace('/', '\\') : input;
 	}
 
 	private class Bundle {
@@ -218,7 +215,7 @@ public class PaddedCellTaskTest extends ResourceHarness {
 				"        @@ -1 +1 @@",
 				"        -CCC",
 				"        +A",
-				"Run 'gradlew spotlessApply' to fix these violations.");
+				TestFixtures.EXPECTED_RUN_SPOTLESS_APPLY_SUGGESTION);
 	}
 
 	@Test
@@ -228,7 +225,7 @@ public class PaddedCellTaskTest extends ResourceHarness {
 				slashify("    src/test.converge"),
 				"        @@ -1 +0,0 @@",
 				"        -CCC",
-				"Run 'gradlew spotlessApply' to fix these violations.");
+				TestFixtures.EXPECTED_RUN_SPOTLESS_APPLY_SUGGESTION);
 	}
 
 	private void assertFailureMessage(Bundle bundle, String... expectedOutput) {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/TestFixtures.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/TestFixtures.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.Locale;
+
+import com.diffplug.common.base.StandardSystemProperty;
+
+interface TestFixtures {
+	boolean IS_WIN = StandardSystemProperty.OS_NAME.value().toLowerCase(Locale.US).contains("win");
+	String EXPECTED_RUN_SPOTLESS_APPLY_SUGGESTION = IS_WIN
+			? "Run 'gradlew.bat :spotlessApply' to fix these violations."
+			: "Run './gradlew :spotlessApply' to fix these violations.";
+}


### PR DESCRIPTION
This PR adds a minor improvement to the suggestion message 

```
Run 'gradlew spotlessApply' to fix these violations.
```

to 

1. use a OS specific invocation of gradlew
2. provide the full task path of the spotlessApply task

which results in

```
// windows
Run 'gradlew.bat :spotlessApply' to fix these violations.

// unix, osx, linux
Run './gradlew :spotlessApply' to fix these violations.
```


Especially for larger multi project builds, this makes copy pasting the suggested fix easier and more efficient as it only runs on the problematic project and not on all projects in the multi project build.
