### PR TITLE
Fix the Gradle plugin not to break the `clean` task when Gradle's configuration cache is enabled

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fixed the `clean` task when Gradle's configuration cache is enabled ([#796](https://github.com/diffplug/spotless/issues/796))
 
 ## [5.10.0] - 2021-02-09
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -42,16 +42,15 @@ public class SpotlessPlugin implements Plugin<Project> {
 		project.getExtensions().create(SpotlessExtension.class, SpotlessExtension.EXTENSION, SpotlessExtensionImpl.class, project);
 
 		// clear spotless' cache when the user does a clean
-		project.getTasks().named(BasePlugin.CLEAN_TASK_NAME).configure(clean -> {
-			clean.doLast(unused -> {
-				// resolution for: https://github.com/diffplug/spotless/issues/243#issuecomment-564323856
-				// project.getRootProject() is consistent across every project, so only of one the clears will
-				// actually happen (as desired)
-				//
-				// we use System.identityHashCode() to avoid a memory leak by hanging on to the reference directly
-				SpotlessCache.clearOnce(System.identityHashCode(project.getRootProject()));
-			});
-		});
+		// resolution for: https://github.com/diffplug/spotless/issues/243#issuecomment-564323856
+		// project.getRootProject() is consistent across every project, so only of one the clears will
+		// actually happen (as desired)
+		//
+		// we use System.identityHashCode() to avoid a memory leak by hanging on to the reference directly
+		int cacheKey = System.identityHashCode(project.getRootProject());
+		project.getTasks().named(BasePlugin.CLEAN_TASK_NAME).configure(clean ->
+			clean.doLast(unused -> SpotlessCache.clearOnce(cacheKey))
+		);
 	}
 
 	static String capitalize(String input) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,7 @@ public class SpotlessPlugin implements Plugin<Project> {
 		//
 		// we use System.identityHashCode() to avoid a memory leak by hanging on to the reference directly
 		int cacheKey = System.identityHashCode(project.getRootProject());
-		project.getTasks().named(BasePlugin.CLEAN_TASK_NAME).configure(clean ->
-			clean.doLast(unused -> SpotlessCache.clearOnce(cacheKey))
-		);
+		project.getTasks().named(BasePlugin.CLEAN_TASK_NAME).configure(clean -> clean.doLast(unused -> SpotlessCache.clearOnce(cacheKey)));
 	}
 
 	static String capitalize(String input) {


### PR DESCRIPTION
Using the project at execution time is not allowed when Gradle's configuration cache is enabled.
https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

Before this commit, the spotless plugin registered a `doLast` task action on the `clean` task that accessed the projet at execution time. The effect of this is to break using the `clean` task on all builds that have the Spotless plugin applied when the configuration cache is enabled.

This manifests the following way:

```
user@host $ ./gradlew --configuration-cache clean
Configuration cache is an incubating feature.

FAILURE: Build failed with an exception.

* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:clean` of type `org.gradle.api.tasks.Delete`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/7.0-20210211110842+0000/userguide/configuration_cache.html#config_cache:requirements:disallowed_types

See the complete report at file:///..../configuration-cache-report.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
1 actionable task: 1 executed
```
Here is a ZIP of the HTML configuration cache report for your curiosity: [configuration-cache-report.zip](https://github.com/diffplug/spotless/files/5965083/configuration-cache-report.zip)


This PR changes the way the Spotless plugin configures the `clean` task to not access a project in the added `doLast` task action by computing the Spotless cache key upfront at configuration time. The effect is that builds with the Spotless plugin applied can now run the `clean` task with the configuration cache enabled.

This is a fix for https://github.com/diffplug/spotless/issues/796
