### PR TITLE
Make the the GitAttributesLineEndingsPolicy relocatable across machines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* `LineEnding.GIT_ATTRIBUTES` now creates a policy whose serialized state can be relocated from one machine to another.  No user-visible change, but paves the way for remote build cache support in Gradle. ([#621](https://github.com/diffplug/spotless/pull/621))
 
 ## [1.34.1] - 2020-06-17
 ### Changed

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -134,24 +133,18 @@ public final class GitAttributesLineEndings {
 		}
 	}
 
-	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	static class FileState implements Serializable {
-		private static final long serialVersionUID = 1L;
-
+	static class FileState {
 		/** /etc/gitconfig (system-global), ~/.gitconfig, project/.git/config (each might-not exist). */
-		transient final FileBasedConfig systemConfig, userConfig, repoConfig;
+		final FileBasedConfig systemConfig, userConfig, repoConfig;
 
 		/** Global .gitattributes file pointed at by systemConfig or userConfig, and the file in the repo. */
-		transient final @Nullable File globalAttributesFile, repoAttributesFile;
+		final @Nullable File globalAttributesFile, repoAttributesFile;
 
 		/** git worktree root, might not exist if we're not in a git repo. */
-		transient final @Nullable File workTree;
+		final @Nullable File workTree;
 
 		/** All the .gitattributes files in the work tree that we're formatting. */
-		transient final List<File> gitattributes;
-
-		/** The signature of *all* of the files below. */
-		final FileSignature signature;
+		final List<File> gitattributes;
 
 		@SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
 		FileState(File projectDir, Iterable<File> toFormat) throws IOException {
@@ -208,14 +201,6 @@ public final class GitAttributesLineEndings {
 
 			// The .gitattributes files which apply to the files we are formatting
 			gitattributes = gitAttributes(toFormat);
-
-			// find every actual File which exists above
-			Stream<File> misc = Stream.of(systemConfig.getFile(), userConfig.getFile(), repoConfig.getFile(), globalAttributesFile, repoAttributesFile);
-			List<File> toSign = Stream.concat(gitattributes.stream(), misc)
-					.filter(file -> file != null && file.exists() && file.isFile())
-					.collect(Collectors.toList());
-			// sign it for up-to-date checking
-			signature = FileSignature.signAsSet(toSign);
 		}
 
 		/** Returns all of the .gitattributes files which affect the given files. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -73,7 +73,8 @@ public final class GitAttributesLineEndings {
 
 	/**
 	 * Creates a line-endings policy whose serialized state is relativized against projectDir,
-	 * at the cost of eagerly evaluating the line-ending state of every target file.
+	 * at the cost of eagerly evaluating the line-ending state of every target file when the
+	 * policy is checked for equality with another policy.
 	 */
 	public static LineEnding.Policy create(File projectDir, Supplier<Iterable<File>> toFormat) {
 		return new RelocatablePolicy(projectDir, toFormat);

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -76,7 +76,7 @@ public final class GitAttributesLineEndings {
 	 * Creates a line-endings policy whose serialized state is relativized against projectDir,
 	 * at the cost of eagerly evaluating the line-ending state of every target file.
 	 */
-	public static LineEnding.Policy createRelocatable(File projectDir, Supplier<Iterable<File>> toFormat) {
+	public static LineEnding.Policy create(File projectDir, Supplier<Iterable<File>> toFormat) {
 		return new RelocatablePolicy(projectDir, toFormat);
 	}
 
@@ -131,42 +131,6 @@ public final class GitAttributesLineEndings {
 			String subpath = FileSignature.subpath(rootDir, path);
 			String ending = hasNonDefaultEnding.getValueForExactKey(subpath);
 			return ending == null ? defaultEnding : ending;
-		}
-	}
-
-	/** Creates a line-endings policy whose serialized state includes absolute paths to this machine. */
-	public static LineEnding.Policy create(File projectDir, Supplier<Iterable<File>> toFormat) {
-		return new Policy(projectDir, toFormat);
-	}
-
-	static class Policy extends LazyForwardingEquality<FileState> implements LineEnding.Policy {
-		private static final long serialVersionUID = 1L;
-
-		final transient File projectDir;
-		final transient Supplier<Iterable<File>> toFormat;
-
-		Policy(File projectDir, Supplier<Iterable<File>> toFormat) {
-			this.projectDir = Objects.requireNonNull(projectDir, "projectDir");
-			this.toFormat = Objects.requireNonNull(toFormat, "toFormat");
-		}
-
-		@Override
-		protected FileState calculateState() throws Exception {
-			return new FileState(projectDir, toFormat.get());
-		}
-
-		/**
-		 * Initializing the state() for up-to-date checking is faster than the full initialization
-		 * needed to actually do the formatting. We load the Runtime lazily from the state().
-		 */
-		transient Runtime runtime;
-
-		@Override
-		public String getEndingFor(File file) {
-			if (runtime == null) {
-				runtime = state().atRuntime();
-			}
-			return runtime.getEndingFor(file);
 		}
 	}
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -86,7 +86,7 @@ public final class GitAttributesLineEndings {
 
 		@Override
 		protected CachedEndings calculateState() throws Exception {
-			Runtime runtime = new FileState(projectDir, toFormat.get()).atRuntime();
+			Runtime runtime = new RuntimeInit(projectDir, toFormat.get()).atRuntime();
 			return new CachedEndings(projectDir, runtime, toFormat.get());
 		}
 
@@ -128,7 +128,7 @@ public final class GitAttributesLineEndings {
 		}
 	}
 
-	static class FileState {
+	static class RuntimeInit {
 		/** /etc/gitconfig (system-global), ~/.gitconfig, project/.git/config (each might-not exist). */
 		final FileBasedConfig systemConfig, userConfig, repoConfig;
 
@@ -139,7 +139,7 @@ public final class GitAttributesLineEndings {
 		final @Nullable File workTree;
 
 		@SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC_ANON")
-		FileState(File projectDir, Iterable<File> toFormat) throws IOException {
+		RuntimeInit(File projectDir, Iterable<File> toFormat) throws IOException {
 			requireElementsNonNull(toFormat);
 			/////////////////////////////////
 			// USER AND SYSTEM-WIDE VALUES //

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -119,4 +119,13 @@ public final class FileSignature implements Serializable {
 	public static String pathUnixToNative(String pathUnix) {
 		return LineEnding.nativeIsWin() ? pathUnix.replace('/', '\\') : pathUnix;
 	}
+
+	/** Asserts that child is a subpath of root. and returns the subpath. */
+	public static String subpath(String root, String child) {
+		if (child.startsWith(root)) {
+			return child.substring(root.length());
+		} else {
+			throw new IllegalArgumentException("Expected '" + child + "' to start with '" + root + "'");
+		}
+	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -7,6 +7,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * `prettier` will now autodetect the parser (and formatter) to use based on the filename, unless you override this using `config()` or `configFile()` with the option `parser` or `filepath`. ([#620](https://github.com/diffplug/spotless/pull/620))
+### Fixed
+* LineEndings.GIT_ATTRIBUTES is now a bit more efficient, and paves the way for remote build cache support in Gradle. ([#621](https://github.com/diffplug/spotless/pull/621))
 
 ## [4.4.0] - 2020-06-19
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -669,13 +669,10 @@ public class FormatExtension {
 	protected void setupTask(SpotlessTask task) {
 		task.setEncoding(getEncoding().name());
 		task.setExceptionPolicy(exceptionPolicy);
-		if (targetExclude == null) {
-			task.setTarget(target);
-		} else {
-			task.setTarget(target.minus(targetExclude));
-		}
+		FileCollection totalTarget = targetExclude == null ? target : target.minus(targetExclude);
+		task.setTarget(totalTarget);
 		task.setSteps(steps);
-		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> task.target));
+		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> totalTarget));
 		if (spotless.project != spotless.project.getRootProject()) {
 			spotless.getRegisterDependenciesTask().hookSubprojectTask(task);
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskBase.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskBase.java
@@ -63,7 +63,7 @@ public class SpotlessTaskBase extends DefaultTask {
 		this.encoding = Objects.requireNonNull(encoding);
 	}
 
-	protected LineEnding.Policy lineEndingsPolicy = LineEnding.UNIX.createPolicy();
+	protected LineEnding.Policy lineEndingsPolicy;
 
 	@Input
 	public LineEnding.Policy getLineEndingsPolicy() {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -37,6 +37,7 @@ public class FormatTaskTest extends ResourceHarness {
 	public void createTask() throws IOException {
 		Project project = TestProvisioner.gradleProject(rootFolder());
 		spotlessTask = project.getTasks().create("spotlessTaskUnderTest", SpotlessTask.class);
+		spotlessTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 	}
 
 	@Test
@@ -44,7 +45,6 @@ public class FormatTaskTest extends ResourceHarness {
 		File testFile = setFile("testFile").toContent("\r\n");
 		File outputFile = new File(spotlessTask.getOutputDirectory(), "testFile");
 
-		spotlessTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 		spotlessTask.setTarget(Collections.singleton(testFile));
 		execute(spotlessTask);
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,4 +56,8 @@ public class FileSignatureTest extends ResourceHarness {
 		return result;
 	}
 
+	@Test
+	public void testSubpath() {
+		assertThat(FileSignature.subpath("root/", "root/child")).isEqualTo("child");
+	}
 }


### PR DESCRIPTION
...and remove `FileSignature` from it completely.

The easy way to understand it is this commit: https://github.com/diffplug/spotless/commit/082f86718e44f791f31fbdc4a7858db78aab354f, which introduces the new policy.  The rest of the PR just removes the old one.  The only downside is that now, when the line endings property is checked for equality (so on task up-to-dateness), the line-endings of every file in the target is computed and stored into this data structure:

https://github.com/diffplug/spotless/blob/758414bc2b9acde11314c29dcf26b5eeb777e0c1/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java#L109-L114

The expensive part of this is iterating over a possibly large target.  But we were doing this before anyway, and users can avoid it if they want by using LineEndings.UNIX, and taking on the git battle themselves.

