### PR TITLE
Restored scope of transitive dependencies to 'compile' in eclipse-base.

### DIFF
--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.2.1`).
 
 ## [Unreleased]
+### Fixed
+* Restored scope of transitive dependencies to 'compile'.
 
 ## [3.4.0] - 2020-09-23
 ### Added

--- a/_ext/eclipse-base/build.gradle
+++ b/_ext/eclipse-base/build.gradle
@@ -8,12 +8,12 @@ ext {
 }
 
 dependencies {
-	implementation("org.eclipse.platform:org.eclipse.core.resources:${VER_ECLIPSE_CORE_RESOURCES}") {
+	api("org.eclipse.platform:org.eclipse.core.resources:${VER_ECLIPSE_CORE_RESOURCES}") {
 		exclude group: 'org.eclipse.platform', module: 'org.eclipse.ant.core'
 		exclude group: 'org.eclipse.platform', module: 'org.eclipse.core.expressions'
 		exclude group: 'org.eclipse.platform', module: 'org.eclipse.core.filesystem'
 	}
-	implementation("org.slf4j:slf4j-api:${VER_SLF4J}")
+	api("org.slf4j:slf4j-api:${VER_SLF4J}")
 
 	testImplementation("org.slf4j:slf4j-simple:${VER_SLF4J}")
 }

--- a/_ext/gradle/java-setup.gradle
+++ b/_ext/gradle/java-setup.gradle
@@ -5,14 +5,18 @@ apply from: rootProject.file('gradle/changelog.gradle')
 version = spotlessChangelog.versionNext
 apply from: rootProject.file('gradle/java-setup.gradle')
 
+// Allow declaration of api/compile dependencies
+apply plugin: 'java-library'
+
 // Show warning locations
-tasks.withType(JavaCompile) { 
+tasks.withType(JavaCompile) {
 	options.compilerArgs << "-Xlint:unchecked"
-	options.compilerArgs << "-Xlint:deprecation" 
+	options.compilerArgs << "-Xlint:deprecation"
 }
 
 //Currently testlib is not used by _ext. Hence the external dependencies are added here.
 dependencies {
 	testImplementation "junit:junit:${VER_JUNIT}"
 	testImplementation "org.assertj:assertj-core:${VER_ASSERTJ}"
+	testImplementation project(':testlib')
 }


### PR DESCRIPTION
With #428 we modernized the build, replacing `compile` dependencies by `implementation`.
As pointed out already in that PR by @jbduncan, `api` from `java-library` might also be required.

The relevant change for `eclipse-base` is actually not caused by the `java-library`, but by the `maven-publish`.
In the [Customizing dependencies versions](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:resolved_dependencies) section it is described that `implementation` is mapped to the `runtime` scope, whereas `api` is mapped to the `compile`.

Apache Maven explained [in their documentation](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope) why their default scope is `compile`. So the "silent change" of Gradle from `compile` to `runtime` comes unexpected.

Where Gradle really fails is the latter usage in `testImplementation`, where for imported M2 `runtime` dependencies the class loading fails at runtime. It seems to be a bug in Gradle or at least an inconsistency.

However, form the Maven perspective the `compile` scope is cleaner, since `eclipse-base` is meant as a framework, providing a minimal Eclipse setup. This explicitly foresees that the interfaces provided by the transitive dependencies shall be used by the `eclipse-base`user.

So the Gradle problem is not investigated further. Instead the dependency scope of `eclipse-base` is restored to `compile` as it has been before version 3.4.0.