### PR TITLE
Improve handling for multiple targets

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Expose configuration exceptions from scalafmt ([#837](https://github.com/diffplug/spotless/issues/837))
 ### Fixed
 * Exclude `.git`, `.gradle` and `build` directories when multiple targets are specified ([#835](https://github.com/diffplug/spotless/issues/835)).
+  * As part of this fix, `**/blah.txt` is now handled the same as `**/*.txt`, which was always the expected behavior. Very unlikely to cause any user-visible changes in behavior.
 
 ## [5.11.1] - 2021-03-26
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump `eclipse-jdt` default version from `4.18.0` to `4.19.0`.
 * Bump `google-java-format` default version from `1.9` to `1.10.0`.
 * Expose configuration exceptions from scalafmt ([#837](https://github.com/diffplug/spotless/issues/837))
+### Fixed
+* Exclude `.git`, `.gradle` and `build` directories when multiple targets are specified ([#835](https://github.com/diffplug/spotless/issues/835)).
 
 ## [5.11.1] - 2021-03-26
 ### Fixed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,20 +22,16 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-import kotlin.jvm.internal.CollectionToArray;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -43,7 +39,6 @@ import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.tasks.util.PatternFilterable;
 
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.FormatterFunc;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -233,7 +233,7 @@ public class FormatExtension {
 			if (isExclude) {
 				return matchedFiles;
 			}
-			if (targetString.startsWith("**/*") || targetString.startsWith("**\\*")) {
+			if (targetString.startsWith("**/") || targetString.startsWith("**\\")) {
 				List<String> excludes = new ArrayList<>();
 				// no git
 				excludes.add(".git");

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import kotlin.jvm.internal.CollectionToArray;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -218,7 +219,9 @@ public class FormatExtension {
 	}
 
 	private final FileCollection parseTargetIsExclude(Object target, boolean isExclude) {
-		if (target instanceof FileCollection) {
+		if (target instanceof Collection) {
+			return parseTargetsIsExclude(((Collection) target).toArray(), isExclude);
+		} else if (target instanceof FileCollection) {
 			return (FileCollection) target;
 		} else if (target instanceof String) {
 			File dir = getProject().getProjectDir();

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultipleTargetsTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultipleTargetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
  */
 package com.diffplug.gradle.spotless;
 
-import com.diffplug.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
+
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.List;
+import com.diffplug.common.collect.Lists;
 
 public class MultipleTargetsTest extends GradleIntegrationHarness {
 	private static final List<String> TARGET_FILES = Lists.newArrayList("src/test.md", "src/test.1.txt", "src/test.2.txt");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultipleTargetsTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultipleTargetsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016-2020 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import com.diffplug.common.collect.Lists;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MultipleTargetsTest extends GradleIntegrationHarness {
+	private static final List<String> TARGET_FILES = Lists.newArrayList("src/test.md", "src/test.1.txt", "src/test.2.txt");
+	private static final List<String> NON_TARGET_FILES = Lists.newArrayList(".git/test.1.txt", ".gradle/test.1.txt", "build/test.1.txt");
+
+	@Test
+	public void testSingleRecursiveTargetMatchingSuffix() throws IOException {
+		runTest("target '**/*.txt'");
+	}
+
+	@Test
+	public void testSingleRecursiveTargetMatchingPrefix() throws IOException {
+		runTest("target '**/test.*'");
+	}
+
+	@Test
+	public void testSingleRecursiveTargetMatchingSubdirectory() throws IOException {
+		runTest("target 'src/**/*.txt'");
+	}
+
+	@Test
+	public void testExplicitTargets() throws IOException {
+		runTest("target('src/test.1.txt', 'src/test.2.txt')");
+	}
+
+	@Test
+	public void testNonRecursiveTargets() throws IOException {
+		runTest("target('src/*.1.txt', 'src/*.2.txt')");
+	}
+
+	@Test
+	public void testTwoRecursiveTargetsMatchingDifferentFiles() throws IOException {
+		runTest("target('**/*.1.txt', '**/*.2.txt')");
+	}
+
+	@Test
+	public void testTwoRecursiveTargetsMatchingIdenticalFiles() throws IOException {
+		runTest("target('**/*.txt', '**/test.*')");
+	}
+
+	@Test
+	public void testTwoRecursiveTargetsProvidedAsList() throws IOException {
+		runTest("target(['**/*.1.txt', '**/*.2.txt'])");
+	}
+
+	private void runTest(String targets) throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"spotless {",
+				"    format 'singleFile', {",
+				"        target 'src/test.md'",
+				"        custom 'lowercase', { it.toLowerCase(Locale.ROOT) }",
+				"        bumpThisNumberIfACustomStepChanges(1)",
+				"    }",
+				"    format 'multipleFiles', {",
+				"        " + targets,
+				"        custom 'lowercase', { it.toLowerCase(Locale.ROOT) }",
+				"        bumpThisNumberIfACustomStepChanges(1)",
+				"    }",
+				"}");
+
+		initContent(TARGET_FILES, "A");
+		initContent(NON_TARGET_FILES, "A");
+
+		BuildResult result = gradleRunner().withArguments("spotlessApply").build();
+
+		checkContent(TARGET_FILES, "a");
+		checkContent(NON_TARGET_FILES, "A");
+	}
+
+	private void initContent(List<String> files, String content) throws IOException {
+		for (String file : files) {
+			setFile(file).toContent(content);
+		}
+	}
+
+	private void checkContent(List<String> files, String content) throws IOException {
+		for (String file : files) {
+			assertFile(file).hasContent(content);
+		}
+	}
+}


### PR DESCRIPTION
Fix #835 by avoiding special treatment for multiple `String` targets.