### PR TITLE
Fix in LicenseHeaderStep which treats address as copyright year

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* LicenseHeaderStep treats address as copyright year ([#716](https://github.com/diffplug/spotless/issues/716))
 
 ## [2.13.2] - 2021-04-12
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -273,14 +273,22 @@ public final class LicenseHeaderStep {
 			Matcher yearMatcher = YYYY.matcher(content);
 			if (yearMatcher.find()) {
 				String firstYear = yearMatcher.group();
-				String secondYear;
+
+				String secondYear = null;
 				if (updateYearWithLatest) {
 					secondYear = firstYear.equals(yearToday) ? null : yearToday;
-				} else if (yearMatcher.find(yearMatcher.end() + 1)) {
-					secondYear = yearMatcher.group();
 				} else {
-					secondYear = null;
+					String contentWithSecondYear = content.substring(yearMatcher.end() + 1);
+					int endOfLine = contentWithSecondYear.indexOf('\n');
+					if (endOfLine != -1) {
+						contentWithSecondYear = contentWithSecondYear.substring(0, endOfLine);
+					}
+					Matcher secondYearMatcher = YYYY.matcher(contentWithSecondYear);
+					if (secondYearMatcher.find()) {
+						secondYear = secondYearMatcher.group();
+					}
 				}
+
 				if (secondYear == null) {
 					return firstYear;
 				} else {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* LicenseHeaderStep treats address as copyright year ([#716](https://github.com/diffplug/spotless/issues/716))
 
 ## [5.12.1] - 2021-04-13
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* LicenseHeaderStep treats address as copyright year ([#716](https://github.com/diffplug/spotless/issues/716))
 
 ## [2.10.1] - 2021-04-13
 ### Fixed

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -120,6 +120,18 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 				.test(getTestResource("license/HasLicense.test"), getTestResource("license/MissingLicense.test"));
 	}
 
+	private String licenceWithAddress() {
+		return "Copyright &#169; $YEAR FooBar Inc. All Rights Reserved.\n" +
+				" *\n" +
+				" * Use of this software is covered by inscrutable legal protection and\n" +
+				" * complex automation. Violaters of undisclosed terms must expect\n" +
+				" * unforeseen consequences.\n" +
+				" *\n" +
+				" * FooBar, Inc.\n" +
+				" * 9 Food Truck\n" +
+				" * Perry Derry, TX 55656 USA";
+	}
+
 	private String header(String contents) throws IOException {
 		return "/*\n" +
 				" * " + contents + "\n" +
@@ -211,5 +223,21 @@ public class LicenseHeaderStepTest extends ResourceHarness {
 	public void should_apply_license_containing_YEAR_token_in_range() throws Throwable {
 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_RANGE_TO_$YEAR), package_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
 		StepHarness.forStep(step).test(hasHeaderWithRangeAndWithYearTo("2015"), hasHeaderWithRangeAndWithYearTo(currentYear()));
+	}
+
+	@Test
+	public void should_update_year_for_license_with_address() throws Throwable {
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), package_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
+		StepHarness.forStep(step).test(
+				hasHeader(licenceWithAddress().replace("$YEAR", "2015")),
+				hasHeader(licenceWithAddress().replace("$YEAR", "2015-2021")));
+	}
+
+	@Test
+	public void should_preserve_year_for_license_with_address() throws Throwable {
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), package_).withYearMode(YearMode.PRESERVE).build();
+		StepHarness.forStep(step).test(
+				hasHeader(licenceWithAddress().replace("$YEAR", "2015").replace("FooBar Inc. All", "FooBar Inc.  All")),
+				hasHeader(licenceWithAddress().replace("$YEAR", "2015")));
 	}
 }


### PR DESCRIPTION
Should fix issue #716 

Currently the method calculateYearBySearching looks for the second year
only to the end of the line. There is no need to search to the end of
the license file because it is easy to confuse other data with the year.
