### PR TITLE
Set the rootDir as / instead of // if the project is in the root of the filesystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fixed a bug which occurred if the root directory of the project was also the filesystem root ([#732](https://github.com/diffplug/spotless/pull/732))
 
 ## [2.10.1] - 2020-11-13
 ### Fixed

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -108,7 +108,8 @@ public final class GitAttributesLineEndings {
 		final ConcurrentRadixTree<String> hasNonDefaultEnding = new ConcurrentRadixTree<>(new DefaultCharSequenceNodeFactory());
 
 		CachedEndings(File projectDir, Runtime runtime, Iterable<File> toFormat) {
-			rootDir = FileSignature.pathNativeToUnix(projectDir.getAbsolutePath()) + "/";
+			String rootPath = FileSignature.pathNativeToUnix(projectDir.getAbsolutePath());
+			rootDir = rootPath.equals("/") ? rootPath : rootPath + "/";
 			defaultEnding = runtime.defaultEnding;
 			for (File file : toFormat) {
 				String ending = runtime.getEndingFor(file);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fixed a bug which occurred if the root directory of the project was also the filesystem root ([#732](https://github.com/diffplug/spotless/pull/732))
 
 ## [5.8.1] - 2020-11-13
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fixed a bug which occurred if the root directory of the project was also the filesystem root ([#732](https://github.com/diffplug/spotless/pull/732))
 
 ## [2.6.0] - 2020-11-13
 ### Added


### PR DESCRIPTION
This PR is to fix a bug if a gradle project is in the root of a filesystem. Normally this would not be an issue as projects would are generally not at the root, but in the case of a Docker or other container, the situation could arise:

		Caused by: java.lang.IllegalArgumentException: Expected '/src/main/java/com/acme/MyApplication.java' to start with '//'
			at com.diffplug.spotless.FileSignature.subpath(FileSignature.java:203)
			at com.diffplug.spotless.extra.GitAttributesLineEndings$CachedEndings.endingFor(GitAttributesLineEndings.java:126)
			at com.diffplug.spotless.extra.GitAttributesLineEndings$RelocatablePolicy.getEndingFor(GitAttributesLineEndings.java:95)
			at com.diffplug.spotless.Formatter.computeLineEndings(Formatter.java:211)
			at com.diffplug.spotless.PaddedCell.calculateDirtyState(PaddedCell.java:203)
			at com.diffplug.spotless.PaddedCell.calculateDirtyState(PaddedCell.java:188)
			at com.diffplug.gradle.spotless.SpotlessTaskImpl.processInputFile(SpotlessTaskImpl.java:71)
			at com.diffplug.gradle.spotless.SpotlessTaskImpl.performAction(SpotlessTaskImpl.java:57)
			at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

I've read the instructions about adding to the CHANGES.md file, but I don't see a `-SNAPSHOT` section. I did see the below however, so I presume it is no longer necessary?

* We no longer publish `-SNAPSHOT` for every build to `main`, since we have good [JitPack integration](https://github.com/diffplug/spotless/blob/main/CONTRIBUTING.md#gradle---any-commit-in-a-public-github-repo-this-one-or-any-fork). ([#508](https://github.com/diffplug/spotless/pull/508))