### PR TITLE
Bugfix/create server resources on function creation

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/npm/FormattedPrinter.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/FormattedPrinter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.npm;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.PrintStream;
+import java.time.LocalDateTime;
+
+public enum FormattedPrinter {
+	SYSOUT(System.out);
+
+	final boolean enabled = true;
+	private final PrintStream printStream;
+
+	FormattedPrinter(PrintStream printStream) {
+		this.printStream = requireNonNull(printStream);
+	}
+
+	public void print(String msg, Object... paramsForStringFormat) {
+		if (!enabled) {
+			return;
+		}
+		String formatted = String.format(msg, paramsForStringFormat);
+		String prefixed = String.format("[%s] %s", LocalDateTime.now().toString(), formatted);
+		this.printStream.println(prefixed);
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -66,7 +66,9 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 				this.npmConfig.getPackageJsonContent());
 		NpmResourceHelper
 				.writeUtf8StringToFile(layout.serveJsFile(), this.npmConfig.getServeScriptContent());
+		FormattedPrinter.SYSOUT.print("running npm install");
 		runNpmInstall(layout.nodeModulesDir());
+		FormattedPrinter.SYSOUT.print("npm install finished");
 		return layout;
 	}
 
@@ -76,6 +78,7 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 
 	protected ServerProcessInfo npmRunServer() throws ServerStartException {
 		try {
+			FormattedPrinter.SYSOUT.print("preparing node server");
 			final NodeServerLayout nodeServerLayout = prepareNodeServer();
 			// The npm process will output the randomly selected port of the http server process to 'server.port' file
 			// so in order to be safe, remove such a file if it exists before starting.

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -32,7 +32,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
 
-import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterFunc;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -43,11 +42,7 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 
 	private static final long serialVersionUID = 1460749955865959948L;
 
-	@SuppressWarnings("unused")
-	private final FileSignature packageJsonSignature;
-
-	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	public final transient File nodeModulesDir;
+	private final File buildDir;
 
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 	private final transient File npmExecutable;
@@ -60,14 +55,11 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 			@Nullable File npm) throws IOException {
 		this.stepName = requireNonNull(stepName);
 		this.npmConfig = requireNonNull(npmConfig);
+		this.buildDir = buildDir;
 		this.npmExecutable = resolveNpm(npm);
-
-		NodeServerLayout layout = prepareNodeServer(buildDir);
-		this.nodeModulesDir = layout.nodeModulesDir();
-		this.packageJsonSignature = FileSignature.signAsList(layout.packageJsonFile());
 	}
 
-	private NodeServerLayout prepareNodeServer(File buildDir) throws IOException {
+	private NodeServerLayout prepareNodeServer() throws IOException {
 		NodeServerLayout layout = new NodeServerLayout(buildDir, stepName);
 		NpmResourceHelper.assertDirectoryExists(layout.nodeModulesDir());
 		NpmResourceHelper.writeUtf8StringToFile(layout.packageJsonFile(),
@@ -84,12 +76,13 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 
 	protected ServerProcessInfo npmRunServer() throws ServerStartException {
 		try {
+			final NodeServerLayout nodeServerLayout = prepareNodeServer();
 			// The npm process will output the randomly selected port of the http server process to 'server.port' file
 			// so in order to be safe, remove such a file if it exists before starting.
-			final File serverPortFile = new File(this.nodeModulesDir, "server.port");
+			final File serverPortFile = new File(nodeServerLayout.nodeModulesDir(), "server.port");
 			NpmResourceHelper.deleteFileIfExists(serverPortFile);
 			// start the http server in node
-			Process server = new NpmProcess(this.nodeModulesDir, this.npmExecutable).start();
+			Process server = new NpmProcess(nodeServerLayout.nodeModulesDir(), this.npmExecutable).start();
 
 			// await the readiness of the http server - wait for at most 60 seconds
 			try {

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -80,6 +80,7 @@ public class PrettierFormatterStep {
 		@Nonnull
 		public FormatterFunc createFormatterFunc() {
 			try {
+				FormattedPrinter.SYSOUT.print("creating formatter function (starting server)");
 				ServerProcessInfo prettierRestServer = npmRunServer();
 				PrettierRestService restService = new PrettierRestService(prettierRestServer.getBaseUrl());
 				String prettierConfigOptions = restService.resolveConfig(this.prettierConfig.getPrettierConfigPath(), this.prettierConfig.getOptions());
@@ -90,6 +91,7 @@ public class PrettierFormatterStep {
 		}
 
 		private void endServer(PrettierRestService restService, ServerProcessInfo restServer) throws Exception {
+			FormattedPrinter.SYSOUT.print("Closing formatting function (ending server).");
 			try {
 				restService.shutdown();
 			} catch (Throwable t) {
@@ -111,6 +113,8 @@ public class PrettierFormatterStep {
 
 		@Override
 		public String applyWithFile(String unix, File file) throws Exception {
+			FormattedPrinter.SYSOUT.print("formatting String '" + unix.substring(0, 50) + "[...]' in file '" + file + "'");
+
 			final String prettierConfigOptionsWithFilepath = assertFilepathInConfigOptions(file);
 			return restService.format(unix, prettierConfigOptionsWithFilepath);
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
@@ -49,6 +49,27 @@ public class PrettierIntegrationTest extends GradleIntegrationHarness {
 	}
 
 	@Test
+	public void verifyCleanSpotlessCheckWorks() throws IOException {
+		setFile("build.gradle").toLines(
+				"buildscript { repositories { mavenCentral() } }",
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"def prettierConfig = [:]",
+				"prettierConfig['printWidth'] = 50",
+				"prettierConfig['parser'] = 'typescript'",
+				"spotless {",
+				"    format 'mytypescript', {",
+				"        target 'test.ts'",
+				"        prettier().config(prettierConfig)",
+				"    }",
+				"}");
+		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "clean", "spotlessCheck").build();
+		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+	}
+
+	@Test
 	public void useFileConfig() throws IOException {
 		setFile(".prettierrc.yml").toResource("npm/prettier/config/.prettierrc.yml");
 		setFile("build.gradle").toLines(


### PR DESCRIPTION
This the pull request ultimately intended to be fixing #651 

The expected problem of "writing to the build dir on step creation" does not appear to be the problem. It seems to me that it is a lifecycle issue.

I've added some debug logging and this results in the following output for my integration test reproducing this issue:

```
> Task :clean

> Task :spotlessMytypescript
[2020-08-04T07:38:02.096] creating formatter function (starting server)
[2020-08-04T07:38:02.098] preparing node server
[2020-08-04T07:38:02.099] running npm install
[2020-08-04T07:38:05.692] npm install finished
[2020-08-04T07:38:06.259] formatting String 'export class MyVeryOwnControllerWithARatherLongNam[...]' in file '/private/var/folders/2q/sbnkqx013ljc3xbv5tnk8yh8000141/T/junit1671766557151280267/test.ts'
[2020-08-04T07:38:06.444] formatting String 'export class MyVeryOwnControllerWithARatherLongNam[...]' in file '/private/var/folders/2q/sbnkqx013ljc3xbv5tnk8yh8000141/T/junit1671766557151280267/test.ts'
[2020-08-04T07:38:06.452] Closing formatting function (ending server).

> Task :spotlessMytypescriptCheck FAILED
[2020-08-04T07:38:06.715] formatting String 'export class MyVeryOwnControllerWithARatherLongNam[...]' in file '/private/var/folders/2q/sbnkqx013ljc3xbv5tnk8yh8000141/T/junit1671766557151280267/test.ts'
Step 'prettier-format' found problem in 'test.ts':
java.net.ConnectException: Connection refused (Connection refused)
```

It shows that the server is started at the beginning of `spotlessMytypescript` and ended/closed at the end of `spotlessMytypescript` again. But then `spotlessMytypescriptCheck` is triggered (which does not prepare a new server instance) but tries to format using the "old" formatting function used in `spotlessMytypescript` (which has already been closed).

Is this a problem that my step is considered "still ready" although it isn't or is this a problem of "closing formatting function too early"?