### PR TITLE
Avoid eager creation of tasks for Spotless plugin

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java
@@ -16,7 +16,6 @@
 package com.diffplug.gradle.spotless;
 
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.TaskContainer;
@@ -25,14 +24,17 @@ import org.gradle.api.tasks.TaskProvider;
 public class SpotlessExtensionModern extends SpotlessExtensionBase {
 	public SpotlessExtensionModern(Project project) {
 		super(project);
-		rootCheckTask = project.task(EXTENSION + CHECK);
-		rootCheckTask.setGroup(TASK_GROUP);
-		rootCheckTask.setDescription(CHECK_DESCRIPTION);
-		rootApplyTask = project.task(EXTENSION + APPLY);
-		rootApplyTask.setGroup(TASK_GROUP);
-		rootApplyTask.setDescription(APPLY_DESCRIPTION);
-		rootDiagnoseTask = project.task(EXTENSION + DIAGNOSE);
-		rootDiagnoseTask.setGroup(TASK_GROUP);	// no description on purpose
+		rootCheckTask = project.getTasks().register(EXTENSION + CHECK, task -> {
+			task.setGroup(TASK_GROUP);
+			task.setDescription(CHECK_DESCRIPTION);
+		});
+		rootApplyTask = project.getTasks().register(EXTENSION + APPLY, task -> {
+			task.setGroup(TASK_GROUP);
+			task.setDescription(APPLY_DESCRIPTION);
+		});
+		rootDiagnoseTask = project.getTasks().register(EXTENSION + DIAGNOSE, task -> {
+			task.setGroup(TASK_GROUP); // no description on purpose
+		});
 
 		project.afterEvaluate(unused -> {
 			if (enforceCheck) {
@@ -42,7 +44,7 @@ public class SpotlessExtensionModern extends SpotlessExtensionBase {
 		});
 	}
 
-	final Task rootCheckTask, rootApplyTask, rootDiagnoseTask;
+	final TaskProvider<?> rootCheckTask, rootApplyTask, rootDiagnoseTask;
 
 	@Override
 	protected void createFormatTasks(String name, FormatExtension formatExtension) {
@@ -51,13 +53,14 @@ public class SpotlessExtensionModern extends SpotlessExtensionBase {
 
 		boolean isIdeHook = project.hasProperty(IdeHook.PROPERTY);
 		TaskContainer tasks = project.getTasks();
+		TaskProvider<?> cleanTask = tasks.named(BasePlugin.CLEAN_TASK_NAME);
 
 		// create the SpotlessTask
 		String taskName = EXTENSION + SpotlessPlugin.capitalize(name);
 		TaskProvider<SpotlessTaskModern> spotlessTask = tasks.register(taskName, SpotlessTaskModern.class, task -> {
 			task.setEnabled(!isIdeHook);
 			// clean removes the SpotlessCache, so we have to run after clean
-			task.mustRunAfter(BasePlugin.CLEAN_TASK_NAME);
+			task.mustRunAfter(cleanTask);
 		});
 
 		project.afterEvaluate(unused -> spotlessTask.configure(formatExtension::setupTask));
@@ -69,6 +72,15 @@ public class SpotlessExtensionModern extends SpotlessExtensionBase {
 			task.setSpotlessOutDirectory(spotlessTask.get().getOutputDirectory());
 			task.linkSource(spotlessTask.get());
 		});
+		rootApplyTask.configure(task -> {
+			task.dependsOn(applyTask);
+
+			if (isIdeHook) {
+				// the rootApplyTask is no longer just a marker task, now it does a bit of work itself
+				task.doLast(unused -> IdeHook.performHook(spotlessTask.get()));
+			}
+		});
+
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
@@ -78,21 +90,13 @@ public class SpotlessExtensionModern extends SpotlessExtensionBase {
 			// if the user runs both, make sure that apply happens first,
 			task.mustRunAfter(applyTask);
 		});
-
-		// the root tasks depend on the control tasks
-		rootCheckTask.dependsOn(checkTask);
-		rootApplyTask.dependsOn(applyTask);
+		rootCheckTask.configure(task -> task.dependsOn(checkTask));
 
 		// create the diagnose task
 		TaskProvider<SpotlessDiagnoseTask> diagnoseTask = tasks.register(taskName + DIAGNOSE, SpotlessDiagnoseTask.class, task -> {
 			task.source = spotlessTask.get();
-			task.mustRunAfter(BasePlugin.CLEAN_TASK_NAME);
+			task.mustRunAfter(cleanTask);
 		});
-		rootDiagnoseTask.dependsOn(diagnoseTask);
-
-		if (isIdeHook) {
-			// the rootApplyTask is no longer just a marker task, now it does a bit of work itself
-			rootApplyTask.doLast(unused -> IdeHook.performHook(spotlessTask.get()));
-		}
+		rootDiagnoseTask.configure(task -> task.dependsOn(diagnoseTask));
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java
@@ -48,8 +48,7 @@ public class SpotlessExtensionModern extends SpotlessExtensionBase {
 
 	@Override
 	protected void createFormatTasks(String name, FormatExtension formatExtension) {
-		// TODO level 1: implement SpotlessExtension::createFormatTasks, but using config avoidance
-		// TODO level 2: override configure(String name, Class<T> clazz, Action<T> configure) so that it is lazy
+		// TODO override configure(String name, Class<T> clazz, Action<T> configure) so that it is lazy
 
 		boolean isIdeHook = project.hasProperty(IdeHook.PROPERTY);
 		TaskContainer tasks = project.getTasks();


### PR DESCRIPTION
Previously applying the Spotless plugin resulted in a many tasks to be created
per subproject, even for an invocation like `gradle help`.
Using "Task configuration avoidance" APIs means that these tasks will
not be constructed if they will not be required during task execution.