### PR TITLE
Bump ktfmt to 0.21 and add support to Google and Kotlinlang formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Bump ktfmt to 0.21 and add support to Google and Kotlinlang formats ([#812](https://github.com/diffplug/spotless/pull/812))
 
 ## [2.12.1] - 2021-02-16
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/BadSemver.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/BadSemver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.kotlin;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class BadSemver {
+	protected static int version(String input) {
+		Matcher matcher = BAD_SEMVER.matcher(input);
+		if (!matcher.find() || matcher.start() != 0) {
+			throw new IllegalArgumentException("Version must start with " + BAD_SEMVER.pattern());
+		}
+		String major = matcher.group(1);
+		String minor = matcher.group(2);
+		return version(Integer.parseInt(major), Integer.parseInt(minor));
+	}
+
+	/** Ambiguous after 2147.483647.blah-blah */
+	protected static int version(int major, int minor) {
+		return major * 1_000_000 + minor;
+	}
+
+	private static final Pattern BAD_SEMVER = Pattern.compile("(\\d+)\\.(\\d+)");
+}

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -16,7 +16,6 @@
 package com.diffplug.spotless.kotlin;
 
 import static com.diffplug.spotless.kotlin.KtfmtStep.Style.DEFAULT;
-import static com.diffplug.spotless.kotlin.KtfmtStep.Style.DROPBOX;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -33,18 +32,34 @@ public class KtfmtStep {
 	// prevent direct instantiation
 	private KtfmtStep() {}
 
-	private static final String DEFAULT_VERSION = "0.19";
+	private static final String DEFAULT_VERSION = "0.21";
 	static final String NAME = "ktfmt";
 	static final String PACKAGE = "com.facebook";
 	static final String MAVEN_COORDINATE = PACKAGE + ":ktfmt:";
 
 	/**
-	 * Used to allow dropbox style option through formatting options.
+	 * Used to allow multiple style option through formatting options and since when is each of them available.
 	 *
 	 * @see <a href="https://github.com/facebookincubator/ktfmt/blob/38486b0fb2edcabeba5540fcb69c6f1fa336c331/core/src/main/java/com/facebook/ktfmt/Formatter.kt#L47-L80">ktfmt source</a>
 	 */
 	public enum Style {
-		DEFAULT, DROPBOX
+		DEFAULT("DEFAULT_FORMAT", "0.0"), DROPBOX("DROPBOX_FORMAT", "0.11"), GOOGLE("GOOGLE_FORMAT", "0.21"), KOTLINLANG("KOTLINLANG_FORMAT", "0.21");
+
+		final private String format;
+		final private String since;
+
+		Style(String format, String since) {
+			this.format = format;
+			this.since = since;
+		}
+
+		String getFormat() {
+			return format;
+		}
+
+		String getSince() {
+			return since;
+		}
 	}
 
 	private static final String DROPBOX_STYLE_METHOD = "dropboxStyle";
@@ -86,6 +101,8 @@ public class KtfmtStep {
 	static final class State implements Serializable {
 		private static final long serialVersionUID = 1L;
 
+		private final String version;
+
 		private final String pkg;
 		/**
 		 * Option that allows to apply formatting options to perform a 4 spaces block and continuation indent.
@@ -95,6 +112,7 @@ public class KtfmtStep {
 		final JarState jarState;
 
 		State(String version, Provisioner provisioner, Style style) throws IOException {
+			this.version = version;
 			this.pkg = PACKAGE;
 			this.style = style;
 			this.jarState = JarState.from(MAVEN_COORDINATE + version, provisioner);
@@ -105,15 +123,15 @@ public class KtfmtStep {
 			Class<?> formatterClazz = classLoader.loadClass(pkg + ".ktfmt.FormatterKt");
 			return input -> {
 				try {
-					if (style == DROPBOX) {
+					if (style == DEFAULT) {
+						Method formatterMethod = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
+						return (String) formatterMethod.invoke(formatterClazz, input);
+					} else {
 						Class<?> formattingOptionsClazz = classLoader.loadClass(pkg + ".ktfmt.FormattingOptions");
 						Method formatterMethod = formatterClazz.getMethod(FORMATTER_METHOD, formattingOptionsClazz,
 								String.class);
-						Object formattingOptions = getDropboxStyleFormattingOptions(classLoader);
+						Object formattingOptions = getCustomFormattingOptions(classLoader, style);
 						return (String) formatterMethod.invoke(formatterClazz, formattingOptions, input);
-					} else {
-						Method formatterMethod = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
-						return (String) formatterMethod.invoke(formatterClazz, input);
 					}
 				} catch (InvocationTargetException e) {
 					throw ThrowingEx.unwrapCause(e);
@@ -121,17 +139,25 @@ public class KtfmtStep {
 			};
 		}
 
-		private Object getDropboxStyleFormattingOptions(ClassLoader classLoader) throws Exception {
+		private Object getCustomFormattingOptions(ClassLoader classLoader, Style style) throws Exception {
+			if (BadSemver.version(version) < BadSemver.version(style.since)) {
+				throw new IllegalStateException(String.format("The style %s is available from version %s (current version: %s)", style.name(), style.since, version));
+			}
+
 			try {
 				// ktfmt v0.19 and later
-				return classLoader.loadClass(pkg + ".ktfmt.FormatterKt").getField("DROPBOX_FORMAT").get(null);
+				return classLoader.loadClass(pkg + ".ktfmt.FormatterKt").getField(style.getFormat()).get(null);
 			} catch (NoSuchFieldException ignored) {}
 
 			// fallback to old, pre-0.19 ktfmt interface.
-			Class<?> formattingOptionsCompanionClazz = classLoader.loadClass(pkg + ".ktfmt.FormattingOptions$Companion");
-			Object companion = formattingOptionsCompanionClazz.getConstructors()[0].newInstance((Object) null);
-			Method formattingOptionsMethod = formattingOptionsCompanionClazz.getDeclaredMethod(DROPBOX_STYLE_METHOD);
-			return formattingOptionsMethod.invoke(companion);
+			if (style == Style.DEFAULT || style == Style.DROPBOX) {
+				Class<?> formattingOptionsCompanionClazz = classLoader.loadClass(pkg + ".ktfmt.FormattingOptions$Companion");
+				Object companion = formattingOptionsCompanionClazz.getConstructors()[0].newInstance((Object) null);
+				Method formattingOptionsMethod = formattingOptionsCompanionClazz.getDeclaredMethod(DROPBOX_STYLE_METHOD);
+				return formattingOptionsMethod.invoke(companion);
+			} else {
+				throw new IllegalStateException("Versions pre-0.19 can only use Default and Dropbox styles");
+			}
 		}
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Bump ktfmt to 0.21 and add support to Google and Kotlinlang formats ([#812](https://github.com/diffplug/spotless/pull/812))
 
 ## [5.10.2] - 2021-02-16
 ### Fixed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -115,6 +115,14 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 			style(Style.DROPBOX);
 		}
 
+		public void googleStyle() {
+			style(Style.GOOGLE);
+		}
+
+		public void kotlinlangStyle() {
+			style(Style.KOTLINLANG);
+		}
+
 		public void style(Style style) {
 			this.style = style;
 			replaceStep(createStep());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -97,9 +97,21 @@ public class KotlinGradleExtension extends FormatExtension {
 			addStep(createStep());
 		}
 
-		public void dropboxStyle() {
-			style = Style.DROPBOX;
+		public void style(Style style) {
+			this.style = style;
 			replaceStep(createStep());
+		}
+
+		public void dropboxStyle() {
+			style(Style.DROPBOX);
+		}
+
+		public void googleStyle() {
+			style(Style.GOOGLE);
+		}
+
+		public void kotlinlangStyle() {
+			style(Style.KOTLINLANG);
 		}
 
 		private FormatterStep createStep() {

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Bump ktfmt to 0.21 and add support to Google and Kotlinlang formats ([#812](https://github.com/diffplug/spotless/pull/812))
 
 ## [2.8.1] - 2021-02-16
 ### Fixed


### PR DESCRIPTION
Manually tested, @cgrushko can you take a look at this PR?

Should `getCustomFormattingOptions` have a better way to manage ktfmt versioning availability? I was thinking about adding to the `Style` enum a `since` property to throw errors.

EDIT:

I added the `since` property so spotless will throw an exception if the user tries to use a ktfmt version that doesn't have a specific format.