### PR TITLE
Make it possible to set `ratchetFrom` at the per-format level

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -10,6 +10,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   * If neither of these work for you, let us know in [this PR](https://github.com/diffplug/spotless/pull/602).
 ### Added
 * If you specify `-PspotlessSetLicenseHeaderYearsFromGitHistory=true`, Spotless will perform an expensive search through git history to determine the oldest and newest commits for each file, and uses that to determine license header years. ([#604](https://github.com/diffplug/spotless/pull/604))
+* It is now possible for individual formats to set their own `ratchetFrom` value, similar to how formats can have their own `encoding`. ([#605](https://github.com/diffplug/spotless/pull/605)).
 * (spotless devs only) if you specify `-PspotlessModern=true` Spotless will run the in-progress Gradle `5.4+` code.  The `modernTest` build task runs our test suite in this way.  It will be weeks/months before this is recommended for end-users. ([#598](https://github.com/diffplug/spotless/pull/598))
 
 ## [4.2.1] - 2020-06-04

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -680,12 +680,12 @@ If your project is not currently enforcing formatting, then it can be a noisy tr
 
 ```gradle
 spotless {
-  ratchetFrom 'origin/master'
+  ratchetFrom 'origin/master' // only format files which have changed since origin/master
   ...
 }
 ```
 
-In this mode, Spotless will apply only to files which have changed since `origin/master`.  You can ratchet from [any point you want](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), even `HEAD`.
+In this mode, Spotless will apply only to files which have changed since `origin/master`.  You can ratchet from [any point you want](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), even `HEAD`.  You can also set `ratchetFrom` per-format if you prefer (e.g. `spotless { java { ratchetFrom ...`).
 
 However, we strongly recommend that you use a non-local branch, such as a tag or `origin/master`.  The problem with `HEAD` or any local branch is that as soon as you commit a file, that is now the canonical formatting, even if it was formatted incorrectly.  By instead specifying `origin/master` or a tag, your CI server will fail unless every changed file is at least as good or better than it was before the change.
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -115,7 +115,7 @@ public class FormatExtension {
 
 	private String ratchetFrom = RATCHETFROM_NOT_SET_AT_FORMAT_LEVEL;
 
-	/** @See {@link #setRatchetFrom(String)} */
+	/** @see #setRatchetFrom(String) */
 	public String getRatchetFrom() {
 		return ratchetFrom == RATCHETFROM_NOT_SET_AT_FORMAT_LEVEL ? spotless.getRatchetFrom() : ratchetFrom;
 	}
@@ -128,7 +128,7 @@ public class FormatExtension {
 		this.ratchetFrom = ratchetFrom;
 	}
 
-	/** @See {@link #setRatchetFrom(String)} */
+	/** @see #setRatchetFrom(String) */
 	public void ratchetFrom(String ratchetFrom) {
 		setRatchetFrom(ratchetFrom);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -110,6 +110,29 @@ public class FormatExtension {
 		setEncoding(Charset.forName(Objects.requireNonNull(name)));
 	}
 
+	/** Sentinel to distinguish between "don't ratchet this format" and "use spotless parent format". */
+	private static final String RATCHETFROM_NOT_SET_AT_FORMAT_LEVEL = " not set at format level ";
+
+	private String ratchetFrom = RATCHETFROM_NOT_SET_AT_FORMAT_LEVEL;
+
+	/** @See {@link #setRatchetFrom(String)} */
+	public String getRatchetFrom() {
+		return ratchetFrom == RATCHETFROM_NOT_SET_AT_FORMAT_LEVEL ? spotless.getRatchetFrom() : ratchetFrom;
+	}
+
+	/**
+	 * Allows you to override the value from the parent {@link SpotlessExtensionBase#setRatchetFrom(String)}
+	 * for this specific format.
+	 */
+	public void setRatchetFrom(String ratchetFrom) {
+		this.ratchetFrom = ratchetFrom;
+	}
+
+	/** @See {@link #setRatchetFrom(String)} */
+	public void ratchetFrom(String ratchetFrom) {
+		setRatchetFrom(ratchetFrom);
+	}
+
 	/** Sets the encoding to use (defaults to {@link SpotlessExtension#getEncoding()}. */
 	public void setEncoding(Charset charset) {
 		encoding = Objects.requireNonNull(charset);
@@ -480,7 +503,7 @@ public class FormatExtension {
 			} else {
 				return FormatterStep.createLazy(LicenseHeaderStep.name(), () -> {
 					// by default, we should update the year if the user is using ratchetFrom
-					boolean updateYear = updateYearWithLatest == null ? FormatExtension.this.spotless.getRatchetFrom() != null : updateYearWithLatest;
+					boolean updateYear = updateYearWithLatest == null ? getRatchetFrom() != null : updateYearWithLatest;
 					return new LicenseHeaderStep(licenseHeader(), delimiter, yearSeparator, updateYear);
 				}, step -> step::format);
 			}
@@ -654,8 +677,8 @@ public class FormatExtension {
 		if (spotless.project != spotless.project.getRootProject()) {
 			spotless.registerDependenciesTask.hookSubprojectTask(task);
 		}
-		if (spotless.getRatchetFrom() != null) {
-			task.setupRatchet(spotless.registerDependenciesTask.gitRatchet, spotless.getRatchetFrom());
+		if (getRatchetFrom() != null) {
+			task.setupRatchet(spotless.registerDependenciesTask.gitRatchet, getRatchetFrom());
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
@@ -104,12 +104,12 @@ public abstract class SpotlessExtensionBase {
 		this.ratchetFrom = ratchetFrom;
 	}
 
-	/** @See {@link #setRatchetFrom(String)} */
+	/** @see #setRatchetFrom(String) */
 	public @Nullable String getRatchetFrom() {
 		return ratchetFrom;
 	}
 
-	/** @See {@link #setRatchetFrom(String)} */
+	/** @see #setRatchetFrom(String) */
 	public void ratchetFrom(String ratchetFrom) {
 		setRatchetFrom(ratchetFrom);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
@@ -104,10 +104,12 @@ public abstract class SpotlessExtensionBase {
 		this.ratchetFrom = ratchetFrom;
 	}
 
+	/** @See {@link #setRatchetFrom(String)} */
 	public @Nullable String getRatchetFrom() {
 		return ratchetFrom;
 	}
 
+	/** @See {@link #setRatchetFrom(String)} */
 	public void ratchetFrom(String ratchetFrom) {
 		setRatchetFrom(ratchetFrom);
 	}


### PR DESCRIPTION
similar to how we do for charset.  A usecase from our own build:

- on every release, we run freshmark to update the README links to the latest
- but because of `ratchetFrom`, this no longer runs if the README is clean, for example because it is just a bugfix release, and the README hasn't changed
- so we need to set `freshmark { ratchetFrom null`, and we can't, but after this PR we will be able to.