### PR TITLE
Slurping Git History respects existing header date claims

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* Changed `spotlessSetLicenseHeaderYearsFromGitHistory` to merge with existing date ranges ([#783](https://github.com/diffplug/spotless/issues/783)).
 
 ## [2.11.0] - 2021-01-04
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changed
+* Changed `spotlessSetLicenseHeaderYearsFromGitHistory` to merge with existing date ranges ([#783](https://github.com/diffplug/spotless/issues/783)).
 
 ## [5.9.0] - 2021-01-04
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -681,7 +681,13 @@ See the [javadoc](https://javadoc.io/static/com.diffplug.spotless/spotless-plugi
 
 ### Retroactively slurp years from git history
 
-If your project has not been rigorous with copyright headers, and you'd like to use git history to repair this retroactively, you can do so with `-PspotlessSetLicenseHeaderYearsFromGitHistory=true`.  When run in this mode, Spotless will do an expensive search through git history for each file, and set the copyright header based on the oldest and youngest commits for that file.  This is intended to be a one-off sort of thing.
+If your project has not been rigorous with copyright headers, and you'd like to use git history to repair this retroactively, you can do so with `-PspotlessSetLicenseHeaderYearsFromGitHistory=true`.  When run in this mode, Spotless will do an expensive search through git history for each file, and set the copyright header based on the oldest and youngest commits for that file.
+
+If some files have an existing license header claiming a date range then it will be merged with the date range from git history, using the earliest and latest years from either range. This is avoids reducing the copyright claim when some files have history pre-dating the git repository.
+
+If you are using the `ratchet` feature then the date range will also be expanded to include the current year.
+
+This is intended to be a one-off operation.
 
 <a name="ratchet"></a>
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -452,14 +452,20 @@ public class FormatExtension {
 		}
 
 		FormatterStep createStep() {
-			return builder.withYearModeLazy(() -> {
-				if ("true".equals(spotless.project.findProperty(LicenseHeaderStep.FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY()))) {
-					return YearMode.SET_FROM_GIT;
-				} else {
-					boolean updateYear = updateYearWithLatest == null ? getRatchetFrom() != null : updateYearWithLatest;
-					return updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
-				}
-			}).build();
+			final boolean useGitHistory = "true".equals(spotless.project.findProperty(
+					LicenseHeaderStep.FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY()));
+
+			return builder
+					.withUseGitHistoryLazy(() -> useGitHistory)
+					.withYearModeLazy(() -> {
+						System.out.println("RATCHET FROM: " + getRatchetFrom());
+
+						return (updateYearWithLatest == null ? getRatchetFrom() != null
+								: updateYearWithLatest)
+										? YearMode.UPDATE_TO_TODAY
+										: YearMode.PRESERVE;
+					})
+					.build();
 		}
 	}
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* Changed `spotlessSetLicenseHeaderYearsFromGitHistory` to merge with existing date ranges ([#783](https://github.com/diffplug/spotless/issues/783)).
 
 ## [2.7.0] - 2021-01-04
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -753,7 +753,13 @@ Once a file's license header has a valid year, whether it is a year (`2020`) or 
 
 ### Retroactively slurp years from git history
 
-If your project has not been rigorous with copyright headers, and you'd like to use git history to repair this retroactively, you can do so with `-DspotlessSetLicenseHeaderYearsFromGitHistory=true`.  When run in this mode, Spotless will do an expensive search through git history for each file, and set the copyright header based on the oldest and youngest commits for that file.  This is intended to be a one-off sort of thing.
+If your project has not been rigorous with copyright headers, and you'd like to use git history to repair this retroactively, you can do so with `-DspotlessSetLicenseHeaderYearsFromGitHistory=true`.  When run in this mode, Spotless will do an expensive search through git history for each file, and set the copyright header based on the oldest and youngest commits for that file.
+
+If some files have an existing license header claiming a date range then it will be merged with the date range from git history, using the earliest and latest years from either range. This is avoids reducing the copyright claim when some files have history pre-dating the git repository.
+
+If you are using the `ratchet` feature then the date range will also be expanded to include the current year.
+
+This is intended to be a one-off operation.
 
 <a name="invisible"></a>
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,15 +44,11 @@ public class LicenseHeader implements FormatterStepFactory {
 			throw new IllegalArgumentException("You need to specify 'delimiter'.");
 		}
 		if (file != null ^ content != null) {
-			YearMode yearMode;
-			if ("true".equals(config.spotlessSetLicenseHeaderYearsFromGitHistory().orElse(""))) {
-				yearMode = YearMode.SET_FROM_GIT;
-			} else {
-				boolean updateYear = config.getRatchetFrom().isPresent();
-				yearMode = updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
-			}
+			final boolean useGitHistory = "true".equals(config.spotlessSetLicenseHeaderYearsFromGitHistory().orElse(""));
+			boolean updateYear = config.getRatchetFrom().isPresent();
 			return LicenseHeaderStep.headerDelimiter(() -> readFileOrContent(config), delimiterString)
-					.withYearMode(yearMode)
+					.withUseGitHistory(useGitHistory)
+					.withYearMode(updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE)
 					.build()
 					.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
 		} else {


### PR DESCRIPTION
- `LicenseHeaderStep`:
  - Added `useGitHistory` field and builder methods independent of year mode.
  - Removed unnecessary `LicenseHeaderStep.YearMode.SET_FROM_GIT`.
  - Maven and Gradle plugins updated to configure `useGitHistory` and `yearMode` independently.
- `LicenseHeaderStep.Runtime`:
  - Unified the separate workflows for "normal" vs "slurp git history" mode of operation.
  - "slurp git history" mode with no `$YEAR` token now inserts the fixed license header rather than none at all, which is more consistent with "normal" mode.
  - "slurp git history" mode now respects the `ratchet` feature and expands the date range to include the current year.
  - All discovered dates are sorted and the final range is composed of the first and last values.