### PR TITLE
Add maven support for git-based copyright headers

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -213,7 +213,7 @@ public final class LicenseHeaderStep implements Serializable {
 		}
 	}
 
-	private static final String spotlessSetLicenseHeaderYearsFromGitHistory = "spotlessSetLicenseHeaderYearsFromGitHistory";
+	public static final String spotlessSetLicenseHeaderYearsFromGitHistory = "spotlessSetLicenseHeaderYearsFromGitHistory";
 
 	public static final String FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY() {
 		return spotlessSetLicenseHeaderYearsFromGitHistory;

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * You can now ratchet a project's style by limiting Spotless only to files which have changed since a given [git reference](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), e.g. `ratchetFrom 'origin/main'`. ([#590](https://github.com/diffplug/spotless/pull/590))
 * Huge speed improvement for multi-module projects thanks to improved cross-project classloader caching ([#571](https://github.com/diffplug/spotless/pull/571), fixes [#559](https://github.com/diffplug/spotless/issues/559)).
+* If you specify `-PspotlessSetLicenseHeaderYearsFromGitHistory=true`, Spotless will perform an expensive search through git history to determine the oldest and newest commits for each file, and uses that to determine license header years. ([#626](https://github.com/diffplug/spotless/pull/626))
 * `prettier` will now autodetect the parser (and formatter) to use based on the filename, unless you override this using `config` or `configFile` with the option `parser` or `filepath` ([#620](https://github.com/diffplug/spotless/pull/620)).
 
 ## [1.31.3] - 2020-06-17

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,7 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * You can now ratchet a project's style by limiting Spotless only to files which have changed since a given [git reference](https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.6.1.202002131546-r/org/eclipse/jgit/lib/Repository.html#resolve-java.lang.String-), e.g. `ratchetFrom 'origin/main'`. ([#590](https://github.com/diffplug/spotless/pull/590))
 * Huge speed improvement for multi-module projects thanks to improved cross-project classloader caching ([#571](https://github.com/diffplug/spotless/pull/571), fixes [#559](https://github.com/diffplug/spotless/issues/559)).
-* If you specify `-PspotlessSetLicenseHeaderYearsFromGitHistory=true`, Spotless will perform an expensive search through git history to determine the oldest and newest commits for each file, and uses that to determine license header years. ([#626](https://github.com/diffplug/spotless/pull/626))
+* If you specify `-DspotlessSetLicenseHeaderYearsFromGitHistory=true`, Spotless will perform an expensive search through git history to determine the oldest and newest commits for each file, and uses that to determine license header years. ([#626](https://github.com/diffplug/spotless/pull/626))
 * `prettier` will now autodetect the parser (and formatter) to use based on the filename, unless you override this using `config` or `configFile` with the option `parser` or `filepath` ([#620](https://github.com/diffplug/spotless/pull/620)).
 
 ## [1.31.3] - 2020-06-17

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -544,7 +544,7 @@ Spotless can inject a license header into your files, including populating an ac
   </licenseHeader>
 ```
 
-If the license header (specified with `licenseHeader` or `licenseHeaderFile`) contains `$YEAR` or `$today.year`, then that token will be replaced with the current 4-digit year.  For example, if Spotless is launched in 2020, then `/* Licensed under Apache-2.0 $YEAR. */` will produce `/* Licensed under Apache-2.0 2020. */`
+If the license header (specified with `content` or `file`) contains `$YEAR` or `$today.year`, then that token will be replaced with the current 4-digit year.  For example, if Spotless is launched in 2020, then `/* Licensed under Apache-2.0 $YEAR. */` will produce `/* Licensed under Apache-2.0 2020. */`
 
 Once a file's license header has a valid year, whether it is a year (`2020`) or a year range (`2017-2020`), it will not be changed.  If you want the date to be updated when it changes, enable the [`ratchetFrom` functionality](#ratchet), and the year will be automatically set to today's year according to the following table (assuming the current year is 2020):
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -526,6 +526,36 @@ Unlike Eclipse, Spotless WTP ignores per default external URIs in schema locatio
 external entities. To allow the access of external URIs, set the property `resolveExternalURI`
 to true.
 
+<a name="license-header"></a>
+
+## License header
+
+Spotless can inject a license header into your files, including populating an accurate copyright header from today's date or from git history.
+
+```xml
+<format>  <!-- or java, scala, kotlin, etc. -->
+  <licenseHeader>
+    <!-- Specify either content or file, but not both -->
+    <content>/* Licensed under Apache-2.0 */</content>
+    <file>${basedir}/license-header</file>
+    <!-- content until first occurrence of the delimiter regex will be interpreted as header section -->
+    <!-- for language-specific formats (java, etc.) this is optional, and the regex is provided automatically. -->
+    <delimiter>#</delimiter>
+  </licenseHeader>
+```
+
+If the license header (specified with `licenseHeader` or `licenseHeaderFile`) contains `$YEAR` or `$today.year`, then that token will be replaced with the current 4-digit year.  For example, if Spotless is launched in 2020, then `/* Licensed under Apache-2.0 $YEAR. */` will produce `/* Licensed under Apache-2.0 2020. */`
+
+Once a file's license header has a valid year, whether it is a year (`2020`) or a year range (`2017-2020`), it will not be changed.  If you want the date to be updated when it changes, enable the [`ratchetFrom` functionality](#ratchet), and the year will be automatically set to today's year according to the following table (assuming the current year is 2020):
+
+* No license header -> `2020`
+* `2017` -> `2017-2020`
+* `2017-2019` -> `2017-2020`
+
+### Retroactively populating year range from git history
+
+If your project has not been rigorous with copyright headers, and you'd like to use git history to repair this retroactively, you can do so with `-DspotlessSetLicenseHeaderYearsFromGitHistory=true`.  When run in this mode, Spotless will do an expensive search through git history for each file, and set the copyright header based on the oldest and youngest commits for that file.  This is intended to be a one-off sort of thing.
+
 <a name="invisible"></a>
 
 ## Line endings and encodings (invisible stuff)

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -120,6 +120,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter(property = "spotlessFiles")
 	private String filePatterns;
 
+	@Parameter(property = "spotlessSetLicenseHeaderYearsFromGitHistory")
+	private String setLicenseHeaderYearsFromGitHistory;
+
 	protected abstract void process(Iterable<File> files, Formatter formatter) throws MojoExecutionException;
 
 	@Override
@@ -189,7 +192,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		Provisioner provisioner = MavenProvisioner.create(resolver);
 		List<FormatterStepFactory> formatterStepFactories = getFormatterStepFactories();
 		FileLocator fileLocator = getFileLocator();
-		return new FormatterConfig(baseDir, encoding, lineEndings, Optional.ofNullable(ratchetFrom), provisioner, fileLocator, formatterStepFactories);
+		return new FormatterConfig(baseDir, encoding, lineEndings, Optional.ofNullable(ratchetFrom), provisioner, fileLocator, formatterStepFactories, Optional.ofNullable(setLicenseHeaderYearsFromGitHistory));
 	}
 
 	private FileLocator getFileLocator() {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -46,6 +46,7 @@ import com.diffplug.common.collect.Iterables;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.generic.LicenseHeaderStep;
 import com.diffplug.spotless.maven.cpp.Cpp;
 import com.diffplug.spotless.maven.generic.Format;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
@@ -120,7 +121,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter(property = "spotlessFiles")
 	private String filePatterns;
 
-	@Parameter(property = "spotlessSetLicenseHeaderYearsFromGitHistory")
+	@Parameter(property = LicenseHeaderStep.spotlessSetLicenseHeaderYearsFromGitHistory)
 	private String setLicenseHeaderYearsFromGitHistory;
 
 	protected abstract void process(Iterable<File> files, Formatter formatter) throws MojoExecutionException;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterConfig.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterConfig.java
@@ -32,15 +32,17 @@ public class FormatterConfig {
 	private final Provisioner provisioner;
 	private final FileLocator fileLocator;
 	private final List<FormatterStepFactory> globalStepFactories;
+	private final Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory;
 
 	public FormatterConfig(File baseDir, String encoding, LineEnding lineEndings, Optional<String> ratchetFrom, Provisioner provisioner,
-			FileLocator fileLocator, List<FormatterStepFactory> globalStepFactories) {
+			FileLocator fileLocator, List<FormatterStepFactory> globalStepFactories, Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory) {
 		this.encoding = encoding;
 		this.lineEndings = lineEndings;
 		this.ratchetFrom = ratchetFrom;
 		this.provisioner = provisioner;
 		this.fileLocator = fileLocator;
 		this.globalStepFactories = globalStepFactories;
+		this.spotlessSetLicenseHeaderYearsFromGitHistory = spotlessSetLicenseHeaderYearsFromGitHistory;
 	}
 
 	public String getEncoding() {
@@ -61,6 +63,10 @@ public class FormatterConfig {
 
 	public List<FormatterStepFactory> getGlobalStepFactories() {
 		return unmodifiableList(globalStepFactories);
+	}
+
+	public Optional<String> getSpotlessSetLicenseHeaderYearsFromGitHistory() {
+		return spotlessSetLicenseHeaderYearsFromGitHistory;
 	}
 
 	public FileLocator getFileLocator() {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -144,7 +144,7 @@ public abstract class FormatterFactory {
 	}
 
 	private FormatterStepConfig stepConfig(Charset encoding, FormatterConfig config) {
-		return new FormatterStepConfig(encoding, licenseHeaderDelimiter(), ratchetFrom(config), config.getProvisioner(), config.getFileLocator());
+		return new FormatterStepConfig(encoding, licenseHeaderDelimiter(), ratchetFrom(config), config.getProvisioner(), config.getFileLocator(), config.getSpotlessSetLicenseHeaderYearsFromGitHistory());
 	}
 
 	private static List<FormatterStepFactory> gatherStepFactories(List<FormatterStepFactory> allGlobal, List<FormatterStepFactory> allConfigured) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -144,7 +144,7 @@ public abstract class FormatterFactory {
 	}
 
 	private FormatterStepConfig stepConfig(Charset encoding, FormatterConfig config) {
-		return new FormatterStepConfig(encoding, licenseHeaderDelimiter(), config.getProvisioner(), config.getFileLocator());
+		return new FormatterStepConfig(encoding, licenseHeaderDelimiter(), ratchetFrom(config), config.getProvisioner(), config.getFileLocator());
 	}
 
 	private static List<FormatterStepFactory> gatherStepFactories(List<FormatterStepFactory> allGlobal, List<FormatterStepFactory> allConfigured) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepConfig.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepConfig.java
@@ -27,13 +27,15 @@ public class FormatterStepConfig {
 	private final Optional<String> ratchetFrom;
 	private final Provisioner provisioner;
 	private final FileLocator fileLocator;
+	private final Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory;
 
-	public FormatterStepConfig(Charset encoding, String licenseHeaderDelimiter, Optional<String> ratchetFrom, Provisioner provisioner, FileLocator fileLocator) {
+	public FormatterStepConfig(Charset encoding, String licenseHeaderDelimiter, Optional<String> ratchetFrom, Provisioner provisioner, FileLocator fileLocator, Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory) {
 		this.encoding = encoding;
 		this.licenseHeaderDelimiter = licenseHeaderDelimiter;
 		this.ratchetFrom = ratchetFrom;
 		this.provisioner = provisioner;
 		this.fileLocator = fileLocator;
+		this.spotlessSetLicenseHeaderYearsFromGitHistory = spotlessSetLicenseHeaderYearsFromGitHistory;
 	}
 
 	public Charset getEncoding() {
@@ -54,5 +56,9 @@ public class FormatterStepConfig {
 
 	public FileLocator getFileLocator() {
 		return fileLocator;
+	}
+
+	public Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory() {
+		return spotlessSetLicenseHeaderYearsFromGitHistory;
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepConfig.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.maven;
 
 import java.nio.charset.Charset;
+import java.util.Optional;
 
 import com.diffplug.spotless.Provisioner;
 
@@ -23,12 +24,14 @@ public class FormatterStepConfig {
 
 	private final Charset encoding;
 	private final String licenseHeaderDelimiter;
+	private final Optional<String> ratchetFrom;
 	private final Provisioner provisioner;
 	private final FileLocator fileLocator;
 
-	public FormatterStepConfig(Charset encoding, String licenseHeaderDelimiter, Provisioner provisioner, FileLocator fileLocator) {
+	public FormatterStepConfig(Charset encoding, String licenseHeaderDelimiter, Optional<String> ratchetFrom, Provisioner provisioner, FileLocator fileLocator) {
 		this.encoding = encoding;
 		this.licenseHeaderDelimiter = licenseHeaderDelimiter;
+		this.ratchetFrom = ratchetFrom;
 		this.provisioner = provisioner;
 		this.fileLocator = fileLocator;
 	}
@@ -39,6 +42,10 @@ public class FormatterStepConfig {
 
 	public String getLicenseHeaderDelimiter() {
 		return licenseHeaderDelimiter;
+	}
+
+	public Optional<String> getRatchetFrom() {
+		return ratchetFrom;
 	}
 
 	public Provisioner getProvisioner() {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class LicenseHeader implements FormatterStepFactory {
 		if (file != null ^ content != null) {
 			FormatterStep step = file != null
 					? createStepFromFile(config, delimiterString)
-					: createStepFromContent(delimiterString);
+					: createStepFromContent(config, delimiterString);
 
 			return step.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
 		} else {
@@ -58,7 +58,7 @@ public class LicenseHeader implements FormatterStepFactory {
 		return LicenseHeaderStep.createFromFile(licenseHeaderFile, config.getEncoding(), delimiterString);
 	}
 
-	private FormatterStep createStepFromContent(String delimiterString) {
+	private FormatterStep createStepFromContent(FormatterStepConfig config, String delimiterString) {
 		return LicenseHeaderStep.createFromHeader(content, delimiterString);
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
@@ -66,13 +66,7 @@ public class LicenseHeader implements FormatterStepFactory {
 				unfiltered = FormatterStep.createLazy(LicenseHeaderStep.name(), () -> {
 					// by default, we should update the year if the user is using ratchetFrom
 					boolean updateYear = config.getRatchetFrom().isPresent();
-					String header;
-					if (content != null) {
-						header = content;
-					} else {
-						byte[] raw = Files.readAllBytes(config.getFileLocator().locateFile(file).toPath());
-						header = new String(raw, config.getEncoding());
-					}
+					String header = readFileOrContent(config);
 					return new LicenseHeaderStep(header, delimiterString, LicenseHeaderStep.defaultYearDelimiter(), updateYear);
 				}, step -> step::format);
 			}


### PR DESCRIPTION
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
