### PR TITLE
Upgraded to CDT version 9.10.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,37 @@ jobs:
       - run:
           name: gradlew :eclipse-jdt:changelogPush
           command: ./gradlew -Pcom.diffplug.spotless.include.ext.nop2=true :eclipse-jdt:changelogPush -Prelease=true --stacktrace
+  ext_do_release_cdt:
+    << : *env_gradle
+    steps:
+      - checkout
+      - *restore_cache_wrapper
+      - *restore_cache_deps
+      - *set_git_origin_to_https
+      - run:
+          name: gradlew :eclipse-cdt:changelogPush
+          command: ./gradlew -Pcom.diffplug.spotless.include.ext.cdt=true :eclipse-cdt:changelogPush -Prelease=true --stacktrace
+  ext_do_release_groovy:
+    << : *env_gradle
+    steps:
+      - checkout
+      - *restore_cache_wrapper
+      - *restore_cache_deps
+      - *set_git_origin_to_https
+      - run:
+          name: gradlew :eclipse-groovy:changelogPush
+          command: ./gradlew -Pcom.diffplug.spotless.include.ext.groovy=true :eclipse-groovy:changelogPush -Prelease=true --stacktrace
+  ext_do_release_wtp:
+    << : *env_gradle
+    steps:
+      - checkout
+      - *restore_cache_wrapper
+      - *restore_cache_deps
+      - *set_git_origin_to_https
+      - run:
+          name: gradlew :eclipse-wtp:changelogPush
+          command: ./gradlew -Pcom.diffplug.spotless.include.ext.wtp=true :eclipse-wtp:changelogPush -Prelease=true --stacktrace
+
 workflows:
   version: 2
   assemble_and_test:
@@ -307,3 +338,33 @@ workflows:
       - ext_do_release_jdt:
           requires:
             - ext_release_jdt
+      - ext_release_cdt:
+          type: approval
+          requires:
+            - ext_changelog_print
+      - ext_do_release_cdt:
+          filters:
+            branches:
+              only: main
+          requires:
+            - ext_release_cdt
+      - ext_release_groovy:
+          type: approval
+          requires:
+            - ext_changelog_print
+      - ext_do_release_groovy:
+          filters:
+            branches:
+              only: main
+          requires:
+            - ext_release_groovy
+      - ext_release_wtp:
+          type: approval
+          requires:
+            - ext_changelog_print
+      - ext_do_release_wtp:
+          filters:
+            branches:
+              only: main
+          requires:
+            - ext_release_wtp

--- a/_ext/eclipse-cdt/CHANGES.md
+++ b/_ext/eclipse-cdt/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `9.9.0`).
 
 ## [Unreleased]
+### Added
+* Upgraded to `CDT` version `9.10`.
 
 ## [9.9.0] - 2019-11-01
 * Switch to Eclipse CDT release 9.9 for Eclipse 4.13 ([#480](https://github.com/diffplug/spotless/issues/480)).

--- a/_ext/eclipse-cdt/build.gradle
+++ b/_ext/eclipse-cdt/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	// Required to by CCorePlugin calling CDTLogWriter
 	implementation "com.ibm.icu:icu4j:${VER_IBM_ICU}"
 	// Required to by CCorePlugin calling PositionTrackerManager
-	implementation "org.eclipse.platform:org.eclipse.core.filebuffers:${VER_ECLISPE_PLATFORM}"
+	implementation "org.eclipse.platform:org.eclipse.core.filebuffers:${VER_ECLISPE_EFS}"
 
 	testImplementation("org.slf4j:slf4j-simple:${VER_SLF4J}")
 }

--- a/_ext/eclipse-cdt/gradle.properties
+++ b/_ext/eclipse-cdt/gradle.properties
@@ -1,12 +1,9 @@
-# Versions correspond to the Eclipse-CDT version used for the fat-JAR.
-# See https://www.eclipse.org/cdt/ for further information about Eclipse-CDT versions.
-# Patch version can be incremented independently for backward compatible patches of this library. 
 artifactId=spotless-eclipse-cdt
 description=Eclipse's CDT C/C++ formatter bundled for Spotless
 
 # Compile dependencies
-VER_ECLIPSE_CDT=9.9
+VER_ECLIPSE_CDT=9.10
 VER_SPOTLESS_ECLISPE_BASE=[3.3.0,4.0.0[
 VER_ECLISPE_JFACE=[3.15.300,4.0.0[
-VER_ECLISPE_PLATFORM=[3.6.700,4.0.0[
-VER_IBM_ICU=[61,62[
+VER_ECLISPE_EFS=[3.6.700,4.0.0[
+VER_IBM_ICU=[61,65[

--- a/_ext/gradle/p2-fat-jar-setup.gradle
+++ b/_ext/gradle/p2-fat-jar-setup.gradle
@@ -47,20 +47,22 @@ ext {
 	embeddedClassesDir = project.file(embeddedClassesDirName)
 }
 
-// build a maven repo in our build folder containing these artifacts
-p2AsMaven {
-	group 'p2', {
-		repo project.p2Repository
-		p2Dependencies.keySet.each { p2.addIU(it) }
-		p2ant {
-			/*
-			Define p2ant proxy settings as a closure. Refer to the API documents for instructions:
-			https://diffplug.github.io/goomph/javadoc/3.17.4/com/diffplug/gradle/p2/AsMavenPlugin.html
-			*/
-			if (project.hasProperty('setP2AntProxy')) {
-				setP2AntProxy(it)
-			}
- 		}
+if (gradle.startParameter.projectProperties.get('com.diffplug.spotless.include.ext.nop2') != 'true') {
+	// build a maven repo in our build folder containing these artifacts
+	p2AsMaven {
+		group 'p2', {
+			repo project.p2Repository
+			p2Dependencies.keySet.each { p2.addIU(it) }
+			p2ant {
+				/*
+				Define p2ant proxy settings as a closure. Refer to the API documents for instructions:
+				https://diffplug.github.io/goomph/javadoc/3.17.4/com/diffplug/gradle/p2/AsMavenPlugin.html
+				*/
+				if (project.hasProperty('setP2AntProxy')) {
+					setP2AntProxy(it)
+				}
+ 			}
+		}
 	}
 }
 

--- a/gradle/changelog.gradle
+++ b/gradle/changelog.gradle
@@ -21,6 +21,12 @@ spotlessChangelog {
 	commitMessage "Published ${kind}/{{version}}" // {{version}} will be replaced
 }
 
+if (gradle.startParameter.projectProperties.get('com.diffplug.spotless.include.ext.nop2') == 'true') {
+	tasks.named('changelogPrint') {
+		enabled = kind.startsWith('ext-')
+	}
+}
+
 if (project == rootProject) {
 	gradle.taskGraph.whenReady { taskGraph ->
 		def changelogPushTasks = taskGraph.allTasks.stream()

--- a/settings.gradle
+++ b/settings.gradle
@@ -79,3 +79,15 @@ if (getStartProperty('com.diffplug.spotless.include.ext.nop2') == 'true') {
 		project(":${dir.name}").projectDir = dir
 	}
 }
+
+// the p2-based projects are too expensive for routine CI builds, so they have to be invoked explicitly
+for (kind in [
+	'cdt',
+	'groovy',
+	'wtp'
+]) {
+	if (getStartProperty("com.diffplug.spotless.include.ext.${kind}") == 'true') {
+		include "eclipse-${kind}"
+		project(":eclipse-${kind}").projectDir = file("_ext/eclipse-${kind}")
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -72,11 +72,10 @@ if (getStartProperty('com.diffplug.spotless.include.ext') == 'true') {
 	}
 }
 
-// include external (_ext) projects from development builds, but only the ones that don't need p2
+// include external (_ext) projects from development builds, but disable the p2 parts
 if (getStartProperty('com.diffplug.spotless.include.ext.nop2') == 'true') {
-	include 'eclipse-base'
-	project(':eclipse-base').projectDir = file('_ext/eclipse-base')
-
-	include 'eclipse-jdt'
-	project(':eclipse-jdt').projectDir = file('_ext/eclipse-jdt')
+	file('_ext').eachDirMatch(~/^(?!(\.|gradle)).*/) { dir ->
+		include dir.name
+		project(":${dir.name}").projectDir = dir
+	}
 }


### PR DESCRIPTION
Upgraded to CDT version 9.10.
The eclipse-base restrictions can remain, since the eclipse-base introduced for Eclipse 2020.09 is compatible with older CDTs (the change in the frame-work utils is intrinsic). The final Eclipse package versions (which determine whether Java 11 is required) are anyhow fine tuned in the lib-extra lock files.