### PR TITLE
feat: 'ratchetFrom' in git submodule supported (#746)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changed
+* Added support for git-submodule with `ratchetFrom` ([#746](https://github.com/diffplug/spotless/issues/746))
 * Update default ktfmt from 0.16 to 0.18 ([#748](https://github.com/diffplug/spotless/issues/748))
 * fix typo in javadoc comment for SQL\_FORMATTER\_INDENT\_TYPE ([#753](https://github.com/diffplug/spotless/pull/753))
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -17,6 +17,8 @@ package com.diffplug.spotless.extra;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -183,13 +185,37 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 		return null;
 	}
 
+	/**
+	 * When populating a new submodule directory with "git submodule init", the $GIT_DIR meta-information directory
+	 * for submodules is created inside $GIT_DIR/modules// directory of the super-project
+	 * and referenced via the git-file mechanism.
+	 */
+	private static @Nullable File getDotGitDir(File dir, String dotGit) {
+		File dotGitPath = new File(dir, dotGit);
+
+		if (dotGitPath.isDirectory()) {
+			return dotGitPath;
+		} else if (dotGitPath.isFile()) {
+			try {
+				String relativePath = new String(Files.readAllBytes(dotGitPath.toPath()), StandardCharsets.UTF_8)
+						.split(":")[1].trim();
+				return getDotGitDir(dir, relativePath);
+			} catch (IOException e) {
+				System.err.println("failed to parse git meta: " + e.getMessage());
+				return null;
+			}
+		} else {
+			return null;
+		}
+	}
+
 	private static boolean isGitRoot(File dir) {
-		File dotGit = new File(dir, Constants.DOT_GIT);
-		return dotGit.isDirectory() && RepositoryCache.FileKey.isGitRepository(dotGit, FS.DETECTED);
+		File dotGit = getDotGitDir(dir, Constants.DOT_GIT);
+		return dotGit != null && RepositoryCache.FileKey.isGitRepository(dotGit, FS.DETECTED);
 	}
 
 	static Repository createRepo(File dir) throws IOException {
-		return FileRepositoryBuilder.create(new File(dir, Constants.DOT_GIT));
+		return FileRepositoryBuilder.create(getDotGitDir(dir, Constants.DOT_GIT));
 	}
 
 	/**

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for git-submodule with `ratchetFrom` ([#746](https://github.com/diffplug/spotless/issues/746))
 
 ## [5.8.2] - 2020-11-16
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for git-submodule with `ratchetFrom` ([#746](https://github.com/diffplug/spotless/issues/746))
 ### Fixed
 * Fix broken test for spotlessFiles parameter on windows ([#737](https://github.com/diffplug/spotless/pull/737))
 


### PR DESCRIPTION
* Added support for git-submodule with `ratchetFrom` ([#746](https://github.com/diffplug/spotless/issues/746))
