### PR TITLE
Allow licence header to be empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Allow licence headers to be blank ([#801](https://github.com/diffplug/spotless/pull/801)).
 
 ## [2.12.0] - 2021-02-09
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ public final class LicenseHeaderStep {
 			}
 			// sanitize the input license
 			licenseHeader = LineEnding.toUnix(licenseHeader);
-			if (!licenseHeader.endsWith("\n")) {
+			if (!licenseHeader.isEmpty() && !licenseHeader.endsWith("\n")) {
 				licenseHeader = licenseHeader + "\n";
 			}
 			this.delimiterPattern = Pattern.compile('^' + delimiter, Pattern.UNIX_LINES | Pattern.MULTILINE);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Allow licence headers to be blank ([#801](https://github.com/diffplug/spotless/pull/801)).
 
 ## [5.10.1] - 2021-02-11
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Allow licence headers to be blank ([#801](https://github.com/diffplug/spotless/pull/801)).
 
 ## [2.8.0] - 2021-02-09
 ### Added

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,13 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				.testUnaffected(hasHeaderYear("2003"))
 				.testUnaffected(hasHeaderYear("1990-2015"))
 				.test(hasHeaderYear("not a year"), hasHeaderYear(currentYear()));
+	}
+
+	@Test
+	public void should_remove_header_when_empty() throws Throwable {
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter("", package_).build())
+				.testUnaffected(getTestResource("license/MissingLicense.test"))
+				.test(getTestResource("license/HasLicense.test"), getTestResource("license/MissingLicense.test"));
 	}
 
 	private String header(String contents) throws IOException {


### PR DESCRIPTION
Allow licence header to be blank

- Previously blank licence headers would have a single new line appended
- This makes it possible to use spotless to remove licence headers on projects that don't want them