### PR TITLE
Add a test for configuring a single thing multiple times.

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `5.6.0` introduced a bug where it was no longer possible to configure a single format twice, e.g. to have two `java{}` blocks in a single file. Fixed by [#702](https://github.com/diffplug/spotless/pull/702).
 
 ## [5.6.0] - 2020-09-21
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -211,7 +211,7 @@ public abstract class SpotlessExtension {
 	protected final <T extends FormatExtension> T maybeCreate(String name, Class<T> clazz) {
 		FormatExtension existing = formats.get(name);
 		if (existing != null) {
-			if (!existing.getClass().equals(clazz)) {
+			if (!clazz.isInstance(existing)) {
 				throw new GradleException("Tried to add format named '" + name + "'" +
 						" of type " + clazz + " but one has already been created of type " + existing.getClass());
 			} else {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
@@ -45,4 +45,21 @@ public class JavaDefaultTargetTest extends GradleIntegrationHarness {
 		assertFile("src/main/groovy/test.java").sameAsResource("java/googlejavaformat/JavaCodeFormatted.test");
 		assertFile("src/main/groovy/test.groovy").sameAsResource("java/googlejavaformat/JavaCodeUnformatted.test");
 	}
+
+	@Test
+	public void multipleBlocksShouldWork() throws IOException {
+		setFile("build.gradle").toLines(
+				"buildscript { repositories { mavenCentral() } }",
+				"plugins {",
+				"  id 'com.diffplug.spotless'",
+				"  id 'java'",
+				"}",
+				"",
+				"spotless {",
+				"  java {  googleJavaFormat()  }",
+				"  java {  eclipse()  }",
+				"}");
+		gradleRunner().withArguments("spotlessApply").build();
+		gradleRunner().withArguments("spotlessApply").build();
+	}
 }


### PR DESCRIPTION
```gradle
spotless {
  java { ... }
  java { ... } // this was fine before 5.6.0, but broken in 5.6.0, and this PR fixes it
}
```
