### PR TITLE
Rename `eclipse` to `eclipseCdt`

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -16,6 +16,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Deprecated
 * The default targets for `C/C++`, `freshmark`, `sql`, and `typescript` now generate a warning, asking the user to specify a target manually. There is no well-established convention for these languages in the gradle ecosystem, and the performance of the default target is far worse than a user-provided one.  If you dislike this change, please complain in [#634](https://github.com/diffplug/spotless/pull/634).
 * `customLazy` and `customLazyGroovy` now generate a warning, asking the user to migrate to `custom`.  There is no longer a performance advantage to `customLazy` in the new modern plugin. See [#635](https://github.com/diffplug/spotless/pull/635/files) for example migrations.
+* inside the `cpp { }` block, the `eclipse` step now generates a warning, asking you to switch to `eclipseCdt`.  It is the same underlying step, but the new name clears up any confusion with the more common Java `eclipse`. [#636](https://github.com/diffplug/spotless/pull/635/files)
 
 ## [4.4.0] - 2020-06-19
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
@@ -30,11 +30,25 @@ public class CppExtension extends FormatExtension implements HasBuiltinDelimiter
 		super(spotless);
 	}
 
-	public EclipseConfig eclipse() {
+	public EclipseConfig eclipseCdt() {
 		return new EclipseConfig(EclipseCdtFormatterStep.defaultVersion());
 	}
 
+	public EclipseConfig eclipseCdt(String version) {
+		return new EclipseConfig(version);
+	}
+
+	/** Use {@link #eclipseCdt} instead. */
+	@Deprecated
+	public EclipseConfig eclipse() {
+		getProject().getLogger().warn("Spotless: in the `cpp { }` block, use `eclipseCdt()` instead of `eclipse()`");
+		return new EclipseConfig(EclipseCdtFormatterStep.defaultVersion());
+	}
+
+	/** Use {@link #eclipseCdt} instead. */
+	@Deprecated
 	public EclipseConfig eclipse(String version) {
+		getProject().getLogger().warn("Spotless: in the `cpp { }` block, use `eclipseCdt('" + version + "')` instead of `eclipse('" + version + "')`");
 		return new EclipseConfig(version);
 	}
 
@@ -53,7 +67,6 @@ public class CppExtension extends FormatExtension implements HasBuiltinDelimiter
 			builder.setPreferences(project.files(configFiles).getFiles());
 			replaceStep(builder.build());
 		}
-
 	}
 
 	@Override

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -11,7 +11,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Added ANTLR4 support ([#326](https://github.com/diffplug/spotless/issues/326)).
 ### Removed
 * **BREAKING** the default includes for `<typescript>` and `<cpp>` were removed, and will now generate an error if an `<include>` is not specified.  There is no well-established convention for these languages in the maven ecosystem, and the performance of the default includes is far worse than a user-provided one.  If you dislike this change, please complain in [#634](https://github.com/diffplug/spotless/pull/634), it would not be a breaking change to bring the defaults back.
-* **BREAKING** the long-deprecated `<xml>` and `<css>` formats have been removed, in favor of the long-available [`<eclipseWtp>`](https://github.com/diffplug/spotless/tree/main/plugin-maven#eclipse-wtp) step which is available in every generic format.
+* **BREAKING** inside the `<cpp>` block, `<eclipse>` has been renamed to `<eclipseCdt>` to avoid any confusion with the java `<eclipse>` ([#636](https://github.com/diffplug/spotless/pull/636)).
+* **BREAKING** the long-deprecated `<xml>` and `<css>` formats have been removed, in favor of the long-available [`<eclipseWtp>`](https://github.com/diffplug/spotless/tree/main/plugin-maven#eclipse-wtp) step which is available in every generic format ([#630](https://github.com/diffplug/spotless/pull/630)).
   * This probably doesn't affect you, but if it does, you just need to change `<xml>...` into `<formats><format><eclipseWtp><type>XML</type>...`
   * In [`1.15.0` (released 2018-09-23)](#1150---2018-09-23), we added support for `xml` and `css` formats using the Eclipse WTP.
   * In [`1.18.0` (released 2019-02-11)](#1180---2019-02-11), we deprecated these, in favor of the generic `eclipseWtp` step which is available for all generic formats.  This allows you to have multiple XML and CSS formats, rather than just one.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/Cpp.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/Cpp.java
@@ -26,7 +26,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
  * A {@link FormatterFactory} implementation that corresponds to {@code <cpp>...</cpp>} configuration element.
  * <p>
  * It defines a formatter for java source files that can execute both language agnostic (e.g. {@link LicenseHeader})
- * and cpp-specific (e.g. {@link Eclipse}) steps.
+ * and cpp-specific (e.g. {@link EclipseCdt}) steps.
  */
 public class Cpp extends FormatterFactory {
 	@Override
@@ -34,7 +34,7 @@ public class Cpp extends FormatterFactory {
 		return Collections.emptySet();
 	}
 
-	public void addEclipse(Eclipse eclipse) {
+	public void addEclipseCdt(EclipseCdt eclipse) {
 		addStepFactory(eclipse);
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/EclipseCdt.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/EclipseCdt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.diffplug.spotless.extra.cpp.EclipseCdtFormatterStep;
 import com.diffplug.spotless.maven.FormatterStepConfig;
 import com.diffplug.spotless.maven.FormatterStepFactory;
 
-public class Eclipse implements FormatterStepFactory {
+public class EclipseCdt implements FormatterStepFactory {
 
 	@Parameter
 	private String file;


### PR DESCRIPTION
In the `java` blocks of gradle and maven, `eclipse()` means `eclipse jdt`, while in the `cpp` blocks, it means `eclipse cdt`.  It's a bit inconsistent, because in the `groovy` block, `greclipse()` is distinct (as it has to be, to disambiguate from `jdt` version).

After the [readme refactor](https://github.com/diffplug/spotless/pull/633), the docs work better if every step has a unique name, so this PR changes the name of the `Eclipse CDT` based formatter step to `eclipseCdt` in both gradle and maven.  The docs were already updated to this in the above-linked readme refactor.