### PR TITLE
Better error message if you try to format a file outside the project directory.

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Users can now run `spotlessCheck` and `spotlessApply` in the same build. ([#584](https://github.com/diffplug/spotless/pull/584))
 * Fixed intermittent `UnsatisfiedLinkError` in nodejs-based steps. ([#586](https://github.com/diffplug/spotless/pull/586))
   * Also, a shared library used by the nodejs steps used to be extracted into the user home directory, but now it is extracted into `{rootProject}/build/spotless-nodejs-cache`.
+* Starting in `4.0`, it is no longer possible for a project to format files which are not within its project folder (for example, `:a` can no longer format files in `:b`).  We did not explicitly note this in the changelog entry for `4.0`, and we gave a very confusing error message if users tried.  We now give a more helpful error message, and this breaking change has been retroactively noted in the changelog for `4.0.0`. ([#588](https://github.com/diffplug/spotless/pull/588))
 
 ## [4.0.1] - 2020-05-21
 ### Fixed
@@ -21,6 +22,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Support for the gradle build cache. ([#576](https://github.com/diffplug/spotless/pull/576))
   * The local cache will work great, but the remote cache will always miss until [#566](https://github.com/diffplug/spotless/issues/566) is resolved.
 ### Removed
+* **BREAKING** it used to be possible for any project to format files in any other project.  For example, `:a` could format files in `:b`.  It is now only possible to format files within the project directory.  It is okay (but not advised) to format files in subprojects, since they are within the project directory.
 * (Power users only) **BREAKING** `void SpotlessTask::setCheck()` and `setApply()` have been removed. ([#576](https://github.com/diffplug/spotless/pull/576))
   * Previously, the `check` and `apply` tasks were just marker tasks, and they called `setCheck` and `setApply` on the "worker" task.  Now `check` and `apply` are real tasks in their own right, so the marker-task kludge is no longer necessary.
 ### Changed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -44,6 +44,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 
 import com.diffplug.common.base.Errors;
+import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.FormatExceptionPolicy;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.Formatter;
@@ -245,7 +246,11 @@ public class SpotlessTask extends DefaultTask {
 	private File getOutputFile(File input) {
 		String outputFileName = FormatExtension.relativize(getProject().getProjectDir(), input);
 		if (outputFileName == null) {
-			outputFileName = input.getAbsolutePath();
+			throw new IllegalArgumentException(StringPrinter.buildString(printer -> {
+				printer.println("Spotless error! All target files must be within the project root. In project " + getProject().getPath());
+				printer.println("  root dir: " + getProject().getProjectDir().getAbsolutePath());
+				printer.println("    target: " + input.getAbsolutePath());
+			}));
 		}
 		return new File(outputDirectory, outputFileName);
 	}


### PR DESCRIPTION
Previously, it was possible to format files which were outside of the project directory.  That was probably always a bug, but it turns out that users were "using" that feature.  With the improved approach of 4.0, it is no longer possible to do that, which is probably good.  But prior to this PR, spotless would still try to, which would lead to an error message [like this](https://github.com/vividus-framework/vividus/runs/703692427?check_suite_focus=true#step:8:105):

```
Execution failed for task ':vividus:spotlessMisc'.
> Illegal char <:> at index 59: D:\a\vividus\vividus\vividus\output\spotless\spotlessMisc\D:\a\vividus\vividus\build.gradle
```

After this PR, that error message is changed to this:

```
> Spotless error! All target files must be within the project root. In project :vividus
    root dir: D:\a\vividus\vividus
      target: D:\a\vividus\build.gradle
```

It is good that 4.0 disallows this.  For example, in the vividus example project above, spotless runs very slowly because every project is accidentally formatting all of the `gradle` files of every single other project.  Before 4.x, Spotless chugged slowly along but eventually completed.  After 4.x, it now errors clearly, and fixing the error will provide far better performance.

@bigdaz just FYI.

