### PR TITLE
Revert goomph to ide pre-3.28, and use Java 11 for p2asmaven fatjar tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,8 +223,6 @@ jobs:
           command: ./gradlew -Pcom.diffplug.spotless.include.ext.nop2=true :eclipse-jdt:changelogPush -Prelease=true --stacktrace
   ext_do_release_cdt:
     << : *env_gradle
-    docker:
-      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - *restore_cache_wrapper
@@ -235,8 +233,6 @@ jobs:
           command: ./gradlew -Pcom.diffplug.spotless.include.ext.cdt=true :eclipse-cdt:changelogPush -Prelease=true --stacktrace
   ext_do_release_groovy:
     << : *env_gradle
-    docker:
-      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - *restore_cache_wrapper
@@ -247,8 +243,6 @@ jobs:
           command: ./gradlew -Pcom.diffplug.spotless.include.ext.groovy=true :eclipse-groovy:changelogPush -Prelease=true --stacktrace
   ext_do_release_wtp:
     << : *env_gradle
-    docker:
-      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - *restore_cache_wrapper

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
 		//   5.6.0+ Tried to add format named 'freshmark' of type class @ spotless-freshmark.gradle:55
 		id 'com.diffplug.spotless'                 version '5.5.0'
 		// https://github.com/diffplug/goomph/blob/main/CHANGES.md
-		id 'com.diffplug.eclipse.resourcefilters'  version '3.29.1'
+		id 'com.diffplug.eclipse.resourcefilters'  version '3.27.0'
 		// https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 		id 'com.gradle.plugin-publish'             version '0.14.0'
 		// https://github.com/gradle-nexus/publish-plugin/releases


### PR DESCRIPTION
Fixes #873
No change record entry required (only affecting Eclipse plugin build and CI).