### PR TITLE
Added missing Eclipse formatter support up to version 4.17.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,16 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for eclipse-cdt 4.14.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-groovy 4.14.0, 4.15.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-jdt 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-wtp 4.14.0, 4.15.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+### Changed
+* Updated default eclipse-cdt from 4.13.0 to 4.16.0 ([#722](https://github.com/diffplug/spotless/pull/722)). Note that version 4.17.0 is supported, but requires Java 11 or higher.
+* Updated default eclipse-groovy from 4.13.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Updated default eclipse-jdt from 4.16.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Updated default eclipse-wtp from 4.13.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
 
 ## [2.8.0] - 2020-10-05
 ### Added

--- a/_ext/eclipse-jdt/gradle.properties
+++ b/_ext/eclipse-jdt/gradle.properties
@@ -1,5 +1,3 @@
-# Mayor/Minor versions correspond to the minimum Eclipse version supported/tested.
-# Patch version is incremented for backward compatible patches of this library.
 artifactId=spotless-eclipse-jdt
 description=Eclipse's JDT formatter bundled for Spotless
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -36,7 +36,7 @@ public final class EclipseCdtFormatterStep {
 
 	private static final String NAME = "eclipse cdt formatter";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.cdt.EclipseCdtFormatterStepImpl";
-	private static final String DEFAULT_VERSION = "4.13.0";
+	private static final String DEFAULT_VERSION = "4.16.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
@@ -33,7 +33,7 @@ public final class GrEclipseFormatterStep {
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.groovy.eclipse.GrEclipseFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-groovy";
-	private static final String DEFAULT_VERSION = "4.13.0";
+	private static final String DEFAULT_VERSION = "4.17.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -32,7 +32,7 @@ public final class EclipseJdtFormatterStep {
 	private static final String FORMATTER_CLASS_OLD = "com.diffplug.gradle.spotless.java.eclipse.EclipseFormatterStepImpl";
 	private static final String FORMATTER_CLASS = "com.diffplug.spotless.extra.eclipse.java.EclipseJdtFormatterStepImpl";
 	private static final String MAVEN_GROUP_ARTIFACT = "com.diffplug.spotless:spotless-eclipse-jdt";
-	private static final String DEFAULT_VERSION = "4.16.0";
+	private static final String DEFAULT_VERSION = "4.17.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	public static String defaultVersion() {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -36,7 +36,7 @@ public enum EclipseWtpFormatterStep {
 
 	private static final String NAME = "eclipse wtp formatters";
 	private static final String FORMATTER_PACKAGE = "com.diffplug.spotless.extra.eclipse.wtp.";
-	private static final String DEFAULT_VERSION = "4.13.0";
+	private static final String DEFAULT_VERSION = "4.17.0";
 	private static final String FORMATTER_METHOD = "format";
 
 	private final String implementationClassName;

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.14.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.14.0.lockfile
@@ -1,0 +1,22 @@
+# Spotless formatter based on CDT version 9.10.0 (see https://www.eclipse.org/cdt/)
+com.diffplug.spotless:spotless-eclipse-cdt:9.10.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+com.ibm.icu:icu4j:64.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.600
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.500
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.800
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.600
+org.eclipse.platform:org.eclipse.core.jobs:3.10.600
+org.eclipse.platform:org.eclipse.core.resources:3.13.600
+org.eclipse.platform:org.eclipse.core.runtime:3.17.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.300
+org.eclipse.platform:org.eclipse.equinox.common:3.10.600
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.600
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.600
+org.eclipse.platform:org.eclipse.jface.text:3.16.100
+org.eclipse.platform:org.eclipse.jface:3.18.0
+org.eclipse.platform:org.eclipse.osgi:3.15.100
+org.eclipse.platform:org.eclipse.text:3.10.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.16.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.16.0.lockfile
@@ -1,0 +1,22 @@
+# Spotless formatter based on CDT version 9.11.1 (see https://www.eclipse.org/cdt/)
+com.diffplug.spotless:spotless-eclipse-cdt:9.11.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+com.google.j2objc:j2objc-annotations:1.3
+com.ibm.icu:icu4j:64.2
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.700
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.1000
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.700
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.700
+org.eclipse.platform:org.eclipse.core.runtime:3.18.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.500
+org.eclipse.platform:org.eclipse.equinox.common:3.12.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.800
+org.eclipse.platform:org.eclipse.jface.text:3.16.300
+org.eclipse.platform:org.eclipse.jface:3.20.0
+org.eclipse.platform:org.eclipse.osgi:3.15.300
+org.eclipse.platform:org.eclipse.text:3.10.200

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.17.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.17.0.lockfile
@@ -1,0 +1,22 @@
+# Spotless formatter based on CDT version 10.0 (see https://www.eclipse.org/cdt/)
+com.diffplug.spotless:spotless-eclipse-cdt:10.0.0
+com.diffplug.spotless:spotless-eclipse-base:3.4.1
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+com.ibm.icu:icu4j:64.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.800
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.1000
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.700
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.800
+org.eclipse.platform:org.eclipse.core.runtime:3.19.0
+org.eclipse.platform:org.eclipse.equinox.app:1.5.0
+org.eclipse.platform:org.eclipse.equinox.common:3.13.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.9.0
+org.eclipse.platform:org.eclipse.jface.text:3.16.400
+org.eclipse.platform:org.eclipse.jface:3.21.0
+org.eclipse.platform:org.eclipse.osgi:3.16.0
+org.eclipse.platform:org.eclipse.text:3.10.300

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.17.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.17.0.lockfile
@@ -1,0 +1,19 @@
+# Spotless formatter based on JDT version 4.17.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
+# Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_17 to determine core version.
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.4.1
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.jdt:org.eclipse.jdt.core:3.23.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.800
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.800
+org.eclipse.platform:org.eclipse.core.runtime:3.19.0
+org.eclipse.platform:org.eclipse.equinox.app:1.5.0
+org.eclipse.platform:org.eclipse.equinox.common:3.13.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.9.0
+org.eclipse.platform:org.eclipse.osgi:3.16.0
+org.eclipse.platform:org.eclipse.text:3.10.300

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.14.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.14.0.lockfile
@@ -1,0 +1,25 @@
+# Spotless formatter based on Eclipse-WTP version 3.16 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.16.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+com.ibm.icu:icu4j:64.2
+org.eclipse.emf:org.eclipse.emf.common:2.17.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.20.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.600
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.500
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.800
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.600
+org.eclipse.platform:org.eclipse.core.jobs:3.10.600
+org.eclipse.platform:org.eclipse.core.resources:3.13.600
+org.eclipse.platform:org.eclipse.core.runtime:3.17.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.300
+org.eclipse.platform:org.eclipse.equinox.common:3.10.600
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.600
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.600
+org.eclipse.platform:org.eclipse.jface.text:3.16.100
+org.eclipse.platform:org.eclipse.jface:3.18.0
+org.eclipse.platform:org.eclipse.osgi.services:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.15.100
+org.eclipse.platform:org.eclipse.text:3.10.0
+org.eclipse.xsd:org.eclipse.xsd:2.12.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.15.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.15.0.lockfile
@@ -1,0 +1,25 @@
+# Spotless formatter based on Eclipse-WTP version 3.17 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.17.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+com.ibm.icu:icu4j:64.2
+org.eclipse.emf:org.eclipse.emf.common:2.18.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.21.0
+org.eclipse.emf:org.eclipse.xsd:2.17.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.600
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.900
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.700
+org.eclipse.platform:org.eclipse.core.jobs:3.10.700
+org.eclipse.platform:org.eclipse.core.resources:3.13.700
+org.eclipse.platform:org.eclipse.core.runtime:3.17.100
+org.eclipse.platform:org.eclipse.equinox.app:1.4.400
+org.eclipse.platform:org.eclipse.equinox.common:3.11.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.700
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.700
+org.eclipse.platform:org.eclipse.jface.text:3.16.200
+org.eclipse.platform:org.eclipse.jface:3.19.0
+org.eclipse.platform:org.eclipse.osgi.services:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.15.200
+org.eclipse.platform:org.eclipse.text:3.10.100

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.16.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.16.0.lockfile
@@ -1,0 +1,25 @@
+# Spotless formatter based on Eclipse-WTP version 3.18 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.18.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+com.ibm.icu:icu4j:64.2
+org.eclipse.emf:org.eclipse.emf.common:2.19.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.22.0
+org.eclipse.emf:org.eclipse.xsd:2.17.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.700
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.1000
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.700
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.700
+org.eclipse.platform:org.eclipse.core.runtime:3.18.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.500
+org.eclipse.platform:org.eclipse.equinox.common:3.12.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.800
+org.eclipse.platform:org.eclipse.jface.text:3.16.300
+org.eclipse.platform:org.eclipse.jface:3.20.0
+org.eclipse.platform:org.eclipse.osgi.services:3.8.0
+org.eclipse.platform:org.eclipse.osgi:3.15.300
+org.eclipse.platform:org.eclipse.text:3.10.200

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.17.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.17.0.lockfile
@@ -1,0 +1,26 @@
+# Spotless formatter based on Eclipse-WTP version 3.19 (see https://www.eclipse.org/webtools/)
+com.diffplug.spotless:spotless-eclipse-wtp:3.19.0
+com.diffplug.spotless:spotless-eclipse-base:3.4.1
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+com.ibm.icu:icu4j:64.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.emf:org.eclipse.emf.common:2.20.0
+org.eclipse.emf:org.eclipse.emf.ecore:2.23.0
+org.eclipse.emf:org.eclipse.xsd:2.18.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.800
+org.eclipse.platform:org.eclipse.core.filebuffers:3.6.1000
+org.eclipse.platform:org.eclipse.core.filesystem:1.7.700
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.800
+org.eclipse.platform:org.eclipse.core.runtime:3.19.0
+org.eclipse.platform:org.eclipse.equinox.app:1.5.0
+org.eclipse.platform:org.eclipse.equinox.common:3.13.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.9.0
+org.eclipse.platform:org.eclipse.jface.text:3.16.400
+org.eclipse.platform:org.eclipse.jface:3.21.0
+org.eclipse.platform:org.eclipse.osgi.services:3.9.0
+org.eclipse.platform:org.eclipse.osgi:3.16.0
+org.eclipse.platform:org.eclipse.text:3.10.300

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.14.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.14.0.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on Groovy-Eclipse version 3.6.0 (see https://github.com/groovy/groovy-eclipse/releases)
+com.diffplug.spotless:spotless-eclipse-groovy:3.6.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+org.eclipse.platform:org.eclipse.core.commands:3.9.600
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.500
+org.eclipse.platform:org.eclipse.core.jobs:3.10.600
+org.eclipse.platform:org.eclipse.core.resources:3.13.600
+org.eclipse.platform:org.eclipse.core.runtime:3.17.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.300
+org.eclipse.platform:org.eclipse.equinox.common:3.10.600
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.600
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.600
+org.eclipse.platform:org.eclipse.jface.text:3.16.100
+org.eclipse.platform:org.eclipse.jface:3.18.0
+org.eclipse.platform:org.eclipse.osgi:3.15.100
+org.eclipse.platform:org.eclipse.text:3.10.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.15.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.15.0.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on Groovy-Eclipse version 3.7.0 (see https://github.com/groovy/groovy-eclipse/releases)
+com.diffplug.spotless:spotless-eclipse-groovy:3.7.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.600
+org.eclipse.platform:org.eclipse.core.jobs:3.10.700
+org.eclipse.platform:org.eclipse.core.resources:3.13.700
+org.eclipse.platform:org.eclipse.core.runtime:3.17.100
+org.eclipse.platform:org.eclipse.equinox.app:1.4.400
+org.eclipse.platform:org.eclipse.equinox.common:3.11.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.7.700
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.700
+org.eclipse.platform:org.eclipse.jface.text:3.16.200
+org.eclipse.platform:org.eclipse.jface:3.19.0
+org.eclipse.platform:org.eclipse.osgi:3.15.200
+org.eclipse.platform:org.eclipse.text:3.10.100

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.16.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.16.0.lockfile
@@ -1,0 +1,18 @@
+# Spotless formatter based on Groovy-Eclipse version 3.8.0 (see https://github.com/groovy/groovy-eclipse/releases)
+com.diffplug.spotless:spotless-eclipse-groovy:3.8.0
+com.diffplug.spotless:spotless-eclipse-base:3.3.0
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.700
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.700
+org.eclipse.platform:org.eclipse.core.runtime:3.18.0
+org.eclipse.platform:org.eclipse.equinox.app:1.4.500
+org.eclipse.platform:org.eclipse.equinox.common:3.12.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.8.800
+org.eclipse.platform:org.eclipse.jface.text:3.16.300
+org.eclipse.platform:org.eclipse.jface:3.20.0
+org.eclipse.platform:org.eclipse.osgi:3.15.300
+org.eclipse.platform:org.eclipse.text:3.10.200

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.17.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.17.0.lockfile
@@ -1,0 +1,19 @@
+# Spotless formatter based on Groovy-Eclipse version 3.9.0 (see https://github.com/groovy/groovy-eclipse/releases)
+com.diffplug.spotless:spotless-eclipse-groovy:3.9.0
+com.diffplug.spotless:spotless-eclipse-base:3.4.1
+com.github.spotbugs:spotbugs-annotations:4.0.2
+com.google.code.findbugs:jsr305:3.0.2
+net.jcip:jcip-annotations:1.0
+org.eclipse.platform:org.eclipse.core.commands:3.9.700
+org.eclipse.platform:org.eclipse.core.contenttype:3.7.800
+org.eclipse.platform:org.eclipse.core.jobs:3.10.800
+org.eclipse.platform:org.eclipse.core.resources:3.13.800
+org.eclipse.platform:org.eclipse.core.runtime:3.19.0
+org.eclipse.platform:org.eclipse.equinox.app:1.5.0
+org.eclipse.platform:org.eclipse.equinox.common:3.13.0
+org.eclipse.platform:org.eclipse.equinox.preferences:3.8.0
+org.eclipse.platform:org.eclipse.equinox.registry:3.9.0
+org.eclipse.platform:org.eclipse.jface.text:3.16.400
+org.eclipse.platform:org.eclipse.jface:3.21.0
+org.eclipse.platform:org.eclipse.osgi:3.16.0
+org.eclipse.platform:org.eclipse.text:3.10.300

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepOldTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepOldTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.extra.cpp;
+
+/** Older versions of CDT support Java 8 or higher */
+public class EclipseCdtFormatterStepOldTest extends EclipseCdtFormatterStepTest {
+
+	@Override
+	protected String[] getSupportedVersions() {
+		return new String[]{"4.7.3a", "4.11.0", "4.12.0", "4.13.0", "4.14.0", "4.16.0"};
+	}
+
+	@Override
+	protected void makeAssumptions() {}
+
+}

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.extra.cpp;
 
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.JreVersion;
 import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.eclipse.EclipseCommonTests;
@@ -24,7 +25,12 @@ public class EclipseCdtFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a", "4.11.0", "4.12.0", "4.13.0"};
+		return new String[]{"4.17.0"};
+	}
+
+	@Override
+	protected void makeAssumptions() {
+		JreVersion.assume11OrGreater();
 	}
 
 	@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepOldTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepOldTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016-2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.extra.groovy;
+
+import com.diffplug.spotless.JreVersion;
+
+/** Older versions only support Java version 11 or lower */
+public class GrEclipseFormatterStepOldTest extends GrEclipseFormatterStepTest {
+	@Override
+	protected String[] getSupportedVersions() {
+		return new String[]{"2.3.0", "4.6.3", "4.8.0", "4.8.1", "4.10.0", "4.12.0", "4.13.0", "4.14.0", "4.15.0", "4.16.0"};
+	}
+
+	@Override
+	protected void makeAssumptions() {
+		// JRE 11 warns like this:
+		//		WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+		//		WARNING: All illegal access operations will be denied in a future release
+		// And after that it fails like this:
+		//		Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.vmplugin.v7.Java7
+		//		at org.codehaus.groovy.vmplugin.VMPluginFactory.<clinit>(VMPluginFactory.java:39)
+		//		at org.codehaus.groovy.ast.ClassHelper.makeCached(ClassHelper.java:133)
+		//		at org.codehaus.groovy.ast.ClassHelper.<clinit>(ClassHelper.java:67)
+		//		at org.codehaus.groovy.classgen.Verifier.<clinit>(Verifier.java:113)
+		//		at org.codehaus.groovy.control.CompilationUnit.<init>(CompilationUnit.java:158)
+		//		at org.codehaus.jdt.groovy.internal.compiler.ast.GroovyParser.makeCompilationUnit(GroovyParser.java:467)
+		//		at org.codehaus.jdt.groovy.internal.compiler.ast.GroovyParser.<init>(GroovyParser.java:247)
+		//		at org.codehaus.jdt.groovy.internal.compiler.ast.GroovyParser.<init>(GroovyParser.java:216)
+		//		at org.codehaus.groovy.eclipse.core.compiler.GroovySnippetParser.dietParse(GroovySnippetParser.java:105)
+		//		at org.codehaus.groovy.eclipse.core.compiler.GroovySnippetParser.parse(GroovySnippetParser.java:69)
+		//		at org.codehaus.groovy.eclipse.refactoring.core.utils.ASTTools.getASTNodeFromSource(ASTTools.java:204)
+		//		at org.codehaus.groovy.eclipse.refactoring.formatter.DefaultGroovyFormatter.initCodebase(DefaultGroovyFormatter.java:109)
+		//		at org.codehaus.groovy.eclipse.refactoring.formatter.DefaultGroovyFormatter.format(DefaultGroovyFormatter.java:121)
+		//		at com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl.format(GrEclipseFormatterStepImpl.java:81)
+		JreVersion.assume11OrLess();
+	}
+
+}

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
@@ -16,7 +16,6 @@
 package com.diffplug.spotless.extra.groovy;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.JreVersion;
 import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.eclipse.EclipseCommonTests;
@@ -24,7 +23,7 @@ import com.diffplug.spotless.extra.eclipse.EclipseCommonTests;
 public class GrEclipseFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"2.3.0", "4.6.3", "4.8.0", "4.8.1", "4.10.0", "4.12.0", "4.13.0"};
+		return new String[]{"4.17.0"};
 	}
 
 	@Override
@@ -35,30 +34,6 @@ public class GrEclipseFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String getTestExpectation(String version) {
 		return "class F{\n\tdef m(){}\n}";
-	}
-
-	@Override
-	protected void makeAssumptions() {
-		// JRE 11 warns like this:
-		//		WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
-		//		WARNING: All illegal access operations will be denied in a future release
-		// And after that it fails like this:
-		//		Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.vmplugin.v7.Java7
-		//		at org.codehaus.groovy.vmplugin.VMPluginFactory.<clinit>(VMPluginFactory.java:39)
-		//		at org.codehaus.groovy.ast.ClassHelper.makeCached(ClassHelper.java:133)
-		//		at org.codehaus.groovy.ast.ClassHelper.<clinit>(ClassHelper.java:67)
-		//		at org.codehaus.groovy.classgen.Verifier.<clinit>(Verifier.java:113)
-		//		at org.codehaus.groovy.control.CompilationUnit.<init>(CompilationUnit.java:158)
-		//		at org.codehaus.jdt.groovy.internal.compiler.ast.GroovyParser.makeCompilationUnit(GroovyParser.java:467)
-		//		at org.codehaus.jdt.groovy.internal.compiler.ast.GroovyParser.<init>(GroovyParser.java:247)
-		//		at org.codehaus.jdt.groovy.internal.compiler.ast.GroovyParser.<init>(GroovyParser.java:216)
-		//		at org.codehaus.groovy.eclipse.core.compiler.GroovySnippetParser.dietParse(GroovySnippetParser.java:105)
-		//		at org.codehaus.groovy.eclipse.core.compiler.GroovySnippetParser.parse(GroovySnippetParser.java:69)
-		//		at org.codehaus.groovy.eclipse.refactoring.core.utils.ASTTools.getASTNodeFromSource(ASTTools.java:204)
-		//		at org.codehaus.groovy.eclipse.refactoring.formatter.DefaultGroovyFormatter.initCodebase(DefaultGroovyFormatter.java:109)
-		//		at org.codehaus.groovy.eclipse.refactoring.formatter.DefaultGroovyFormatter.format(DefaultGroovyFormatter.java:121)
-		//		at com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl.format(GrEclipseFormatterStepImpl.java:81)
-		JreVersion.assume11OrLess();
 	}
 
 	@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
@@ -25,7 +25,7 @@ public class EclipseJdtFormatterStepTest extends EclipseCommonTests {
 	@Override
 	protected String[] getSupportedVersions() {
 		return new String[]{"4.6.1", "4.6.2", "4.6.3", "4.7.0", "4.7.1", "4.7.2", "4.7.3a", "4.8.0", "4.9.0", "4.10.0",
-				"4.11.0", "4.12.0", "4.13.0", "4.14.0", "4.15.0", "4.16.0"};
+				"4.11.0", "4.12.0", "4.13.0", "4.14.0", "4.15.0", "4.16.0", "4.17.0"};
 	}
 
 	@Override

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class EclipseWtpFormatterStepTest extends EclipseCommonTests {
 
 	@Override
 	protected String[] getSupportedVersions() {
-		return new String[]{"4.7.3a", "4.7.3b", "4.8.0", "4.12.0", "4.13.0"};
+		return new String[]{"4.7.3a", "4.7.3b", "4.8.0", "4.12.0", "4.13.0", "4.14.0", "4.15.0", "4.16.0", "4.17.0"};
 	}
 
 	@Override

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,16 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for eclipse-cdt 4.14.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-groovy 4.14.0, 4.15.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-jdt 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-wtp 4.14.0, 4.15.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+### Changed
+* Updated default eclipse-cdt from 4.13.0 to 4.16.0 ([#722](https://github.com/diffplug/spotless/pull/722)). Note that version 4.17.0 is supported, but requires Java 11 or higher.
+* Updated default eclipse-groovy from 4.13.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Updated default eclipse-jdt from 4.16.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Updated default eclipse-wtp from 4.13.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
 
 ## [5.6.1] - 2020-09-21
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,16 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for eclipse-cdt 4.14.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-groovy 4.14.0, 4.15.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-jdt 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Added support for eclipse-wtp 4.14.0, 4.15.0, 4.16.0 and 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+### Changed
+* Updated default eclipse-cdt from 4.13.0 to 4.16.0 ([#722](https://github.com/diffplug/spotless/pull/722)). Note that version 4.17.0 is supported, but requires Java 11 or higher.
+* Updated default eclipse-groovy from 4.13.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Updated default eclipse-jdt from 4.16.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
+* Updated default eclipse-wtp from 4.13.0 to 4.17.0 ([#722](https://github.com/diffplug/spotless/pull/722)).
 
 ## [2.4.2] - 2020-10-05
 ### Fixed


### PR DESCRIPTION
Added missing Eclipse versions for formatter extension up to version 4.17.
The default formatter version is now 4.17, except for CDT formatter, since CDT 10.0 requires Java 11.

A default version  depending on the the executing JRE version is discouraged, since this would mean that the desired formatting may change dependent on the underlying JRE version. A general approach should be taken in future how to deal with the fact that more and more formatters do not work anymore with Java 8.

This PR demonstrates that most Eclipse 4.17 formatters still work perfectly with Java 8. Hence it is recommended to close  #547.
This PR makes Groovy-Eclipse 3.9.0 the new default formatter, which solves #685.