### PR TITLE
Configuration cache (JVM-local support only, just an idea)

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -747,15 +747,14 @@ public class FormatExtension {
 	 */
 	public SpotlessApply createIndependentApplyTask(String taskName) {
 		// create and setup the task
-		SpotlessTask spotlessTask = spotless.project.getTasks().create(taskName + "Helper", SpotlessTaskImpl.class);
+		SpotlessTaskImpl spotlessTask = spotless.project.getTasks().create(taskName + "Helper", SpotlessTaskImpl.class);
 		setupTask(spotlessTask);
 		// enforce the clean ordering
 		Task clean = spotless.project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME);
 		spotlessTask.mustRunAfter(clean);
 		// create the apply task
 		SpotlessApply applyTask = spotless.project.getTasks().create(taskName, SpotlessApply.class);
-		applyTask.setSpotlessOutDirectory(spotlessTask.getOutputDirectory());
-		applyTask.linkSource(spotlessTask);
+		applyTask.link(spotlessTask);
 		applyTask.dependsOn(spotlessTask);
 
 		return applyTask;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
@@ -19,21 +19,20 @@ import java.io.File;
 
 import javax.annotation.Nullable;
 
-import org.gradle.api.Project;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 
 import com.diffplug.spotless.extra.GitRatchet;
 
 /** Gradle implementation of GitRatchet. */
-public abstract class GitRatchetGradle extends GitRatchet<Project> implements BuildService<BuildServiceParameters.None> {
+public abstract class GitRatchetGradle extends GitRatchet<File> implements BuildService<BuildServiceParameters.None> {
 	@Override
-	protected File getDir(Project project) {
-		return project.getProjectDir();
+	protected File getDir(File project) {
+		return project;
 	}
 
 	@Override
-	protected @Nullable Project getParent(Project project) {
-		return project.getParent();
+	protected @Nullable File getParent(File project) {
+		return project.getParentFile();
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
@@ -33,7 +33,7 @@ class IdeHook {
 		System.err.println("IS CLEAN");
 	}
 
-	static void performHook(SpotlessTask spotlessTask) {
+	static void performHook(SpotlessTaskImpl spotlessTask) {
 		String path = (String) spotlessTask.getProject().property(PROPERTY);
 		File file = new File(path);
 		if (!file.isAbsolute()) {
@@ -43,7 +43,7 @@ class IdeHook {
 		if (spotlessTask.getTarget().contains(file)) {
 			try (Formatter formatter = spotlessTask.buildFormatter()) {
 				if (spotlessTask.ratchet != null) {
-					if (spotlessTask.ratchet.isClean(spotlessTask.getProject(), spotlessTask.rootTreeSha, file)) {
+					if (spotlessTask.ratchet.isClean(spotlessTask.getProjectDir(), spotlessTask.rootTreeSha, file)) {
 						dumpIsClean();
 						return;
 					}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -35,7 +35,6 @@ public class SpotlessApply extends DefaultTask {
 	/** Bidirectional link between Apply and Spotless allows check to know if Apply ran or not. */
 	void linkSource(SpotlessTask source) {
 		this.source = source;
-		source.applyTask = this;
 	}
 
 	private File spotlessOutDirectory;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -20,40 +20,18 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
-import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
-public class SpotlessApply extends DefaultTask {
-	private SpotlessTask source;
-
-	/** Bidirectional link between Apply and Spotless allows check to know if Apply ran or not. */
-	void linkSource(SpotlessTask source) {
-		this.source = source;
-	}
-
-	private File spotlessOutDirectory;
-
-	@PathSensitive(PathSensitivity.RELATIVE)
-	@InputDirectory
-	public File getSpotlessOutDirectory() {
-		return spotlessOutDirectory;
-	}
-
-	public void setSpotlessOutDirectory(File spotlessOutDirectory) {
-		this.spotlessOutDirectory = spotlessOutDirectory;
-	}
-
+public abstract class SpotlessApply extends SpotlessTaskService.DependentTask {
 	@TaskAction
 	public void performAction() {
-		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
+		SpotlessTaskImpl task = source();
+		ConfigurableFileTree files = task.outputFiles();
 		if (files.isEmpty()) {
-			getState().setDidWork(source.getDidWork());
+			getState().setDidWork(task.getDidWork());
 		} else {
 			files.visit(new FileVisitor() {
 				@Override
@@ -64,7 +42,7 @@ public class SpotlessApply extends DefaultTask {
 				@Override
 				public void visitFile(FileVisitDetails fileVisitDetails) {
 					String path = fileVisitDetails.getPath();
-					File originalSource = new File(getProject().getProjectDir(), path);
+					File originalSource = new File(task.getProjectDir(), path);
 					try {
 						getLogger().debug("Copying " + fileVisitDetails.getFile() + " to " + originalSource);
 						Files.copy(fileVisitDetails.getFile().toPath(), originalSource.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -66,9 +66,6 @@ public class SpotlessCheck extends DefaultTask {
 		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
 		if (files.isEmpty()) {
 			getState().setDidWork(source.getDidWork());
-		} else if (!isTest && getProject().getGradle().getTaskGraph().hasTask(source.applyTask)) {
-			// if our matching apply has already run, then we don't need to do anything
-			getState().setDidWork(false);
 		} else {
 			List<File> problemFiles = new ArrayList<>();
 			files.visit(new FileVisitor() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 
-import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 
 import com.diffplug.spotless.Formatter;
@@ -31,22 +29,16 @@ import com.diffplug.spotless.PaddedCell;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class SpotlessDiagnoseTask extends DefaultTask {
-	SpotlessTask source;
-
-	@Internal
-	public SpotlessTask getSource() {
-		return source;
-	}
+public abstract class SpotlessDiagnoseTask extends SpotlessTaskService.DependentTask {
 
 	@TaskAction
 	@SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
 	public void performAction() throws IOException {
 		Path srcRoot = getProject().getProjectDir().toPath();
-		Path diagnoseRoot = getProject().getBuildDir().toPath().resolve("spotless-diagnose-" + source.formatName());
+		Path diagnoseRoot = getProject().getBuildDir().toPath().resolve("spotless-diagnose-" + source().formatName());
 		getProject().delete(diagnoseRoot.toFile());
-		try (Formatter formatter = source.buildFormatter()) {
-			for (File file : source.target) {
+		try (Formatter formatter = source().buildFormatter()) {
+			for (File file : source().target) {
 				getLogger().debug("Running padded cell check on " + file);
 				PaddedCell padded = PaddedCell.check(formatter, file);
 				if (!padded.misbehaved()) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -89,8 +89,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		TaskProvider<SpotlessApply> applyTask = tasks.register(taskName + APPLY, SpotlessApply.class, task -> {
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
-			task.setSpotlessOutDirectory(spotlessTask.get().getOutputDirectory());
-			task.linkSource(spotlessTask.get());
+			task.link(spotlessTask.get());
 		});
 		rootApplyTask.configure(task -> {
 			task.dependsOn(applyTask);
@@ -104,8 +103,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
-			task.setSpotlessOutDirectory(spotlessTask.get().getOutputDirectory());
-			task.source = spotlessTask.get();
+			task.link(spotlessTask.get());
 
 			// if the user runs both, make sure that apply happens first,
 			task.mustRunAfter(applyTask);
@@ -121,7 +119,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 
 		// create the diagnose task
 		TaskProvider<SpotlessDiagnoseTask> diagnoseTask = tasks.register(taskName + DIAGNOSE, SpotlessDiagnoseTask.class, task -> {
-			task.source = spotlessTask.get();
+			task.link(spotlessTask.get());
 			task.mustRunAfter(cleanTask);
 		});
 		rootDiagnoseTask.configure(task -> task.dependsOn(diagnoseTask));

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -112,6 +112,13 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		});
 		rootCheckTask.configure(task -> task.dependsOn(checkTask));
 
+		// no need to run check if apply is going to run
+		project.getGradle().getTaskGraph().whenReady(graph -> {
+			if (graph.hasTask(taskName + APPLY) && graph.hasTask(taskName + CHECK)) {
+				checkTask.get().setEnabled(false);
+			}
+		});
+
 		// create the diagnose task
 		TaskProvider<SpotlessDiagnoseTask> diagnoseTask = tasks.register(taskName + DIAGNOSE, SpotlessDiagnoseTask.class, task -> {
 			task.source = spotlessTask.get();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -16,7 +16,6 @@
 package com.diffplug.gradle.spotless;
 
 import java.io.File;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +37,6 @@ import org.gradle.work.Incremental;
 
 import com.diffplug.spotless.FormatExceptionPolicy;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
-import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
@@ -80,8 +78,8 @@ public class SpotlessTask extends DefaultTask {
 
 	public void setupRatchet(GitRatchetGradle gitRatchet, String ratchetFrom) {
 		ratchet = gitRatchet;
-		rootTreeSha = gitRatchet.rootTreeShaOf(getProject(), ratchetFrom);
-		subtreeSha = gitRatchet.subtreeShaOf(getProject(), rootTreeSha);
+		rootTreeSha = gitRatchet.rootTreeShaOf(getProject().getProjectDir(), ratchetFrom);
+		subtreeSha = gitRatchet.subtreeShaOf(getProject().getProjectDir(), rootTreeSha);
 	}
 
 	@Internal
@@ -157,15 +155,5 @@ public class SpotlessTask extends DefaultTask {
 		} else {
 			return name;
 		}
-	}
-
-	Formatter buildFormatter() {
-		return Formatter.builder()
-				.lineEndingsPolicy(lineEndingsPolicy)
-				.encoding(Charset.forName(encoding))
-				.rootDir(getProject().getRootDir().toPath())
-				.steps(steps)
-				.exceptionPolicy(exceptionPolicy)
-				.build();
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -43,14 +43,6 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
 public class SpotlessTask extends DefaultTask {
-	SpotlessApply applyTask;
-
-	/** Internal use only, allows coordination between check and apply when they are in the same build */
-	@Internal
-	SpotlessApply getApplyTask() {
-		return applyTask;
-	}
-
 	// set by SpotlessExtension, but possibly overridden by FormatExtension
 	protected String encoding = "UTF-8";
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+
+/** A service which allows looking up a SpotlessTaskImpl from its path. */
+public abstract class SpotlessTaskService implements BuildService<BuildServiceParameters.None> {
+	private Map<String, SpotlessTaskImpl> taskPathToTask = new HashMap<>();
+
+	public static abstract class DependentTask extends DefaultTask {
+		private String sourceTaskPath;
+		private transient SpotlessTaskService taskService;
+
+		@Input
+		public final String getSourceTaskPath() {
+			return sourceTaskPath;
+		}
+
+		@Internal
+		public SpotlessTaskService getTaskService() {
+			return taskService;
+		}
+
+		protected final SpotlessTaskImpl source() {
+			return Objects.requireNonNull(taskService.taskPathToTask.get(sourceTaskPath), sourceTaskPath);
+		}
+
+		public void link(SpotlessTaskImpl task) {
+			sourceTaskPath = task.getPath();
+			taskService = task.getProject().getGradle().getSharedServices()
+					.registerIfAbsent("SpotlessTaskService", SpotlessTaskService.class, unused -> {}).get();
+			if (taskService.taskPathToTask.put(sourceTaskPath, task) == null) {
+				task.taskService = taskService;
+			}
+		}
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
@@ -26,6 +26,7 @@ public class ConfigurationCacheTest extends GradleIntegrationHarness {
 	protected void runTasks(String... tasks) throws IOException {
 		setFile("gradle.properties").toContent("org.gradle.unsafe.configuration-cache=true");
 		List<String> args = new ArrayList<>();
+		args.add("--stacktrace");
 		args.addAll(Arrays.asList(tasks));
 		gradleRunner()
 				.withGradleVersion(GradleVersionSupport.CONFIGURATION_CACHE.version)
@@ -65,5 +66,24 @@ public class ConfigurationCacheTest extends GradleIntegrationHarness {
 				"}",
 				"tasks.named('spotlessJavaApply').get()");
 		runTasks("help");
+	}
+
+	@Test
+	public void spotlessConfigures() throws IOException {
+		setFile("build.gradle").toLines(
+				"buildscript { repositories { mavenCentral() } }",
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"spotless {",
+				"    format 'misc', {",
+				"        target '*.txt'",
+				"        custom 'lowercase', { str -> str.toLowerCase() }",
+				"        bumpThisNumberIfACustomStepChanges(1)",
+				"    }",
+				"}");
+		setFile("test.txt").toContent("ABC");
+		runTasks("spotlessApply");
+		assertFile("test.txt").hasContent("abc");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
@@ -86,5 +86,9 @@ public class ConfigurationCacheTest extends GradleIntegrationHarness {
 		runTasks("spotlessApply");
 		assertFile("test.txt").hasContent("abc");
 		runTasks("spotlessApply");
+		runTasks("spotlessApply");
+		setFile("test.txt").toContent("ABC");
+		runTasks("spotlessApply");
+		assertFile("test.txt").hasContent("abc");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
@@ -91,4 +91,29 @@ public class ConfigurationCacheTest extends GradleIntegrationHarness {
 		runTasks("spotlessApply");
 		assertFile("test.txt").hasContent("abc");
 	}
+
+	@Test
+	public void spotlessWorksForComplexStep() throws IOException {
+		setFile("build.gradle").toLines(
+				"buildscript { repositories { mavenCentral() } }",
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"apply plugin: 'java'",
+				"spotless {",
+				"    java {",
+				"        target 'test.java'",
+				"        googleJavaFormat('1.2')",
+				"    }",
+				"}");
+		setFile("test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		runTasks("spotlessApply");
+		assertFile("test.java").sameAsResource("java/googlejavaformat/JavaCodeFormatted.test");
+		runTasks("spotlessApply");
+		runTasks("spotlessApply");
+
+		setFile("test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		runTasks("spotlessApply");
+		assertFile("test.java").sameAsResource("java/googlejavaformat/JavaCodeFormatted.test");
+	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
@@ -69,7 +69,7 @@ public class ConfigurationCacheTest extends GradleIntegrationHarness {
 	}
 
 	@Test
-	public void spotlessConfigures() throws IOException {
+	public void spotlessWorksForSimpleStep() throws IOException {
 		setFile("build.gradle").toLines(
 				"buildscript { repositories { mavenCentral() } }",
 				"plugins {",
@@ -85,5 +85,6 @@ public class ConfigurationCacheTest extends GradleIntegrationHarness {
 		setFile("test.txt").toContent("ABC");
 		runTasks("spotlessApply");
 		assertFile("test.txt").hasContent("abc");
+		runTasks("spotlessApply");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -57,17 +57,15 @@ public class DiffMessageFormatterTest extends ResourceHarness {
 			return task;
 		}
 
-		private SpotlessCheck createCheckTask(String name, SpotlessTask source) {
+		private SpotlessCheck createCheckTask(String name, SpotlessTaskImpl source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
-			task.source = source;
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
+			task.link(source);
 			return task;
 		}
 
-		private SpotlessApply createApplyTask(String name, SpotlessTask source) {
+		private SpotlessApply createApplyTask(String name, SpotlessTaskImpl source) {
 			SpotlessApply task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Apply", SpotlessApply.class);
-			task.linkSource(this.task);
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
+			task.link(source);
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -62,17 +62,15 @@ public class PaddedCellTaskTest extends ResourceHarness {
 			return task;
 		}
 
-		private SpotlessCheck createCheckTask(String name, SpotlessTask source) {
+		private SpotlessCheck createCheckTask(String name, SpotlessTaskImpl source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
-			task.source = source;
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
+			task.link(source);
 			return task;
 		}
 
-		private SpotlessApply createApplyTask(String name, SpotlessTask source) {
+		private SpotlessApply createApplyTask(String name, SpotlessTaskImpl source) {
 			SpotlessApply task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Apply", SpotlessApply.class);
-			task.linkSource(source);
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
+			task.link(source);
 			return task;
 		}
 
@@ -87,7 +85,7 @@ public class PaddedCellTaskTest extends ResourceHarness {
 
 		void diagnose() throws IOException {
 			SpotlessDiagnoseTask diagnose = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Diagnose", SpotlessDiagnoseTask.class);
-			diagnose.source = task;
+			diagnose.link(task);
 			diagnose.performAction();
 		}
 


### PR DESCRIPTION
This PR builds on top of #720, to build full support for the configuration cache.  The big thing left is that everything in Spotless (namely the git line-endings policy and all the FormatterStep) need to become round-trip serializable, with custom `readObject` / `writeObject` methods.

In many places throughout Spotless, we use a trick where if two objects serialize to the same bytes, then they are equal.  To make that work, almost everything in Spotless is serializable, but there are *lots*  of `transient` fields, which are not correctly restored when an object is deserialized.  I can think of two solutions:

1) Remove all the transient fields all over the place, and implement equality "properly", rather than cheating and using a "serializes to the same bytes" hack.
2) Create a special `BuildService` which persists across the lifetime of a given configuration-cache, and use that to "rehydrate" fields which are not correctly deserialized.

Solution 2 is a *lot* easier for us, and it also has the benefit that it would support Spotless' full suite of features.  With solution 1, we will never be able to support closures which are in-line within a buildscript.  That would be a real shame, because Gradle's inline closures are such a great part of the tool, and every plugin (not just Spotless) will be unable to use such closures unless there is some kind of long-lived `BuildService`.