### PR TITLE
Upgraded to WebTools version 2019-12.

### DIFF
--- a/_ext/eclipse-wtp/CHANGES.md
+++ b/_ext/eclipse-wtp/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.15.1`).
 
 ## [Unreleased]
+### Added
+* Upgraded to `WebTools` version `2019-12`.
 
 ## [3.15.3] - 2020-03-26
 ### Fixed

--- a/_ext/eclipse-wtp/gradle.properties
+++ b/_ext/eclipse-wtp/gradle.properties
@@ -1,13 +1,10 @@
-# Versions correspond to the Eclipse-WTP version used for the fat-JAR.
-# See https://www.eclipse.org/webtools/ for further information about Eclipse-WTP versions.
-# Patch version can be incremented independently for backward compatible patches of this library. 
 artifactId=spotless-eclipse-wtp
 description=Eclipse's WTP formatters bundled for Spotless
 
 # Compile
-VER_ECLIPSE_WTP=2019-09
+VER_ECLIPSE_WTP=2019-12
 VER_SPOTLESS_ECLISPE_BASE=[3.3.0,4.0.0[
-VER_IBM_ICU=[61,62[
+VER_IBM_ICU=[61,65[
 VER_ECLISPE_EMF=[2.16.0,3.0.0[
 VER_ECLIPSE_OSGI_SERVICES=[3.8.0,4.0.0[
 VER_ECLIPSE_FILE_BUFFERS=[3.6.700,4.0.0[


### PR DESCRIPTION
Upgraded to WebTools version 2019-12.
The eclipse-base restrictions can remain, since the eclipse-base introduced for Eclipse 2020.09 is compatible with older WTPs (the change in the frame-work utils is intrinsic). The final Eclipse package versions (which determine whether Java 11 is required) are anyhow fine tuned in the lib-extra lock files.