### PR TITLE
Ensure consistent ordering of inputs for RegisterDependenciesTask

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Ensure consistent ordering of task inputs for `RegisterDependenciesTask`,bso the task is `up-to-date` when the spotless config has not changed.
 
 ## [5.11.0] - 2021-03-05
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.execution.TaskExecutionGraph;
@@ -52,11 +54,10 @@ public class RegisterDependenciesTask extends DefaultTask {
 	public List<FormatterStep> getSteps() {
 		List<FormatterStep> allSteps = new ArrayList<>();
 		TaskExecutionGraph taskGraph = getProject().getGradle().getTaskGraph();
-		for (SpotlessTask task : tasks) {
-			if (taskGraph.hasTask(task)) {
-				allSteps.addAll(task.getSteps());
-			}
-		}
+		tasks.stream()
+				.filter(taskGraph::hasTask)
+				.sorted()
+				.forEach(task -> allSteps.addAll(task.getSteps()));
 		return allSteps;
 	}
 


### PR DESCRIPTION
Since the order that tasks are registered is not guaranteed, this can result in non-deterministic ordering of `RegisterDependenciesTask.getSteps()` which is declared as a Task input.

With this PR we sort the task list prior to constructing the list of formatter steps, ensuring that the task is `UP-TO-DATE` when no changes are made to formatters.
