### PR TITLE
Added scalafmt 3 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0)
 
 ## [2.15.2] - 2021-07-20
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0)
+### Changed
+* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0) and bump default scalafmt version to `3.0.0` ([#913](https://github.com/diffplug/spotless/pull/913)).
 
 ## [2.15.2] - 2021-07-20
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -40,10 +40,12 @@ public class ScalaFmtStep {
 	private ScalaFmtStep() {}
 
 	private static final Pattern VERSION_PRE_2_0 = Pattern.compile("[10]\\.(\\d+)\\.\\d+");
+	private static final Pattern VERSION_PRE_3_0 = Pattern.compile("2\\.(\\d+)\\.\\d+");
 	private static final String DEFAULT_VERSION = "2.0.1";
 	static final String NAME = "scalafmt";
 	static final String MAVEN_COORDINATE_PRE_2_0 = "com.geirsson:scalafmt-core_2.11:";
-	static final String MAVEN_COORDINATE = "org.scalameta:scalafmt-core_2.11:";
+	static final String MAVEN_COORDINATE_PRE_3_0 = "org.scalameta:scalafmt-core_2.11:";
+	static final String MAVEN_COORDINATE = "org.scalameta:scalafmt-core_2.13:";
 
 	public static FormatterStep create(Provisioner provisioner) {
 		return create(defaultVersion(), provisioner, null);
@@ -69,9 +71,11 @@ public class ScalaFmtStep {
 
 		State(String version, Provisioner provisioner, @Nullable File configFile) throws IOException {
 			String mavenCoordinate;
-			Matcher versionMatcher = VERSION_PRE_2_0.matcher(version);
-			if (versionMatcher.matches()) {
+			Matcher versionMatcher;
+			if ((versionMatcher = VERSION_PRE_2_0.matcher(version)).matches()) {
 				mavenCoordinate = MAVEN_COORDINATE_PRE_2_0;
+			} else if ((versionMatcher = VERSION_PRE_3_0.matcher(version)).matches()) {
+				mavenCoordinate = MAVEN_COORDINATE_PRE_3_0;
 			} else {
 				mavenCoordinate = MAVEN_COORDINATE;
 			}

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -34,14 +34,14 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
 
-/** Wraps up [scalafmt](https://github.com/olafurpg/scalafmt) as a FormatterStep. */
+/** Wraps up [scalafmt](https://github.com/scalameta/scalafmt) as a FormatterStep. */
 public class ScalaFmtStep {
 	// prevent direct instantiation
 	private ScalaFmtStep() {}
 
 	private static final Pattern VERSION_PRE_2_0 = Pattern.compile("[10]\\.(\\d+)\\.\\d+");
 	private static final Pattern VERSION_PRE_3_0 = Pattern.compile("2\\.(\\d+)\\.\\d+");
-	private static final String DEFAULT_VERSION = "2.0.1";
+	private static final String DEFAULT_VERSION = "3.0.0";
 	static final String NAME = "scalafmt";
 	static final String MAVEN_COORDINATE_PRE_2_0 = "com.geirsson:scalafmt-core_2.11:";
 	static final String MAVEN_COORDINATE_PRE_3_0 = "org.scalameta:scalafmt-core_2.11:";

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0)
 
 ## [5.14.2] - 2021-07-20
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,7 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
-* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0)
+### Changed
+* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0) and bump default scalafmt version to `3.0.0` ([#913](https://github.com/diffplug/spotless/pull/913)).
 
 ## [5.14.2] - 2021-07-20
 ### Fixed

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ScalaExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ScalaExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ public class ScalaExtensionTest extends GradleIntegrationHarness {
 		setFile("scalafmt.conf").toResource("scala/scalafmt/scalafmt.conf");
 		setFile("src/main/scala/basic.scala").toResource("scala/scalafmt/basic.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/scala/basic.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf_2.0.1");
+		assertFile("src/main/scala/basic.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf_3.0.0");
 	}
 }

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,7 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0)
+### Changed
+* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0) and bump default scalafmt version to `3.0.0` ([#913](https://github.com/diffplug/spotless/pull/913)).
 
 ## [2.12.2] - 2021-07-20
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0)
 
 ## [2.12.2] - 2021-07-20
 ### Fixed

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/IncludesExcludesTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/IncludesExcludesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ public class IncludesExcludesTest extends MavenIntegrationHarness {
 	private static final String JAVA_FORMATTED = "java/eclipse/JavaCodeFormatted.test";
 	private static final String JAVA_UNFORMATTED = "java/eclipse/JavaCodeUnformatted.test";
 	private static final String SCALA_UNFORMATTED = "scala/scalafmt/basic.dirty";
-	private static final String SCALA_FORMATTED = "scala/scalafmt/basic.clean_2.0.1";
+	private static final String SCALA_FORMATTED = "scala/scalafmt/basic.clean_3.0.0";
 
 	@Test
 	public void testDefaultIncludesJava() throws Exception {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public class MultiModuleProjectTest extends MavenIntegrationHarness {
 		assertFile("two/src/main/java/test1.java").sameAsResource("java/eclipse/JavaCodeFormatted.test");
 		assertFile("two/src/test/java/test2.java").sameAsResource("java/eclipse/JavaCodeFormatted.test");
 
-		assertFile("three/src/main/scala/test1.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf_2.0.1");
-		assertFile("three/src/test/scala/test2.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf_2.0.1");
+		assertFile("three/src/main/scala/test1.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf_3.0.0");
+		assertFile("three/src/test/scala/test2.scala").sameAsResource("scala/scalafmt/basic.cleanWithCustomConf_3.0.0");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/scala/ScalafmtTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/scala/ScalafmtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ public class ScalafmtTest extends MavenIntegrationHarness {
 	public void testScalafmtWithDefaultConfig() throws Exception {
 		writePomWithScalaSteps("<scalafmt/>");
 
-		runTest("scala/scalafmt/basic.clean_2.0.1");
+		runTest("scala/scalafmt/basic.clean_3.0.0");
 	}
 
 	@Test
@@ -36,7 +36,7 @@ public class ScalafmtTest extends MavenIntegrationHarness {
 				"  <file>${project.basedir}/scalafmt.conf</file>",
 				"</scalafmt>");
 
-		runTest("scala/scalafmt/basic.cleanWithCustomConf_2.0.1");
+		runTest("scala/scalafmt/basic.cleanWithCustomConf_3.0.0");
 	}
 
 	private void runTest(String s) throws Exception {

--- a/testlib/src/main/resources/scala/scalafmt/basic.cleanWithCustomConf_3.0.0
+++ b/testlib/src/main/resources/scala/scalafmt/basic.cleanWithCustomConf_3.0.0
@@ -1,0 +1,27 @@
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a
+    extends b
+    with c {
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1
+      x: Int @annot2 =
+        2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 =>
+        3
+      case <A>2</A> =>
+        2
+    }
+  }
+}

--- a/testlib/src/main/resources/scala/scalafmt/basic.clean_3.0.0
+++ b/testlib/src/main/resources/scala/scalafmt/basic.clean_3.0.0
@@ -1,0 +1,20 @@
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+  def foo[T: Int#Double#Triple, R <% String](
+      @annot1
+      x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 =>
+        3
+      case <A>2</A> => 2
+    }
+  }
+}

--- a/testlib/src/main/resources/scala/scalafmt/basicPost3.0.0.clean
+++ b/testlib/src/main/resources/scala/scalafmt/basicPost3.0.0.clean
@@ -1,0 +1,20 @@
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+  def foo[T: Int#Double#Triple, R <% String](
+      @annot1
+      x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 =>
+        3
+      case <A>2</A> => 2
+    }
+  }
+}

--- a/testlib/src/main/resources/scala/scalafmt/basicPost3.0.0.cleanWithCustomConf
+++ b/testlib/src/main/resources/scala/scalafmt/basicPost3.0.0.cleanWithCustomConf
@@ -1,0 +1,27 @@
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a
+    extends b
+    with c {
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1
+      x: Int @annot2 =
+        2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 =>
+        3
+      case <A>2</A> =>
+        2
+    }
+  }
+}

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -39,6 +39,8 @@ public class ScalaFmtStepTest extends ResourceHarness {
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.clean_1.1.0");
 		StepHarness.forStep(ScalaFmtStep.create("2.0.1", TestProvisioner.mavenCentral(), null))
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.clean_2.0.1");
+		StepHarness.forStep(ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), null))
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.clean_3.0.0");
 	}
 
 	@Test
@@ -47,6 +49,8 @@ public class ScalaFmtStepTest extends ResourceHarness {
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.cleanWithCustomConf_1.1.0");
 		StepHarness.forStep(ScalaFmtStep.create("2.0.1", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf")))
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.cleanWithCustomConf_2.0.1");
+		StepHarness.forStep(ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf")))
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.cleanWithCustomConf_3.0.0");
 	}
 
 	@Test
@@ -61,6 +65,20 @@ public class ScalaFmtStepTest extends ResourceHarness {
 		FormatterStep step = ScalaFmtStep.create("2.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf"));
 		StepHarness.forStep(step)
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basicPost2.0.0.cleanWithCustomConf");
+	}
+
+	@Test
+	public void behaviorDefaultConfigVersion_3_0_0() throws Exception {
+		FormatterStep step = ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), null);
+		StepHarness.forStep(step)
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basicPost3.0.0.clean");
+	}
+
+	@Test
+	public void behaviorCustomConfigVersion_3_0_0() throws Exception {
+		FormatterStep step = ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf"));
+		StepHarness.forStep(step)
+				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basicPost3.0.0.cleanWithCustomConf");
 	}
 
 	@Test
@@ -106,5 +124,9 @@ public class ScalaFmtStepTest extends ResourceHarness {
 		exception = assertThrows(InvocationTargetException.class,
 				() -> StepHarness.forStep(ScalaFmtStep.create("2.0.1", provisioner, invalidConfFile)).test("", ""));
 		assertThat(exception.getTargetException().getMessage(), containsString("Invalid field: invalidScalaFmtConfigField"));
+
+		exception = assertThrows(InvocationTargetException.class,
+				() -> StepHarness.forStep(ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile)).test("", ""));
+		assertThat(exception.getTargetException().getMessage(), containsString("found option 'invalidScalaFmtConfigField' which wasn't expected"));
 	}
 }


### PR DESCRIPTION
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
