### PR TITLE
Support ktfmt v0.19+ with dropboxStyle()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * Update default ktfmt from 0.16 to 0.18 ([#748](https://github.com/diffplug/spotless/issues/748))
 * fix typo in javadoc comment for SQL\_FORMATTER\_INDENT\_TYPE ([#753](https://github.com/diffplug/spotless/pull/753))
+* Unbreak ktfmt v0.19 (https://github.com/facebookincubator/ktfmt/issues/155)
 
 ## [2.10.2] - 2020-11-16
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -118,6 +118,12 @@ public class KtfmtStep {
 		}
 
 		private Object getDropboxStyleFormattingOptions(ClassLoader classLoader) throws Exception {
+			try {
+				// ktfmt v0.19 and later
+				return classLoader.loadClass(pkg + ".ktfmt.FormatterKt").getField("DROPBOX_FORMAT").get(null);
+			} catch (NoSuchFieldException ignored) {}
+
+			// fallback to old, pre-0.19 ktfmt interface.
 			Class<?> formattingOptionsCompanionClazz = classLoader.loadClass(pkg + ".ktfmt.FormattingOptions$Companion");
 			Object companion = formattingOptionsCompanionClazz.getConstructors()[0].newInstance((Object) null);
 			Method formattingOptionsMethod = formattingOptionsCompanionClazz.getDeclaredMethod(DROPBOX_STYLE_METHOD);

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -67,6 +67,46 @@ public class KotlinExtensionTest extends GradleIntegrationHarness {
 	}
 
 	@Test
+	public void integrationKtfmt_dropboxStyle_0_18() throws IOException {
+		// ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
+		JreVersion.assume11OrGreater();
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'nebula.kotlin' version '1.3.72'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktfmt('0.18').dropboxStyle()",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktfmt/basic.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktfmt/basic-dropboxstyle.clean");
+	}
+
+	@Test
+	public void integrationKtfmt_dropboxStyle_0_19() throws IOException {
+		// ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
+		JreVersion.assume11OrGreater();
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'nebula.kotlin' version '1.3.72'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktfmt('0.19').dropboxStyle()",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktfmt/basic.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktfmt/basic-dropboxstyle.clean");
+	}
+
+	@Test
 	public void testWithIndentation() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",

--- a/testlib/build/resources/main/kotlin/ktfmt/basic-dropboxstyle.clean
+++ b/testlib/build/resources/main/kotlin/ktfmt/basic-dropboxstyle.clean
@@ -1,0 +1,13 @@
+import a.*
+import a.b
+import a.b.c.*
+import kotlinx.android.synthetic.main.layout_name.*
+
+fun main() {
+    fun name() {
+        a()
+        return b
+    }
+    println(";")
+    println()
+}

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtfmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtfmtStepTest.java
@@ -31,6 +31,22 @@ public class KtfmtStepTest extends ResourceHarness {
 	}
 
 	@Test
+	public void dropboxStyle_0_18() throws Exception {
+		// ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
+		JreVersion.assume11OrGreater();
+		FormatterStep step = KtfmtStep.create("0.18", TestProvisioner.mavenCentral(), KtfmtStep.Style.DROPBOX);
+		StepHarness.forStep(step).testResource("kotlin/ktfmt/basic.dirty", "kotlin/ktfmt/basic-dropboxstyle.clean");
+	}
+
+	@Test
+	public void dropboxStyle_0_19() throws Exception {
+		// ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
+		JreVersion.assume11OrGreater();
+		FormatterStep step = KtfmtStep.create("0.19", TestProvisioner.mavenCentral(), KtfmtStep.Style.DROPBOX);
+		StepHarness.forStep(step).testResource("kotlin/ktfmt/basic.dirty", "kotlin/ktfmt/basic-dropboxstyle.clean");
+	}
+
+	@Test
 	public void equality() throws Exception {
 		new SerializableEqualityTester() {
 			String version = "0.13";


### PR DESCRIPTION
An interface used by Spotless changed in v0.19, leading to a runtime crash.

This fixes https://github.com/facebookincubator/ktfmt/issues/155.
