### PR TITLE
Use JDK 11 in CI (but still target JDK 8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ anchors:
        # we're only allowed to use 2 vCPUs
       GRADLE_OPTS: "-Dorg.gradle.workers.max=2"
     docker:
-      - image: cimg/opejdk:11.0
+      - image: cimg/openjdk:11.0
   env_gradle_large: &env_gradle_large
     << : *env_gradle
     resource_class: large # https://circleci.com/docs/2.0/configuration-reference/#resource_class

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ anchors:
        # and we're only allowed to use 2 vCPUs
       GRADLE_OPTS: "-Dorg.gradle.workers.max=2"
     docker:
-      - image: cimg/openjdk:8.0
+      - image: cimg/openjdk:11.0
   env_gradle_large: &env_gradle_large
     << : *env_gradle
     resource_class: large # https://circleci.com/docs/2.0/configuration-reference/#resource_class

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
             - ~/project/plugin-maven/build/localMavenRepository
           key: gradle-deps2-{{ checksum "build.gradle" }}-{{ checksum "gradle.properties" }}
   test_nomaven_11:
-  # JRE8: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew check
     # latest LTS version
     <<: *env_gradle_large
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,10 @@ orbs:
 anchors:
   env_gradle: &env_gradle
     environment:
-      # java doesn't play nice with containers, it tries to hog the entire machine
-      # https://circleci.com/blog/how-to-handle-java-oom-errors/
-      # try the experimental JVM option
-      _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
-       # and we're only allowed to use 2 vCPUs
+       # we're only allowed to use 2 vCPUs
       GRADLE_OPTS: "-Dorg.gradle.workers.max=2"
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/opejdk:11.0
   env_gradle_large: &env_gradle_large
     << : *env_gradle
     resource_class: large # https://circleci.com/docs/2.0/configuration-reference/#resource_class
@@ -70,27 +66,20 @@ jobs:
             - ~/.m2
             - ~/project/plugin-maven/build/localMavenRepository
           key: gradle-deps2-{{ checksum "build.gradle" }}-{{ checksum "gradle.properties" }}
-  # JRE8: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew check
-  test_nomaven_8:
-    <<: *env_gradle_large
-    <<: *test_nomaven
   test_nomaven_11:
+  # JRE8: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew check
     # latest LTS version
     <<: *env_gradle_large
     docker:
       - image: cimg/openjdk:11.0
-    environment: # java 11 does play nice with containers, doesn't need special settings
-      _JAVA_OPTIONS: ""
     <<: *test_nomaven
   test_nomaven_14:
     # latest JDK, replace with 15 when it comes out
     <<: *env_gradle_large
     docker:
       - image: cimg/openjdk:14.0
-    environment: # java 14 does play nice with containers, doesn't need special settings
-      _JAVA_OPTIONS: ""
     <<: *test_nomaven
-  test_justmaven_8:
+  test_justmaven_11:
     << : *env_gradle
     steps:
       - checkout
@@ -103,6 +92,11 @@ jobs:
           path: plugin-maven/build/test-results/test
   test_npm_8:
     << : *env_gradle
+    environment:
+      # java doesn't play nice with containers, it tries to hog the entire machine
+      # https://circleci.com/blog/how-to-handle-java-oom-errors/
+      # try the experimental JVM option
+      _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
     docker:
       - image: cimg/openjdk:8.0-node
     steps:
@@ -269,10 +263,7 @@ workflows:
     jobs:
       - test_windows
       - assemble_testClasses
-      - test_justmaven_8:
-          requires:
-            - assemble_testClasses
-      - test_nomaven_8:
+      - test_justmaven_11:
           requires:
             - assemble_testClasses
       - test_nomaven_11:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,22 +122,18 @@ jobs:
           command: choco install ojdkbuild8
       - run:
           name: gradlew check
-          command: gradlew check --build-cache
+          command: set SPOTLESS_EXCLUDE_MAVEN=true && gradlew check --build-cache
       - store_test_results:
           path: testlib/build/test-results/test
       - store_test_results:
           path: lib-extra/build/test-results/test
       - store_test_results:
           path: plugin-gradle/build/test-results/test
-      - store_test_results:
-          path: plugin-maven/build/test-results/test
       - run:
           name: gradlew npmTest
-          command: gradlew npmTest --build-cache
+          command: set SPOTLESS_EXCLUDE_MAVEN=true && gradlew npmTest --build-cache
       - store_test_results:
           path: testlib/build/test-results/npm
-      - store_test_results:
-          path: plugin-maven/build/test-results/npm
       - store_test_results:
           path: plugin-gradle/build/test-results/npm
   changelog_print:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,11 @@ jobs:
     docker:
       - image: cimg/openjdk:11.0
     <<: *test_nomaven
-  test_nomaven_14:
-    # latest JDK, replace with 15 when it comes out
+  test_nomaven_15:
+    # latest JDK, replace with 16 when it comes out
     <<: *env_gradle_large
     docker:
-      - image: cimg/openjdk:14.0
+      - image: cimg/openjdk:15.0
     <<: *test_nomaven
   test_justmaven_11:
     << : *env_gradle
@@ -264,7 +264,7 @@ workflows:
       - test_nomaven_11:
           requires:
             - assemble_testClasses
-      - test_nomaven_14:
+      - test_nomaven_15:
           requires:
             - assemble_testClasses
       - test_npm_8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           command: choco install ojdkbuild8
       - run:
           name: gradlew check
-          command: set SPOTLESS_EXCLUDE_MAVEN=true && gradlew check --build-cache
+          command: gradlew check --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
       - store_test_results:
           path: testlib/build/test-results/test
       - store_test_results:
@@ -131,7 +131,7 @@ jobs:
           path: plugin-gradle/build/test-results/test
       - run:
           name: gradlew npmTest
-          command: set SPOTLESS_EXCLUDE_MAVEN=true && gradlew npmTest --build-cache
+          command: gradlew npmTest --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
       - store_test_results:
           path: testlib/build/test-results/npm
       - store_test_results:

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FreshMarkExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FreshMarkExtensionTest.java
@@ -19,9 +19,12 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import com.diffplug.spotless.JreVersion;
+
 public class FreshMarkExtensionTest extends GradleIntegrationHarness {
 	@Test
 	public void integration() throws IOException {
+		JreVersion.assumeLessThan15();
 		setFile("build.gradle").toLines(
 				"buildscript { repositories { mavenCentral() } }",
 				"plugins {",

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -44,7 +44,10 @@ public class GradleIntegrationHarness extends ResourceHarness {
 		final String version;
 
 		GradleVersionSupport(String version) {
-			if (JreVersion.thisVm() >= 14) {
+			if (JreVersion.thisVm() >= 15) {
+				// the first version with support for Java 15+
+				this.version = "6.7";
+			} else if (JreVersion.thisVm() >= 14) {
 				// the first version with support for Java 14+
 				this.version = "6.3";
 			} else {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPluginRedirectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPluginRedirectTest.java
@@ -32,7 +32,6 @@ public class SpotlessPluginRedirectTest extends GradleIntegrationHarness {
 				"}");
 		Assertions.assertThat(gradleRunner().buildAndFail().getOutput().replace("\r", ""))
 				.contains(StringPrinter.buildStringFromLines(
-						"> Failed to apply plugin [id 'com.diffplug.gradle.spotless']",
 						"   > We have moved from 'com.diffplug.gradle.spotless'",
 						"                     to 'com.diffplug.spotless'",
 						"     To migrate:",

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,10 +42,6 @@ include 'testlib'	// library for sharing test infrastructure between the project
 include 'lib-extra'	// reusable library with lots of dependencies
 include 'plugin-gradle'	// gradle-specific glue code
 
-if (System.getenv('SPOTLESS_EXCLUDE_MAVEN') != 'true' && System.getenv('JITPACK') != 'true') {
-	include 'plugin-maven'	// maven-specific glue code
-}
-
 def getStartProperty(java.lang.String name) {
 	def value = startParameter.getProjectProperties().get(name)
 	if(null != value) {
@@ -59,6 +55,10 @@ def getStartProperty(java.lang.String name) {
 	}
 	return userProperties.get(name)
 
+}
+
+if (System.getenv('SPOTLESS_EXCLUDE_MAVEN') != 'true' && getStartProperty('SPOTLESS_EXCLUDE_MAVEN') != 'true' && System.getenv('JITPACK') != 'true') {
+	include 'plugin-maven'	// maven-specific glue code
 }
 
 // include external (_ext) projects from development builds

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,11 +42,8 @@ include 'testlib'	// library for sharing test infrastructure between the project
 include 'lib-extra'	// reusable library with lots of dependencies
 include 'plugin-gradle'	// gradle-specific glue code
 
-if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
-	// only build Java 8
-	if (System.getenv('SPOTLESS_EXCLUDE_MAVEN') != 'true' && System.getenv('JITPACK') != 'true') {
-		include 'plugin-maven'	// maven-specific glue code
-	}
+if (System.getenv('SPOTLESS_EXCLUDE_MAVEN') != 'true' && System.getenv('JITPACK') != 'true') {
+	include 'plugin-maven'	// maven-specific glue code
 }
 
 def getStartProperty(java.lang.String name) {

--- a/testlib/src/main/java/com/diffplug/spotless/JreVersion.java
+++ b/testlib/src/main/java/com/diffplug/spotless/JreVersion.java
@@ -51,4 +51,8 @@ public class JreVersion {
 	public static void assume11OrLess() {
 		assume(v -> v <= 11);
 	}
+
+	public static void assumeLessThan15() {
+		assume(v -> v < 15);
+	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/markdown/FreshMarkStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/markdown/FreshMarkStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.JreVersion;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
@@ -28,6 +29,7 @@ import com.diffplug.spotless.TestProvisioner;
 public class FreshMarkStepTest {
 	@Test
 	public void behavior() throws Exception {
+		JreVersion.assumeLessThan15();
 		HashMap<String, String> map = new HashMap<>();
 		map.put("lib", "MyLib");
 		map.put("author", "Me");
@@ -37,6 +39,7 @@ public class FreshMarkStepTest {
 
 	@Test
 	public void equality() throws Exception {
+		JreVersion.assumeLessThan15();
 		new SerializableEqualityTester() {
 			String version = "1.3.1";
 			Map<String, Object> props = new HashMap<>();


### PR DESCRIPTION
In order to build the latest `eclipse-cdt` shim, it is now necessary to build against JDK 11.  This PR bumps our default build JDK to 11, although we still build JDK 8 bytecode by default.  This will allow us to build minimum-requirement 11 artifacts where necessary.