### PR TITLE
Convert `SpotlessTaskModern` to use `InputChanges` API

### DIFF
--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigAvoidanceTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigAvoidanceTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 public class ConfigAvoidanceTest extends GradleIntegrationHarness {
 	protected final GradleRunner gradleRunnerConfigAvoidance() throws IOException {
-		return gradleRunner().withGradleVersion(SpotlessPluginPreConfigAvoidance.CONFIG_AVOIDANCE_INTRODUCED.getVersion());
+		return gradleRunner().withGradleVersion(GradleVersionSupport.CONFIG_AVOIDANCE.version);
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre8Test.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowJre8Test.java
@@ -123,7 +123,7 @@ public class ErrorShouldRethrowJre8Test extends GradleIntegrationHarness {
 		if (JreVersion.thisVm() != JreVersion._8) {
 			return;
 		}
-		BuildResult result = gradleRunner().withGradleVersion(SpotlessPluginModern.MINIMUM_GRADLE).withArguments("check").build();
+		BuildResult result = gradleRunner().withGradleVersion(GradleVersionSupport.MODERN.version).withArguments("check").build();
 		assertResultAndMessages(result, TaskOutcome.SUCCESS, messages);
 	}
 
@@ -131,7 +131,7 @@ public class ErrorShouldRethrowJre8Test extends GradleIntegrationHarness {
 		if (JreVersion.thisVm() != JreVersion._8) {
 			return;
 		}
-		BuildResult result = gradleRunner().withGradleVersion(SpotlessPluginModern.MINIMUM_GRADLE).withArguments("check").buildAndFail();
+		BuildResult result = gradleRunner().withGradleVersion(GradleVersionSupport.MODERN.version).withArguments("check").buildAndFail();
 		assertResultAndMessages(result, TaskOutcome.FAILED, messages);
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
@@ -70,7 +70,7 @@ public class IdeHookTest extends GradleIntegrationHarness {
 			// gradle 4.7 -> 5.1 don't work in tooling API because of https://github.com/gradle/gradle/issues/7617
 			// gradle 5.1 -> current confirmed to work
 			gradleRunner()
-					.withGradleVersion(SpotlessPluginModern.MINIMUM_GRADLE)
+					.withGradleVersion(GradleVersionSupport.MODERN.version)
 					.withProjectDir(rootFolder())
 					.withPluginClasspath()
 					.withArguments(arguments)

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectAfterEvaluate.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectAfterEvaluate.java
@@ -39,6 +39,6 @@ public class MultiProjectAfterEvaluate extends GradleIntegrationHarness {
 	}
 
 	private final GradleRunner gradleRunner6() throws IOException {
-		return gradleRunner().withGradleVersion("6.0");
+		return gradleRunner().withGradleVersion(GradleVersionSupport.MODERN.version);
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RatchetFromTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RatchetFromTest.java
@@ -116,11 +116,11 @@ public class RatchetFromTest extends GradleIntegrationHarness {
 	}
 
 	private BuildResultAssertion assertPass(String... tasks) throws Exception {
-		return new BuildResultAssertion(gradleRunner().withGradleVersion("6.0").withArguments(tasks).build());
+		return new BuildResultAssertion(gradleRunner().withGradleVersion(GradleVersionSupport.SETTINGS_PLUGINS.version).withArguments(tasks).build());
 	}
 
 	private BuildResultAssertion assertFail(String... tasks) throws Exception {
-		return new BuildResultAssertion(gradleRunner().withGradleVersion("6.0").withArguments(tasks).buildAndFail());
+		return new BuildResultAssertion(gradleRunner().withGradleVersion(GradleVersionSupport.SETTINGS_PLUGINS.version).withArguments(tasks).buildAndFail());
 	}
 
 	private static final String BASELINE_ROOT = "ebb03d6940ee0254010e71917735efa203c27e16";

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
@@ -39,7 +39,7 @@ public class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 				"}");
 
 		setFile("gradle.properties").toLines();
-		String newestSupported = gradleRunner().withGradleVersion(SpotlessPluginModern.MINIMUM_GRADLE)
+		String newestSupported = gradleRunner().withGradleVersion(GradleVersionSupport.MODERN.version)
 				.withArguments("spotlessCheck").build().getOutput();
 		Assertions.assertThat(newestSupported.replace("\r", ""))
 				.startsWith("> Task :spotlessCheck UP-TO-DATE\n" +

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpecificFilesTest.java
@@ -116,7 +116,7 @@ public class SpecificFilesTest extends GradleIntegrationHarness {
 		GradleRunner runner = gradleRunner()
 				.withArguments("spotlessApply", "-PspotlessFiles=" + patterns);
 		if (isKotlin) {
-			runner.withGradleVersion(requestGradleForJre8and11("4.0"));
+			runner.withGradleVersion(GradleVersionSupport.KOTLIN.version);
 		}
 		runner.build();
 


### PR DESCRIPTION
This minimal change updates the task to use the non-deprecated
`InputChanges` API, making it compatible with an upcoming Gradle 7.0
release. This addresses one part of #601.

I haven't updated `CHANGES.md` since "spotlessModern" is not yet mentioned.
