### PR TITLE
Inception (languages within languages within...)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* `PipeStepPair.Builder` now has a method `.buildStepWhichAppliesSubSteps(Path rootPath, Collection<FormatterStep> steps)`, which returns a single `FormatterStep` that applies the given steps within the regex defined earlier in the builder. Used for formatting inception (implements [#412](https://github.com/diffplug/spotless/issues/412)).
 
 ## [2.6.1] - 2020-09-12
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
@@ -63,7 +63,7 @@ public class PipeStepPair {
 
 		/** Defines the pipe via regex. Must have *exactly one* capturing group. */
 		public Builder regex(Pattern regex) {
-			this.regex = regex;
+			this.regex = Objects.requireNonNull(regex);
 			return this;
 		}
 
@@ -96,7 +96,7 @@ public class PipeStepPair {
 		final Pattern regex;
 
 		public StateIn(Pattern regex) {
-			this.regex = regex;
+			this.regex = Objects.requireNonNull(regex);
 		}
 
 		final transient ArrayList<String> groups = new ArrayList<>();
@@ -118,7 +118,7 @@ public class PipeStepPair {
 		final StateIn in;
 
 		StateOut(StateIn in) {
-			this.in = in;
+			this.in = Objects.requireNonNull(in);
 		}
 
 		final transient StringBuilder builder = new StringBuilder();

--- a/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
@@ -105,6 +105,7 @@ public class PipeStepPair {
 		return out;
 	}
 
+	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 	static class StateApplyToBlock extends StateIn implements Serializable {
 		private static final long serialVersionUID = -844178006407733370L;
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* [`withinBlocks` allows you to apply rules only to specific sections of files](README.md#inception-languages-within-languages-within), for example formatting javascript within html, code examples within markdown, and things like that (implements [#412](https://github.com/diffplug/spotless/issues/412) - formatting inception).
 
 ## [5.5.1] - 2020-09-12
 ### Fixed

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -787,12 +787,10 @@ spotless {
     target 'src/templates/**/*.foo.html'
     prettier().config(['parser': 'html'])
     withinBlocks 'javascript block', '<script>', '</script>', {
-      // note the "it.", otherwise it will apply to the whole file, rather than just <script> tags
-      it.prettier().config(['parser': 'javascript'])
+      prettier().config(['parser': 'javascript'])
     }
     withinBlocksRegex 'single-line @(java-expresion)', '@\\((.*?)\\)', JavaExtension, {
-      // note the "it.", otherwise it will apply to the whole file, rather than just @() tags
-      it.googleJavaFormat()
+      googleJavaFormat()
     }
 ```
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -780,15 +780,19 @@ If you'd like to create a one-off Spotless task outside of the `check`/`apply` f
 In very rare cases, you might want to format e.g. javascript which is written inside JSP templates, or maybe java within a markdown file, or something wacky like that.  You can specify hunks within a file using either open/close tags or a regex with a single capturing group, and then specify rules within it, like so.  See [javadoc TODO](https://javadoc.io/static/com.diffplug.spotless/spotless-plugin-gradle/5.5.1/com/diffplug/gradle/spotless/FormatExtension.html#target-java.lang.Object...-) for more details.
 
 ```gradle
+import com.diffplug.gradle.spotless.JavaExtension
+
 spotless {
   format 'templates', {
     target 'src/templates/**/*.foo.html'
     prettier().config(['parser': 'html'])
     withinBlocks 'javascript block', '<script>', '</script>', {
-      prettier().config(['parser': 'javascript'])
+      // note the "it.", otherwise it will apply to the whole file, rather than just <script> tags
+      it.prettier().config(['parser': 'javascript'])
     }
-    withinBlocksRegex 'single-line @(java-expresion)', '@\\((.*?)\\)', com.diffplug.gradle.spotless.JavaExtension, {
-      googleJavaFormat()
+    withinBlocksRegex 'single-line @(java-expresion)', '@\\((.*?)\\)', JavaExtension, {
+      // note the "it.", otherwise it will apply to the whole file, rather than just @() tags
+      it.googleJavaFormat()
     }
 ```
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -82,6 +82,7 @@ Spotless supports all of Gradle's built-in performance features (incremental bui
   - [Line endings and encodings (invisible stuff)](#line-endings-and-encodings-invisible-stuff)
   - [Custom steps](#custom-steps)
   - [Multiple (or custom) language-specific blocks](#multiple-or-custom-language-specific-blocks)
+  - [Inception (languages within languages within...)](#inception-languages-within-languages-within)
   - [Disabling warnings and error messages](#disabling-warnings-and-error-messages)
   - [How do I preview what `spotlessApply` will do?](#how-do-i-preview-what-spotlessapply-will-do)
   - [Example configurations (from real-world projects)](#example-configurations-from-real-world-projects)
@@ -773,6 +774,23 @@ spotless {
 ```
 
 If you'd like to create a one-off Spotless task outside of the `check`/`apply` framework, see [`FormatExtension.createIndependentApplyTask`](https://javadoc.io/static/com.diffplug.spotless/spotless-plugin-gradle/5.5.1/com/diffplug/gradle/spotless/FormatExtension.html#createIndependentApplyTask-java.lang.String-).
+
+## Inception (languages within languages within...)
+
+In very rare cases, you might want to format e.g. javascript which is written inside JSP templates, or maybe java within a markdown file, or something wacky like that.  You can specify hunks within a file using either open/close tags or a regex with a single capturing group, and then specify rules within it, like so.  See [javadoc TODO](https://javadoc.io/static/com.diffplug.spotless/spotless-plugin-gradle/5.5.1/com/diffplug/gradle/spotless/FormatExtension.html#target-java.lang.Object...-) for more details.
+
+```gradle
+spotless {
+  format 'templates', {
+    target 'src/templates/**/*.foo.html'
+    prettier().config(['parser': 'html'])
+    withinBlocks 'javascript block', '<script>', '</script>', {
+      prettier().config(['parser': 'javascript'])
+    }
+    withinBlocksRegex 'single-line @(java-expresion)', '@\\((.*?)\\)', com.diffplug.gradle.spotless.JavaExtension, {
+      googleJavaFormat()
+    }
+```
 
 <a name="enforceCheck"></a>
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/Antlr4Extension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/Antlr4Extension.java
@@ -17,6 +17,8 @@ package com.diffplug.gradle.spotless;
 
 import java.util.Objects;
 
+import javax.inject.Inject;
+
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.antlr4.Antlr4Defaults;
 import com.diffplug.spotless.antlr4.Antlr4FormatterStep;
@@ -24,6 +26,7 @@ import com.diffplug.spotless.antlr4.Antlr4FormatterStep;
 public class Antlr4Extension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "antlr4";
 
+	@Inject
 	public Antlr4Extension(SpotlessExtension rootExtension) {
 		super(rootExtension);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
@@ -17,6 +17,8 @@ package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
 
+import javax.inject.Inject;
+
 import org.gradle.api.Project;
 
 import com.diffplug.spotless.cpp.CppDefaults;
@@ -26,6 +28,7 @@ import com.diffplug.spotless.extra.cpp.EclipseCdtFormatterStep;
 public class CppExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "cpp";
 
+	@Inject
 	public CppExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -632,12 +632,12 @@ public class FormatExtension {
 	 *   format 'examples', {
 	 *     target 'src/**\/*.md'
 	 *     withinBlocks 'javascript examples', '\n```javascript\n', '\n```\n`, {
-	 *       prettier().config(['parser': 'javascript'])
+	 *       it.prettier().config(['parser': 'javascript']) // note the "it."
 	 *     }
 	 *     ...
 	 * ```
 	 */
-	public <T extends FormatExtension> void withinBlocks(String name, String open, String close, Action<FormatExtension> configure) {
+	public void withinBlocks(String name, String open, String close, Action<FormatExtension> configure) {
 		withinBlocks(name, open, close, FormatExtension.class, configure);
 	}
 
@@ -649,8 +649,8 @@ public class FormatExtension {
 	 * spotless {
 	 *   format 'examples', {
 	 *     target 'src/**\/*.md'
-	 *     withinBlocks 'javascript examples', '\n```java\n', '\n```\n`, com.diffplug.spotless.JavaExtension, {
-	 *       googleJavaFormat()
+	 *     withinBlocks 'java examples', '\n```java\n', '\n```\n`, com.diffplug.spotless.JavaExtension, {
+	 *       it.googleJavaFormat() // note the "it."
 	 *     }
 	 *     ...
 	 * ```
@@ -660,7 +660,7 @@ public class FormatExtension {
 	}
 
 	/** Same as {@link #withinBlocks(String, String, String, Action)}, except instead of an open/close pair, you specify a regex with exactly one capturing group. */
-	public <T extends FormatExtension> void withinBlocksRegex(String name, String regex, Action<FormatExtension> configure) {
+	public void withinBlocksRegex(String name, String regex, Action<FormatExtension> configure) {
 		withinBlocksRegex(name, regex, FormatExtension.class, configure);
 	}
 
@@ -673,7 +673,7 @@ public class FormatExtension {
 		try {
 			// create the sub-extension
 			Constructor<T> constructor = clazz.getConstructor(SpotlessExtension.class);
-			T formatExtension = constructor.newInstance(this);
+			T formatExtension = constructor.newInstance(spotless);
 			// configure it
 			configure.execute(formatExtension);
 			// create a step which applies all of those steps as sub-steps

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -632,7 +632,7 @@ public class FormatExtension {
 	 *   format 'examples', {
 	 *     target 'src/**\/*.md'
 	 *     withinBlocks 'javascript examples', '\n```javascript\n', '\n```\n`, {
-	 *       it.prettier().config(['parser': 'javascript']) // note the "it."
+	 *       prettier().config(['parser': 'javascript'])
 	 *     }
 	 *     ...
 	 * ```
@@ -650,7 +650,7 @@ public class FormatExtension {
 	 *   format 'examples', {
 	 *     target 'src/**\/*.md'
 	 *     withinBlocks 'java examples', '\n```java\n', '\n```\n`, com.diffplug.spotless.JavaExtension, {
-	 *       it.googleJavaFormat() // note the "it."
+	 *       googleJavaFormat()
 	 *     }
 	 *     ...
 	 * ```

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -649,7 +649,7 @@ public class FormatExtension {
 	 * spotless {
 	 *   format 'examples', {
 	 *     target 'src/**\/*.md'
-	 *     withinBlocks 'java examples', '\n```java\n', '\n```\n`, com.diffplug.spotless.JavaExtension, {
+	 *     withinBlocks 'java examples', '\n```java\n', '\n```\n`, com.diffplug.gradle.spotless.JavaExtension, {
 	 *       googleJavaFormat()
 	 *     }
 	 *     ...

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.inject.Inject;
+
 import org.gradle.api.Action;
 
 import com.diffplug.spotless.FormatterProperties;
@@ -33,6 +35,7 @@ public class FreshMarkExtension extends FormatExtension {
 
 	public final List<Action<Map<String, Object>>> propertyActions = new ArrayList<>();
 
+	@Inject
 	public FreshMarkExtension(SpotlessExtension spotless) {
 		super(spotless);
 		addStep(FreshMarkStep.create(() -> {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyExtension.java
@@ -19,6 +19,8 @@ import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElem
 
 import java.util.Objects;
 
+import javax.inject.Inject;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
@@ -36,6 +38,7 @@ import com.diffplug.spotless.java.ImportOrderStep;
 public class GroovyExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "groovy";
 
+	@Inject
 	public GroovyExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GroovyGradleExtension.java
@@ -17,6 +17,8 @@ package com.diffplug.gradle.spotless;
 
 import java.util.Objects;
 
+import javax.inject.Inject;
+
 import com.diffplug.spotless.extra.groovy.GrEclipseFormatterStep;
 import com.diffplug.spotless.java.ImportOrderStep;
 
@@ -24,6 +26,7 @@ public class GroovyGradleExtension extends FormatExtension {
 	private static final String GRADLE_FILE_EXTENSION = "*.gradle";
 	static final String NAME = "groovyGradle";
 
+	@Inject
 	public GroovyGradleExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -19,6 +19,8 @@ import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElem
 
 import java.util.Objects;
 
+import javax.inject.Inject;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
@@ -36,6 +38,7 @@ import com.diffplug.spotless.java.RemoveUnusedImportsStep;
 public class JavaExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "java";
 
+	@Inject
 	public JavaExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.inject.Inject;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -34,6 +36,7 @@ import com.diffplug.spotless.kotlin.KtfmtStep.Style;
 public class KotlinExtension extends FormatExtension implements HasBuiltinDelimiterForLicense {
 	static final String NAME = "kotlin";
 
+	@Inject
 	public KotlinExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -19,6 +19,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.inject.Inject;
+
 import com.diffplug.common.collect.ImmutableSortedMap;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.kotlin.KtLintStep;
@@ -30,6 +32,7 @@ public class KotlinGradleExtension extends FormatExtension {
 
 	static final String NAME = "kotlinGradle";
 
+	@Inject
 	public KotlinGradleExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PythonExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PythonExtension.java
@@ -15,12 +15,15 @@
  */
 package com.diffplug.gradle.spotless;
 
+import javax.inject.Inject;
+
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.python.BlackStep;
 
 public class PythonExtension extends FormatExtension {
 	static final String NAME = "python";
 
+	@Inject
 	public PythonExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ScalaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ScalaExtension.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
@@ -31,6 +32,7 @@ import com.diffplug.spotless.scala.ScalaFmtStep;
 public class ScalaExtension extends FormatExtension {
 	static final String NAME = "scala";
 
+	@Inject
 	public ScalaExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SqlExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SqlExtension.java
@@ -17,6 +17,8 @@ package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
 
+import javax.inject.Inject;
+
 import org.gradle.api.Project;
 
 import com.diffplug.spotless.FormatterStep;
@@ -25,6 +27,7 @@ import com.diffplug.spotless.sql.DBeaverSQLFormatterStep;
 public class SqlExtension extends FormatExtension {
 	static final String NAME = "sql";
 
+	@Inject
 	public SqlExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.TreeMap;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.gradle.api.Project;
 
@@ -36,6 +37,7 @@ public class TypescriptExtension extends FormatExtension {
 
 	static final String NAME = "typescript";
 
+	@Inject
 	public TypescriptExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/WithinBlockTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/WithinBlockTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class WithinBlockTest extends GradleIntegrationHarness {
+	@Test
+	public void genericFormatTest() throws IOException {
+		// make sure that the "typed-generic" closure works
+		// it does, and it doesn't need `it`
+		setFile("build.gradle").toLines(
+				"plugins { id 'com.diffplug.spotless' }",
+				"import com.diffplug.gradle.spotless.JavaExtension",
+				"spotless {",
+				"  format 'customJava', JavaExtension, {",
+				"    target '*.java'",
+				"    googleJavaFormat('1.2')",
+				"  }",
+				"}");
+		setFile("test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("test.java").sameAsResource("java/googlejavaformat/JavaCodeFormatted.test");
+	}
+
+	@Test
+	public void withinBlocksTourDeForce() throws IOException {
+		// but down here, we need `it`, or it will bind to the parent context, why?
+		setFile("build.gradle").toLines(
+				"plugins { id 'com.diffplug.spotless' }",
+				"import com.diffplug.gradle.spotless.JavaExtension",
+				"spotless {",
+				"  format 'docs', {",
+				"    target '*.md'",
+				"    withinBlocks 'toLower', '\\n```lower\\n', '\\n```\\n', {",
+				"      it.custom 'lowercase', { str -> str.toLowerCase() }",
+				"    }",
+				"    withinBlocks 'java only', '\\n```java\\n', '\\n```\\n', JavaExtension, {",
+				"      it.googleJavaFormat()",
+				"    }",
+				"  }",
+				"}");
+		setFile("test.md").toLines(
+				"Some stuff",
+				"```lower",
+				" A B C",
+				"D E F",
+				"```",
+				"And some java stuff",
+				"```java",
+				" public class SomeClass { public void method() {}}",
+				"```",
+				"And MORE!");
+		gradleRunner().forwardOutput().withArguments("spotlessApply", "--stacktrace").build();
+		assertFile("test.md").hasLines(
+				"Some stuff",
+				"```lower",
+				" a b c",
+				"d e f",
+				"```",
+				"And some java stuff",
+				"```java",
+				"public class SomeClass {",
+				"  public void method() {}",
+				"}",
+				"",
+				"```",
+				"And MORE!");
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/WithinBlockTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/WithinBlockTest.java
@@ -48,10 +48,10 @@ public class WithinBlockTest extends GradleIntegrationHarness {
 				"  format 'docs', {",
 				"    target '*.md'",
 				"    withinBlocks 'toLower', '\\n```lower\\n', '\\n```\\n', {",
-				"      it.custom 'lowercase', { str -> str.toLowerCase() }",
+				"      custom 'lowercase', { str -> str.toLowerCase() }",
 				"    }",
 				"    withinBlocks 'java only', '\\n```java\\n', '\\n```\\n', JavaExtension, {",
-				"      it.googleJavaFormat()",
+				"      googleJavaFormat()",
 				"    }",
 				"  }",
 				"}");

--- a/testlib/src/test/java/com/diffplug/spotless/generic/PipeStepPairTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/PipeStepPairTest.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.generic;
 
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -92,5 +94,25 @@ public class PipeStepPairTest {
 				"G H I"), exception -> {
 					exception.hasMessage("An intermediate step removed a match of spotless:off spotless:on");
 				});
+	}
+
+	@Test
+	public void andApply() throws Exception {
+		FormatterStep lowercase = FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT));
+		FormatterStep lowercaseSometimes = PipeStepPair.named("lowercaseSometimes").openClose("<lower>", "</lower>")
+				.buildStepWhichAppliesSubSteps(Paths.get(""), Arrays.asList(lowercase));
+		StepHarness.forSteps(lowercaseSometimes).test(
+				StringPrinter.buildStringFromLines(
+						"A B C",
+						"<lower>",
+						"D E F",
+						"</lower>",
+						"G H I"),
+				StringPrinter.buildStringFromLines(
+						"A B C",
+						"<lower>",
+						"d e f",
+						"</lower>",
+						"G H I"));
 	}
 }


### PR DESCRIPTION
Implements #412, based on the work we did in #691.  This allows users to apply different formatters to specific subsections of code.  For example, the following config:

```gradle
spotless {
  format 'docs', {
    target '*.md'
    withinBlocks 'toLower', '\\n```lower\\n', '\\n```\\n', {
      custom 'lowercase', { str -> str.toLowerCase() }
    }
    withinBlocks 'java only', '\\n```java\\n', '\\n```\\n', JavaExtension, {
      googleJavaFormat()
    }
  }
}
```

Turns this:

    Some stuff
    ```lower
     A B C
    D E F
    ```
    And some java stuff
    ```java
     public class SomeClass { public void method() {}}
    ```
    And MORE!

Into this:

    Some stuff
    ```lower
     a b c
    d e f
    ```
    And some java stuff
    ```java
    public class SomeClass {
      public void method() {}
    }

    ```
    And MORE!