### PR TITLE
Improve JsonSimple exception messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* Improved exception messages for [JSON formatting](https://github.com/diffplug/spotless/pull/885) failures
 
 ## [2.15.0] - 2021-06-17
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changed
+* Improved exception messages for [JSON formatting](https://github.com/diffplug/spotless/pull/885) failures
 
 ## [5.14.0] - 2021-06-17
 

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
@@ -73,12 +73,18 @@ public class JsonSimpleStepTest {
 
 	@Test
 	public void handlesInvalidJson() {
-		assertThatThrownBy(() -> doWithResource(stepHarness, "invalidJson")).isInstanceOf(AssertionError.class).hasMessage("Invalid JSON file provided");
+		assertThatThrownBy(() -> doWithResource(stepHarness, "invalidJson"))
+				.isInstanceOf(AssertionError.class)
+				.hasMessage("Unable to format JSON")
+				.hasRootCauseMessage("Expected a ',' or '}' at 9 [character 0 line 3]");
 	}
 
 	@Test
 	public void handlesNotJson() {
-		assertThatThrownBy(() -> doWithResource(stepHarness, "notJson")).isInstanceOf(AssertionError.class).hasMessage("Invalid JSON file provided");
+		assertThatThrownBy(() -> doWithResource(stepHarness, "notJson"))
+				.isInstanceOf(AssertionError.class)
+				.hasMessage("Unable to determine JSON type, expected a '{' or '[' but found '#'")
+				.hasNoCause();
 	}
 
 	@Test


### PR DESCRIPTION
Hey, just a small PR to improve some of the exception messages when formatting fails in JsonSimple.

Previously the target exception was silently discarded, so you knew a file couldn't be formatted but was up to you to work out why.  We now include the target exception as cause so it can appear in stack trace.

Also tweaked the message for the case where we can't determine if the root of the json tree is an object or array.