### PR TITLE
Remove all eager task creation for SpotlessModern

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -64,7 +64,7 @@ public class FormatExtension {
 	}
 
 	protected final Provisioner provisioner() {
-		return spotless.registerDependenciesTask.rootProvisioner;
+		return spotless.getRegisterDependenciesTask().rootProvisioner;
 	}
 
 	private String formatName() {
@@ -677,10 +677,10 @@ public class FormatExtension {
 		task.setSteps(steps);
 		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> task.target));
 		if (spotless.project != spotless.project.getRootProject()) {
-			spotless.registerDependenciesTask.hookSubprojectTask(task);
+			spotless.getRegisterDependenciesTask().hookSubprojectTask(task);
 		}
 		if (getRatchetFrom() != null) {
-			task.setupRatchet(spotless.registerDependenciesTask.gitRatchet, getRatchetFrom());
+			task.setupRatchet(spotless.getRegisterDependenciesTask().gitRatchet, getRatchetFrom());
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -39,7 +39,7 @@ public class GradleProvisioner {
 
 	@Deprecated
 	public static Provisioner fromProject(Project project) {
-		return project.getPlugins().apply(SpotlessPlugin.class).getExtension().registerDependenciesTask.rootProvisioner;
+		return project.getPlugins().apply(SpotlessPlugin.class).getExtension().getRegisterDependenciesTask().rootProvisioner;
 	}
 
 	/** The provisioner used for the root project. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -23,6 +23,7 @@ import org.gradle.api.plugins.BasePlugin;
 public class SpotlessExtension extends SpotlessExtensionBase {
 	final Task rootCheckTask, rootApplyTask, rootDiagnoseTask;
 	private static final String FILES_PROPERTY = "spotlessFiles";
+	private final RegisterDependenciesTask registerDependenciesTask;
 
 	public SpotlessExtension(Project project) {
 		super(project);
@@ -34,6 +35,18 @@ public class SpotlessExtension extends SpotlessExtensionBase {
 		rootApplyTask.setDescription(APPLY_DESCRIPTION);
 		rootDiagnoseTask = project.task(EXTENSION + DIAGNOSE);
 		rootDiagnoseTask.setGroup(TASK_GROUP);	// no description on purpose
+
+		RegisterDependenciesTask registerDependenciesTask = (RegisterDependenciesTask) project.getRootProject().getTasks().findByName(RegisterDependenciesTask.TASK_NAME);
+		if (registerDependenciesTask == null) {
+			registerDependenciesTask = project.getRootProject().getTasks().create(RegisterDependenciesTask.TASK_NAME, RegisterDependenciesTask.class);
+			registerDependenciesTask.setup();
+		}
+		this.registerDependenciesTask = registerDependenciesTask;
+	}
+
+	@Override
+	RegisterDependenciesTask getRegisterDependenciesTask() {
+		return registerDependenciesTask;
 	}
 
 	/**

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionBase.java
@@ -34,7 +34,6 @@ import com.diffplug.spotless.LineEnding;
 
 public abstract class SpotlessExtensionBase {
 	final Project project;
-	final RegisterDependenciesTask registerDependenciesTask;
 
 	protected static final String TASK_GROUP = "Verification";
 	protected static final String CHECK_DESCRIPTION = "Checks that sourcecode satisfies formatting steps.";
@@ -47,14 +46,9 @@ public abstract class SpotlessExtensionBase {
 
 	public SpotlessExtensionBase(Project project) {
 		this.project = requireNonNull(project);
-
-		RegisterDependenciesTask registerDependenciesTask = (RegisterDependenciesTask) project.getRootProject().getTasks().findByName(RegisterDependenciesTask.TASK_NAME);
-		if (registerDependenciesTask == null) {
-			registerDependenciesTask = project.getRootProject().getTasks().create(RegisterDependenciesTask.TASK_NAME, RegisterDependenciesTask.class);
-			registerDependenciesTask.setup();
-		}
-		this.registerDependenciesTask = registerDependenciesTask;
 	}
+
+	abstract RegisterDependenciesTask getRegisterDependenciesTask();
 
 	/** Line endings (if any). */
 	LineEnding lineEndings = LineEnding.GIT_ATTRIBUTES;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionModern.java
@@ -23,6 +23,8 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 public class SpotlessExtensionModern extends SpotlessExtensionBase {
+	private final TaskProvider<RegisterDependenciesTask> registerDependenciesTask;
+
 	public SpotlessExtensionModern(Project project) {
 		super(project);
 		rootCheckTask = project.getTasks().register(EXTENSION + CHECK, task -> {
@@ -37,6 +39,13 @@ public class SpotlessExtensionModern extends SpotlessExtensionBase {
 			task.setGroup(TASK_GROUP); // no description on purpose
 		});
 
+		TaskContainer rootProjectTasks = project.getRootProject().getTasks();
+		if (!rootProjectTasks.getNames().contains(RegisterDependenciesTask.TASK_NAME)) {
+			this.registerDependenciesTask = rootProjectTasks.register(RegisterDependenciesTask.TASK_NAME, RegisterDependenciesTask.class, RegisterDependenciesTask::setup);
+		} else {
+			this.registerDependenciesTask = rootProjectTasks.named(RegisterDependenciesTask.TASK_NAME, RegisterDependenciesTask.class);
+		}
+
 		project.afterEvaluate(unused -> {
 			if (enforceCheck) {
 				project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME)
@@ -46,6 +55,11 @@ public class SpotlessExtensionModern extends SpotlessExtensionBase {
 	}
 
 	final TaskProvider<?> rootCheckTask, rootApplyTask, rootDiagnoseTask;
+
+	@Override
+	RegisterDependenciesTask getRegisterDependenciesTask() {
+		return registerDependenciesTask.get();
+	}
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPluginModern.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPluginModern.java
@@ -17,7 +17,6 @@ package com.diffplug.gradle.spotless;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.plugins.BasePlugin;
 
 import com.diffplug.spotless.SpotlessCache;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPluginModern.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPluginModern.java
@@ -35,14 +35,15 @@ public class SpotlessPluginModern implements Plugin<Project> {
 		project.getExtensions().create(SpotlessExtension.EXTENSION, SpotlessExtensionModern.class, project);
 
 		// clear spotless' cache when the user does a clean
-		Task clean = project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME);
-		clean.doLast(unused -> {
-			// resolution for: https://github.com/diffplug/spotless/issues/243#issuecomment-564323856
-			// project.getRootProject() is consistent across every project, so only of one the clears will
-			// actually happen (as desired)
-			//
-			// we use System.identityHashCode() to avoid a memory leak by hanging on to the reference directly
-			SpotlessCache.clearOnce(System.identityHashCode(project.getRootProject()));
+		project.getTasks().named(BasePlugin.CLEAN_TASK_NAME).configure(clean -> {
+			clean.doLast(unused -> {
+				// resolution for: https://github.com/diffplug/spotless/issues/243#issuecomment-564323856
+				// project.getRootProject() is consistent across every project, so only of one the clears will
+				// actually happen (as desired)
+				//
+				// we use System.identityHashCode() to avoid a memory leak by hanging on to the reference directly
+				SpotlessCache.clearOnce(System.identityHashCode(project.getRootProject()));
+			});
 		});
 	}
 }


### PR DESCRIPTION
This PR removes the last 2 tasks that were being eagerly instantiated when the `SpotlessPluginModern` was applied. While not particularly impactful, it's good form for a plugin to avoid forcing tasks to be instantiated unless they are required for execution.