### PR TITLE
Bump defaults to latest for GJF, ktlint, and ktfmt.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0) and bump default scalafmt version to `3.0.0` ([#913](https://github.com/diffplug/spotless/pull/913)).
+* Bump default versions ([#915](https://github.com/diffplug/spotless/pull/915))
+  * `ktfmt` from `0.24` to `0.27`
+  * `ktlint` from `0.35.0` to `0.42.1`
+  * `google-java-format` from `1.10.0` to `1.11.0`
 
 ## [2.15.2] - 2021-07-20
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -100,7 +100,7 @@ public class GoogleJavaFormatStep {
 	}
 
 	private static final String LATEST_VERSION_JRE_8 = "1.7";
-	private static final String LATEST_VERSION_JRE_11 = "1.10.0";
+	private static final String LATEST_VERSION_JRE_11 = "1.11.0";
 
 	public static String defaultStyle() {
 		return DEFAULT_STYLE;

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -37,7 +37,7 @@ public class KtLintStep {
 	// prevent direct instantiation
 	private KtLintStep() {}
 
-	private static final String DEFAULT_VERSION = "0.35.0";
+	private static final String DEFAULT_VERSION = "0.42.1";
 	static final String NAME = "ktlint";
 	static final String PACKAGE_PRE_0_32 = "com.github.shyiko";
 	static final String PACKAGE = "com.pinterest";

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -32,7 +32,7 @@ public class KtfmtStep {
 	// prevent direct instantiation
 	private KtfmtStep() {}
 
-	private static final String DEFAULT_VERSION = "0.24";
+	private static final String DEFAULT_VERSION = "0.27";
 	static final String NAME = "ktfmt";
 	static final String PACKAGE = "com.facebook";
 	static final String MAVEN_COORDINATE = PACKAGE + ":ktfmt:";

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0) and bump default scalafmt version to `3.0.0` ([#913](https://github.com/diffplug/spotless/pull/913)).
+* Bump default versions ([#915](https://github.com/diffplug/spotless/pull/915))
+  * `ktfmt` from `0.24` to `0.27`
+  * `ktlint` from `0.35.0` to `0.42.1`
+  * `google-java-format` from `1.10.0` to `1.11.0`
 
 ## [5.14.2] - 2021-07-20
 ### Fixed

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -126,8 +126,7 @@ public class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 				"    }",
 				"}");
 		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/basic.dirty");
-		BuildResult result = gradleRunner().withArguments("spotlessApply").buildAndFail();
-		assertThat(result.getOutput()).contains("Unexpected indentation (4) (it should be 6)");
+		gradleRunner().withArguments("spotlessCheck").buildAndFail();
 	}
 
 	@Test

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Added support for [scalafmt 3.0.0](https://github.com/scalameta/scalafmt/releases/tag/v3.0.0) and bump default scalafmt version to `3.0.0` ([#913](https://github.com/diffplug/spotless/pull/913)).
+* Bump default versions ([#915](https://github.com/diffplug/spotless/pull/915))
+  * `ktfmt` from `0.24` to `0.27`
+  * `ktlint` from `0.35.0` to `0.42.1`
+  * `google-java-format` from `1.10.0` to `1.11.0`
 
 ## [2.12.2] - 2021-07-20
 ### Fixed


### PR DESCRIPTION
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
