### PR TITLE
Use -- to separate arguments from paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Explicitly separate target file from git arguments when parsing year for license header to prevent command from failing on argument-like paths ([#847](https://github.com/diffplug/spotless/pull/847))
 
 ## [2.13.3] - 2021-04-20
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -335,7 +335,7 @@ public final class LicenseHeaderStep {
 		}
 
 		private static String parseYear(String cmd, File file) throws IOException {
-			String fullCmd = cmd + " " + file.getAbsolutePath();
+			String fullCmd = cmd + " -- " + file.getAbsolutePath();
 			ProcessBuilder builder = new ProcessBuilder().directory(file.getParentFile());
 			if (FileSignature.machineIsWin()) {
 				builder.command("cmd", "/c", fullCmd);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Explicitly separate target file from git arguments when parsing year for license header to prevent command from failing on argument-like paths ([#847](https://github.com/diffplug/spotless/pull/847))
 
 ## [5.12.2] - 2021-04-20
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Explicitly separate target file from git arguments when parsing year for license header to prevent command from failing on argument-like paths ([#847](https://github.com/diffplug/spotless/pull/847))
 
 ## [2.10.2] - 2021-04-20
 ### Fixed


### PR DESCRIPTION
Some paths have characters which make them ambiguous as to whether they're a path or argument

For example,

    $ git log --follow --find-renames=40% --reverse a/b-c-d/e.txt
    fatal: ambiguous argument 'a/b-c-d/e.txt': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'

    $ echo $?
    128

compared to

    $ git log --follow --find-renames=40% --reverse -- a/b-c-d/e.txt

    $ echo $?
    0

---

Please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)
