### PR TITLE
Reinstall node if necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Update ktfmt from 0.21 to 0.24
 ### Fixed
 * The `<url>` field in the maven POM is now set correctly ([#798](https://github.com/diffplug/spotless/issues/798))
+* Node is re-installed if some other build step removed it ([#863](https://github.com/diffplug/spotless/issues/863))
 
 ## [2.13.4] - 2021-04-21
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,5 +45,9 @@ class NodeServerLayout {
 
 	public File npmrcFile() {
 		return npmrcFile;
+	}
+
+	static File getBuildDirFromNodeModulesDir(File nodeModulesDir) {
+		return nodeModulesDir.getParentFile();
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,11 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 		new NpmProcess(npmProjectDir, this.npmExecutable).install();
 	}
 
-	protected ServerProcessInfo npmRunServer() throws ServerStartException {
+	protected ServerProcessInfo npmRunServer() throws ServerStartException, IOException {
+		if (!this.nodeModulesDir.exists()) {
+			prepareNodeServer(NodeServerLayout.getBuildDirFromNodeModulesDir(this.nodeModulesDir));
+		}
+
 		try {
 			// The npm process will output the randomly selected port of the http server process to 'server.port' file
 			// so in order to be safe, remove such a file if it exists before starting.

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Update ktfmt from 0.21 to 0.24
 ### Fixed
 * The `<url>` field in the maven POM is now set correctly ([#798](https://github.com/diffplug/spotless/issues/798))
+* Node is re-installed if some other build step removed it ([#863](https://github.com/diffplug/spotless/issues/863))
 
 ## [5.12.4] - 2021-04-21
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Node is re-installed if some other build step removed it ([#863](https://github.com/diffplug/spotless/issues/863))
 
 ## [2.11.0] - 2021-05-03
 ### Added


### PR DESCRIPTION
If node has been deleted between Spotless installing it and using it
(for example because React's `build` removes everything from the `build`
dir), it is not re-installed.

Fixes #863
