### PR TITLE
Rename our main branch to 'main'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ workflows:
       - changelog_print:
           filters:
             branches:
-              only: master
+              only: main
       - release_all:
           type: approval
           requires:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,7 +75,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Build
 * All `CHANGES.md` are now in keepachangelog format. ([#507](https://github.com/diffplug/spotless/pull/507))
 * We now use [javadoc.io](https://javadoc.io/) instead of github pages. ([#508](https://github.com/diffplug/spotless/pull/508))
-* We no longer publish `-SNAPSHOT` for every build to `master`, since we have good [JitPack integration](https://github.com/diffplug/spotless/blob/master/CONTRIBUTING.md#gradle---any-commit-in-a-public-github-repo-this-one-or-any-fork). ([#508](https://github.com/diffplug/spotless/pull/508))
+* We no longer publish `-SNAPSHOT` for every build to `main`, since we have good [JitPack integration](https://github.com/diffplug/spotless/blob/main/CONTRIBUTING.md#gradle---any-commit-in-a-public-github-repo-this-one-or-any-fork). ([#508](https://github.com/diffplug/spotless/pull/508))
 * Improved how we use Spotless on itself. ([#509](https://github.com/diffplug/spotless/pull/509))
 * Fix build warnings when building on Gradle 6+, bump build gradle to 6.2.2, and fix javadoc links. ([#536](https://github.com/diffplug/spotless/pull/536))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Spotless
 
-Pull requests are welcome, preferably against `master`.  Feel free to develop spotless any way you like, but the easiest way to look at the code is to clone the repo and run `gradlew ide`, which will download, setup, and start an Eclipse IDE for you.
+Pull requests are welcome, preferably against `main`.  Feel free to develop spotless any way you like, but the easiest way to look at the code is to clone the repo and run `gradlew ide`, which will download, setup, and start an Eclipse IDE for you.
 
 ## How Spotless works
 
@@ -195,7 +195,7 @@ Run `./gradlew publishToMavenLocal` to publish this to your local repository. Th
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/diffplug/spotless/blob/master/LICENSE.txt
+By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/diffplug/spotless/blob/main/LICENSE.txt
 
 All files are released with the Apache 2.0 license as such:
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Please make sure that your [PR allows edits from maintainers](https://help.githu
 
 ![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
 
-After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/master/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/master/plugin-maven/CHANGES.md) which includes:
+After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:
 
 - [ ] a summary of the change
 - either

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 <!---freshmark shields
 output = [
-  link(image('Travis CI', 'https://travis-ci.org/{{org}}/{{name}}.svg?branch=master'), 'https://travis-ci.org/{{org}}/{{name}}'),
+  link(image('Travis CI', 'https://travis-ci.org/{{org}}/{{name}}.svg?branch=main'), 'https://travis-ci.org/{{org}}/{{name}}'),
   link(shield('Live chat', 'gitter', 'chat', 'brightgreen'), 'https://gitter.im/{{org}}/{{name}}'),
   link(shield('License Apache', 'license', 'apache', 'brightgreen'), 'https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)')
   ].join('\n');
 -->
-[![Travis CI](https://travis-ci.org/diffplug/spotless.svg?branch=master)](https://travis-ci.org/diffplug/spotless)
+[![Travis CI](https://travis-ci.org/diffplug/spotless.svg?branch=main)](https://travis-ci.org/diffplug/spotless)
 [![Live chat](https://img.shields.io/badge/gitter-chat-brightgreen.svg)](https://gitter.im/diffplug/spotless)
 [![License Apache](https://img.shields.io/badge/license-apache-brightgreen.svg)](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 <!---freshmark /shields -->

--- a/_ext/eclipse-wtp/src/test/resources/xml/expected/dtd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/expected/dtd_external.test
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE r SYSTEM "https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.dtd">
+<!DOCTYPE r SYSTEM "https://raw.githubusercontent.com/diffplug/spotless/main/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.dtd">
 <r>
   <x>indent
     this text</x>

--- a/_ext/eclipse-wtp/src/test/resources/xml/expected/xsd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/expected/xsd_external.test
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <t:r xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:t="http://foo.bar/test"
-  xsi:schemaLocation="http://foo.bar/test https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.xsd">
+  xsi:schemaLocation="http://foo.bar/test https://raw.githubusercontent.com/diffplug/spotless/main/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.xsd">
   <t:x>remove spaces</t:x>
   <t:y> preserve spaces </t:y>
 </t:r>

--- a/_ext/eclipse-wtp/src/test/resources/xml/input/dtd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/input/dtd_external.test
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE r SYSTEM "https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.dtd">
+<!DOCTYPE r SYSTEM "https://raw.githubusercontent.com/diffplug/spotless/main/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.dtd">
 <r>
 	<x>indent
   this text</x>

--- a/_ext/eclipse-wtp/src/test/resources/xml/input/xsd_external.test
+++ b/_ext/eclipse-wtp/src/test/resources/xml/input/xsd_external.test
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<t:r xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://foo.bar/test" xsi:schemaLocation="http://foo.bar/test https://raw.githubusercontent.com/diffplug/spotless/master/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.xsd">
+<t:r xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://foo.bar/test" xsi:schemaLocation="http://foo.bar/test https://raw.githubusercontent.com/diffplug/spotless/main/_ext/eclipse-wtp/src/test/resources/xml/restrictions/test.xsd">
 <t:x> remove spaces </t:x><t:y> preserve spaces </t:y>
 </t:r>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	// https://github.com/diffplug/goomph/blob/master/CHANGES.md
+	// https://github.com/diffplug/goomph/blob/main/CHANGES.md
 	id 'com.diffplug.eclipse.resourcefilters' version '3.22.0'
 	// https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 	id 'com.gradle.plugin-publish' version '0.11.0' apply false

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -15,7 +15,7 @@ spotless {
 	if (project.name != 'ide' && project != rootProject) {
 		// the rootProject and ide projects don't have any java
 		java {
-			ratchetFrom 'origin/master'
+			ratchetFrom 'origin/main'
 			custom 'noInternalDeps', noInternalDepsClosure
 			bumpThisNumberIfACustomStepChanges(1)
 			licenseHeaderFile rootProject.file('gradle/spotless.license')

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -15,8 +15,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [4.3.0] - 2020-06-05
 ### Deprecated
 * `-PspotlessFiles` has been deprecated and will be removed.  It is slow and error-prone, especially for win/unix cross-platform, and we have better options available now:
-  * If you are formatting just one file, try the much faster [IDE hook](https://github.com/diffplug/spotless/blob/master/plugin-gradle/IDE_HOOK.md)
-  * If you are integrating with git, try the much easier (and faster) [`ratchetFrom 'origin/master'`](https://github.com/diffplug/spotless/tree/master/plugin-gradle#ratchet)
+  * If you are formatting just one file, try the much faster [IDE hook](https://github.com/diffplug/spotless/blob/main/plugin-gradle/IDE_HOOK.md)
+  * If you are integrating with git, try the much easier (and faster) [`ratchetFrom 'origin/main'`](https://github.com/diffplug/spotless/tree/main/plugin-gradle#ratchet)
   * If neither of these work for you, let us know in [this PR](https://github.com/diffplug/spotless/pull/602).
 ### Added
 * If you specify `-PspotlessSetLicenseHeaderYearsFromGitHistory=true`, Spotless will perform an expensive search through git history to determine the oldest and newest commits for each file, and uses that to determine license header years. ([#604](https://github.com/diffplug/spotless/pull/604))
@@ -41,7 +41,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [4.1.0] - 2020-06-01
 ### Added
-* You can now ratchet a project's style by limiting Spotless only to files which have changed since a given [git reference](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), e.g. `ratchetFrom 'origin/master'`. ([#590](https://github.com/diffplug/spotless/pull/590))
+* You can now ratchet a project's style by limiting Spotless only to files which have changed since a given [git reference](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), e.g. `ratchetFrom 'origin/main'`. ([#590](https://github.com/diffplug/spotless/pull/590))
 * Support for ktfmt in KotlinGradleExtension. ([#583](https://github.com/diffplug/spotless/pull/583))
 ### Fixed
 * Users can now run `spotlessCheck` and `spotlessApply` in the same build. ([#584](https://github.com/diffplug/spotless/pull/584))
@@ -257,7 +257,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [3.8.0] - 2018-01-02
 * Bugfix: if the specified target of a spotless task was reduced, Spotless could keep giving warnings until the cache file was deleted.
-* LicenseHeader now supports time-aware license headers. ([docs](https://github.com/diffplug/spotless/tree/master/plugin-gradle#license-header), [#179](https://github.com/diffplug/spotless/pull/179), thanks to @baptistemesta)
+* LicenseHeader now supports time-aware license headers. ([docs](https://github.com/diffplug/spotless/tree/main/plugin-gradle#license-header), [#179](https://github.com/diffplug/spotless/pull/179), thanks to @baptistemesta)
 
 ## [3.7.0] - 2017-12-02
 * Updated default eclipse-jdt version to `4.7.1` from `4.6.3`.
@@ -357,7 +357,7 @@ custom 'no swearing', {
 
 ## [2.3.0] - 2016-10-27
 * When `spotlessCheck` fails, the error message now contains a short diff of what is neccessary to fix the issue ([#10](https://github.com/diffplug/spotless/issues/10), thanks to Jonathan Bluett-Duncan).
-* Added a [padded-cell mode](https://github.com/diffplug/spotless/blob/master/PADDEDCELL.md) which allows spotless to band-aid over misbehaving rules, and generate error reports for these rules (See [#37](https://github.com/diffplug/spotless/issues/37) for an example).
+* Added a [padded-cell mode](https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md) which allows spotless to band-aid over misbehaving rules, and generate error reports for these rules (See [#37](https://github.com/diffplug/spotless/issues/37) for an example).
 * Character encoding is now configurable (spotless-global or format-by-format).
 * Line endings were previously only spotless-global, they now also support format-by-format.
 * Upgraded eclipse formatter from 4.6.0 to 4.6.1

--- a/plugin-gradle/IDE_HOOK.md
+++ b/plugin-gradle/IDE_HOOK.md
@@ -3,7 +3,7 @@
 Thanks to `spotlessApply`, it is not necessary for Spotless and your IDE to agree on formatting - you can always run spotless at the end to fix things up.  But if you want them to agree, there are two approaches:
 
 - 👎setup your IDE to match Spotless: tricky to get right, hard to keep up-to-date
-  - [eclipse](https://github.com/diffplug/spotless/blob/master/ECLIPSE_SCREENSHOTS.md)
+  - [eclipse](https://github.com/diffplug/spotless/blob/main/ECLIPSE_SCREENSHOTS.md)
 - 👍setup your IDE to use Spotless as the source of truth: easy to setup, guaranteed to stay up-to-date
   - [VS Code](https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-spotless-gradle)
   - (add your IDE here!)

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -9,7 +9,7 @@ output = [
   link(shield('License Apache', 'license', 'apache', 'blue'), 'https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)'),
   link(shield('Changelog', 'changelog', '{{versionLast}}', 'blue'), 'CHANGES.md'),
   '',
-  link(image('Circle CI', 'https://circleci.com/gh/diffplug/spotless/tree/master.svg?style=shield'), 'https://circleci.com/gh/diffplug/spotless/tree/master'),
+  link(image('Circle CI', 'https://circleci.com/gh/diffplug/spotless/tree/main.svg?style=shield'), 'https://circleci.com/gh/diffplug/spotless/tree/main'),
   link(shield('Live chat', 'gitter', 'chat', 'brightgreen'), 'https://gitter.im/{{org}}/{{name}}'),
   link(shield('VS Code plugin Apache', 'IDE', 'VS Code', 'blueviolet'), 'https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-spotless-gradle'),
   link(shield('VS Code plugin Apache', 'IDE', 'add yours', 'blueviolet'), 'IDE_HOOK.md')
@@ -21,7 +21,7 @@ output = [
 [![License Apache](https://img.shields.io/badge/license-apache-blue.svg)](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 [![Changelog](https://img.shields.io/badge/changelog-4.3.0-blue.svg)](CHANGES.md)
 
-[![Circle CI](https://circleci.com/gh/diffplug/spotless/tree/master.svg?style=shield)](https://circleci.com/gh/diffplug/spotless/tree/master)
+[![Circle CI](https://circleci.com/gh/diffplug/spotless/tree/main.svg?style=shield)](https://circleci.com/gh/diffplug/spotless/tree/main)
 [![Live chat](https://img.shields.io/badge/gitter-chat-brightgreen.svg)](https://gitter.im/diffplug/spotless)
 [![VS Code plugin Apache](https://img.shields.io/badge/IDE-VS_Code-blueviolet.svg)](https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-spotless-gradle)
 [![VS Code plugin Apache](https://img.shields.io/badge/IDE-add_yours-blueviolet.svg)](IDE_HOOK.md)
@@ -128,7 +128,7 @@ spotless {
     eclipse().configFile 'spotless.eclipseformat.xml'	// XML file dumped out by the Eclipse formatter
     // If you have Eclipse preference or property files, you can use them too.
     // eclipse('4.7.1') to specify a specific version of eclipse,
-    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter
+    // available versions are: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter
   }
 }
 ```
@@ -210,7 +210,7 @@ spotless {
     // Use the default version and Groovy-Eclipse default configuration
     greclipse()
     // optional: you can specify a specific version or config file(s)
-    // available versions: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter
+    // available versions: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter
     greclipse('2.3.0').configFile('spotless.eclipseformat.xml', 'org.codehaus.groovy.eclipse.ui.prefs')
   }
 }
@@ -310,7 +310,7 @@ spotless {
   sql {
     // default value for target files
     target '**/*.sql'
-    // configFile is optional, arguments available here: https://github.com/diffplug/spotless/blob/master/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java
+    // configFile is optional, arguments available here: https://github.com/diffplug/spotless/blob/main/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java
     dbeaver().configFile('dbeaver.props')
   }
 }
@@ -339,7 +339,7 @@ spotless {
     eclipse().configFile 'spotless.eclipseformat.xml'	// XML file dumped out by the Eclipse formatter
     // If you have Eclipse preference or property files, you can use them too.
     // eclipse('4.7.1') to specify a specific version of Eclipse,
-    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter
+    // available versions are: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter
     licenseHeader '// Licensed under Apache'	// License header
     licenseHeaderFile './license.txt'	// License header file
   }
@@ -527,7 +527,7 @@ spotless {
       exclude '**/build/**'
     }
     // Use for example eclipseWtp('xml', '4.7.3a') to specify a specific version of Eclipse,
-    // available versions are: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters
+    // available versions are: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters
     eclipseWtp('xml').configFile 'spotless.xml.prefs', 'spotless.common.properties'
   }
 }
@@ -697,14 +697,14 @@ If your project is not currently enforcing formatting, then it can be a noisy tr
 
 ```gradle
 spotless {
-  ratchetFrom 'origin/master' // only format files which have changed since origin/master
+  ratchetFrom 'origin/main' // only format files which have changed since origin/main
   ...
 }
 ```
 
-In this mode, Spotless will apply only to files which have changed since `origin/master`.  You can ratchet from [any point you want](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), even `HEAD`.  You can also set `ratchetFrom` per-format if you prefer (e.g. `spotless { java { ratchetFrom ...`).
+In this mode, Spotless will apply only to files which have changed since `origin/main`.  You can ratchet from [any point you want](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), even `HEAD`.  You can also set `ratchetFrom` per-format if you prefer (e.g. `spotless { java { ratchetFrom ...`).
 
-However, we strongly recommend that you use a non-local branch, such as a tag or `origin/master`.  The problem with `HEAD` or any local branch is that as soon as you commit a file, that is now the canonical formatting, even if it was formatted incorrectly.  By instead specifying `origin/master` or a tag, your CI server will fail unless every changed file is at least as good or better than it was before the change.
+However, we strongly recommend that you use a non-local branch, such as a tag or `origin/main`.  The problem with `HEAD` or any local branch is that as soon as you commit a file, that is now the canonical formatting, even if it was formatted incorrectly.  By instead specifying `origin/main` or a tag, your CI server will fail unless every changed file is at least as good or better than it was before the change.
 
 This is especially helpful for injecting accurate copyright dates using the [license step](#license-header).
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -74,13 +74,13 @@ public class FormatExtension {
 		throw new IllegalStateException("This format is not contained by any SpotlessExtension.");
 	}
 
-	/** Enables paddedCell mode. @see <a href="https://github.com/diffplug/spotless/blob/master/PADDEDCELL.md">Padded cell</a> */
+	/** Enables paddedCell mode. @see <a href="https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md">Padded cell</a> */
 	@Deprecated
 	public void paddedCell() {
 		paddedCell(true);
 	}
 
-	/** Enables paddedCell mode. @see <a href="https://github.com/diffplug/spotless/blob/master/PADDEDCELL.md">Padded cell</a> */
+	/** Enables paddedCell mode. @see <a href="https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md">Padded cell</a> */
 	@Deprecated
 	public void paddedCell(boolean paddedCell) {
 		spotless.project.getLogger().warn("PaddedCell is now always on, and cannot be turned off.");

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -72,7 +72,7 @@ public class GroovyExtension extends FormatExtension implements HasBuiltinDelimi
 				StringPrinter.buildStringFromLines(
 						"'importOrder([x, y, z])' is deprecated.",
 						"Use 'importOrder x, y, z' instead.",
-						"For details see https://github.com/diffplug/spotless/tree/master/plugin-gradle#applying-to-java-source"));
+						"For details see https://github.com/diffplug/spotless/tree/main/plugin-gradle#applying-to-java-source"));
 		importOrder(importOrder.toArray(new String[0]));
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
@@ -59,7 +59,7 @@ class IdeHook {
 					dumpIsClean();
 				} else if (dirty.didNotConverge()) {
 					System.err.println("DID NOT CONVERGE");
-					System.err.println("Run 'spotlessDiagnose' for details https://github.com/diffplug/spotless/blob/master/PADDEDCELL.md");
+					System.err.println("Run 'spotlessDiagnose' for details https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md");
 				} else {
 					System.err.println("IS DIRTY");
 					if (spotlessTask.getProject().hasProperty(USE_STD_OUT)) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -66,7 +66,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 				StringPrinter.buildStringFromLines(
 						"'importOrder([x, y, z])' is deprecated.",
 						"Use 'importOrder x, y, z' instead.",
-						"For details see https://github.com/diffplug/spotless/tree/master/plugin-gradle#applying-to-java-source"));
+						"For details see https://github.com/diffplug/spotless/tree/main/plugin-gradle#applying-to-java-source"));
 		addStep(ImportOrderStep.createFromOrder(importOrder));
 	}
 
@@ -94,7 +94,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 				StringPrinter.buildStringFromLines(
 						"'eclipseFormatFile [version] <file>' is deprecated.",
 						"Use 'eclipse([version]).configFile(<file>)' instead.",
-						"For details see https://github.com/diffplug/spotless/tree/master/plugin-gradle#applying-to-java-source"));
+						"For details see https://github.com/diffplug/spotless/tree/main/plugin-gradle#applying-to-java-source"));
 		eclipse(eclipseVersion).configFile(eclipseFormatFile);
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -93,8 +93,8 @@ public class SpotlessExtension extends SpotlessExtensionBase {
 			String filePatterns;
 			if (project.hasProperty(FILES_PROPERTY) && project.property(FILES_PROPERTY) instanceof String) {
 				System.err.println("Spotless with -P" + FILES_PROPERTY + " has been deprecated and will be removed. It is slow and error-prone, especially for win/unix cross-platform, and we have better options available now:");
-				System.err.println("  If you are formatting just one file, try the much faster IDE hook: https://github.com/diffplug/spotless/blob/master/plugin-gradle/IDE_HOOK.md");
-				System.err.println("  If you are integrating with git, try `ratchetFrom 'origin/master'`: https://github.com/diffplug/spotless/tree/master/plugin-gradle#ratchet");
+				System.err.println("  If you are formatting just one file, try the much faster IDE hook: https://github.com/diffplug/spotless/blob/main/plugin-gradle/IDE_HOOK.md");
+				System.err.println("  If you are integrating with git, try `ratchetFrom 'origin/main'`: https://github.com/diffplug/spotless/tree/main/plugin-gradle#ratchet");
 				System.err.println("  If neither of these work for you, please let us know in this PR: https://github.com/diffplug/spotless/pull/602");
 				filePatterns = (String) project.property(FILES_PROPERTY);
 			} else {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SelfTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SelfTest.java
@@ -40,7 +40,7 @@ public class SelfTest {
 	/** Runs a full task manually, so you can step through all the logic. */
 	private static void runTaskManually() throws Exception {
 		Project project = createProject(extension -> {
-			extension.ratchetFrom("origin/master");
+			extension.ratchetFrom("origin/main");
 			extension.java(java -> {
 				java.target("src/*/java/**/*.java");
 				java.licenseHeaderFile("../gradle/spotless.license");

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -25,7 +25,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support for google-java-format 1.8 (requires build to run on Java 11+) ([#562](https://github.com/diffplug/spotless/issues/562))
 * Support for ktfmt 0.13 (requires build to run on Java 11+) ([#569](https://github.com/diffplug/spotless/pull/569))
-* `mvn spotless:apply` is now guaranteed to be idempotent, even if some of the formatters are not.  See [`PADDEDCELL.md` for details](https://github.com/diffplug/spotless/blob/master/PADDEDCELL.md) if you're curious. ([#565](https://github.com/diffplug/spotless/pull/565))
+* `mvn spotless:apply` is now guaranteed to be idempotent, even if some of the formatters are not.  See [`PADDEDCELL.md` for details](https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md) if you're curious. ([#565](https://github.com/diffplug/spotless/pull/565))
 * Updated a bunch of dependencies, most notably jgit `5.5.0.201909110433-r` -> `5.7.0.202003110725-r`. ([#564](https://github.com/diffplug/spotless/pull/564))
 
 ## [1.30.0] - 2020-04-10

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -6,7 +6,7 @@ output = [
   link(shield('Javadoc', 'javadoc', '{{versionLast}}', 'blue'), 'https://javadoc.io/doc/com.diffplug.spotless/spotless-maven-plugin/{{versionLast}}/index.html'),
   '',
   link(shield('Changelog', 'changelog', '{{versionLast}}', 'brightgreen'), 'CHANGES.md'),
-  link(image('Travis CI', 'https://travis-ci.org/{{org}}/{{name}}.svg?branch=master'), 'https://travis-ci.org/{{org}}/{{name}}'),
+  link(image('Travis CI', 'https://travis-ci.org/{{org}}/{{name}}.svg?branch=main'), 'https://travis-ci.org/{{org}}/{{name}}'),
   link(shield('Live chat', 'gitter', 'chat', 'brightgreen'), 'https://gitter.im/{{org}}/{{name}}'),
   link(shield('License Apache', 'license', 'apache', 'brightgreen'), 'https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)')
   ].join('\n');
@@ -15,7 +15,7 @@ output = [
 [![Javadoc](https://img.shields.io/badge/javadoc-1.31.2-blue.svg)](https://javadoc.io/doc/com.diffplug.spotless/spotless-maven-plugin/1.31.2/index.html)
 
 [![Changelog](https://img.shields.io/badge/changelog-1.31.2-brightgreen.svg)](CHANGES.md)
-[![Travis CI](https://travis-ci.org/diffplug/spotless.svg?branch=master)](https://travis-ci.org/diffplug/spotless)
+[![Travis CI](https://travis-ci.org/diffplug/spotless.svg?branch=main)](https://travis-ci.org/diffplug/spotless)
 [![Live chat](https://img.shields.io/badge/gitter-chat-brightgreen.svg)](https://gitter.im/diffplug/spotless)
 [![License Apache](https://img.shields.io/badge/license-apache-brightgreen.svg)](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 <!---freshmark /shields -->
@@ -101,13 +101,13 @@ By default, all files matching `src/main/java/**/*.java` and `src/test/java/**/*
      <eclipse>
        <!-- Optional, otherwise Eclipse defaults are used. Eclipse preference or property files are also supported. -->
        <file>${basedir}/eclipse-format.xml</file>
-       <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter -->
+       <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter -->
        <version>4.7.1</version>
      </eclipse>
      <googleJavaFormat>
        <!-- Optional, available versions: https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.google.googlejavaformat%22%20AND%20a%3A%22google-java-format%22 -->
        <version>1.5</version>
-       <!-- Optional, available versions: GOOGLE, AOSP  https://github.com/google/google-java-format/blob/master/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java -->
+       <!-- Optional, available versions: GOOGLE, AOSP  https://github.com/google/google-java-format/blob/main/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java -->
        <style>GOOGLE</style>
      </googleJavaFormat>
      <removeUnusedImports/>
@@ -209,7 +209,7 @@ By default, all files matching `src/main/cpp/**/*.<ext>` and `src/test/cpp/**/*.
      </licenseHeader>
      <eclipse>
        <file>${basedir}/eclipse-fmt.xml</file>
-       <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter -->
+       <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter -->
        <version>4.7.3a</version>
      </eclipse>
   </cpp>
@@ -478,7 +478,7 @@ The Eclipse [WTP](https://www.eclipse.org/webtools/) formatter can be applied as
           <file>${basedir}/xml.prefs</file>
           <file>${basedir}/additional.properties</file>
         </files>
-        <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/master/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters -->
+        <!-- Optional, available versions: https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters -->
         <version>4.7.3a</version>
       </eclipseWtp>
     </format>


### PR DESCRIPTION
Once this PR has been merged, `main` will be our main branch, rather than `master`.  

We have many links to our documentation out in the wild, such as: https://github.com/diffplug/spotless/blob/master/plugin-gradle/README.md#license-header-options

Preserving the history of these links is an absolute must.  For now, I will manually keep it parallel with `main`, and I'll happily help anyone migrate any PRs against the deprecated `master` to their new home at `main`.  Eventually I plan to build a tool to create an orphan commit at `master` which replaces every `.md` file, including anchors, with a link to the appropriately anchored place at our new `main` branch.