### PR TITLE
Make it easier to keep copyright headers up-to-date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* `LicenseHeaderStep` now has an `updateYearWithLatest` parameter which can update copyright headers to today's date. ([#593](https://github.com/diffplug/spotless/pull/593))
+  * Parsing of existing years from headers is now more lenient.
+  * The `LicenseHeaderStep` constructor is now public, which allows capturing its state lazily, which is helpful for setting defaults based on `ratchetFrom`.
 
 ## [1.32.0] - 2020-06-01
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -40,50 +40,44 @@ public final class LicenseHeaderStep implements Serializable {
 
 	private static final String NAME = "licenseHeader";
 	private static final String DEFAULT_YEAR_DELIMITER = "-";
-	private static final boolean DEFAULT_OVERWRITE_YEAR_WITH_LATEST = false;
 	private static final List<String> YEAR_TOKENS = Arrays.asList("$YEAR", "$today.year");
 
 	private static final SerializableFileFilter UNSUPPORTED_JVM_FILES_FILTER = SerializableFileFilter.skipFilesNamed(
 			"package-info.java", "package-info.groovy", "module-info.java");
 
-	/** @see #createFromHeader(String, String, String, boolean) */
+	/** Creates a FormatterStep which forces the start of each file to match a license header. */
 	public static FormatterStep createFromHeader(String licenseHeader, String delimiter) {
 		return createFromHeader(licenseHeader, delimiter, DEFAULT_YEAR_DELIMITER);
 	}
 
-	/** @see #createFromHeader(String, String, String, boolean) */
 	public static FormatterStep createFromHeader(String licenseHeader, String delimiter, String yearSeparator) {
-		return createFromHeader(licenseHeader, delimiter, yearSeparator, DEFAULT_OVERWRITE_YEAR_WITH_LATEST);
-	}
-
-	/** Creates a FormatterStep which forces the start of each file to match a license header. */
-	public static FormatterStep createFromHeader(String licenseHeader, String delimiter, String yearSeparator, boolean updateYearWithLatest) {
 		Objects.requireNonNull(licenseHeader, "licenseHeader");
 		Objects.requireNonNull(delimiter, "delimiter");
 		Objects.requireNonNull(yearSeparator, "yearSeparator");
 		return FormatterStep.create(LicenseHeaderStep.NAME,
-				new LicenseHeaderStep(licenseHeader, delimiter, yearSeparator, updateYearWithLatest),
+				new LicenseHeaderStep(licenseHeader, delimiter, yearSeparator),
 				step -> step::format);
 	}
 
-	/** @see #createFromFile(File, Charset, String, String, boolean) */
+	/**
+	 * Creates a FormatterStep which forces the start of each file to match the license header
+	 * contained in the given file.
+	 */
 	public static FormatterStep createFromFile(File licenseHeaderFile, Charset encoding, String delimiter) {
 		return createFromFile(licenseHeaderFile, encoding, delimiter, DEFAULT_YEAR_DELIMITER);
 	}
 
-	/** @see #createFromFile(File, Charset, String, String, boolean) */
+	/**
+	 * Creates a FormatterStep which forces the start of each file to match the license header
+	 * contained in the given file.
+	 */
 	public static FormatterStep createFromFile(File licenseHeaderFile, Charset encoding, String delimiter, String yearSeparator) {
-		return createFromFile(licenseHeaderFile, encoding, delimiter, yearSeparator, DEFAULT_OVERWRITE_YEAR_WITH_LATEST);
-	}
-
-	/** Creates a FormatterStep which forces the start of each file to match a license header. */
-	public static FormatterStep createFromFile(File licenseHeaderFile, Charset encoding, String delimiter, String yearSeparator, boolean updateYearWithLatest) {
 		Objects.requireNonNull(licenseHeaderFile, "licenseHeaderFile");
 		Objects.requireNonNull(encoding, "encoding");
 		Objects.requireNonNull(delimiter, "delimiter");
 		Objects.requireNonNull(yearSeparator, "yearSeparator");
 		return FormatterStep.createLazy(LicenseHeaderStep.NAME,
-				() -> new LicenseHeaderStep(licenseHeaderFile, encoding, delimiter, yearSeparator, updateYearWithLatest),
+				() -> new LicenseHeaderStep(new String(Files.readAllBytes(licenseHeaderFile.toPath()), encoding), delimiter, yearSeparator),
 				step -> step::format);
 	}
 
@@ -93,10 +87,6 @@ public final class LicenseHeaderStep implements Serializable {
 
 	public static String defaultYearDelimiter() {
 		return DEFAULT_YEAR_DELIMITER;
-	}
-
-	public static boolean defaultOverwriteYearWithLatest() {
-		return DEFAULT_OVERWRITE_YEAR_WITH_LATEST;
 	}
 
 	public static SerializableFileFilter unsupportedJvmFilesFilter() {
@@ -109,6 +99,10 @@ public final class LicenseHeaderStep implements Serializable {
 	private final @Nullable String beforeYear;
 	private final @Nullable String afterYear;
 	private final boolean updateYearWithLatest;
+
+	private LicenseHeaderStep(String licenseHeader, String delimiter, String yearSeparator) {
+		this(licenseHeader, delimiter, yearSeparator, false);
+	}
 
 	/** The license that we'd like enforced. */
 	public LicenseHeaderStep(String licenseHeader, String delimiter, String yearSeparator, boolean updateYearWithLatest) {

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -16,7 +16,6 @@
 package com.diffplug.spotless.generic;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -146,11 +145,6 @@ public final class LicenseHeaderStep implements Serializable {
 		return YEAR_TOKENS.stream().filter(licenseHeader::contains).findFirst();
 	}
 
-	/** Reads the license file from the given file. */
-	public LicenseHeaderStep(File licenseFile, Charset encoding, String delimiter, String yearSeparator, boolean updateYearWithLatest) throws IOException {
-		this(new String(Files.readAllBytes(licenseFile.toPath()), encoding), delimiter, yearSeparator, updateYearWithLatest);
-	}
-
 	/** Formats the given string. */
 	public String format(String raw) {
 		Matcher contentMatcher = delimiterPattern.matcher(raw);
@@ -213,5 +207,4 @@ public final class LicenseHeaderStep implements Serializable {
 			}
 		}
 	}
-
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,12 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* If you use `ratchetFrom` and `licenseHeader`, the year in your license header will now be automatically kept up-to-date for changed files. For example, if the current year is 2020: ([#593](https://github.com/diffplug/spotless/pull/593))
+  * `/** Copyright 2020 */` -> unchanged
+  * `/** Copyright 1990 */` -> `/** Copyright 1990-2020 */`
+  * `/** Copyright 1990-1993 */` -> `/** Copyright 1990-2020 */`
+  * You can disable this behavior with `licenseHeader(...).updateYearWithLatest(false)`, or you can enable it without using `ratchetFrom` by using `updateYearWithLatest(true)` (not recommended).
 
 ## [4.1.0] - 2020-06-01
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -543,32 +543,15 @@ to true.
 
 ## License header options
 
-If the license header (specified with `licenseHeader` or `licenseHeaderFile`) contains `$YEAR` or `$today.year`, then that token will be replaced with the current 4-digit year.  For example, if Spotless is launched in 2017, then `/* Licensed under Apache-2.0 $YEAR. */` will produce `/* Licensed under Apache-2.0 2017. */`
+If the license header (specified with `licenseHeader` or `licenseHeaderFile`) contains `$YEAR` or `$today.year`, then that token will be replaced with the current 4-digit year.  For example, if Spotless is launched in 2020, then `/* Licensed under Apache-2.0 $YEAR. */` will produce `/* Licensed under Apache-2.0 2020. */`
 
-The `licenseHeader` and `licenseHeaderFile` steps will generate license headers with automatic years according to the following rules:
-* A generated license header will be updated with the current year when
-  * the generated license header is missing
-  * the generated license header is not formatted correctly
-* A generated license header will _not_ be updated when
-  * a single year is already present, e.g.
-  `/* Licensed under Apache-2.0 1990. */`
-  * a year range is already present, e.g.
-  `/* Licensed under Apache-2.0 1990-2003. */`
-  * the `$YEAR` token is otherwise missing
+Once a file's license header has a valid year, whether it is a year (`2020`) or a year range (`2017-2020`), it will not be changed.  If you want the date to be updated when it changes, enable the [`ratchetFrom` functionality](#ratchet), and the year will be automatically set to today's year according to the following table (assuming the current year is 2020):
 
-The separator for the year range defaults to the hyphen character, e.g `1990-2003`, but can be customized with the `yearSeparator` property.
+* No license header -> `2020`
+* `2017` -> `2017-2020`
+* `2017-2019` -> `2017-2020`
 
-For instance, the following configuration treats `1990, 2003` as a valid year range.
-
-```gradle
-spotless {
-  java {
-    licenseHeader('Licensed under Apache-2.0 $YEAR').yearSeparator(', ')
-  }
-}
-```
-
-To update the copyright notice only for changed files, use the [`ratchetFrom` functionality](#ratchet).
+See the [javadoc](https://javadoc.io/static/com.diffplug.spotless/spotless-plugin-gradle/4.1.0/com/diffplug/gradle/spotless/FormatExtension.LicenseHeaderConfig.html) for a complete listing of options.
 
 <a name="custom"></a>
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -408,6 +408,11 @@ public class FormatExtension {
 		addStep(IndentStep.Type.TAB.create());
 	}
 
+	/**
+	 * Created by {@link FormatExtension#licenseHeader(String, String)} or {@link FormatExtension#licenseHeaderFile(Object, String)}.
+	 * For most language-specific formats (e.g. java, scala, etc.) you can omit the second `delimiter` argument, because it is supplied
+	 * automatically ({@link HasBuiltinDelimiterForLicense}).
+	 */
 	public abstract class LicenseHeaderConfig {
 		String delimiter;
 		String yearSeparator = LicenseHeaderStep.defaultYearDelimiter();
@@ -459,7 +464,7 @@ public class FormatExtension {
 		}
 	}
 
-	public class LicenseStringHeaderConfig extends LicenseHeaderConfig {
+	private class LicenseStringHeaderConfig extends LicenseHeaderConfig {
 		private String header;
 
 		LicenseStringHeaderConfig(String delimiter, String header) {
@@ -473,7 +478,7 @@ public class FormatExtension {
 		}
 	}
 
-	public class LicenseFileHeaderConfig extends LicenseHeaderConfig {
+	private class LicenseFileHeaderConfig extends LicenseHeaderConfig {
 		private Object headerFile;
 
 		LicenseFileHeaderConfig(String delimiter, Object headerFile) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -409,6 +409,7 @@ public class FormatExtension {
 	public abstract class LicenseHeaderConfig {
 		String delimiter;
 		String yearSeparator = LicenseHeaderStep.defaultYearDelimiter();
+		boolean overwriteYearLatest = LicenseHeaderStep.defaultOverwriteYearWithLatest();
 
 		public LicenseHeaderConfig(String delimiter) {
 			this.delimiter = Objects.requireNonNull(delimiter, "delimiter");
@@ -430,6 +431,16 @@ public class FormatExtension {
 		 */
 		public LicenseHeaderConfig yearSeparator(String yearSeparator) {
 			this.yearSeparator = Objects.requireNonNull(yearSeparator, "yearSeparator");
+			replaceStep(createStep());
+			return this;
+		}
+
+		/**
+		 * @param overwriteYearLatest
+		 *           Will turn `2004` into `2004-2020`, and `2004-2019` into `2004-2020`
+		 */
+		public LicenseHeaderConfig overwriteYearLatest(boolean overwriteYearLatest) {
+			this.overwriteYearLatest = overwriteYearLatest;
 			replaceStep(createStep());
 			return this;
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -193,7 +193,7 @@ public class KotlinExtensionTest extends GradleIntegrationTest {
 			matcher.startsWith("// License Header 2012, 2014");
 		});
 		assertFile("src/main/kotlin/test2.kt").matches(matcher -> {
-			matcher.startsWith(HEADER_WITH_YEAR.replace("$YEAR", String.valueOf(YearMonth.now().getYear())));
+			matcher.startsWith("// License Header 2012, 2014");
 		});
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -18,7 +18,6 @@ package com.diffplug.gradle.spotless;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.time.YearMonth;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.Test;
@@ -223,7 +222,7 @@ public class KotlinExtensionTest extends GradleIntegrationTest {
 			matcher.startsWith("// License Header 2012, 2014");
 		});
 		assertFile("src/main/kotlin/test2.kt").matches(matcher -> {
-			matcher.startsWith(HEADER_WITH_YEAR.replace("$YEAR", String.valueOf(YearMonth.now().getYear())));
+			matcher.startsWith("// License Header 2012, 2014");
 		});
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2016 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+import java.time.YearMonth;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Test;
+
+public class LicenseHeaderTest extends GradleIntegrationTest {
+	private static final String NOW = String.valueOf(YearMonth.now().getYear());
+
+	private static final String TEST_JAVA = "src/main/java/pkg/Test.java";
+	private static final String CONTENT = "package pkg;\npublic class Test {}";
+
+	private void setLicenseStep(String licenseLine) throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"  id 'com.diffplug.gradle.spotless'",
+				"  id 'java'",
+				"}",
+				"spotless {",
+				"  java {",
+				licenseLine,
+				"  }",
+				"}");
+	}
+
+	private void assertUnchanged(String year) throws IOException {
+		assertTransform(year, year);
+	}
+
+	private void assertTransform(String yearBefore, String yearAfter) throws IOException {
+		setFile(TEST_JAVA).toContent("/** " + yearBefore + " */\n" + CONTENT);
+		gradleRunner().withArguments("spotlessApply", "--stacktrace").build();
+		assertFile(TEST_JAVA).hasContent("/** " + yearAfter + " */\n" + CONTENT);
+	}
+
+	private void testSuiteUpdateWithLatest(boolean update) throws IOException {
+		if (update) {
+			assertTransform("2003", "2003-" + NOW);
+			assertTransform("2003-2005", "2003-" + NOW);
+		} else {
+			assertUnchanged("2003");
+			assertUnchanged("2003-2005");
+		}
+		assertUnchanged(NOW);
+		assertTransform("", NOW);
+	}
+
+	@Test
+	public void normal() throws IOException {
+		setLicenseStep("licenseHeader('/** $YEAR */')");
+		testSuiteUpdateWithLatest(false);
+	}
+
+	@Test
+	public void updateYearWithLatestTrue() throws IOException {
+		setLicenseStep("licenseHeader('/** $YEAR */').updateYearWithLatest(true)");
+		testSuiteUpdateWithLatest(true);
+	}
+
+	@Test
+	public void ratchetFrom() throws Exception {
+		try (Git git = Git.init().setDirectory(rootFolder()).call()) {
+			git.commit().setMessage("First commit").call();
+		}
+		setLicenseStep("licenseHeader('/** $YEAR */')\nratchetFrom 'HEAD'");
+		testSuiteUpdateWithLatest(true);
+	}
+
+	@Test
+	public void ratchetFromButUpdateFalse() throws Exception {
+		try (Git git = Git.init().setDirectory(rootFolder()).call()) {
+			git.commit().setMessage("First commit").call();
+		}
+		Git.init().setDirectory(rootFolder()).call();
+		setLicenseStep("licenseHeader('/** $YEAR */').updateYearWithLatest(false)\nratchetFrom 'HEAD'");
+		testSuiteUpdateWithLatest(false);
+	}
+}

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `licenseHeader` is now more robust when parsing years from existing license headers. ([#593](https://github.com/diffplug/spotless/pull/593))
 
 ## [1.31.2] - 2020-06-01
 ### Fixed

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -71,7 +71,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"))
 				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"))
 				.test(fileWithLicenseContaining("Something before license.*/\n/* \n * " + LICENSE_HEADER_YEAR, "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR + "\n **/\n/* Something after license.", "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR + "\n **/\n/* Something after license.", "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"))
 				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "not a year"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
 
 		// Check with variant
@@ -98,7 +98,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 		StepHarness.forStep(step)
 				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990, 2015"))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990, 2015"));
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 		StepHarness.forStep(step)
 				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990(2015"))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990(2015"));
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -93,7 +93,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	}
 
 	@Test
-	public void overwriteYearWithLatest() throws Throwable {
+	public void updateYearWithLatest() throws Throwable {
 		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, "-", true);
 		StepHarness.forStep(step)
 				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -93,6 +93,15 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	}
 
 	@Test
+	public void overwriteYearWithLatest() throws Throwable {
+		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, "-", true);
+		StepHarness.forStep(step)
+				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003-" + currentYear()))
+				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-" + currentYear()));
+	}
+
+	@Test
 	public void should_apply_license_containing_YEAR_token_with_non_default_year_separator() throws Throwable {
 		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, ", ");
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -38,12 +38,12 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	private static final String KEY_LICENSE_WITH_PLACEHOLDER = "license/LicenseHeaderWithPlaceholder";
 	private static final String KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER = "license/FileWithLicenseHeaderAndPlaceholder.test";
 	// Licenses to test $YEAR token replacement
-	private static final String LICENSE_HEADER_YEAR = "This is a fake license, $YEAR. ACME corp.";
+	private static final String HEADER_WITH_YEAR = "This is a fake license, $YEAR. ACME corp.";
 	// License to test $today.year token replacement
-	private static final String LICENSE_HEADER_YEAR_INTELLIJ_TOKEN = "This is a fake license, $today.year. ACME corp.";
+	private static final String HEADER_WITH_YEAR_INTELLIJ = "This is a fake license, $today.year. ACME corp.";
 	// Special case where the characters immediately before and after the year token are the same,
 	// start position of the second part might overlap the end position of the first part.
-	private static final String LICENSE_HEADER_YEAR_VARIANT = "This is a fake license. Copyright $YEAR ACME corp.";
+	private static final String HEADER_WITH_YEAR_VARIANT = "This is a fake license. Copyright $YEAR ACME corp.";
 
 	// If this constant changes, don't forget to change the similarly-named one in
 	// plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java as well
@@ -63,88 +63,76 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	public void should_apply_license_containing_YEAR_token() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
-
-		StepHarness.forStep(step)
-				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"))
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"))
-				.test(fileWithLicenseContaining("Something before license.*/\n/* \n * " + LICENSE_HEADER_YEAR, "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR + "\n **/\n/* Something after license.", "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "not a year"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
-
+		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER))
+				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileContainingYear(HEADER_WITH_YEAR, currentYear()))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, currentYear()))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "2003"))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "1990-2015"))
+				.test(fileContainingYear("Something before license.*/\n/* \n * " + HEADER_WITH_YEAR, "2003"), fileContainingYear(HEADER_WITH_YEAR, currentYear()))
+				.test(fileContainingYear(HEADER_WITH_YEAR + "\n **/\n/* Something after license.", "2003"), fileContainingYear(HEADER_WITH_YEAR, "2003"))
+				.test(fileContainingYear(HEADER_WITH_YEAR, "not a year"), fileContainingYear(HEADER_WITH_YEAR, currentYear()));
 		// Check with variant
-		step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR_VARIANT), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
-
-		StepHarness.forStep(step)
-				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()))
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()))
-				.test(fileWithLicenseContaining("This is a fake license. Copyright "), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()))
-				.test(fileWithLicenseContaining(" ACME corp."), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()))
-				.test(fileWithLicenseContaining("This is a fake license. Copyright ACME corp."), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()))
-				.test(fileWithLicenseContaining("This is a fake license. CopyrightACME corp."), fileWithLicenseContaining(LICENSE_HEADER_YEAR_VARIANT, currentYear()));
+		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR_VARIANT), LICENSE_HEADER_DELIMITER))
+				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
+				.test(fileContaining("This is a fake license. Copyright "), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
+				.test(fileContaining(" ACME corp."), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
+				.test(fileContaining("This is a fake license. Copyright ACME corp."), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
+				.test(fileContaining("This is a fake license. CopyrightACME corp."), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()));
 
 		//Check when token is of the format $today.year
-		step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR_INTELLIJ_TOKEN), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
-
-		StepHarness.forStep(step)
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR_INTELLIJ_TOKEN), fileWithLicenseContaining(LICENSE_HEADER_YEAR_INTELLIJ_TOKEN, currentYear(), "$today.year"));
-	}
-
-	@Test
-	public void updateYearWithLatest() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, "-", true);
-		StepHarness.forStep(step)
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003-" + currentYear()))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-" + currentYear()));
-	}
-
-	@Test
-	public void should_apply_license_containing_YEAR_token_with_non_default_year_separator() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, ", ");
-
-		StepHarness.forStep(step)
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990, 2015"))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990, 2015"));
-	}
-
-	@Test
-	public void should_apply_license_containing_YEAR_token_with_special_character_in_year_separator() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER, "(");
-
-		StepHarness.forStep(step)
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990(2015"))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990(2015"));
-	}
-
-	@Test
-	public void should_apply_license_containing_YEAR_token_with_custom_separator() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromFile(createLicenseWith(LICENSE_HEADER_YEAR), StandardCharsets.UTF_8, LICENSE_HEADER_DELIMITER);
-
-		StepHarness.forStep(step)
-				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()))
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "2003"))
-				.testUnaffected(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "1990-2015"))
-				.test(fileWithLicenseContaining(LICENSE_HEADER_YEAR, "not a year"), fileWithLicenseContaining(LICENSE_HEADER_YEAR, currentYear()));
-	}
-
-	private File createLicenseWith(String contents) throws IOException {
-		return createTestFile(KEY_LICENSE_WITH_PLACEHOLDER, c -> c.replace("__LICENSE_PLACEHOLDER__", contents));
-	}
-
-	private String fileWithLicenseContaining(String license) throws IOException {
-		return fileWithLicenseContaining(license, "");
-	}
-
-	private String fileWithLicenseContaining(String license, String yearContent) throws IOException {
-		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__LICENSE_PLACEHOLDER__", license).replace("$YEAR", yearContent);
+		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR_INTELLIJ), LICENSE_HEADER_DELIMITER))
+				.test(fileContaining(HEADER_WITH_YEAR_INTELLIJ), fileWithLicenseContaining(HEADER_WITH_YEAR_INTELLIJ, currentYear(), "$today.year"));
 	}
 
 	private String fileWithLicenseContaining(String license, String yearContent, String token) throws IOException {
 		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__LICENSE_PLACEHOLDER__", license).replace(token, yearContent);
+	}
+
+	@Test
+	public void updateYearWithLatest() throws Throwable {
+		LicenseHeaderStep stepState = new LicenseHeaderStep(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER, "-", true);
+		FormatterStep step = FormatterStep.create(LicenseHeaderStep.name(), stepState, s -> s::format);
+		StepHarness.forStep(step)
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, currentYear()))
+				.test(fileContainingYear(HEADER_WITH_YEAR, "2003"), fileContainingYear(HEADER_WITH_YEAR, "2003-" + currentYear()))
+				.test(fileContainingYear(HEADER_WITH_YEAR, "1990-2015"), fileContainingYear(HEADER_WITH_YEAR, "1990-" + currentYear()));
+	}
+
+	@Test
+	public void should_apply_license_containing_YEAR_token_with_non_default_year_separator() throws Throwable {
+		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER, ", "))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "1990, 2015"))
+				.test(fileContainingYear(HEADER_WITH_YEAR, "1990-2015"), fileContainingYear(HEADER_WITH_YEAR, "1990, 2015"));
+	}
+
+	@Test
+	public void should_apply_license_containing_YEAR_token_with_special_character_in_year_separator() throws Throwable {
+		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER, "("))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "1990(2015"))
+				.test(fileContainingYear(HEADER_WITH_YEAR, "1990-2015"), fileContainingYear(HEADER_WITH_YEAR, "1990(2015"));
+	}
+
+	@Test
+	public void should_apply_license_containing_YEAR_token_with_custom_separator() throws Throwable {
+		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER))
+				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileContainingYear(HEADER_WITH_YEAR, currentYear()))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, currentYear()))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "2003"))
+				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "1990-2015"))
+				.test(fileContainingYear(HEADER_WITH_YEAR, "not a year"), fileContainingYear(HEADER_WITH_YEAR, currentYear()));
+	}
+
+	private String licenseWith(String contents) throws IOException {
+		return getTestResource(KEY_LICENSE_WITH_PLACEHOLDER).replace("__LICENSE_PLACEHOLDER__", contents);
+	}
+
+	private String fileContaining(String license) throws IOException {
+		return fileContainingYear(license, "");
+	}
+
+	private String fileContainingYear(String license, String yearContent) throws IOException {
+		return getTestResource(KEY_FILE_WITH_LICENSE_AND_PLACEHOLDER).replace("__LICENSE_PLACEHOLDER__", license).replace("$YEAR", yearContent);
 	}
 
 	private String currentYear() {
@@ -183,6 +171,8 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 		new SerializableEqualityTester() {
 			String header = "LICENSE";
 			String delimiter = "package";
+			String yearSep = "-";
+			boolean updateYearWithLatest = false;
 
 			@Override
 			protected void setupTest(API api) {
@@ -191,16 +181,23 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				delimiter = "crate";
 				api.areDifferentThan();
 
-				header = "APACHE";
+				header = "APACHE $YEAR";
 				api.areDifferentThan();
 
 				delimiter = "package";
+				api.areDifferentThan();
+
+				yearSep = " - ";
+				api.areDifferentThan();
+
+				updateYearWithLatest = true;
 				api.areDifferentThan();
 			}
 
 			@Override
 			protected FormatterStep create() {
-				return LicenseHeaderStep.createFromHeader(header, delimiter);
+				LicenseHeaderStep stepState = new LicenseHeaderStep(header, delimiter, yearSep, updateYearWithLatest);
+				return FormatterStep.create(LicenseHeaderStep.name(), stepState, s -> s::format);
 			}
 		}.testEquals();
 	}


### PR DESCRIPTION
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/master/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
