### PR TITLE
Performance functional-bug fix for the Maven-plugin

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Upgraded org.codehaus.plexus:plexus-utils to its latest version (3.3.0)  ([#736](https://github.com/diffplug/spotless/pull/736))
 
 ## [2.6.0] - 2020-11-13
 ### Added

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -70,6 +70,12 @@ dependencies {
 	}
 
 	implementation "org.codehaus.plexus:plexus-resources:${VER_PLEXUS_RESOURCES}"
+	constraints {
+		implementation("org.codehaus.plexus:plexus-utils:3.3.0") {
+			because("version pulled by plexus-resources has a functional-bug affecting " +
+					"directory scanning times")
+		}
+	}
 
 	compileOnly "org.apache.maven:maven-plugin-api:${VER_MAVEN_API}"
 	compileOnly "org.apache.maven.plugin-tools:maven-plugin-annotations:${VER_MAVEN_API}"


### PR DESCRIPTION
Upgraded org.codehaus.plexus:plexus-utils to its latest version (3.3.0) to resolve long directory scanning times for the maven plugin.

Resolves #729 
