### PR TITLE
spotlessApply no longer clobbers file permissions

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Depending on the file system, executing `gradle spotlessApply` might change permission on the changed files from `644` to `755`; fixes ([#656](https://github.com/diffplug/spotless/pull/656))
 * Bump default ktfmt from 0.15 to 0.16, and remove duplicated logic for the --dropbox-style option ([#642](https://github.com/diffplug/spotless/pull/648))
 
 ## [5.1.0] - 2020-07-13

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -68,7 +68,7 @@ public class SpotlessApply extends DefaultTask {
 					File originalSource = new File(getProject().getProjectDir(), path);
 					try {
 						getLogger().debug("Copying " + fileVisitDetails.getFile() + " to " + originalSource);
-						Files.copy(fileVisitDetails.getFile().toPath(), originalSource.toPath(), StandardCopyOption.REPLACE_EXISTING);
+						Files.copy(fileVisitDetails.getFile().toPath(), originalSource.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 					} catch (IOException e) {
 						throw new RuntimeException(e);
 					}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 
 import org.gradle.api.GradleException;
@@ -80,6 +81,8 @@ public class SpotlessTaskImpl extends SpotlessTask {
 				throw new IllegalStateException("Every file has a parent folder.");
 			}
 			Files.createDirectories(parentDir);
+			// Need to copy the original file to the tmp location just to remember the file attributes
+			Files.copy(input.toPath(), output.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
 			dirtyState.writeCanonicalTo(output);
 		}
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -82,7 +82,7 @@ public class SpotlessTaskImpl extends SpotlessTask {
 			}
 			Files.createDirectories(parentDir);
 			// Need to copy the original file to the tmp location just to remember the file attributes
-			Files.copy(input.toPath(), output.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
+			Files.copy(input.toPath(), output.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 			dirtyState.writeCanonicalTo(output);
 		}
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -157,6 +157,8 @@ public class PaddedCellTaskTest extends ResourceHarness {
 		assertFile(converge.file).hasContent("");	// converge -> converges
 		assertFile(diverge.file).hasContent("CCC");	// diverge -> no change
 
+		assertFileAttributesEqual(wellbehaved.file, wellbehaved.outputFile);
+
 		// After apply, check should pass
 		wellbehaved.check();
 		cycle.check();

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -157,8 +157,6 @@ public class PaddedCellTaskTest extends ResourceHarness {
 		assertFile(converge.file).hasContent("");	// converge -> converges
 		assertFile(diverge.file).hasContent("CCC");	// diverge -> no change
 
-		assertFileAttributesEqual(wellbehaved.file, wellbehaved.outputFile);
-
 		// After apply, check should pass
 		wellbehaved.check();
 		cycle.check();

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -22,9 +22,10 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclFileAttributeView;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -168,15 +169,9 @@ public class ResourceHarness {
 	}
 
 	/** Reads file attributes from the output file and compares it to the attributes from the input file. */
-	protected void assertFileAttributesEqual(File input, File output) {
-		List<Boolean> inputAttributes = new LinkedList<>();
-		List<Boolean> outputAttributes = new LinkedList<>();
-		inputAttributes.add(Files.isReadable(input.toPath()));
-		inputAttributes.add(Files.isWritable(input.toPath()));
-		inputAttributes.add(Files.isExecutable(input.toPath()));
-		outputAttributes.add(Files.isReadable(output.toPath()));
-		outputAttributes.add(Files.isWritable(output.toPath()));
-		outputAttributes.add(Files.isExecutable(output.toPath()));
+	protected void assertFileAttributesEqual(File input, File output) throws IOException {
+		List<AclEntry> inputAttributes = Files.getFileAttributeView(input.toPath(), AclFileAttributeView.class).getAcl();
+		List<AclEntry> outputAttributes = Files.getFileAttributeView(output.toPath(), AclFileAttributeView.class).getAcl();
 		Assertions.assertThat(outputAttributes).isEqualTo(inputAttributes);
 	}
 

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclFileAttributeView;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -164,6 +166,13 @@ public class ResourceHarness {
 		// unix-ify the test resource output in case git screwed it up
 		String expected = LineEnding.toUnix(getTestResource(expectedPath)); // unix-ified output
 		Assert.assertEquals(expected, formatted);
+	}
+
+	/** Reads file attributes from the output file and compares it to the attributes from the input file. */
+	protected void assertFileAttributesEqual(File input, File output) throws IOException {
+		List<AclEntry> inputAttributes = Files.getFileAttributeView(input.toPath(), AclFileAttributeView.class).getAcl();
+		List<AclEntry> outputAttributes = Files.getFileAttributeView(output.toPath(), AclFileAttributeView.class).getAcl();
+		Assertions.assertThat(outputAttributes).isEqualTo(inputAttributes);
 	}
 
 	@CheckReturnValue

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -22,10 +22,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.AclEntry;
-import java.nio.file.attribute.AclFileAttributeView;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -169,9 +168,15 @@ public class ResourceHarness {
 	}
 
 	/** Reads file attributes from the output file and compares it to the attributes from the input file. */
-	protected void assertFileAttributesEqual(File input, File output) throws IOException {
-		List<AclEntry> inputAttributes = Files.getFileAttributeView(input.toPath(), AclFileAttributeView.class).getAcl();
-		List<AclEntry> outputAttributes = Files.getFileAttributeView(output.toPath(), AclFileAttributeView.class).getAcl();
+	protected void assertFileAttributesEqual(File input, File output) {
+		List<Boolean> inputAttributes = new LinkedList<>();
+		List<Boolean> outputAttributes = new LinkedList<>();
+		inputAttributes.add(Files.isReadable(input.toPath()));
+		inputAttributes.add(Files.isWritable(input.toPath()));
+		inputAttributes.add(Files.isExecutable(input.toPath()));
+		outputAttributes.add(Files.isReadable(output.toPath()));
+		outputAttributes.add(Files.isWritable(output.toPath()));
+		outputAttributes.add(Files.isExecutable(output.toPath()));
 		Assertions.assertThat(outputAttributes).isEqualTo(inputAttributes);
 	}
 

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.AclEntry;
-import java.nio.file.attribute.AclFileAttributeView;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -166,13 +164,6 @@ public class ResourceHarness {
 		// unix-ify the test resource output in case git screwed it up
 		String expected = LineEnding.toUnix(getTestResource(expectedPath)); // unix-ified output
 		Assert.assertEquals(expected, formatted);
-	}
-
-	/** Reads file attributes from the output file and compares it to the attributes from the input file. */
-	protected void assertFileAttributesEqual(File input, File output) throws IOException {
-		List<AclEntry> inputAttributes = Files.getFileAttributeView(input.toPath(), AclFileAttributeView.class).getAcl();
-		List<AclEntry> outputAttributes = Files.getFileAttributeView(output.toPath(), AclFileAttributeView.class).getAcl();
-		Assertions.assertThat(outputAttributes).isEqualTo(inputAttributes);
 	}
 
 	@CheckReturnValue


### PR DESCRIPTION
(edited by @nedtwigg): Fixes #654.