### PR TITLE
Fix spotlessFiles parameter tests

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix broken test for spotlessFiles parameter on windows ([#737](https://github.com/diffplug/spotless/pull/737))
 
 ## [2.6.0] - 2020-11-13
 ### Added

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpecificFilesTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpecificFilesTest.java
@@ -16,17 +16,30 @@
 package com.diffplug.spotless.maven;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.Test;
 
 public class SpecificFilesTest extends MavenIntegrationHarness {
 	private String testFile(int number, boolean absolute) throws IOException {
 		String rel = "src/main/java/test" + number + ".java";
+		Path path;
 		if (absolute) {
-			return rootFolder() + "/" + rel;
+			path = Paths.get(rootFolder().getAbsolutePath(), rel);
 		} else {
-			return rel;
+			path = Paths.get(rel);
 		}
+		String result = path.toString();
+		if (!isOnWindows()) {
+			return result;
+		} else {
+			return result.replace("\\", "\\\\");
+		}
+	}
+
+	private boolean isOnWindows() {
+		return System.getProperty("os.name").startsWith("Windows");
 	}
 
 	private String testFile(int number) throws IOException {
@@ -73,6 +86,11 @@ public class SpecificFilesTest extends MavenIntegrationHarness {
 
 	@Test
 	public void regexp() throws IOException, InterruptedException {
-		integration(".*/src/main/java/test\\(1\\|3\\).java", true, false, true);
+		String pattern;
+		if (isOnWindows())
+			pattern = "\".*\\\\src\\\\main\\\\java\\\\test(1|3).java\"";
+		else
+			pattern = "'.*/src/main/java/test(1|3).java'";
+		integration(pattern, true, false, true);
 	}
 }


### PR DESCRIPTION
- `(`,`|` and `)` should not be escaped with `\`, otherwise they get
  interpreted as literals and no file matches
- On Windows paths use backslashes, so `\\\\` has to be used.
2 for java strings and 2 since this parameter is treated as a regex.

Few remarks:
- No issue for this, I just couldn't make it run `check` on Windows. Changes only on Tests.
- I don't have a unix machine right now to test it on.
- I'm not sure if/how it was even running for unix. `.*/src/main/java/test\\(1\\|3\\).java` should have been interpreted as literal.



