### PR TITLE
Help SpotlessTask to handle a removed directory.

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -240,7 +241,14 @@ public class SpotlessTask extends DefaultTask {
 
 	private void deletePreviousResult(File input) throws IOException {
 		File output = getOutputFile(input);
-		Files.deleteIfExists(output.toPath());
+		if (output.isDirectory()) {
+			Files.walk(output.toPath())
+					.sorted(Comparator.reverseOrder())
+					.map(Path::toFile)
+					.forEach(File::delete);
+		} else {
+			Files.deleteIfExists(output.toPath());
+		}
 	}
 
 	private File getOutputFile(File input) {


### PR DESCRIPTION
@bigdaz in a local build with Gradle 6.4.1, I was getting this error:

```
Caused by: java.nio.file.DirectoryNotEmptyException: C:\Users\ntwigg\Documents\dev\test\build\spotless\spotlessJava\...
```

so I added special handling for directories.  I was a little surprised, I figured that Gradle would pass removed subfolders and such so that you could always just do `Files.deleteIfExists()`.

Unfortunately, I wasn't able to recreate in an integration test.  It's surprising, because I had a very simple one that recreated the `DirectoryNotEmptyException` every single time, but it never triggered the error when running via testkit:

```gradle
plugins {
    id 'java'
    id 'com.diffplug.gradle.spotless'
}

def generatedDir = new File(project.buildDir, "generated/src/constants/java")
def outputFile = new File(generatedDir, "project/Version.java")
outputFile.getParentFile().mkdirs()
outputFile.setText("package blah; public class Version {}");

sourceSets.main {
    java.srcDir(generatedDir)
}

spotless {
    java {
        targetExclude 'build/**' // comment and uncomment to generate DirectoryNotEmptyException
        googleJavaFormat()
    }
}
```

Regardless, this small change fixes it and seems harmless.  Does this smell right to you?