### PR TITLE
Expose configuration exceptions in scalafmt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Update default google-java-format from 1.9 to 1.10.0
+* Expose configuration exceptions from scalafmt ([#837](https://github.com/diffplug/spotless/issues/837))
 
 ## [2.13.0] - 2021-03-05
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -106,7 +106,7 @@ public class ScalaFmtStep {
 				Class<?> configCls = classLoader.loadClass("org.scalafmt.config.Config");
 				Class<?> scalafmtCls = classLoader.loadClass("org.scalafmt.Scalafmt");
 
-				Object either;
+				Object configured;
 
 				try {
 					// scalafmt >= 1.6.0
@@ -114,8 +114,7 @@ public class ScalaFmtStep {
 
 					String configStr = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
-					Object configured = parseHoconConfig.invoke(null, configStr);
-					either = invokeNoArg(configured, "toEither");
+					configured = parseHoconConfig.invoke(null, configStr);
 				} catch (NoSuchMethodException e) {
 					// scalafmt >= v0.7.0-RC1 && scalafmt < 1.6.0
 					Method fromHocon = configCls.getMethod("fromHoconString", String.class, optionCls);
@@ -123,11 +122,10 @@ public class ScalaFmtStep {
 
 					String configStr = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
-					Object configured = fromHocon.invoke(null, configStr, fromHoconEmptyPath);
-					either = invokeNoArg(configured, "toEither");
+					configured = fromHocon.invoke(null, configStr, fromHoconEmptyPath);
 				}
 
-				config = invokeNoArg(invokeNoArg(either, "right"), "get");
+				config = invokeNoArg(configured, "get");
 			}
 			return input -> {
 				Object resultInsideFormatted = formatMethod.invoke(null, input, config, emptyRange);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -8,6 +8,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * Bump `eclipse-jdt` default version from `4.18.0` to `4.19.0`.
 * Bump `google-java-format` default version from `1.9` to `1.10.0`.
+* Expose configuration exceptions from scalafmt ([#837](https://github.com/diffplug/spotless/issues/837))
 
 ## [5.11.1] - 2021-03-26
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -8,6 +8,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * Bump `eclipse-jdt` default version from `4.18.0` to `4.19.0`.
 * Bump `google-java-format` default version from `1.9` to `1.10.0`.
+* Expose configuration exceptions from scalafmt ([#837](https://github.com/diffplug/spotless/issues/837))
 
 ## [2.9.0] - 2021-03-05
 ### Added

--- a/testlib/src/main/resources/scala/scalafmt/scalafmt.invalid.conf
+++ b/testlib/src/main/resources/scala/scalafmt/scalafmt.invalid.conf
@@ -1,0 +1,1 @@
+invalidScalaFmtConfigField = true

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -105,6 +105,6 @@ public class ScalaFmtStepTest extends ResourceHarness {
 
 		exception = assertThrows(InvocationTargetException.class,
 				() -> StepHarness.forStep(ScalaFmtStep.create("2.0.1", provisioner, invalidConfFile)).test("", ""));
-		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField"));
+		assertThat(exception.getTargetException().getMessage(), containsString("Invalid field: invalidScalaFmtConfigField"));
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -17,6 +17,9 @@ package com.diffplug.spotless.scala;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import com.diffplug.spotless.Provisioner;
 
 import org.junit.Test;
 
@@ -25,6 +28,12 @@ import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
+
+import org.junit.function.ThrowingRunnable;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class ScalaFmtStepTest extends ResourceHarness {
 	@Test
@@ -83,5 +92,21 @@ public class ScalaFmtStepTest extends ResourceHarness {
 				return ScalaFmtStep.create(version, TestProvisioner.mavenCentral(), configFile);
 			}
 		}.testEquals();
+	}
+
+	@Test
+	public void invalidConfiguration() throws Exception {
+		File invalidConfFile = createTestFile( "scala/scalafmt/scalafmt.invalid.conf" );
+		Provisioner provisioner = TestProvisioner.mavenCentral();
+
+		InvocationTargetException exception;
+
+		exception = assertThrows( InvocationTargetException.class,
+				() -> StepHarness.forStep(ScalaFmtStep.create("1.1.0", provisioner, invalidConfFile)).test( "", "" ) );
+		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField") );
+
+		exception = assertThrows( InvocationTargetException.class,
+				() -> StepHarness.forStep(ScalaFmtStep.create("2.0.1", provisioner, invalidConfFile)).test( "", "" ) );
+		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField") );
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,22 @@
  */
 package com.diffplug.spotless.scala;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
-import com.diffplug.spotless.Provisioner;
-
 import org.junit.Test;
 
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
-
-import org.junit.function.ThrowingRunnable;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
 
 public class ScalaFmtStepTest extends ResourceHarness {
 	@Test
@@ -96,18 +93,18 @@ public class ScalaFmtStepTest extends ResourceHarness {
 
 	@Test
 	public void invalidConfiguration() throws Exception {
-		File invalidConfFile = createTestFile( "scala/scalafmt/scalafmt.invalid.conf" );
+		File invalidConfFile = createTestFile("scala/scalafmt/scalafmt.invalid.conf");
 		Provisioner provisioner = TestProvisioner.mavenCentral();
 
 		InvocationTargetException exception;
 
-		exception = assertThrows( InvocationTargetException.class,
-				() -> StepHarness.forStep(ScalaFmtStep.create("1.1.0", provisioner, invalidConfFile)).test( "", "" ) );
-		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField") );
+		exception = assertThrows(InvocationTargetException.class,
+				() -> StepHarness.forStep(ScalaFmtStep.create("1.1.0", provisioner, invalidConfFile)).test("", ""));
+		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField"));
 		exception.printStackTrace();
 
-		exception = assertThrows( InvocationTargetException.class,
-				() -> StepHarness.forStep(ScalaFmtStep.create("2.0.1", provisioner, invalidConfFile)).test( "", "" ) );
-		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField") );
+		exception = assertThrows(InvocationTargetException.class,
+				() -> StepHarness.forStep(ScalaFmtStep.create("2.0.1", provisioner, invalidConfFile)).test("", ""));
+		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField"));
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -104,6 +104,7 @@ public class ScalaFmtStepTest extends ResourceHarness {
 		exception = assertThrows( InvocationTargetException.class,
 				() -> StepHarness.forStep(ScalaFmtStep.create("1.1.0", provisioner, invalidConfFile)).test( "", "" ) );
 		assertThat(exception.getTargetException().getMessage(), containsString("Invalid fields: invalidScalaFmtConfigField") );
+		exception.printStackTrace();
 
 		exception = assertThrows( InvocationTargetException.class,
 				() -> StepHarness.forStep(ScalaFmtStep.create("2.0.1", provisioner, invalidConfFile)).test( "", "" ) );


### PR DESCRIPTION
Read scalafmt configuration in a way that shows parsing errors.

Before this change invalid scalafmt configuration files would fail like this:

```
java.lang.reflect.InvocationTargetException
    ...
Caused by: java.util.NoSuchElementException: Either.right.value on Left
    at scala.util.Either$RightProjection.get(Either.scala:453
    ...
```

With this change any exceptions from scalafmt configuration parsing will be visible, for example:

```
java.lang.reflect.InvocationTargetException
    ...
Caused by: java.lang.IllegalStateException: Invalid fields: invalidScalaFmtConfigField
    at metaconfig.Configured.get(Configured.scala:11)
    ...
```

Resolves #837
