### PR TITLE
When ratcheting, check dirty files from Git first

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -69,7 +69,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 	 * true if that file is clean relative to that tree.  A naive implementation of this
 	 * could be verrrry slow, so the rest of this is about speeding this up.
 	 */
-	public boolean isClean(Project project, ObjectId treeSha, String relativePath) throws IOException {
+	public boolean isClean(Project project, ObjectId treeSha, String relativePathUnix) throws IOException {
 		Repository repo = repositoryFor(project);
 
 		// TODO: should be cached-per-repo if it is thread-safe, or per-repo-per-thread if it is not
@@ -81,7 +81,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 			treeWalk.addTree(new DirCacheIterator(dirCache));
 			treeWalk.addTree(new FileTreeIterator(repo));
 			treeWalk.setFilter(AndTreeFilter.create(
-					PathFilter.create(relativePath),
+					PathFilter.create(relativePathUnix),
 					new IndexDiffFilter(INDEX, WORKDIR)));
 
 			if (!treeWalk.next()) {
@@ -108,7 +108,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 						} else if (treeEqualsIndex) {
 							// this means they are all equal to each other, which should never happen
 							// the IndexDiffFilter should keep those out of the TreeWalk entirely
-							throw new IllegalStateException("Index status for " + relativePath + " against treeSha " + treeSha + " is invalid.");
+							throw new IllegalStateException("Index status for " + relativePathUnix + " against treeSha " + treeSha + " is invalid.");
 						} else {
 							// they are all unique
 							// we have to check manually

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -56,15 +56,21 @@ import com.diffplug.spotless.FileSignature;
  * - If you have up-to-date checking and want the best possible performance, use {@link #subtreeShaOf(Object, ObjectId)} to optimize up-to-date checks on a per-project basis.
  */
 public abstract class GitRatchet<Project> implements AutoCloseable {
+
+	public boolean isClean(Project project, ObjectId treeSha, File file) throws IOException {
+		Repository repo = repositoryFor(project);
+		String relativePath = FileSignature.pathNativeToUnix(repo.getWorkTree().toPath().relativize(file.toPath()).toString());
+		return isClean(project, treeSha, relativePath);
+	}
+
 	/**
 	 * This is the highest-level method, which all the others serve.  Given the sha
 	 * of a git tree (not a commit!), and the file in question, this method returns
 	 * true if that file is clean relative to that tree.  A naive implementation of this
 	 * could be verrrry slow, so the rest of this is about speeding this up.
 	 */
-	public boolean isClean(Project project, ObjectId treeSha, File file) throws IOException {
+	public boolean isClean(Project project, ObjectId treeSha, String relativePath) throws IOException {
 		Repository repo = repositoryFor(project);
-		String path = FileSignature.pathNativeToUnix(repo.getWorkTree().toPath().relativize(file.toPath()).toString());
 
 		// TODO: should be cached-per-repo if it is thread-safe, or per-repo-per-thread if it is not
 		DirCache dirCache = repo.readDirCache();
@@ -75,7 +81,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 			treeWalk.addTree(new DirCacheIterator(dirCache));
 			treeWalk.addTree(new FileTreeIterator(repo));
 			treeWalk.setFilter(AndTreeFilter.create(
-					PathFilter.create(path),
+					PathFilter.create(relativePath),
 					new IndexDiffFilter(INDEX, WORKDIR)));
 
 			if (!treeWalk.next()) {
@@ -102,7 +108,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 						} else if (treeEqualsIndex) {
 							// this means they are all equal to each other, which should never happen
 							// the IndexDiffFilter should keep those out of the TreeWalk entirely
-							throw new IllegalStateException("Index status for " + file + " against treeSha " + treeSha + " is invalid.");
+							throw new IllegalStateException("Index status for " + relativePath + " against treeSha " + treeSha + " is invalid.");
 						} else {
 							// they are all unique
 							// we have to check manually

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -135,7 +135,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 	 * builds and submodules, it's quite possible that a single Gradle project will span across multiple git repositories.
 	 * We cache the Repository for every Project in `gitRoots`, and use dynamic programming to populate it.
 	 */
-	private Repository repositoryFor(Project project) throws IOException {
+	protected Repository repositoryFor(Project project) throws IOException {
 		Repository repo = gitRoots.get(project);
 		if (repo == null) {
 			if (isGitRoot(getDir(project))) {

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+Improve speed of plugin when using `<ratchetFrom>` ([#701](https://github.com/diffplug/spotless/pull/706)).
 
 ## [2.4.1] - 2020-09-18
 ### Fixed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.maven;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -59,8 +61,6 @@ import com.diffplug.spotless.maven.kotlin.Kotlin;
 import com.diffplug.spotless.maven.scala.Scala;
 import com.diffplug.spotless.maven.sql.Sql;
 import com.diffplug.spotless.maven.typescript.Typescript;
-
-import static java.util.stream.Collectors.toList;
 
 public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
@@ -180,14 +180,14 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	private List<File> collectFilesFromGit(FormatterFactory formatterFactory, String ratchetFrom) throws MojoExecutionException {
 		MatchPatterns includePatterns = MatchPatterns.from(
-			withNormalizedFileSeparators(getIncludes(formatterFactory)));
+				withNormalizedFileSeparators(getIncludes(formatterFactory)));
 		MatchPatterns excludePatterns = MatchPatterns.from(
-			withNormalizedFileSeparators(getExcludes(formatterFactory)));
+				withNormalizedFileSeparators(getExcludes(formatterFactory)));
 
 		Iterable<String> dirtyFiles;
 		try {
 			dirtyFiles = GitRatchetMaven
-				.instance().getDirtyFiles(baseDir, ratchetFrom);
+					.instance().getDirtyFiles(baseDir, ratchetFrom);
 		} catch (IOException e) {
 			throw new MojoExecutionException("Unable to scan file tree rooted at " + baseDir, e);
 		} catch (GitAPIException e) {
@@ -195,7 +195,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		}
 
 		List<File> result = new ArrayList<>();
-		for (String file: withNormalizedFileSeparators(dirtyFiles)) {
+		for (String file : withNormalizedFileSeparators(dirtyFiles)) {
 			if (includePatterns.matches(file, true)) {
 				if (!excludePatterns.matches(file, true)) {
 					result.add(Paths.get(baseDir.getPath(), file).toFile());
@@ -215,9 +215,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	private Iterable<String> withNormalizedFileSeparators(Iterable<String> patterns) {
 		return StreamSupport.stream(patterns.spliterator(), true)
-			.map(pattern -> pattern.replace('/', File.separatorChar))
-			.map(pattern -> pattern.replace('\\', File.separatorChar))
-			.collect(Collectors.toSet());
+				.map(pattern -> pattern.replace('/', File.separatorChar))
+				.map(pattern -> pattern.replace('\\', File.separatorChar))
+				.collect(Collectors.toSet());
 	}
 
 	private static String withTrailingSeparator(String path) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -19,7 +19,6 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -195,7 +194,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		for (String file : withNormalizedFileSeparators(dirtyFiles)) {
 			if (includePatterns.matches(file, true)) {
 				if (!excludePatterns.matches(file, true)) {
-					result.add(Paths.get(baseDir.getPath(), file).toFile());
+					result.add(new File(baseDir.getPath(), file));
 				}
 			}
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -45,7 +45,6 @@ import org.codehaus.plexus.util.MatchPatterns;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.jgit.api.errors.GitAPIException;
 
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.LineEnding;
@@ -190,8 +189,6 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 					.instance().getDirtyFiles(baseDir, ratchetFrom);
 		} catch (IOException e) {
 			throw new MojoExecutionException("Unable to scan file tree rooted at " + baseDir, e);
-		} catch (GitAPIException e) {
-			throw new MojoExecutionException("Error getting diff against 'ratchetFrom' setting '" + ratchetFrom + "'", e);
 		}
 
 		List<File> result = new ArrayList<>();

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -15,10 +15,10 @@
  */
 package com.diffplug.spotless.maven;
 
-import static java.util.stream.Collectors.toList;
-
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -38,11 +39,12 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.resource.ResourceManager;
 import org.codehaus.plexus.resource.loader.FileResourceLoader;
 import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.MatchPatterns;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.jgit.api.errors.GitAPIException;
 
-import com.diffplug.common.collect.Iterables;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.Provisioner;
@@ -57,6 +59,8 @@ import com.diffplug.spotless.maven.kotlin.Kotlin;
 import com.diffplug.spotless.maven.scala.Scala;
 import com.diffplug.spotless.maven.sql.Sql;
 import com.diffplug.spotless.maven.typescript.Typescript;
+
+import static java.util.stream.Collectors.toList;
 
 public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
@@ -137,38 +141,23 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private void execute(FormatterFactory formatterFactory) throws MojoExecutionException {
-		List<File> files = collectFiles(formatterFactory);
 		FormatterConfig config = getFormatterConfig();
-		Optional<String> ratchetFrom = formatterFactory.ratchetFrom(config);
-		Iterable<File> toFormat;
-		if (!ratchetFrom.isPresent()) {
-			toFormat = files;
-		} else {
-			toFormat = Iterables.filter(files, GitRatchetMaven.instance().isGitDirty(baseDir, ratchetFrom.get()));
-		}
+		List<File> files = collectFiles(formatterFactory, config);
+
 		try (Formatter formatter = formatterFactory.newFormatter(files, config)) {
-			process(toFormat, formatter);
+			process(files, formatter);
 		}
 	}
 
-	private List<File> collectFiles(FormatterFactory formatterFactory) throws MojoExecutionException {
-		Set<String> configuredIncludes = formatterFactory.includes();
-		Set<String> configuredExcludes = formatterFactory.excludes();
-
-		Set<String> includes = configuredIncludes.isEmpty() ? formatterFactory.defaultIncludes() : configuredIncludes;
-		if (includes.isEmpty()) {
-			throw new MojoExecutionException("You must specify some files to include, such as '<includes><include>src/**</include></includes>'");
-		}
-
-		Set<String> excludes = new HashSet<>(FileUtils.getDefaultExcludesAsList());
-		excludes.add(withTrailingSeparator(buildDir.toString()));
-		excludes.addAll(configuredExcludes);
-
-		String includesString = String.join(",", includes);
-		String excludesString = String.join(",", excludes);
-
+	private List<File> collectFiles(FormatterFactory formatterFactory, FormatterConfig config) throws MojoExecutionException {
+		Optional<String> ratchetFrom = formatterFactory.ratchetFrom(config);
 		try {
-			final List<File> files = FileUtils.getFiles(baseDir, includesString, excludesString);
+			final List<File> files;
+			if (ratchetFrom.isPresent()) {
+				files = collectFilesFromGit(formatterFactory, ratchetFrom.get());
+			} else {
+				files = collectFilesFromFormatterFactory(formatterFactory);
+			}
 			if (filePatterns == null || filePatterns.isEmpty()) {
 				return files;
 			}
@@ -189,8 +178,68 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		}
 	}
 
+	private List<File> collectFilesFromGit(FormatterFactory formatterFactory, String ratchetFrom) throws MojoExecutionException {
+		MatchPatterns includePatterns = MatchPatterns.from(
+			withNormalizedFileSeparators(getIncludes(formatterFactory)));
+		MatchPatterns excludePatterns = MatchPatterns.from(
+			withNormalizedFileSeparators(getExcludes(formatterFactory)));
+
+		Iterable<String> dirtyFiles;
+		try {
+			dirtyFiles = GitRatchetMaven
+				.instance().getDirtyFiles(baseDir, ratchetFrom);
+		} catch (IOException e) {
+			throw new MojoExecutionException("Unable to scan file tree rooted at " + baseDir, e);
+		} catch (GitAPIException e) {
+			throw new MojoExecutionException("Error getting diff against 'ratchetFrom' setting '" + ratchetFrom + "'", e);
+		}
+
+		List<File> result = new ArrayList<>();
+		for (String file: withNormalizedFileSeparators(dirtyFiles)) {
+			if (includePatterns.matches(file, true)) {
+				if (!excludePatterns.matches(file, true)) {
+					result.add(Paths.get(baseDir.getPath(), file).toFile());
+				}
+			}
+		}
+		return result;
+	}
+
+	private List<File> collectFilesFromFormatterFactory(FormatterFactory formatterFactory)
+			throws MojoExecutionException, IOException {
+		String includesString = String.join(",", getIncludes(formatterFactory));
+		String excludesString = String.join(",", getExcludes(formatterFactory));
+
+		return FileUtils.getFiles(baseDir, includesString, excludesString);
+	}
+
+	private Iterable<String> withNormalizedFileSeparators(Iterable<String> patterns) {
+		return StreamSupport.stream(patterns.spliterator(), true)
+			.map(pattern -> pattern.replace('/', File.separatorChar))
+			.map(pattern -> pattern.replace('\\', File.separatorChar))
+			.collect(Collectors.toSet());
+	}
+
 	private static String withTrailingSeparator(String path) {
 		return path.endsWith(File.separator) ? path : path + File.separator;
+	}
+
+	private Set<String> getIncludes(FormatterFactory formatterFactory) throws MojoExecutionException {
+		Set<String> configuredIncludes = formatterFactory.includes();
+		Set<String> includes = configuredIncludes.isEmpty() ? formatterFactory.defaultIncludes() : configuredIncludes;
+		if (includes.isEmpty()) {
+			throw new MojoExecutionException("You must specify some files to include, such as '<includes><include>src/**</include></includes>'");
+		}
+		return includes;
+	}
+
+	private Set<String> getExcludes(FormatterFactory formatterFactory) {
+		Set<String> configuredExcludes = formatterFactory.excludes();
+
+		Set<String> excludes = new HashSet<>(FileUtils.getDefaultExcludesAsList());
+		excludes.add(withTrailingSeparator(buildDir.toString()));
+		excludes.addAll(configuredExcludes);
+		return excludes;
 	}
 
 	private FormatterConfig getFormatterConfig() {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/GitRatchetMaven.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/GitRatchetMaven.java
@@ -19,16 +19,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.lib.IndexDiff;
 import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.FileTreeIterator;
 
 import com.diffplug.spotless.extra.GitRatchet;
 
@@ -58,28 +56,44 @@ final class GitRatchetMaven extends GitRatchet<File> {
 		return instance;
 	}
 
-	Iterable<String> getDirtyFiles(File baseDir, String ratchetFrom)
-			throws IOException, GitAPIException {
+	Iterable<String> getDirtyFiles(File baseDir, String ratchetFrom) throws IOException {
 		Repository repository = repositoryFor(baseDir);
 		ObjectId sha = rootTreeShaOf(baseDir, ratchetFrom);
 
-		ObjectReader oldReader = repository.newObjectReader();
-		CanonicalTreeParser oldTree = new CanonicalTreeParser();
-		oldTree.reset(oldReader, sha);
-
-		Git git = new Git(repository);
-		List<DiffEntry> diffs = git.diff()
-				.setShowNameAndStatusOnly(true)
-				.setOldTree(oldTree)
-				.call();
+		IndexDiff indexDiff = new IndexDiff(repository, sha, new FileTreeIterator(repository));
+		indexDiff.diff();
 
 		String workTreePath = repository.getWorkTree().getPath();
 		Path baseDirPath = Paths.get(baseDir.getPath());
 
-		return diffs.stream()
-				.map(DiffEntry::getNewPath)
-				.map(path -> Paths.get(workTreePath, path))
-				.map(path -> baseDirPath.relativize(path).toString())
+		Set<String> dirtyPaths = new HashSet<>(indexDiff.getChanged());
+		dirtyPaths.addAll(indexDiff.getAdded());
+		dirtyPaths.addAll(indexDiff.getConflicting());
+		dirtyPaths.addAll(indexDiff.getUntracked());
+
+		for (String path : indexDiff.getModified()) {
+			if (!dirtyPaths.add(path)) {
+				// File differs to index both in working tree and local repository,
+				// which means the working tree and local repository versions may be equal
+				if (isClean(baseDir, sha, path)) {
+					dirtyPaths.remove(path);
+				}
+			}
+		}
+		for (String path : indexDiff.getRemoved()) {
+			if (dirtyPaths.contains(path)) {
+				// A removed file can also be untracked, if a new file with the same name has been created.
+				// This file may be identical to the one in the local repository.
+				if (isClean(baseDir, sha, path)) {
+					dirtyPaths.remove(path);
+				}
+			}
+		}
+		// A file can be modified in the index but removed in the tree
+		dirtyPaths.removeAll(indexDiff.getMissing());
+
+		return dirtyPaths.stream()
+				.map(path -> baseDirPath.relativize(Paths.get(workTreePath, path)).toString())
 				.collect(Collectors.toList());
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/GitRatchetMaven.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/GitRatchetMaven.java
@@ -69,17 +69,17 @@ final class GitRatchetMaven extends GitRatchet<File> {
 
 		Git git = new Git(repository);
 		List<DiffEntry> diffs = git.diff()
-			.setShowNameAndStatusOnly(true)
-			.setOldTree(oldTree)
-			.call();
+				.setShowNameAndStatusOnly(true)
+				.setOldTree(oldTree)
+				.call();
 
 		String workTreePath = repository.getWorkTree().getPath();
 		Path baseDirPath = Paths.get(baseDir.getPath());
 
 		return diffs.stream()
-			.map(DiffEntry::getNewPath)
-			.map(path -> Paths.get(workTreePath, path))
-			.map(path -> baseDirPath.relativize(path).toString())
-			.collect(Collectors.toList());
+				.map(DiffEntry::getNewPath)
+				.map(path -> Paths.get(workTreePath, path))
+				.map(path -> baseDirPath.relativize(path).toString())
+				.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
Regarding #701 

Spent a lot of time getting the thing set up. IntelliJ refused to cooperate, Gradle isn't my strong suit, and debugging Maven when run through Gradle had its challenges too...

At first it wouldn't run the Maven plugin build at all, but I realized it was because I was using Java 11.

The `SpecificFilesTest` fail because I'm on Windows, they can probably be fixed by adding enough `pattern.replace("/", "\\\\\\\\")` statements.

There is still an issue with this code that I haven't been able to figure out. The `diff` picks up a lot more files than I have actually changed (~400 instead of 3). I believe it's related to line ending normalization, if I run `git add --renormalize .` it changes a lot of files, probably the same files that the `diff` picks up.

But if I run `git diff` manually against the same merge base, or if I run the old plugin version, they don't have this problem.

So that still needs to be fixed, if you have any idea do tell. Even so, it's about three times faster for me than before.