### PR TITLE
Deprecate customLazy in the gradle plugin

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -15,6 +15,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * `ratchetFrom` now ratchets from the merge base of `HEAD` and the specified branch.  This fixes the surprising behavior when a remote branch advanced ([#631](https://github.com/diffplug/spotless/pull/631) fixes [#627](https://github.com/diffplug/spotless/issues/627)).
 ### Deprecated
 * The default targets for `C/C++`, `freshmark`, `sql`, and `typescript` now generate a warning, asking the user to specify a target manually. There is no well-established convention for these languages in the gradle ecosystem, and the performance of the default target is far worse than a user-provided one.  If you dislike this change, please complain in [#634](https://github.com/diffplug/spotless/pull/634).
+* `customLazy` and `customLazyGroovy` now generate a warning, asking the user to migrate to `custom`.  There is no longer a performance advantage to `customLazy` in the new modern plugin. See [#635](https://github.com/diffplug/spotless/pull/635/files) for example migrations.
 
 ## [4.4.0] - 2020-06-19
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -335,13 +335,13 @@ public class FormatExtension {
 	}
 
 	/**
-	 * An optional performance optimization if you are using any of the `custom` or `customLazy`
-	 * methods.  If you aren't explicitly calling `custom` or `customLazy`, then this method
+	 * An optional performance optimization if you are using any of the `custom`
+	 * methods.  If you aren't explicitly calling `custom`, then this method
 	 * has no effect.
 	 *
 	 * Spotless tracks what files have changed from run to run, so that it can run faster
 	 * by only checking files which have changed, or whose formatting steps have changed.
-	 * If you use either the `custom` or `customLazy` methods, then gradle can never mark
+	 * If you use the `custom` methods, then gradle can never mark
 	 * your files as `up-to-date`, because it can't know if perhaps the behavior of your
 	 * custom function has changed.
 	 *
@@ -367,20 +367,21 @@ public class FormatExtension {
 	}
 
 	/**
-	 * Adds the given custom step, which is constructed lazily for performance reasons.
+	 * Adds the given custom step, which is constructed lazily for ~~performance reasons~~.
 	 *
-	 * The resulting function will receive a string with unix-newlines, and it must return a string unix newlines.
-	 *
-	 * If you're getting errors about `closure cannot be cast to com.diffplug.common.base.Throwing$Function`, then use
-	 * {@link #customLazyGroovy(String, ThrowingEx.Supplier)}.
+	 * @deprecated starting in spotless 5.0, you get the same performance benefit out of
+	 * {@link #custom(String, FormatterFunc)}, so you should just use that.
 	 */
+	@Deprecated
 	public void customLazy(String name, ThrowingEx.Supplier<FormatterFunc> formatterSupplier) {
+		getProject().getLogger().warn("Spotless: customLazy has been deprecated, use custom instead");
 		Objects.requireNonNull(name, "name");
 		Objects.requireNonNull(formatterSupplier, "formatterSupplier");
 		addStep(FormatterStep.createLazy(name, () -> globalState, unusedState -> formatterSupplier.get()));
 	}
 
 	/** Same as {@link #customLazy(String, ThrowingEx.Supplier)}, but for Groovy closures. */
+	@Deprecated
 	public void customLazyGroovy(String name, ThrowingEx.Supplier<Closure<String>> formatterSupplier) {
 		Objects.requireNonNull(formatterSupplier, "formatterSupplier");
 		customLazy(name, () -> formatterSupplier.get()::call);
@@ -395,7 +396,7 @@ public class FormatExtension {
 	/** Adds a custom step. Receives a string with unix-newlines, must return a string with unix newlines. */
 	public void custom(String name, FormatterFunc formatter) {
 		Objects.requireNonNull(formatter, "formatter");
-		customLazy(name, () -> formatter);
+		addStep(FormatterStep.createLazy(name, () -> globalState, unusedState -> formatter));
 	}
 
 	/** Highly efficient find-replace char sequence. */

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BumpThisNumberIfACustomStepChangesTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BumpThisNumberIfACustomStepChangesTest.java
@@ -29,9 +29,7 @@ public class BumpThisNumberIfACustomStepChangesTest extends GradleIntegrationHar
 				"spotless {",
 				"    format 'misc', {",
 				"        target file('README.md')",
-				"        customLazyGroovy('lowercase') {",
-				"             return { str -> str.toLowerCase(Locale.ROOT) }",
-				"        }",
+				"        custom 'lowercase', { str -> str.toLowerCase(Locale.ROOT) }",
 				toInsert,
 				"    }",
 				"}");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
@@ -40,15 +40,11 @@ public class IdeHookTest extends GradleIntegrationHarness {
 				"spotless {",
 				"  format 'misc', {",
 				"    target 'DIRTY.md', 'CLEAN.md'",
-				"    customLazyGroovy('lowercase') {",
-				"       return { str -> str.toLowerCase(Locale.ROOT) }",
-				"    }",
+				"    custom 'lowercase', { str -> str.toLowerCase(Locale.ROOT) }",
 				"  }",
 				"  format 'diverge', {",
 				"    target 'DIVERGE.md'",
-				"    customLazyGroovy('diverge') {",
-				"       return { str -> str + ' ' }",
-				"    }",
+				"    custom 'diverge', { str -> str + ' ' }",
 				"  }",
 				"}");
 		dirty = new File(rootFolder(), "DIRTY.md");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
@@ -32,9 +32,7 @@ public class UpToDateTest extends GradleIntegrationHarness {
 				"spotless {",
 				"    format 'misc', {",
 				"        target file('README.md')",
-				"        customLazyGroovy('lowercase') {",
-				"             return { str -> str.toLowerCase(Locale.ROOT) }",
-				"        }",
+				"        custom 'lowercase', { str -> str.toLowerCase(Locale.ROOT) }",
 				"        bumpThisNumberIfACustomStepChanges(1)",
 				"    }",
 				"}");


### PR DESCRIPTION
`customLazy` and `customLazyGroovy` now generate a warning, asking the user to migrate to `custom`.  There is no longer a performance advantage to `customLazy` in the new modern plugin.