### PR TITLE
Update ktfmt default version and add dropbox-style option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-* Adding ktfmt(version, withDropBoxStyle) to allow [--dropbox-style option](https://github.com/diffplug/spotless/issues/641) which enables 4 spaces indenting.
+* Bump default ktfmt from 0.13 to 0.15, and add support for the --dropbox-style option ([#641](https://github.com/diffplug/spotless/issues/641)).
 
 ## [2.1.0] - 2020-07-04
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Adding ktfmt(version, withDropBoxStyle) to allow [--dropbox-style option](https://github.com/diffplug/spotless/issues/641) which enables 4 spaces indenting.
 
 ## [2.1.0] - 2020-07-04
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -97,6 +97,9 @@ public class KtfmtStep {
 			return input -> {
 				try {
 					if (withDropboxStyle) {
+						// we are duplicating the result of this parsing logic from ktfmt 0.15
+						// https://github.com/facebookincubator/ktfmt/blob/59f7ad8d1fde08f3402a013571c9997316083ebf/core/src/main/java/com/facebook/ktfmt/ParsedArgs.kt#L37
+						// if the code above changes in a future version, we will need to change this code
 						Class<?> formattingOptionsClazz = classLoader.loadClass(pkg + ".ktfmt.FormattingOptions");
 						Object formattingOptions = formattingOptionsClazz.getConstructor(
 								int.class, int.class, int.class).newInstance(

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -36,7 +36,8 @@ public class KtfmtStep {
 	/**
 	 * Used to allow drpobox style option through formatting options.
 	 *
-	 * @see: https://github.com/facebookincubator/ktfmt/blob/master/core/src/main/java/com/facebook/ktfmt/Formatter.kt#L47-L73
+	 * @see:
+	 *     https://github.com/facebookincubator/ktfmt/blob/bfd3f08059eace1562191d542d11c0f9dbd49332/core/src/main/java/com/facebook/ktfmt/Formatter.kt#L47-L73
 	 */
 	private static final int MAX_WIDTH_LINE = 100;
 	private static final int BLOCK_INDENT = 4;
@@ -46,7 +47,7 @@ public class KtfmtStep {
 	 * The <code>format</code> method is available in the link below.
 	 *
 	 * @see:
-	 *     https://github.com/facebookincubator/ktfmt/blob/master/core/src/main/java/com/facebook/ktfmt/Formatter.kt#L79-L92
+	 *     https://github.com/facebookincubator/ktfmt/blob/bfd3f08059eace1562191d542d11c0f9dbd49332/core/src/main/java/com/facebook/ktfmt/Formatter.kt#L75-L92
 	 */
 	static final String FORMATTER_METHOD = "format";
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 **5.x preview:** If you are using Gradle 5.4+, you can preview thew upcoming `com.diffplug.spotless` plugin by adding `-PspotlessModern`, see [CHANGES-5.x-PREVIEW.md](CHANGES-5.x-PREVIEW.md) for details.
 
 ## [Unreleased]
+* Adding ktfmt(version, withDropBoxStyle) to allow [--dropbox-style option](https://github.com/diffplug/spotless/issues/641) which enables 4 spaces indenting.
 
 ## [4.5.1] - 2020-07-04
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 **5.x preview:** If you are using Gradle 5.4+, you can preview thew upcoming `com.diffplug.spotless` plugin by adding `-PspotlessModern`, see [CHANGES-5.x-PREVIEW.md](CHANGES-5.x-PREVIEW.md) for details.
 
 ## [Unreleased]
-* Adding ktfmt(version, withDropBoxStyle) to allow [--dropbox-style option](https://github.com/diffplug/spotless/issues/641) which enables 4 spaces indenting.
+* Bump default ktfmt from 0.13 to 0.15, and add support for the --dropbox-style option ([#641](https://github.com/diffplug/spotless/issues/641)).
 
 ## [4.5.1] - 2020-07-04
 ### Fixed

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -273,7 +273,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 ```kotlin
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
   kotlin {
-    ktfmt('0.13') // version is optional
+    ktfmt('0.15').dropboxStyle() // version and dropbox style are optional
 ```
 
 <a name="applying-scalafmt-to-scala-files"></a>

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.SourceSet;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.kotlin.KtLintStep;
 import com.diffplug.spotless.kotlin.KtfmtStep;
+import com.diffplug.spotless.kotlin.KtfmtStep.Style;
 
 public class KotlinExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "kotlin";
@@ -86,41 +87,31 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 	}
 
 	/**
-	 * Uses the given version of [ktfmt](https://github.com/facebookincubator/ktfmt) to format source
-	 * code.
-	 */
-	public KtfmtConfig ktfmt(String version) {
-		return ktfmt(version, false);
-	}
-
-	/**
 	 * Uses the given version of [ktfmt](https://github.com/facebookincubator/ktfmt) and applies the dropbox style
 	 * option to format source code.
 	 */
-	public KtfmtConfig ktfmt(String version, Boolean withDropboxStyle) {
+	public KtfmtConfig ktfmt(String version) {
 		Objects.requireNonNull(version);
-		Objects.requireNonNull(withDropboxStyle);
-		return new KtfmtConfig(version, withDropboxStyle);
+		return new KtfmtConfig(version);
 	}
 
 	public class KtfmtConfig {
 		final String version;
-		final Boolean withDropboxStyle;
+		Style style;
 
 		KtfmtConfig(String version) {
 			this.version = Objects.requireNonNull(version);
-			this.withDropboxStyle = false;
+			this.style = Style.DEFAULT;
 			addStep(createStep());
 		}
 
-		KtfmtConfig(String version, Boolean withDropBoxStyle) {
-			this.version = Objects.requireNonNull(version);
-			this.withDropboxStyle = withDropBoxStyle;
-			addStep(createStep());
+		public void dropboxStyle() {
+			style = Style.DROPBOX;
+			replaceStep(createStep());
 		}
 
 		private FormatterStep createStep() {
-			return KtfmtStep.create(version, provisioner(), withDropboxStyle);
+			return KtfmtStep.create(version, provisioner(), style);
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -90,20 +90,37 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 	 * code.
 	 */
 	public KtfmtConfig ktfmt(String version) {
+		return ktfmt(version, false);
+	}
+
+	/**
+	 * Uses the given version of [ktfmt](https://github.com/facebookincubator/ktfmt) and applies the dropbox style
+	 * option to format source code.
+	 */
+	public KtfmtConfig ktfmt(String version, Boolean withDropboxStyle) {
 		Objects.requireNonNull(version);
-		return new KtfmtConfig(version);
+		Objects.requireNonNull(withDropboxStyle);
+		return new KtfmtConfig(version, withDropboxStyle);
 	}
 
 	public class KtfmtConfig {
 		final String version;
+		final Boolean withDropboxStyle;
 
 		KtfmtConfig(String version) {
 			this.version = Objects.requireNonNull(version);
+			this.withDropboxStyle = false;
+			addStep(createStep());
+		}
+
+		KtfmtConfig(String version, Boolean withDropBoxStyle) {
+			this.version = Objects.requireNonNull(version);
+			this.withDropboxStyle = withDropBoxStyle;
 			addStep(createStep());
 		}
 
 		private FormatterStep createStep() {
-			return KtfmtStep.create(version, provisioner());
+			return KtfmtStep.create(version, provisioner(), withDropboxStyle);
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -80,16 +80,34 @@ public class KotlinGradleExtension extends FormatExtension {
 		return new KtfmtConfig(version);
 	}
 
+	/**
+	 * Uses the given version of [ktfmt](https://github.com/facebookincubator/ktfmt) to format source
+	 * code.
+	 */
+	public KtfmtConfig ktfmt(String version, Boolean withDropboxStyle) {
+		Objects.requireNonNull(version);
+		Objects.requireNonNull(withDropboxStyle);
+		return new KtfmtConfig(version, withDropboxStyle);
+	}
+
 	public class KtfmtConfig {
 		final String version;
+		Boolean withDropboxStyle;
 
 		KtfmtConfig(String version) {
 			this.version = Objects.requireNonNull(version);
+			this.withDropboxStyle = false;
+			addStep(createStep());
+		}
+
+		KtfmtConfig(String version, Boolean withDropboxStyle) {
+			this.version = Objects.requireNonNull(version);
+			this.withDropboxStyle = Objects.requireNonNull(withDropboxStyle);
 			addStep(createStep());
 		}
 
 		private FormatterStep createStep() {
-			return KtfmtStep.create(version, provisioner());
+			return KtfmtStep.create(version, provisioner(), withDropboxStyle);
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -23,6 +23,7 @@ import com.diffplug.common.collect.ImmutableSortedMap;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.kotlin.KtLintStep;
 import com.diffplug.spotless.kotlin.KtfmtStep;
+import com.diffplug.spotless.kotlin.KtfmtStep.Style;
 
 public class KotlinGradleExtension extends FormatExtension {
 	private static final String GRADLE_KOTLIN_DSL_FILE_EXTENSION = "*.gradle.kts";
@@ -80,34 +81,23 @@ public class KotlinGradleExtension extends FormatExtension {
 		return new KtfmtConfig(version);
 	}
 
-	/**
-	 * Uses the given version of [ktfmt](https://github.com/facebookincubator/ktfmt) to format source
-	 * code.
-	 */
-	public KtfmtConfig ktfmt(String version, Boolean withDropboxStyle) {
-		Objects.requireNonNull(version);
-		Objects.requireNonNull(withDropboxStyle);
-		return new KtfmtConfig(version, withDropboxStyle);
-	}
-
 	public class KtfmtConfig {
 		final String version;
-		Boolean withDropboxStyle;
+		Style style;
 
 		KtfmtConfig(String version) {
 			this.version = Objects.requireNonNull(version);
-			this.withDropboxStyle = false;
+			this.style = Style.DEFAULT;
 			addStep(createStep());
 		}
 
-		KtfmtConfig(String version, Boolean withDropboxStyle) {
-			this.version = Objects.requireNonNull(version);
-			this.withDropboxStyle = Objects.requireNonNull(withDropboxStyle);
-			addStep(createStep());
+		public void dropboxStyle() {
+			style = Style.DROPBOX;
+			replaceStep(createStep());
 		}
 
 		private FormatterStep createStep() {
-			return KtfmtStep.create(version, provisioner(), withDropboxStyle);
+			return KtfmtStep.create(version, provisioner(), style);
 		}
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -147,7 +147,7 @@ public class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 				"repositories { mavenCentral() }",
 				"spotless {",
 				"    kotlinGradle {",
-				"        ktfmt('0.15', true)",
+				"        ktfmt('0.15').dropboxStyle()",
 				"    }",
 				"}");
 		setFile("configuration.gradle.kts").toResource("kotlin/ktfmt/dropboxstyle.dirty");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -134,6 +134,28 @@ public class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 	}
 
 	@Test
+	public void integration_ktfmt_with_dropbox_style() throws IOException {
+		if (JreVersion.thisVm() == JreVersion._8) {
+			// ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
+			return;
+		}
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'nebula.kotlin' version '1.0.6'",
+				"    id 'com.diffplug.gradle.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlinGradle {",
+				"        ktfmt('0.15', true)",
+				"    }",
+				"}");
+		setFile("configuration.gradle.kts").toResource("kotlin/ktfmt/dropboxstyle.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktfmt/dropboxstyle.clean");
+	}
+
+	@Test
 	public void integration_lint_script_files_without_top_level_declaration() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+*  Bump default ktfmt from 0.13 to 0.15 (#641).
 
 ## [2.0.1] - 2020-07-04
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,7 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-*  Bump default ktfmt from 0.13 to 0.15 (#641).
+*  Bump default ktfmt from 0.13 to 0.15 ([#641](https://github.com/diffplug/spotless/issues/641)).
 
 ## [2.0.1] - 2020-07-04
 ### Fixed

--- a/testlib/src/main/resources/kotlin/ktfmt/dropboxstyle.clean
+++ b/testlib/src/main/resources/kotlin/ktfmt/dropboxstyle.clean
@@ -4,10 +4,10 @@ import a.b.c.*
 import kotlinx.android.synthetic.main.layout_name.*
 
 fun main() {
-  fun name() {
-    a()
-    return b
-  }
-  println(";")
-  println()
+    fun name() {
+        a()
+        return b
+    }
+    println(";")
+    println()
 }

--- a/testlib/src/main/resources/kotlin/ktfmt/dropboxstyle.dirty
+++ b/testlib/src/main/resources/kotlin/ktfmt/dropboxstyle.dirty
@@ -1,0 +1,12 @@
+import a.*
+
+import kotlinx.android.synthetic.main.layout_name.*
+
+import a.b.c.*
+import a.b
+
+fun main() {
+fun name() { a(); return b }
+println(";")
+println();
+}


### PR DESCRIPTION
Update ktfmt default version and add dropbox-style option to allow 4 spaces block and continuation indenting.

Solves: https://github.com/diffplug/spotless/issues/641