### PR TITLE
Fix the GitRatchet problem on bare checkouts.

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -8,6 +8,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   * This removes the dependency to the no-longer-maintained Linux/Windows/macOs variants of J2V8.
   * This enables spotless to use the latest `prettier` versions (instead of being stuck at prettier version <= `1.19.0`)
   * Bumped default versions, prettier `1.16.4` -> `2.0.5`, tslint `5.12.1` -> `6.1.2`
+### Fixed
+* Using `ratchetFrom 'origin/main'` on a bare checkout generated a cryptic error, now generates a clear error. ([#608](https://github.com/diffplug/spotless/issues/608))
 
 ## [4.3.0] - 2020-06-05
 ### Deprecated

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchet.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchet.java
@@ -152,13 +152,16 @@ class GitRatchet implements AutoCloseable {
 	}
 
 	private static @Nullable Repository traverseParentsUntil(File startWith, File file) throws IOException {
-		do {
+		while (startWith != null) {
 			if (isGitRoot(startWith)) {
 				return createRepo(startWith);
 			} else {
 				startWith = startWith.getParentFile();
+				if (Objects.equals(startWith, file)) {
+					return null;
+				}
 			}
-		} while (!Objects.equals(startWith, file));
+		}
 		return null;
 	}
 


### PR DESCRIPTION
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/master/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
