### PR TITLE
Execute the configuration actions lazily

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -56,6 +57,7 @@ import groovy.lang.Closure;
 /** Adds a `spotless{Name}Check` and `spotless{Name}Apply` task. */
 public class FormatExtension {
 	final SpotlessExtensionBase spotless;
+	final List<Action<FormatExtension>> modernLazyActions = new ArrayList<>();
 
 	public FormatExtension(SpotlessExtensionBase spotless) {
 		this.spotless = Objects.requireNonNull(spotless);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -44,7 +44,7 @@ public class SpotlessExtension extends SpotlessExtensionBase {
 	 */
 	@Deprecated
 	public void css(Action<CssExtension> closure) {
-		configure(CssExtension.NAME, CssExtension.class, closure);
+		format(CssExtension.NAME, CssExtension.class, closure);
 	}
 
 	/**
@@ -55,7 +55,7 @@ public class SpotlessExtension extends SpotlessExtensionBase {
 	 */
 	@Deprecated
 	public void xml(Action<XmlExtension> closure) {
-		configure(XmlExtension.NAME, XmlExtension.class, closure);
+		format(XmlExtension.NAME, XmlExtension.class, closure);
 	}
 
 	/**

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
@@ -115,63 +115,63 @@ public abstract class SpotlessExtensionBase {
 	/** Configures the special java-specific extension. */
 	public void java(Action<JavaExtension> closure) {
 		requireNonNull(closure);
-		configure(JavaExtension.NAME, JavaExtension.class, closure);
+		format(JavaExtension.NAME, JavaExtension.class, closure);
 	}
 
 	/** Configures the special scala-specific extension. */
 	public void scala(Action<ScalaExtension> closure) {
 		requireNonNull(closure);
-		configure(ScalaExtension.NAME, ScalaExtension.class, closure);
+		format(ScalaExtension.NAME, ScalaExtension.class, closure);
 	}
 
 	/** Configures the special kotlin-specific extension. */
 	public void kotlin(Action<KotlinExtension> closure) {
 		requireNonNull(closure);
-		configure(KotlinExtension.NAME, KotlinExtension.class, closure);
+		format(KotlinExtension.NAME, KotlinExtension.class, closure);
 	}
 
 	/** Configures the special Gradle Kotlin DSL specific extension. */
 	public void kotlinGradle(Action<KotlinGradleExtension> closure) {
 		requireNonNull(closure);
-		configure(KotlinGradleExtension.NAME, KotlinGradleExtension.class, closure);
+		format(KotlinGradleExtension.NAME, KotlinGradleExtension.class, closure);
 	}
 
 	/** Configures the special freshmark-specific extension. */
 	public void freshmark(Action<FreshMarkExtension> closure) {
 		requireNonNull(closure);
-		configure(FreshMarkExtension.NAME, FreshMarkExtension.class, closure);
+		format(FreshMarkExtension.NAME, FreshMarkExtension.class, closure);
 	}
 
 	/** Configures the special groovy-specific extension. */
 	public void groovy(Action<GroovyExtension> closure) {
-		configure(GroovyExtension.NAME, GroovyExtension.class, closure);
+		format(GroovyExtension.NAME, GroovyExtension.class, closure);
 	}
 
 	/** Configures the special groovy-specific extension for Gradle files. */
 	public void groovyGradle(Action<GroovyGradleExtension> closure) {
-		configure(GroovyGradleExtension.NAME, GroovyGradleExtension.class, closure);
+		format(GroovyGradleExtension.NAME, GroovyGradleExtension.class, closure);
 	}
 
 	/** Configures the special sql-specific extension for SQL files. */
 	public void sql(Action<SqlExtension> closure) {
-		configure(SqlExtension.NAME, SqlExtension.class, closure);
+		format(SqlExtension.NAME, SqlExtension.class, closure);
 	}
 
 	/** Configures the special C/C++-specific extension. */
 	public void cpp(Action<CppExtension> closure) {
-		configure(CppExtension.NAME, CppExtension.class, closure);
+		format(CppExtension.NAME, CppExtension.class, closure);
 	}
 
 	/** Configures the special typescript-specific extension for typescript files. */
 	public void typescript(Action<TypescriptExtension> closure) {
-		configure(TypescriptExtension.NAME, TypescriptExtension.class, closure);
+		format(TypescriptExtension.NAME, TypescriptExtension.class, closure);
 	}
 
 	/** Configures a custom extension. */
 	public void format(String name, Action<FormatExtension> closure) {
 		requireNonNull(name, "name");
 		requireNonNull(closure, "closure");
-		configure(name, FormatExtension.class, closure);
+		format(name, FormatExtension.class, closure);
 	}
 
 	/** Makes it possible to remove a format which was created earlier. */
@@ -200,13 +200,13 @@ public abstract class SpotlessExtensionBase {
 		this.enforceCheck = enforceCheck;
 	}
 
-	protected <T extends FormatExtension> void configure(String name, Class<T> clazz, Action<T> configure) {
-		T value = maybeCreate(name, clazz);
-		configure.execute(value);
+	public <T extends FormatExtension> void format(String name, Class<T> clazz, Action<T> configure) {
+		T format = maybeCreate(name, clazz);
+		configure.execute(format);
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T extends FormatExtension> T maybeCreate(String name, Class<T> clazz) {
+	protected final <T extends FormatExtension> T maybeCreate(String name, Class<T> clazz) {
 		FormatExtension existing = formats.get(name);
 		if (existing != null) {
 			if (!existing.getClass().equals(clazz)) {


### PR DESCRIPTION
The only substantive change is that instead of this in the legacy `SpotlessExtension`...

https://github.com/diffplug/spotless/blob/1e2801d161551c5b2790bd9cdacefefbf0ff6229/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java#L203-L206

...we add a field to `FormatExtension`, and populate it in each call to `SpotlessExtension::format(name, clazz, action)`

https://github.com/diffplug/spotless/blob/1e2801d161551c5b2790bd9cdacefefbf0ff6229/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java#L60

https://github.com/diffplug/spotless/blob/1e2801d161551c5b2790bd9cdacefefbf0ff6229/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java#L52-L54

Instead of executing the closures when they are declared, we store them, and only execute them when the task is configured:

https://github.com/diffplug/spotless/blob/1e2801d161551c5b2790bd9cdacefefbf0ff6229/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java#L70-L79

In my head, I thought that we would be able to remove the `afterEvaluate` block, but now I see that it was a mirage.  If someone eagerly creates the task, and then calls `java { blah }`, it's important for that `blah` to have effect, but it wouldn't if you don't do the `afterEvaluate`.

It seems to me that this is as lazy as it could possibly be - we don't describe any of the properties of a task, or even execute the code that describes those those properties, until/unless that task is being configured.  It also seems to me like it's quite difficult to avoid the `afterEvaluate`, which I guess is the point of the `Provider<>` stuff.  We could change `FormatExtension` so that it applied itself directly against the `SpotlessTask`, rather than storing its own field for `encoding`, etc.  The only hard part against that is cases where a user sets `UTF-8` at the level of the Spotless block, but has some legacy subproject where encoding is `CP-1252`, cases like that.

Is `afterEvaluate` in any long-term trouble?  Whaddya think @bigdaz?