### PR TITLE
Fixed typo in _ext build description.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ The `_ext` projects are disabled per default, since:
 * the downloaded content may change on server side and break CI builds
 
 
-The `_ext` can be activated via the root project property `com.diffplug.spotless.include_ext`.
+The `_ext` can be activated via the root project property `com.diffplug.spotless.include.ext`.
 
 Activate the the property via command line, like for example:
 


### PR DESCRIPTION
Once the property was called `include_ext`. But it has been agreed to rename it to `include.ext`. Forgot to rename occurrence in markdown.