### PR TITLE
Fix typos in MarkDown

### DIFF
--- a/PADDEDCELL.md
+++ b/PADDEDCELL.md
@@ -48,7 +48,7 @@ This is easiest to show in an example:
 * Convergence: `'ATT' 'AT' 'A' 'A'`
   + `F(F('ATT'))` did not equal `F('ATT')`, but there is no cycle.
   + Eventually, the sequence converged on `A`.
-  + As a result, we will use `A` as the canoncial format.
+  + As a result, we will use `A` as the canonical format.
 
 * Divergence: `'1' '12' '123' '1234' '12345' ...`
   + This format does not cycle or converge

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -468,7 +468,7 @@ sql.formatter.keyword.case=UPPER
 sql.formatter.statement.delimiter=;
 # Indentation style (space or tab)
 sql.formatter.indent.type=space
-# Number of identation characters
+# Number of indentation characters
 sql.formatter.indent.size=4
 ```
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -410,9 +410,9 @@ Groovy-Eclipse formatting errors/warnings lead per default to a build failure. T
 [homepage](https://dbeaver.io/). DBeaver is only distributed as a monolithic jar, so the formatter used here was copy-pasted into Spotless, and thus there is no version to change.
 
 ```xml
-<dbveaer>
+<dbeaver>
     <configFile>dbeaver.props</configFile> <!-- configFile is optional -->
-</dbveaer>
+</dbeaver>
 ```
 
 Default configuration file, other options [available here](https://github.com/diffplug/spotless/blob/main/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java).


### PR DESCRIPTION
> If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.
>
>If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.
>
>This makes it easier for the maintainers to quickly release your changes :)

Since this is just a change to the MarkDown documentation, I guess this doens't need a change to `CHANGES.md`?