### PR TITLE
Added support for  eclipse-jdt 4.14.0, 4.15.0 and 4.16.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for  eclipse-jdt 4.14.0, 4.15.0 and 4.16.0 ([#678](https://github.com/diffplug/spotless/pull/678)).
+### Changed
+* Updated default eclipse-jdt from 4.13.0 to 4.16.0 ([#678](https://github.com/diffplug/spotless/pull/678)).
 
 ## [2.2.2] - 2020-08-21
 ### Fixed

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public final class EclipseJdtFormatterStep {
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.java.EclipseJdtFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-jdt";
-	private static final String DEFAULT_VERSION = "4.13.0";
+	private static final String DEFAULT_VERSION = "4.16.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.14.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.14.0.lockfile
@@ -1,0 +1,19 @@
+# Spotless formatter based on JDT version 4.14.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_14 to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.20.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.600
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.500
+org.eclipse.platform:org.eclipse.core.jobs:3.10.600
+org.eclipse.platform:org.eclipse.core.resources:3.13.600
+org.eclipse.platform:org.eclipse.core.runtime:3.17.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.300
+org.eclipse.platform:org.eclipse.equinox.common:3.10.600
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.600
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.600
+org.eclipse.platform:org.eclipse.osgi:3.15.100
+org.eclipse.platform:org.eclipse.text:3.10.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.15.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.15.0.lockfile
@@ -1,0 +1,19 @@
+# Spotless formatter based on JDT version 4.15.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_15 to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.21.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.600
+org.eclipse.platform:org.eclipse.core.jobs:3.10.700
+org.eclipse.platform:org.eclipse.core.resources:3.13.600
+org.eclipse.platform:org.eclipse.core.runtime:3.17.100
+org.eclipse.platform:org.eclipse.equinox.app:1.4.400
+org.eclipse.platform:org.eclipse.equinox.common:3.11.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.700
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.700
+org.eclipse.platform:org.eclipse.osgi:3.15.200
+org.eclipse.platform:org.eclipse.text:3.10.100

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.16.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.16.0.lockfile
@@ -1,0 +1,19 @@
+# Spotless formatter based on JDT version 4.16.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_16 to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.22.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.700
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.700
+org.eclipse.platform:org.eclipse.core.runtime:3.18.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.500
+org.eclipse.platform:org.eclipse.equinox.common:3.12.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.800
+org.eclipse.platform:org.eclipse.osgi:3.15.300
+org.eclipse.platform:org.eclipse.text:3.10.200

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public class EclipseJdtFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String[] getSupportedVersions() {
 		return new String[]{"4.6.1", "4.6.2", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.7.3a", "4.8.0", "4.9.0", "4.10.0",
-				"4.11.0", "4.12.0", "4.13.0"};
+				"4.11.0", "4.12.0", "4.13.0", "4.14.0", "4.15.0", "4.16.0"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for  eclipse-jdt 4.14.0, 4.15.0 and 4.16.0 ([#678](https://github.com/diffplug/spotless/pull/678)).
+### Changed
+* Updated default eclipse-jdt from 4.13.0 to 4.16.0 ([#678](https://github.com/diffplug/spotless/pull/678)).
 
 ## [5.1.2] - 2020-08-21
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for  eclipse-jdt 4.14.0, 4.15.0 and 4.16.0 ([#678](https://github.com/diffplug/spotless/pull/678)).
+### Changed
+* Updated default eclipse-jdt from 4.13.0 to 4.16.0 ([#678](https://github.com/diffplug/spotless/pull/678)).
 
 ## [2.0.3] - 2020-08-21
 ### Fixed


### PR DESCRIPTION
Default version set to 4.16.0.
Tested default version manually with older checkout of JUnit5.