### PR TITLE
Adds a 'addXmlDeclaration' step to add missing xml declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added `addXmlDeclaration` step that will add an xml declaration if it is missing in an xml file.
 
 ## [1.30.1] - 2020-05-17
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/xml/AddXmlDeclarationStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/xml/AddXmlDeclarationStep.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.diffplug.spotless.xml;
 
 import com.diffplug.spotless.FormatterStep;
@@ -9,8 +24,8 @@ public class AddXmlDeclarationStep {
 
 	public static FormatterStep create() {
 		return FormatterStep.create("addXmlDeclaration",
-			AddXmlDeclarationStep.class,
-			unused -> AddXmlDeclarationStep::format);
+				AddXmlDeclarationStep.class,
+				unused -> AddXmlDeclarationStep::format);
 	}
 
 	private static String format(String rawString) {
@@ -21,4 +36,3 @@ public class AddXmlDeclarationStep {
 		return replacement;
 	}
 }
-

--- a/lib/src/main/java/com/diffplug/spotless/xml/AddXmlDeclarationStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/xml/AddXmlDeclarationStep.java
@@ -31,7 +31,7 @@ public class AddXmlDeclarationStep {
 	private static String format(String rawString) {
 		String replacement = rawString;
 		if (!(rawString.startsWith(XML_DECLARATION))) {
-			replacement = XML_DECLARATION + LineEnding.PLATFORM_NATIVE.str() + replacement;
+			replacement = XML_DECLARATION + LineEnding.UNIX.str() + replacement;
 		}
 		return replacement;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/xml/AddXmlDeclarationStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/xml/AddXmlDeclarationStep.java
@@ -1,0 +1,24 @@
+package com.diffplug.spotless.xml;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.LineEnding;
+
+public class AddXmlDeclarationStep {
+
+	public static final String XML_DECLARATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+
+	public static FormatterStep create() {
+		return FormatterStep.create("addXmlDeclaration",
+			AddXmlDeclarationStep.class,
+			unused -> AddXmlDeclarationStep::format);
+	}
+
+	private static String format(String rawString) {
+		String replacement = rawString;
+		if (!(rawString.startsWith(XML_DECLARATION))) {
+			replacement = XML_DECLARATION + LineEnding.PLATFORM_NATIVE.str() + replacement;
+		}
+		return replacement;
+	}
+}
+

--- a/testlib/src/main/resources/xmldeclaration/xmlmissingdeclaration.test
+++ b/testlib/src/main/resources/xmldeclaration/xmlmissingdeclaration.test
@@ -1,0 +1,3 @@
+<string>
+   <element name="this is a fake element"/>
+</string>

--- a/testlib/src/main/resources/xmldeclaration/xmlwithdeclaration.test
+++ b/testlib/src/main/resources/xmldeclaration/xmlwithdeclaration.test
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<string>
+   <element name="this is a fake element"/>
+</string>

--- a/testlib/src/test/java/com/diffplug/spotless/xml/AddXmlDeclarationStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/xml/AddXmlDeclarationStepTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.xml;
+
+import org.junit.Test;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.ResourceHarness;
+
+public class AddXmlDeclarationStepTest extends ResourceHarness {
+
+	@Test
+	public void addMissingXmlDeclaration() throws Throwable {
+		FormatterStep xmldeclaration = AddXmlDeclarationStep.create();
+		assertOnResources(xmldeclaration, "xmldeclaration/xmlmissingdeclaration.test", "xmldeclaration/xmlwithdeclaration.test");
+	}
+
+	@Test
+	public void filesAreTheSame() throws Throwable {
+		FormatterStep xmldeclaration = AddXmlDeclarationStep.create();
+		assertOnResources(xmldeclaration, "xmldeclaration/xmlwithdeclaration.test", "xmldeclaration/xmlwithdeclaration.test");
+	}
+
+}

--- a/testlib/src/test/java/com/diffplug/spotless/xml/AddXmlDeclarationStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/xml/AddXmlDeclarationStepTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
+import com.diffplug.spotless.SerializableEqualityTester;
 
 public class AddXmlDeclarationStepTest extends ResourceHarness {
 
@@ -32,6 +33,21 @@ public class AddXmlDeclarationStepTest extends ResourceHarness {
 	public void filesAreTheSame() throws Throwable {
 		FormatterStep xmldeclaration = AddXmlDeclarationStep.create();
 		assertOnResources(xmldeclaration, "xmldeclaration/xmlwithdeclaration.test", "xmldeclaration/xmlwithdeclaration.test");
+	}
+
+	@Test
+	public void equality() throws Exception {
+		new SerializableEqualityTester() {
+			@Override
+			protected void setupTest(API api) {
+				api.areDifferentThan();
+			}
+
+			@Override
+			protected FormatterStep create() {
+				return AddXmlDeclarationStep.create();
+			}
+		}.testEquals();
 	}
 
 }


### PR DESCRIPTION
This adds a Xml Step to add a missing xml declaration to a xml file.  If the xml declaration is there it will not change the file.  If the xml declaration is missing it will add an XML 1.0 declaration.
