### PR TITLE
Dodge StringIndexOutOfBoundsException on empty files (prettier/css)

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -113,7 +113,9 @@ public class PrettierFormatterStep {
 
 		@Override
 		public String applyWithFile(String unix, File file) throws Exception {
-			FormattedPrinter.SYSOUT.print("formatting String '" + unix.substring(0, Math.min(50, unix.length() - 1)) + "[...]' in file '" + file + "'");
+            if (unix.length() > 0) {
+			  FormattedPrinter.SYSOUT.print("formatting String '" + unix.substring(0, Math.min(50, unix.length() - 1)) + "[...]' in file '" + file + "'");
+            }
 
 			final String prettierConfigOptionsWithFilepath = assertFilepathInConfigOptions(file);
 			return restService.format(unix, prettierConfigOptionsWithFilepath);


### PR DESCRIPTION
Trivial fix for empty css files causing out-of-bounds exception with prettier:
```
> Task :dcs:contexts:frontend:spotlessJs
Step 'prettier-format' found problem in '...\SearchApp.css':
begin 0, end -1, length 0
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 0
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3756)
        at java.base/java.lang.String.substring(String.java:1902)
        at com.diffplug.spotless.npm.PrettierFormatterStep$PrettierFilePathPassingFormatterFunc.applyWithFile(PrettierFormatterStep.java:116)
        at com.diffplug.spotless.FormatterFunc$NeedsFile.apply(FormatterFunc.java:154)
```