### PR TITLE
Refactor the public API of `LicenseHeaderStep`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * **BREAKING** `FileSignature` can no longer sign folders, only files.  Signatures are now based only on filename (not path), size, and a content hash.  It throws an error if a signature is attempted on a folder or on multiple files with different paths but the same filename - it never breaks silently.  This change does not break any of Spotless' internal logic, so it is unlikely to affect any of Spotless' consumers either. ([#571](https://github.com/diffplug/spotless/pull/571))
   * This change allows the maven plugin to cache classloaders across subprojects when loading config resources from the classpath (fixes [#559](https://github.com/diffplug/spotless/issues/559)).
   * This change also allows the gradle plugin to work with the remote buildcache (fixes [#280](https://github.com/diffplug/spotless/issues/280)).
+* **BREAKING** Heavy refactor of the `LicenseHeaderStep` public API.  Doesn't change internal behavior, but makes implementation of the gradle and maven plugins much easier. ([#628](https://github.com/diffplug/spotless/pull/628))
 
 ## [1.34.1] - 2020-06-17
 ### Changed

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -125,11 +125,6 @@ public final class LicenseHeaderStep implements Serializable {
 
 	private static final long serialVersionUID = 2L;
 
-	public static FormatterStep createFromHeader(String header, String delimiterExpr) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
 	private static final String NAME = "licenseHeader";
 	private static final String DEFAULT_YEAR_DELIMITER = "-";
 	private static final List<String> YEAR_TOKENS = Arrays.asList("$YEAR", "$today.year");

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -39,91 +39,95 @@ import com.diffplug.spotless.ThrowingEx;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Prefixes a license header before the package statement. */
-public final class LicenseHeaderStep implements Serializable {
+public final class LicenseHeaderStep {
 	public enum YearMode {
 		PRESERVE, UPDATE_TO_TODAY, SET_FROM_GIT
 	}
 
-	public static Builder headerDelimiter(ThrowingEx.Supplier<String> headerLazy, String delimiter) {
-		return new Builder(headerLazy, delimiter, DEFAULT_YEAR_DELIMITER, YearMode.PRESERVE);
-	}
-
-	public static Builder headerDelimiter(String header, String delimiter) {
+	public static LicenseHeaderStep headerDelimiter(String header, String delimiter) {
 		return headerDelimiter(() -> header, delimiter);
 	}
 
-	public static final class Builder {
-		final ThrowingEx.Supplier<String> headerLazy;
-		final String delimiter;
-		final String yearSeparator;
-		final YearMode yearMode;
+	public static LicenseHeaderStep headerDelimiter(ThrowingEx.Supplier<String> headerLazy, String delimiter) {
+		return new LicenseHeaderStep(headerLazy, delimiter, DEFAULT_YEAR_DELIMITER, YearMode.PRESERVE);
+	}
 
-		private Builder(ThrowingEx.Supplier<String> headerLazy, String delimiter, String yearSeparator, YearMode yearMode) {
-			this.headerLazy = Objects.requireNonNull(headerLazy);
-			this.delimiter = Objects.requireNonNull(delimiter);
-			this.yearSeparator = Objects.requireNonNull(yearSeparator);
-			this.yearMode = Objects.requireNonNull(yearMode);
+	final ThrowingEx.Supplier<String> headerLazy;
+	final String delimiter;
+	final String yearSeparator;
+	final YearMode yearMode;
+
+	private LicenseHeaderStep(ThrowingEx.Supplier<String> headerLazy, String delimiter, String yearSeparator, YearMode yearMode) {
+		this.headerLazy = Objects.requireNonNull(headerLazy);
+		this.delimiter = Objects.requireNonNull(delimiter);
+		this.yearSeparator = Objects.requireNonNull(yearSeparator);
+		this.yearMode = Objects.requireNonNull(yearMode);
+	}
+
+	public LicenseHeaderStep withHeaderString(String header) {
+		return withHeaderLazy(() -> header);
+	}
+
+	public LicenseHeaderStep withHeaderLazy(ThrowingEx.Supplier<String> headerLazy) {
+		return new LicenseHeaderStep(headerLazy, delimiter, yearSeparator, yearMode);
+	}
+
+	public LicenseHeaderStep withDelimiter(String delimiter) {
+		return new LicenseHeaderStep(headerLazy, delimiter, yearSeparator, yearMode);
+	}
+
+	public LicenseHeaderStep withYearSeparator(String yearSeparator) {
+		return new LicenseHeaderStep(headerLazy, delimiter, yearSeparator, yearMode);
+	}
+
+	public LicenseHeaderStep withYearMode(YearMode yearMode) {
+		return new LicenseHeaderStep(headerLazy, delimiter, yearSeparator, yearMode);
+	}
+
+	private static class SetFromGitFormatterFunc implements FormatterFunc {
+		private final Runtime runtime;
+
+		private SetFromGitFormatterFunc(Runtime runtime) {
+			this.runtime = runtime;
 		}
 
-		public Builder withHeaderString(String header) {
-			return withHeaderLazy(() -> header);
+		@Override
+		public String apply(String input, File source) throws Exception {
+			return runtime.setLicenseHeaderYearsFromGitHistory(input, source);
 		}
 
-		public Builder withHeaderLazy(ThrowingEx.Supplier<String> headerLazy) {
-			return new Builder(headerLazy, delimiter, yearSeparator, yearMode);
-		}
-
-		public Builder withDelimiter(String delimiter) {
-			return new Builder(headerLazy, delimiter, yearSeparator, yearMode);
-		}
-
-		public Builder withYearSeparator(String yearSeparator) {
-			return new Builder(headerLazy, delimiter, yearSeparator, yearMode);
-		}
-
-		public Builder withYearMode(YearMode yearMode) {
-			return new Builder(headerLazy, delimiter, yearSeparator, yearMode);
-		}
-
-		public FormatterStep build() {
-			if (yearMode == YearMode.SET_FROM_GIT) {
-				return FormatterStep.createNeverUpToDateLazy(LicenseHeaderStep.name(), () -> {
-					boolean updateYear = false; // doesn't matter
-					LicenseHeaderStep step = new LicenseHeaderStep(headerLazy.get(), delimiter, yearSeparator, updateYear);
-					return new FormatterFunc() {
-						@Override
-						public String apply(String input, File source) throws Exception {
-							return step.setLicenseHeaderYearsFromGitHistory(input, source);
-						}
-
-						@Override
-						public String apply(String input) throws Exception {
-							throw new UnsupportedOperationException();
-						}
-					};
-				});
-			} else {
-				return FormatterStep.createLazy(LicenseHeaderStep.name(), () -> {
-					// by default, we should update the year if the user is using ratchetFrom
-					boolean updateYear;
-					switch (yearMode) {
-					case PRESERVE:
-						updateYear = false;
-						break;
-					case UPDATE_TO_TODAY:
-						updateYear = true;
-						break;
-					case SET_FROM_GIT:
-					default:
-						throw new IllegalStateException(yearMode.toString());
-					}
-					return new LicenseHeaderStep(headerLazy.get(), delimiter, yearSeparator, updateYear);
-				}, step -> step::format);
-			}
+		@Override
+		public String apply(String input) throws Exception {
+			throw new UnsupportedOperationException();
 		}
 	}
 
-	private static final long serialVersionUID = 2L;
+	public FormatterStep build() {
+		if (yearMode == YearMode.SET_FROM_GIT) {
+			return FormatterStep.createNeverUpToDateLazy(LicenseHeaderStep.name(), () -> {
+				boolean updateYear = false; // doesn't matter
+				Runtime step = new Runtime(headerLazy.get(), delimiter, yearSeparator, updateYear);
+				return new SetFromGitFormatterFunc(step);
+			});
+		} else {
+			return FormatterStep.createLazy(LicenseHeaderStep.name(), () -> {
+				// by default, we should update the year if the user is using ratchetFrom
+				boolean updateYear;
+				switch (yearMode) {
+				case PRESERVE:
+					updateYear = false;
+					break;
+				case UPDATE_TO_TODAY:
+					updateYear = true;
+					break;
+				case SET_FROM_GIT:
+				default:
+					throw new IllegalStateException(yearMode.toString());
+				}
+				return new Runtime(headerLazy.get(), delimiter, yearSeparator, updateYear);
+			}, step -> step::format);
+		}
+	}
 
 	private static final String NAME = "licenseHeader";
 	private static final String DEFAULT_YEAR_DELIMITER = "-";
@@ -144,185 +148,189 @@ public final class LicenseHeaderStep implements Serializable {
 		return UNSUPPORTED_JVM_FILES_FILTER;
 	}
 
-	private final Pattern delimiterPattern;
-	private final String yearSepOrFull;
-	private final @Nullable String yearToday;
-	private final @Nullable String beforeYear;
-	private final @Nullable String afterYear;
-	private final boolean updateYearWithLatest;
-
-	/** The license that we'd like enforced. */
-	private LicenseHeaderStep(String licenseHeader, String delimiter, String yearSeparator, boolean updateYearWithLatest) {
-		if (delimiter.contains("\n")) {
-			throw new IllegalArgumentException("The delimiter must not contain any newlines.");
-		}
-		// sanitize the input license
-		licenseHeader = LineEnding.toUnix(licenseHeader);
-		if (!licenseHeader.endsWith("\n")) {
-			licenseHeader = licenseHeader + "\n";
-		}
-		this.delimiterPattern = Pattern.compile('^' + delimiter, Pattern.UNIX_LINES | Pattern.MULTILINE);
-
-		Optional<String> yearToken = getYearToken(licenseHeader);
-		if (yearToken.isPresent()) {
-			yearToday = String.valueOf(YearMonth.now().getYear());
-			int yearTokenIndex = licenseHeader.indexOf(yearToken.get());
-			beforeYear = licenseHeader.substring(0, yearTokenIndex);
-			afterYear = licenseHeader.substring(yearTokenIndex + yearToken.get().length());
-			yearSepOrFull = yearSeparator;
-			this.updateYearWithLatest = updateYearWithLatest;
-		} else {
-			yearToday = null;
-			beforeYear = null;
-			afterYear = null;
-			this.yearSepOrFull = licenseHeader;
-			this.updateYearWithLatest = false;
-		}
-	}
-
-	private static final Pattern patternYearSingle = Pattern.compile("[0-9]{4}");
-
-	/**
-	 * Get the first place holder token being used in the
-	 * license header for specifying the year
-	 *
-	 * @param licenseHeader String representation of the license header
-	 * @return Matching value from YEAR_TOKENS or null if none exist
-	 */
-	private static Optional<String> getYearToken(String licenseHeader) {
-		return YEAR_TOKENS.stream().filter(licenseHeader::contains).findFirst();
-	}
-
-	/** Formats the given string. */
-	private String format(String raw) {
-		Matcher contentMatcher = delimiterPattern.matcher(raw);
-		if (!contentMatcher.find()) {
-			throw new IllegalArgumentException("Unable to find delimiter regex " + delimiterPattern);
-		} else {
-			if (yearToday == null) {
-				// the no year case is easy
-				if (contentMatcher.start() == yearSepOrFull.length() && raw.startsWith(yearSepOrFull)) {
-					// if no change is required, return the raw string without
-					// creating any other new strings for maximum performance
-					return raw;
-				} else {
-					// otherwise we'll have to add the header
-					return yearSepOrFull + raw.substring(contentMatcher.start());
-				}
-			} else {
-				// the yes year case is a bit harder
-				int beforeYearIdx = raw.indexOf(beforeYear);
-				int afterYearIdx = raw.indexOf(afterYear, beforeYearIdx + beforeYear.length() + 1);
-
-				if (beforeYearIdx >= 0 && afterYearIdx >= 0 && afterYearIdx + afterYear.length() <= contentMatcher.start()) {
-					boolean noPadding = beforeYearIdx == 0 && afterYearIdx + afterYear.length() == contentMatcher.start(); // allows fastpath return raw
-					String parsedYear = raw.substring(beforeYearIdx + beforeYear.length(), afterYearIdx);
-					if (parsedYear.equals(yearToday)) {
-						// it's good as is!
-						return noPadding ? raw : beforeYear + yearToday + afterYear + raw.substring(contentMatcher.start());
-					} else if (patternYearSingle.matcher(parsedYear).matches()) {
-						if (updateYearWithLatest) {
-							// expand from `2004` to `2004-2020`
-							return beforeYear + parsedYear + yearSepOrFull + yearToday + afterYear + raw.substring(contentMatcher.start());
-						} else {
-							// it's already good as a single year
-							return noPadding ? raw : beforeYear + parsedYear + afterYear + raw.substring(contentMatcher.start());
-						}
-					} else {
-						Matcher yearMatcher = patternYearSingle.matcher(parsedYear);
-						if (yearMatcher.find()) {
-							String firstYear = yearMatcher.group();
-							String newYear;
-							String secondYear;
-							if (updateYearWithLatest) {
-								secondYear = firstYear.equals(yearToday) ? null : yearToday;
-							} else if (yearMatcher.find(yearMatcher.end() + 1)) {
-								secondYear = yearMatcher.group();
-							} else {
-								secondYear = null;
-							}
-							if (secondYear == null) {
-								newYear = firstYear;
-							} else {
-								newYear = firstYear + yearSepOrFull + secondYear;
-							}
-							return noPadding && newYear.equals(parsedYear) ? raw : beforeYear + newYear + afterYear + raw.substring(contentMatcher.start());
-						}
-					}
-				}
-				// at worst, we just say that it was made today
-				return beforeYear + yearToday + afterYear + raw.substring(contentMatcher.start());
-			}
-		}
-	}
-
 	public static final String spotlessSetLicenseHeaderYearsFromGitHistory = "spotlessSetLicenseHeaderYearsFromGitHistory";
 
 	public static final String FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY() {
 		return spotlessSetLicenseHeaderYearsFromGitHistory;
 	}
 
-	/** Sets copyright years on the given file by finding the oldest and most recent commits throughout git history. */
-	private String setLicenseHeaderYearsFromGitHistory(String raw, File file) throws IOException {
-		if (yearToday == null) {
-			return raw;
-		}
-		Matcher contentMatcher = delimiterPattern.matcher(raw);
-		if (!contentMatcher.find()) {
-			throw new IllegalArgumentException("Unable to find delimiter regex " + delimiterPattern);
+	private static class Runtime implements Serializable {
+		private static final long serialVersionUID = 1475199492829130965L;
+
+		private final Pattern delimiterPattern;
+		private final String yearSepOrFull;
+		private final @Nullable String yearToday;
+		private final @Nullable String beforeYear;
+		private final @Nullable String afterYear;
+		private final boolean updateYearWithLatest;
+
+		/** The license that we'd like enforced. */
+		private Runtime(String licenseHeader, String delimiter, String yearSeparator, boolean updateYearWithLatest) {
+			if (delimiter.contains("\n")) {
+				throw new IllegalArgumentException("The delimiter must not contain any newlines.");
+			}
+			// sanitize the input license
+			licenseHeader = LineEnding.toUnix(licenseHeader);
+			if (!licenseHeader.endsWith("\n")) {
+				licenseHeader = licenseHeader + "\n";
+			}
+			this.delimiterPattern = Pattern.compile('^' + delimiter, Pattern.UNIX_LINES | Pattern.MULTILINE);
+
+			Optional<String> yearToken = getYearToken(licenseHeader);
+			if (yearToken.isPresent()) {
+				yearToday = String.valueOf(YearMonth.now().getYear());
+				int yearTokenIndex = licenseHeader.indexOf(yearToken.get());
+				beforeYear = licenseHeader.substring(0, yearTokenIndex);
+				afterYear = licenseHeader.substring(yearTokenIndex + yearToken.get().length());
+				yearSepOrFull = yearSeparator;
+				this.updateYearWithLatest = updateYearWithLatest;
+			} else {
+				yearToday = null;
+				beforeYear = null;
+				afterYear = null;
+				this.yearSepOrFull = licenseHeader;
+				this.updateYearWithLatest = false;
+			}
 		}
 
-		String oldYear;
-		try {
-			oldYear = parseYear("git log --follow --find-renames=40% --diff-filter=A", file);
-		} catch (IllegalArgumentException e) {
-			// Ideally, git log would always find the commit where it was added.
-			// For some reason, that is sometimes not possible - in that case,
-			// we'll settle for just the most recent, even if it was just a modification.
-			oldYear = parseYear("git log --follow --find-renames=40% --reverse", file);
-		}
-		String newYear = parseYear("git log --max-count=1", file);
-		String yearRange;
-		if (oldYear.equals(newYear)) {
-			yearRange = oldYear;
-		} else {
-			yearRange = oldYear + yearSepOrFull + newYear;
-		}
-		return beforeYear + yearRange + afterYear + raw.substring(contentMatcher.start());
-	}
+		private static final Pattern patternYearSingle = Pattern.compile("[0-9]{4}");
 
-	private static String parseYear(String cmd, File file) throws IOException {
-		String fullCmd = cmd + " " + file.getAbsolutePath();
-		ProcessBuilder builder = new ProcessBuilder().directory(file.getParentFile());
-		if (LineEnding.nativeIsWin()) {
-			builder.command("cmd", "/c", fullCmd);
-		} else {
-			builder.command("bash", "-c", fullCmd);
+		/**
+		 * Get the first place holder token being used in the
+		 * license header for specifying the year
+		 *
+		 * @param licenseHeader String representation of the license header
+		 * @return Matching value from YEAR_TOKENS or null if none exist
+		 */
+		private static Optional<String> getYearToken(String licenseHeader) {
+			return YEAR_TOKENS.stream().filter(licenseHeader::contains).findFirst();
 		}
-		Process process = builder.start();
-		String output = drain(process.getInputStream());
-		String error = drain(process.getErrorStream());
-		if (!error.isEmpty()) {
-			throw new IllegalArgumentException("Error for command '" + fullCmd + "':\n" + error);
-		}
-		Matcher matcher = FIND_YEAR.matcher(output);
-		if (matcher.find()) {
-			return matcher.group(1);
-		} else {
-			throw new IllegalArgumentException("Unable to parse date from command '" + fullCmd + "':\n" + output);
-		}
-	}
 
-	private static final Pattern FIND_YEAR = Pattern.compile("Date:   .* ([0-9]{4}) ");
+		/** Formats the given string. */
+		private String format(String raw) {
+			Matcher contentMatcher = delimiterPattern.matcher(raw);
+			if (!contentMatcher.find()) {
+				throw new IllegalArgumentException("Unable to find delimiter regex " + delimiterPattern);
+			} else {
+				if (yearToday == null) {
+					// the no year case is easy
+					if (contentMatcher.start() == yearSepOrFull.length() && raw.startsWith(yearSepOrFull)) {
+						// if no change is required, return the raw string without
+						// creating any other new strings for maximum performance
+						return raw;
+					} else {
+						// otherwise we'll have to add the header
+						return yearSepOrFull + raw.substring(contentMatcher.start());
+					}
+				} else {
+					// the yes year case is a bit harder
+					int beforeYearIdx = raw.indexOf(beforeYear);
+					int afterYearIdx = raw.indexOf(afterYear, beforeYearIdx + beforeYear.length() + 1);
 
-	@SuppressFBWarnings("DM_DEFAULT_ENCODING")
-	private static String drain(InputStream stream) throws IOException {
-		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		byte[] buf = new byte[1024];
-		int numRead;
-		while ((numRead = stream.read(buf)) != -1) {
-			output.write(buf, 0, numRead);
+					if (beforeYearIdx >= 0 && afterYearIdx >= 0 && afterYearIdx + afterYear.length() <= contentMatcher.start()) {
+						boolean noPadding = beforeYearIdx == 0 && afterYearIdx + afterYear.length() == contentMatcher.start(); // allows fastpath return raw
+						String parsedYear = raw.substring(beforeYearIdx + beforeYear.length(), afterYearIdx);
+						if (parsedYear.equals(yearToday)) {
+							// it's good as is!
+							return noPadding ? raw : beforeYear + yearToday + afterYear + raw.substring(contentMatcher.start());
+						} else if (patternYearSingle.matcher(parsedYear).matches()) {
+							if (updateYearWithLatest) {
+								// expand from `2004` to `2004-2020`
+								return beforeYear + parsedYear + yearSepOrFull + yearToday + afterYear + raw.substring(contentMatcher.start());
+							} else {
+								// it's already good as a single year
+								return noPadding ? raw : beforeYear + parsedYear + afterYear + raw.substring(contentMatcher.start());
+							}
+						} else {
+							Matcher yearMatcher = patternYearSingle.matcher(parsedYear);
+							if (yearMatcher.find()) {
+								String firstYear = yearMatcher.group();
+								String newYear;
+								String secondYear;
+								if (updateYearWithLatest) {
+									secondYear = firstYear.equals(yearToday) ? null : yearToday;
+								} else if (yearMatcher.find(yearMatcher.end() + 1)) {
+									secondYear = yearMatcher.group();
+								} else {
+									secondYear = null;
+								}
+								if (secondYear == null) {
+									newYear = firstYear;
+								} else {
+									newYear = firstYear + yearSepOrFull + secondYear;
+								}
+								return noPadding && newYear.equals(parsedYear) ? raw : beforeYear + newYear + afterYear + raw.substring(contentMatcher.start());
+							}
+						}
+					}
+					// at worst, we just say that it was made today
+					return beforeYear + yearToday + afterYear + raw.substring(contentMatcher.start());
+				}
+			}
 		}
-		return new String(output.toByteArray());
+
+		/** Sets copyright years on the given file by finding the oldest and most recent commits throughout git history. */
+		private String setLicenseHeaderYearsFromGitHistory(String raw, File file) throws IOException {
+			if (yearToday == null) {
+				return raw;
+			}
+			Matcher contentMatcher = delimiterPattern.matcher(raw);
+			if (!contentMatcher.find()) {
+				throw new IllegalArgumentException("Unable to find delimiter regex " + delimiterPattern);
+			}
+
+			String oldYear;
+			try {
+				oldYear = parseYear("git log --follow --find-renames=40% --diff-filter=A", file);
+			} catch (IllegalArgumentException e) {
+				// Ideally, git log would always find the commit where it was added.
+				// For some reason, that is sometimes not possible - in that case,
+				// we'll settle for just the most recent, even if it was just a modification.
+				oldYear = parseYear("git log --follow --find-renames=40% --reverse", file);
+			}
+			String newYear = parseYear("git log --max-count=1", file);
+			String yearRange;
+			if (oldYear.equals(newYear)) {
+				yearRange = oldYear;
+			} else {
+				yearRange = oldYear + yearSepOrFull + newYear;
+			}
+			return beforeYear + yearRange + afterYear + raw.substring(contentMatcher.start());
+		}
+
+		private static String parseYear(String cmd, File file) throws IOException {
+			String fullCmd = cmd + " " + file.getAbsolutePath();
+			ProcessBuilder builder = new ProcessBuilder().directory(file.getParentFile());
+			if (LineEnding.nativeIsWin()) {
+				builder.command("cmd", "/c", fullCmd);
+			} else {
+				builder.command("bash", "-c", fullCmd);
+			}
+			Process process = builder.start();
+			String output = drain(process.getInputStream());
+			String error = drain(process.getErrorStream());
+			if (!error.isEmpty()) {
+				throw new IllegalArgumentException("Error for command '" + fullCmd + "':\n" + error);
+			}
+			Matcher matcher = FIND_YEAR.matcher(output);
+			if (matcher.find()) {
+				return matcher.group(1);
+			} else {
+				throw new IllegalArgumentException("Unable to parse date from command '" + fullCmd + "':\n" + output);
+			}
+		}
+
+		private static final Pattern FIND_YEAR = Pattern.compile("Date:   .* ([0-9]{4}) ");
+
+		@SuppressFBWarnings("DM_DEFAULT_ENCODING")
+		private static String drain(InputStream stream) throws IOException {
+			ByteArrayOutputStream output = new ByteArrayOutputStream();
+			byte[] buf = new byte[1024];
+			int numRead;
+			while ((numRead = stream.read(buf)) != -1) {
+				output.write(buf, 0, numRead);
+			}
+			return new String(output.toByteArray());
+		}
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -483,14 +483,14 @@ public class FormatExtension {
 		}
 
 		FormatterStep createStep() {
-			YearMode yearMode;
-			if ("true".equals(spotless.project.findProperty(LicenseHeaderStep.FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY()))) {
-				yearMode = YearMode.SET_FROM_GIT;
-			} else {
-				boolean updateYear = updateYearWithLatest == null ? getRatchetFrom() != null : updateYearWithLatest;
-				yearMode = updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
-			}
-			return builder.withYearMode(yearMode).build();
+			return builder.withYearModeLazy(() -> {
+				if ("true".equals(spotless.project.findProperty(LicenseHeaderStep.FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY()))) {
+					return YearMode.SET_FROM_GIT;
+				} else {
+					boolean updateYear = updateYearWithLatest == null ? getRatchetFrom() != null : updateYearWithLatest;
+					return updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
+				}
+			}).build();
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -18,7 +18,6 @@ package com.diffplug.gradle.spotless;
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -47,6 +46,7 @@ import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 import com.diffplug.spotless.generic.EndWithNewlineStep;
 import com.diffplug.spotless.generic.IndentStep;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
+import com.diffplug.spotless.generic.LicenseHeaderStep.YearMode;
 import com.diffplug.spotless.generic.ReplaceRegexStep;
 import com.diffplug.spotless.generic.ReplaceStep;
 import com.diffplug.spotless.generic.TrimTrailingWhitespaceStep;
@@ -443,13 +443,12 @@ public class FormatExtension {
 	 * For most language-specific formats (e.g. java, scala, etc.) you can omit the second `delimiter` argument, because it is supplied
 	 * automatically ({@link HasBuiltinDelimiterForLicense}).
 	 */
-	public abstract class LicenseHeaderConfig {
-		String delimiter;
-		String yearSeparator = LicenseHeaderStep.defaultYearDelimiter();
+	public class LicenseHeaderConfig {
+		LicenseHeaderStep.Builder builder;
 		Boolean updateYearWithLatest = null;
 
-		public LicenseHeaderConfig(String delimiter) {
-			this.delimiter = Objects.requireNonNull(delimiter, "delimiter");
+		public LicenseHeaderConfig(LicenseHeaderStep.Builder builder) {
+			this.builder = builder;
 		}
 
 		/**
@@ -457,7 +456,7 @@ public class FormatExtension {
 		 *            Spotless will look for a line that starts with this regular expression pattern to know what the "top" is.
 		 */
 		public LicenseHeaderConfig delimiter(String delimiter) {
-			this.delimiter = Objects.requireNonNull(delimiter, "delimiter");
+			builder = builder.withDelimiter(delimiter);
 			replaceStep(createStep());
 			return this;
 		}
@@ -467,7 +466,7 @@ public class FormatExtension {
 		 *           The characters used to separate the first and last years in multi years patterns.
 		 */
 		public LicenseHeaderConfig yearSeparator(String yearSeparator) {
-			this.yearSeparator = Objects.requireNonNull(yearSeparator, "yearSeparator");
+			builder = builder.withYearSeparator(yearSeparator);
 			replaceStep(createStep());
 			return this;
 		}
@@ -483,61 +482,15 @@ public class FormatExtension {
 			return this;
 		}
 
-		protected abstract String licenseHeader() throws IOException;
-
 		FormatterStep createStep() {
+			YearMode yearMode;
 			if ("true".equals(spotless.project.findProperty(LicenseHeaderStep.FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY()))) {
-				return FormatterStep.createNeverUpToDateLazy(LicenseHeaderStep.name(), () -> {
-					boolean updateYear = false; // doesn't matter
-					LicenseHeaderStep step = new LicenseHeaderStep(licenseHeader(), delimiter, yearSeparator, updateYear);
-					return new FormatterFunc() {
-						@Override
-						public String apply(String input, File source) throws Exception {
-							return step.setLicenseHeaderYearsFromGitHistory(input, source);
-						}
-
-						@Override
-						public String apply(String input) throws Exception {
-							throw new UnsupportedOperationException();
-						}
-					};
-				});
+				yearMode = YearMode.SET_FROM_GIT;
 			} else {
-				return FormatterStep.createLazy(LicenseHeaderStep.name(), () -> {
-					// by default, we should update the year if the user is using ratchetFrom
-					boolean updateYear = updateYearWithLatest == null ? getRatchetFrom() != null : updateYearWithLatest;
-					return new LicenseHeaderStep(licenseHeader(), delimiter, yearSeparator, updateYear);
-				}, step -> step::format);
+				boolean updateYear = updateYearWithLatest == null ? getRatchetFrom() != null : updateYearWithLatest;
+				yearMode = updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
 			}
-		}
-	}
-
-	private class LicenseStringHeaderConfig extends LicenseHeaderConfig {
-		private String header;
-
-		LicenseStringHeaderConfig(String delimiter, String header) {
-			super(delimiter);
-			this.header = Objects.requireNonNull(header, "header");
-		}
-
-		@Override
-		protected String licenseHeader() {
-			return header;
-		}
-	}
-
-	private class LicenseFileHeaderConfig extends LicenseHeaderConfig {
-		private Object headerFile;
-
-		LicenseFileHeaderConfig(String delimiter, Object headerFile) {
-			super(delimiter);
-			this.headerFile = Objects.requireNonNull(headerFile, "headerFile");
-		}
-
-		@Override
-		protected String licenseHeader() throws IOException {
-			byte[] content = Files.readAllBytes(getProject().file(headerFile).toPath());
-			return new String(content, getEncoding());
+			return builder.withYearMode(yearMode).build();
 		}
 	}
 
@@ -548,7 +501,7 @@ public class FormatExtension {
 	 *            Spotless will look for a line that starts with this regular expression pattern to know what the "top" is.
 	 */
 	public LicenseHeaderConfig licenseHeader(String licenseHeader, String delimiter) {
-		LicenseHeaderConfig config = new LicenseStringHeaderConfig(delimiter, licenseHeader);
+		LicenseHeaderConfig config = new LicenseHeaderConfig(LicenseHeaderStep.headerDelimiter(licenseHeader, delimiter));
 		addStep(config.createStep());
 		return config;
 	}
@@ -560,7 +513,11 @@ public class FormatExtension {
 	 *            Spotless will look for a line that starts with this regular expression pattern to know what the "top" is.
 	 */
 	public LicenseHeaderConfig licenseHeaderFile(Object licenseHeaderFile, String delimiter) {
-		LicenseHeaderConfig config = new LicenseFileHeaderConfig(delimiter, licenseHeaderFile);
+		LicenseHeaderConfig config = new LicenseHeaderConfig(LicenseHeaderStep.headerDelimiter(() -> {
+			File file = getProject().file(licenseHeaderFile);
+			byte[] data = Files.readAllBytes(file.toPath());
+			return new String(data, getEncoding());
+		}, delimiter));
 		addStep(config.createStep());
 		return config;
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -444,10 +444,10 @@ public class FormatExtension {
 	 * automatically ({@link HasBuiltinDelimiterForLicense}).
 	 */
 	public class LicenseHeaderConfig {
-		LicenseHeaderStep.Builder builder;
+		LicenseHeaderStep builder;
 		Boolean updateYearWithLatest = null;
 
-		public LicenseHeaderConfig(LicenseHeaderStep.Builder builder) {
+		public LicenseHeaderConfig(LicenseHeaderStep builder) {
 			this.builder = builder;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
@@ -46,7 +46,7 @@ public class LicenseHeaderTest extends GradleIntegrationHarness {
 
 	private void assertTransform(String yearBefore, String yearAfter) throws IOException {
 		setFile(TEST_JAVA).toContent("/** " + yearBefore + " */\n" + CONTENT);
-		gradleRunner().withArguments("spotlessApply", "--stacktrace").build();
+		gradleRunner().withArguments("spotlessApply", "--stacktrace").forwardOutput().build();
 		assertFile(TEST_JAVA).hasContent("/** " + yearAfter + " */\n" + CONTENT);
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
@@ -15,15 +15,14 @@
  */
 package com.diffplug.spotless.maven.generic;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
-import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
+import com.diffplug.spotless.generic.LicenseHeaderStep.YearMode;
 import com.diffplug.spotless.maven.FormatterStepConfig;
 import com.diffplug.spotless.maven.FormatterStepFactory;
 
@@ -45,32 +44,17 @@ public class LicenseHeader implements FormatterStepFactory {
 			throw new IllegalArgumentException("You need to specify 'delimiter'.");
 		}
 		if (file != null ^ content != null) {
-			FormatterStep unfiltered;
+			YearMode yearMode;
 			if ("true".equals(config.spotlessSetLicenseHeaderYearsFromGitHistory().orElse(""))) {
-				unfiltered = FormatterStep.createNeverUpToDateLazy(LicenseHeaderStep.name(), () -> {
-					boolean updateYear = false; // doesn't matter
-					LicenseHeaderStep step = new LicenseHeaderStep(readFileOrContent(config), delimiterString, LicenseHeaderStep.defaultYearDelimiter(), updateYear);
-					return new FormatterFunc() {
-						@Override
-						public String apply(String input, File source) throws Exception {
-							return step.setLicenseHeaderYearsFromGitHistory(input, source);
-						}
-
-						@Override
-						public String apply(String input) throws Exception {
-							throw new UnsupportedOperationException();
-						}
-					};
-				});
+				yearMode = YearMode.SET_FROM_GIT;
 			} else {
-				unfiltered = FormatterStep.createLazy(LicenseHeaderStep.name(), () -> {
-					// by default, we should update the year if the user is using ratchetFrom
-					boolean updateYear = config.getRatchetFrom().isPresent();
-					String header = readFileOrContent(config);
-					return new LicenseHeaderStep(header, delimiterString, LicenseHeaderStep.defaultYearDelimiter(), updateYear);
-				}, step -> step::format);
+				boolean updateYear = config.getRatchetFrom().isPresent();
+				yearMode = updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
 			}
-			return unfiltered.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
+			return LicenseHeaderStep.headerDelimiter(() -> readFileOrContent(config), delimiterString)
+					.withYearMode(yearMode)
+					.build()
+					.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
 		} else {
 			throw new IllegalArgumentException("Must specify exactly one of 'file' or 'content'.");
 		}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderRatchetTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderRatchetTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.generic;
+
+import java.io.IOException;
+import java.time.YearMonth;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+public class LicenseHeaderRatchetTest extends MavenIntegrationHarness {
+	private static final String NOW = String.valueOf(YearMonth.now().getYear());
+
+	private static final String TEST_JAVA = "src/main/java/pkg/Test.java";
+	private static final String CONTENT = "package pkg;\npublic class Test {}";
+
+	private void setRatchetFrom(String ratchetFrom) throws IOException {
+		writePomWithJavaSteps(
+				"<licenseHeader>",
+				"  <content>/** $YEAR */</content>",
+				"</licenseHeader>",
+				ratchetFrom);
+	}
+
+	private void assertUnchanged(String year) throws Exception {
+		assertTransform(year, year);
+	}
+
+	private void assertTransform(String yearBefore, String yearAfter) throws Exception {
+		setFile(TEST_JAVA).toContent("/** " + yearBefore + " */\n" + CONTENT);
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(TEST_JAVA).hasContent("/** " + yearAfter + " */\n" + CONTENT);
+	}
+
+	private void testSuiteUpdateWithLatest(boolean update) throws Exception {
+		if (update) {
+			assertTransform("2003", "2003-" + NOW);
+			assertTransform("2003-2005", "2003-" + NOW);
+		} else {
+			assertUnchanged("2003");
+			assertUnchanged("2003-2005");
+		}
+		assertUnchanged(NOW);
+		assertTransform("", NOW);
+	}
+
+	@Test
+	public void normal() throws Exception {
+		setRatchetFrom("");
+		testSuiteUpdateWithLatest(false);
+	}
+
+	@Test
+	public void ratchetFrom() throws Exception {
+		try (Git git = Git.init().setDirectory(rootFolder()).call()) {
+			git.commit().setMessage("First commit").call();
+		}
+		setRatchetFrom("<ratchetFrom>HEAD</ratchetFrom>");
+		testSuiteUpdateWithLatest(true);
+	}
+}

--- a/testlib/src/test/java/com/diffplug/spotless/cpp/CppDefaultsTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/cpp/CppDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class CppDefaultsTest extends ResourceHarness {
 	@Test
 	public void testDelimiterExpr() throws Exception {
 		final String header = "/*My tests header*/";
-		FormatterStep step = LicenseHeaderStep.createFromHeader(header, CppDefaults.DELIMITER_EXPR);
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header, CppDefaults.DELIMITER_EXPR).build();
 		final File dummyFile = setFile("src/main/cpp/file1.dummy").toContent("");
 		for (String testSource : Arrays.asList(
 				"//Accpet multiple spaces between composed term.@using  namespace std;",

--- a/testlib/src/test/java/com/diffplug/spotless/css/CssDefaultsTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/css/CssDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class CssDefaultsTest extends ResourceHarness {
 	@Test
 	public void testDelimiterExpr() throws Exception {
 		final String header = "/*My tests header*/";
-		FormatterStep step = LicenseHeaderStep.createFromHeader(header, CssDefaults.DELIMITER_EXPR);
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header, CssDefaults.DELIMITER_EXPR).build();
 		final File dummyFile = setFile("src/main/cpp/file1.dummy").toContent("");
 		for (String testSource : Arrays.asList(
 				"/* Starts with element selector */@\np {",

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -51,13 +51,13 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	public void fromHeader() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromHeader(getTestResource(KEY_LICENSE), LICENSE_HEADER_DELIMITER);
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(getTestResource(KEY_LICENSE), LICENSE_HEADER_DELIMITER).build();
 		assertOnResources(step, KEY_FILE_NOTAPPLIED, KEY_FILE_APPLIED);
 	}
 
 	@Test
 	public void should_apply_license_containing_YEAR_token() throws Throwable {
-		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER))
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER).build())
 				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileContainingYear(HEADER_WITH_YEAR, currentYear()))
 				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, currentYear()))
 				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "2003"))
@@ -66,7 +66,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				.test(fileContainingYear(HEADER_WITH_YEAR + "\n **/\n/* Something after license.", "2003"), fileContainingYear(HEADER_WITH_YEAR, "2003"))
 				.test(fileContainingYear(HEADER_WITH_YEAR, "not a year"), fileContainingYear(HEADER_WITH_YEAR, currentYear()));
 		// Check with variant
-		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR_VARIANT), LICENSE_HEADER_DELIMITER))
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(licenseWith(HEADER_WITH_YEAR_VARIANT), LICENSE_HEADER_DELIMITER).build())
 				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
 				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
 				.test(fileContaining("This is a fake license. Copyright "), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()))
@@ -75,7 +75,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				.test(fileContaining("This is a fake license. CopyrightACME corp."), fileContainingYear(HEADER_WITH_YEAR_VARIANT, currentYear()));
 
 		//Check when token is of the format $today.year
-		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR_INTELLIJ), LICENSE_HEADER_DELIMITER))
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(licenseWith(HEADER_WITH_YEAR_INTELLIJ), LICENSE_HEADER_DELIMITER).build())
 				.test(fileContaining(HEADER_WITH_YEAR_INTELLIJ), fileWithLicenseContaining(HEADER_WITH_YEAR_INTELLIJ, currentYear(), "$today.year"));
 	}
 
@@ -110,7 +110,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	public void should_apply_license_containing_YEAR_token_with_custom_separator() throws Throwable {
-		StepHarness.forStep(LicenseHeaderStep.createFromHeader(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER))
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(licenseWith(HEADER_WITH_YEAR), LICENSE_HEADER_DELIMITER).build())
 				.test(getTestResource(KEY_FILE_WITHOUT_LICENSE), fileContainingYear(HEADER_WITH_YEAR, currentYear()))
 				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, currentYear()))
 				.testUnaffected(fileContainingYear(HEADER_WITH_YEAR, "2003"))
@@ -136,7 +136,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	public void efficient() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.createFromHeader("LicenseHeader\n", "contentstart");
+		FormatterStep step = LicenseHeaderStep.headerDelimiter("LicenseHeader\n", "contentstart").build();
 		String alreadyCorrect = "LicenseHeader\ncontentstart";
 		Assert.assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
 		// If no change is required, it should return the exact same string for efficiency reasons
@@ -146,7 +146,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	@Test
 	public void sanitized() throws Throwable {
 		// The sanitizer should add a \n
-		FormatterStep step = LicenseHeaderStep.createFromHeader("LicenseHeader", "contentstart");
+		FormatterStep step = LicenseHeaderStep.headerDelimiter("LicenseHeader", "contentstart").build();
 		String alreadyCorrect = "LicenseHeader\ncontentstart";
 		Assert.assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
 		Assert.assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));
@@ -155,7 +155,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	@Test
 	public void sanitizerDoesntGoTooFar() throws Throwable {
 		// if the user wants extra lines after the header, we shouldn't clobber them
-		FormatterStep step = LicenseHeaderStep.createFromHeader("LicenseHeader\n\n", "contentstart");
+		FormatterStep step = LicenseHeaderStep.headerDelimiter("LicenseHeader\n\n", "contentstart").build();
 		String alreadyCorrect = "LicenseHeader\n\ncontentstart";
 		Assert.assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
 		Assert.assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -164,7 +164,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	@Test
 	public void equality() {
 		new SerializableEqualityTester() {
-			LicenseHeaderStep.Builder builder = LicenseHeaderStep.headerDelimiter("LICENSE", "package")
+			LicenseHeaderStep builder = LicenseHeaderStep.headerDelimiter("LICENSE", "package")
 					.withYearSeparator("-")
 					.withYearMode(YearMode.PRESERVE);
 

--- a/testlib/src/test/java/com/diffplug/spotless/xml/XmlDefaultsTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/xml/XmlDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class XmlDefaultsTest extends ResourceHarness {
 	@Test
 	public void testDelimiterExpr() throws Exception {
 		final String header = "<!--My tests header-->";
-		FormatterStep step = LicenseHeaderStep.createFromHeader(header, XmlDefaults.DELIMITER_EXPR);
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header, XmlDefaults.DELIMITER_EXPR).build();
 		final File dummyFile = setFile("src/main/file.dummy").toContent("");
 		for (String testSource : Arrays.asList(
 				"<!--XML starts with element-->@\n<a></a>",


### PR DESCRIPTION
It had gotten very messy.  It turns out that it's important to determine the year-handling lazily, because the sensible default is to depend on `ratchetFrom`.  To enable this, much of LicenseHeaderStep's guts had become public, and it had factory methods with way too many parameters.

This PR refactors LicenseHeaderStep into an immutable builder pattern, which allows us to remove a lot of code from the gradle and maven plugins.  It also offers a clean foundation for implementing features like #323.