### PR TITLE
Fix license header bug for years in range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix license header bug for years in range ([#840](https://github.com/diffplug/spotless/pull/840)).
 
 ## [2.13.1] - 2021-04-10
 ### Changed

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -175,11 +175,10 @@ public final class LicenseHeaderStep {
 				this.updateYearWithLatest = updateYearWithLatest;
 
 				boolean hasHeaderWithRange = false;
-				// year plus separator
-				int lastChars = 4 + yearSeparator.length();
-				if (beforeYear.endsWith(yearSeparator) && yearTokenIndex > lastChars) {
+				int yearPlusSep = 4 + yearSeparator.length();
+				if (beforeYear.endsWith(yearSeparator) && yearTokenIndex > yearPlusSep) {
 					// year from in range
-					String yearFrom = licenseHeader.substring(yearTokenIndex - lastChars, yearTokenIndex).substring(0, 4);
+					String yearFrom = licenseHeader.substring(yearTokenIndex - yearPlusSep, yearTokenIndex).substring(0, 4);
 					hasHeaderWithRange = YYYY.matcher(yearFrom).matches();
 				}
 				this.licenseHeaderWithRange = hasHeaderWithRange;

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix license header bug for years in range ([#840](https://github.com/diffplug/spotless/pull/840)).
 
 ## [5.12.0] - 2021-04-10
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix license header bug for years in range ([#840](https://github.com/diffplug/spotless/pull/840)).
 
 ## [2.10.0] - 2021-04-10
 ### Added

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -32,6 +32,7 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	private static final String FILE_NO_LICENSE = "license/FileWithoutLicenseHeader.test";
 	private static final String package_ = "package ";
 	private static final String HEADER_WITH_$YEAR = "This is a fake license, $YEAR. ACME corp.";
+	private static final String HEADER_WITH_RANGE_TO_$YEAR = "This is a fake license with range, 2009-$YEAR. ACME corp.";
 
 	@Test
 	public void parseExistingYear() throws Exception {
@@ -137,6 +138,10 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 		return hasHeaderYear(HEADER_WITH_$YEAR, years);
 	}
 
+	private String hasHeaderWithRangeAndWithYearTo(String toYear) throws IOException {
+		return hasHeaderYear(HEADER_WITH_RANGE_TO_$YEAR, toYear);
+	}
+
 	private static String currentYear() {
 		return String.valueOf(YearMonth.now().getYear());
 	}
@@ -200,5 +205,11 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				return builder.build();
 			}
 		}.testEquals();
+	}
+
+	@Test
+	public void should_apply_license_containing_YEAR_token_in_range() throws Throwable {
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_RANGE_TO_$YEAR), package_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
+		StepHarness.forStep(step).test(hasHeaderWithRangeAndWithYearTo("2015"), hasHeaderWithRangeAndWithYearTo(currentYear()));
 	}
 }


### PR DESCRIPTION
Added new field in LicenseHeaderStep:
- licenseHeaderWithRange

When license header contains range years then calculateYearExact
should return only second year in range

Should prevent the plugin from changing 2011-2020 to 2011-2011-2020 if the range of years is specified in the license file.
