### PR TITLE
update kt fmt

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -115,6 +115,14 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 			style(Style.DROPBOX);
 		}
 
+		public void googleStyle() {
+			style(Style.GOOGLE);
+		}
+
+		public void kotlinlangStyle() {
+			style(Style.KOTLINLANG);
+		}
+
 		public void style(Style style) {
 			this.style = style;
 			replaceStep(createStep());


### PR DESCRIPTION
Just a quick poc to update the ktfmt. As there has been a new release  (https://github.com/facebookincubator/ktfmt/commit/7fbc9d98cb2c5b003ffd6dc28f095ea452f757ac).

I didn't test this, and this probably should be refactored more to use the `X_FORMAT` as the main driver instead of `Style` which is one of 3 variables and not the name of the combination of them.

Feel free to ignore this (but please still update spotless to be able to use the new formats in ktfmt 0.21) or to take over the branch.

I just felt like playing with the code for a little bit.