### PR TITLE
Fix javadoc publishing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   * `ktfmt` from `0.24` to `0.27`
   * `ktlint` from `0.35.0` to `0.42.1`
   * `google-java-format` from `1.10.0` to `1.11.0`
+* Fix javadoc publishing ([#916](https://github.com/diffplug/spotless/pull/916) fixes [#775](https://github.com/diffplug/spotless/issues/775)).
 
 ## [2.15.2] - 2021-07-20
 ### Fixed

--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -23,13 +23,17 @@ if (project.parent == null) {
 ///////////
 // MAVEN //
 ///////////
+java {
+	withJavadocJar()
+	withSourcesJar()
+}
+
+tasks.named('sourcesJar') {
+	dependsOn 'jar'
+}
+
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-
-task sourcesJar(type: Jar) {
-	classifier = 'sources'
-	from sourceSets.main.allJava
-}
 
 // Where it's possible to name parameters and methods clearly enough
 // that javadoc is not necessary, why make the code bigger?
@@ -38,7 +42,6 @@ task sourcesJar(type: Jar) {
 javadoc {
 	options.addStringOption('Xdoclint:none', '-quiet')
 	options.addStringOption('Xwerror', '-quiet')
-	enabled = org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8
 }
 // make sure bad javadoc breaks the build
 tasks.named('check') {
@@ -51,7 +54,6 @@ def javadocInfo = '<h2>' + makeLink("https://github.com/${org}/${name}", "${grou
 		' by ' + makeLink('https://www.diffplug.com', 'DiffPlug') + '</h2>'
 
 String dotdotGradle = project.name.startsWith('eclipse-') ? '../../gradle' : '../gradle'
-apply plugin: 'org.jdrupes.mdoclet'
 javadoc {
 	options.encoding = 'UTF-8'
 	// Where it's possible to name parameters and methods clearly enough
@@ -59,6 +61,7 @@ javadoc {
 	//
 	// Thus, no javadoc warnings.
 	options.addStringOption('Xdoclint:none', '-quiet')
+	options.addStringOption('source', '8')
 	// setup the header
 	options.header javadocInfo
 	options.footer javadocInfo
@@ -69,11 +72,6 @@ javadoc {
 	// links to javadoc from the other versions
 	options.linksOffline("https://javadoc.io/static/com.diffplug.spotless/spotless-lib/${rootProject.spotlessChangelog.versionLast}", "${dotdotGradle}/javadoc/spotless-lib")
 	options.linksOffline("https://javadoc.io/static/com.diffplug.spotless/spotless-lib-extra/${rootProject.spotlessChangelog.versionLast}", "${dotdotGradle}/javadoc/spotless-lib-extra")
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-	classifier = 'javadoc'
-	from javadoc.destinationDir
 }
 
 ////////////////

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Uses [.gitattributes](https://git-scm.com/docs/gitattributes) to determine
- * the appropriate line ending. Falls back to the `core.eol` property in the
+ * the appropriate line ending. Falls back to the {@code core.eol} property in the
  * git config if there are no applicable git attributes, then finally falls
  * back to the platform native.
  */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -53,7 +53,7 @@ import com.diffplug.spotless.FileSignature;
 /**
  * How to use:
  * - For best performance, you should have one instance of GitRatchet, shared by all projects.
- * - Use {@link #rootTreeShaOf(Object, String)} to turn `origin/master` into the SHA of the tree object at that reference
+ * - Use {@link #rootTreeShaOf(Object, String)} to turn {@code origin/master} into the SHA of the tree object at that reference
  * - Use {@link #isClean(Object, ObjectId, File)} to see if the given file is "git clean" relative to that tree
  * - If you have up-to-date checking and want the best possible performance, use {@link #subtreeShaOf(Object, ObjectId)} to optimize up-to-date checks on a per-project basis.
  */
@@ -141,7 +141,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 	/**
 	 * The first part of making this fast is finding the appropriate git repository quickly.  Because of composite
 	 * builds and submodules, it's quite possible that a single Gradle project will span across multiple git repositories.
-	 * We cache the Repository for every Project in `gitRoots`, and use dynamic programming to populate it.
+	 * We cache the Repository for every Project in {@code gitRoots}, and use dynamic programming to populate it.
 	 */
 	protected Repository repositoryFor(Project project) throws IOException {
 		Repository repo = gitRoots.get(project);

--- a/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
+++ b/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * If either part of that fails, it shows you why
  * and helps you fix it.
  *
- * Usage: `ForeignExe.nameAndVersion("grep", "2.5.7").confirmVersionAndGetAbsolutePath()`
+ * Usage: {@code ForeignExe.nameAndVersion("grep", "2.5.7").confirmVersionAndGetAbsolutePath()}
  * will find grep, confirm that it is version 2.5.7, and then return.
  */
 public class ForeignExe {
@@ -55,7 +55,7 @@ public class ForeignExe {
 		return this;
 	}
 
-	/** A regex which can parse the version out of the output of the {@link #versionFlag(String)} command (defaults to `version (\\S*)`) */
+	/** A regex which can parse the version out of the output of the {@link #versionFlag(String)} command (defaults to {@code version (\\S*)}) */
 	public ForeignExe versionRegex(Pattern versionRegex) {
 		this.versionRegex = Objects.requireNonNull(versionRegex);
 		return this;

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ public interface FormatExceptionPolicy extends Serializable, NoLambda {
 	public void handleError(Throwable e, FormatterStep step, String relativePath);
 
 	/**
-	 * Returns a byte array representation of everything inside this `FormatExceptionPolicy`.
+	 * Returns a byte array representation of everything inside this {@code FormatExceptionPolicy}.
 	 *
 	 * The main purpose of this method is to ensure one can't instantiate this class with lambda
 	 * expressions, which are notoriously difficult to serialize and deserialize properly.
@@ -31,7 +31,7 @@ public interface FormatExceptionPolicy extends Serializable, NoLambda {
 	public byte[] toBytes();
 
 	/**
-	 * A policy which rethrows subclasses of `Error` and logs other kinds of Exception.
+	 * A policy which rethrows subclasses of {@code Error} and logs other kinds of Exception.
 	 */
 	public static FormatExceptionPolicy failOnlyOnError() {
 		return new FormatExceptionPolicyLegacy();

--- a/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
@@ -33,7 +33,7 @@ public interface FormatterFunc {
 	}
 
 	/**
-	 * `Function<String, String>` and `BiFunction<String, File, String>` whose implementation
+	 * {@code Function<String, String>} and {@code BiFunction<String, File, String>} whose implementation
 	 * requires a resource which should be released when the function is no longer needed.
 	 */
 	interface Closeable extends FormatterFunc, AutoCloseable {
@@ -45,10 +45,10 @@ public interface FormatterFunc {
 		 *
 		 * It's important for FormatterStep's to allocate their resources as lazily as possible.
 		 * It's easy to create a resource inside the state, and not realize that it may not be
-		 * released.  It's far better to use one of the non-deprecated `of()` methods below.
+		 * released.  It's far better to use one of the non-deprecated {@code of()} methods below.
 		 *
 		 * The bug (and its fix) which is easy to write using this method: https://github.com/diffplug/spotless/commit/7f16ecca031810b5e6e6f647e1f10a6d2152d9f4
-		 * How the `of()` methods below make the correct thing easier to write and safer: https://github.com/diffplug/spotless/commit/18c10f9c93d6f18f753233d0b5f028d5f0961916
+		 * How the {@code of()} methods below make the correct thing easier to write and safer: https://github.com/diffplug/spotless/commit/18c10f9c93d6f18f753233d0b5f028d5f0961916
 		 */
 		public static Closeable ofDangerous(AutoCloseable closeable, FormatterFunc function) {
 			Objects.requireNonNull(closeable, "closeable");
@@ -135,7 +135,7 @@ public interface FormatterFunc {
 
 	/**
 	 * Ideally, formatters don't need the underlying file. But in case they do, they should only use it's path,
-	 * and should never read the content inside the file, because that breaks the `Function<String, String>` composition
+	 * and should never read the content inside the file, because that breaks the {@code Function<String, String>} composition
 	 * that Spotless is based on.  For the rare case that you need access to the file, use this method
 	 * or {@link NeedsFile} to create a {@link FormatterFunc} which needs the File.
 	 */

--- a/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import java.io.File;
 import java.util.Objects;
 
 /**
- * A `Function<String, String>` which can throw an exception.  Technically, there
- * is also a `File` argument which gets passed around as well, but that is invisible
+ * A {@code Function<String, String>} which can throw an exception.  Technically, there
+ * is also a {@code File} argument which gets passed around as well, but that is invisible
  * to formatters.  If you need the File, see {@link NeedsFile}.
  */
 @FunctionalInterface

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ public interface FormatterStep extends Serializable {
 	 * @param rawUnix
 	 *            the content to format, guaranteed to have unix-style newlines ('\n'); never null
 	 * @param file
-	 *            the file which `rawUnix` was obtained from; never null. Pass an empty file using
-	 *            `new File("")` if and only if no file is actually associated with `rawUnix`
+	 *            the file which {@code rawUnix} was obtained from; never null. Pass an empty file using
+	 *            {@code new File("")} if and only if no file is actually associated with {@code rawUnix}
 	 * @return the formatted content, guaranteed to only have unix-style newlines; may return null
 	 *         if the formatter step doesn't have any changes to make
 	 * @throws Exception if the formatter step experiences a problem

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public final class JarState implements Serializable {
 
 	/**
 	 * Returns a classloader containing the only jars in this JarState.
-	 * Look-up of classes in the `org.slf4j` package
+	 * Look-up of classes in the {@code org.slf4j} package
 	 * are not taken from the JarState, but instead redirected to the class loader of this class to enable
 	 * passthrough logging.
 	 * <br/>
@@ -91,7 +91,7 @@ public final class JarState implements Serializable {
 
 	/**
 	 * Returns a classloader containing the only jars in this JarState.
-	 * Look-up of classes in the `org.slf4j` package
+	 * Look-up of classes in the {@code org.slf4j} package
 	 * are not taken from the JarState, but instead redirected to the class loader of this class to enable
 	 * passthrough logging.
 	 * <br/>

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  */
 public enum LineEnding {
 	// @formatter:off
-	/** Uses the same line endings as Git, using `.gitattributes` and the `core.eol` property. */
+	/** Uses the same line endings as Git, using {@code .gitattributes} and the {@code core.eol} property. */
 	GIT_ATTRIBUTES {
 		/** .gitattributes is path-specific, so you must use {@link LineEnding#createPolicy(File, Supplier)}. */
 		@Override @Deprecated
@@ -37,11 +37,11 @@ public enum LineEnding {
 			return super.createPolicy();
 		}
 	},
-	/** `\n` on unix systems, `\r\n` on windows systems. */
+	/** {@code \n} on unix systems, {@code \r\n} on windows systems. */
 	PLATFORM_NATIVE,
-	/** `\r\n` */
+	/** {@code \r\n} */
 	WINDOWS,
-	/** `\n` */
+	/** {@code \n} */
 	UNIX;
 	// @formatter:on
 

--- a/lib/src/main/java/com/diffplug/spotless/NoLambda.java
+++ b/lib/src/main/java/com/diffplug/spotless/NoLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,11 @@ import java.util.Arrays;
  */
 public interface NoLambda extends Serializable {
 	/**
-	 * Returns a byte array representation of everything inside this `SerializableFileFilter`.
+	 * Returns a byte array representation of everything inside this {@code SerializableFileFilter}.
 	 *
 	 * The main purpose of this method is to ensure one can't instantiate this class with lambda
 	 * expressions, which are notoriously difficult to serialize and deserialize properly. (See
-	 * `SerializableFileFilterImpl.SkipFilesNamed` for an example of how to make a serializable
+	 * {@code SerializableFileFilterImpl.SkipFilesNamed} for an example of how to make a serializable
 	 * subclass.)
 	 */
 	public byte[] toBytes();

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -256,7 +256,7 @@ public final class PaddedCell {
 
 		private byte[] canonicalBytes() {
 			if (canonicalBytes == null) {
-				throw new IllegalStateException("First make sure that `!isClean()` and `!didNotConverge()`");
+				throw new IllegalStateException("First make sure that {@code !isClean()} and {@code !didNotConverge()}");
 			}
 			return canonicalBytes;
 		}
@@ -270,7 +270,7 @@ public final class PaddedCell {
 		}
 	}
 
-	/** Returns the DirtyState which corresponds to `isClean()`. */
+	/** Returns the DirtyState which corresponds to {@code isClean()}. */
 	public static DirtyState isClean() {
 		return isClean;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,12 +48,12 @@ public class ProcessRunner implements AutoCloseable {
 
 	public ProcessRunner() {}
 
-	/** Executes the given shell command (using `cmd` on windows and `sh` on unix). */
+	/** Executes the given shell command (using {@code cmd} on windows and {@code sh} on unix). */
 	public Result shell(String cmd) throws IOException, InterruptedException {
 		return shellWinUnix(cmd, cmd);
 	}
 
-	/** Executes the given shell command (using `cmd` on windows and `sh` on unix). */
+	/** Executes the given shell command (using {@code cmd} on windows and {@code sh} on unix). */
 	public Result shellWinUnix(String cmdWin, String cmdUnix) throws IOException, InterruptedException {
 		List<String> args;
 		if (FileSignature.machineIsWin()) {

--- a/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
+++ b/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,8 +96,8 @@ public final class SpotlessCache {
 	private static volatile Object lastClear;
 
 	/**
-	 * Closes all cached classloaders iff `key` is not `.equals()` to the last call to `clearOnce()`.
-	 * If `key` is null, the clear will always happen (as though null != null).
+	 * Closes all cached classloaders iff {@code key} is not {@code .equals()} to the last call to {@code clearOnce()}.
+	 * If {@code key} is null, the clear will always happen (as though null != null).
 	 */
 	public static boolean clearOnce(@Nullable Object key) {
 		synchronized (instance) {

--- a/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
+++ b/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,13 +96,13 @@ public final class ThrowingEx {
 	/**
 	 * Utility method for rethrowing an exception's cause with as few wrappers as possible.
 	 *
-	 * ```java
+	 * <pre>{@code
 	 * try {
 	 *     doSomething();
 	 * } catch (Throwable e) {
 	 *     throw unwrapCause(e);
 	 * }
-	 * ```
+	 * }</pre>
 	 */
 	public static RuntimeException unwrapCause(Throwable e) {
 		Throwable cause = e.getCause();

--- a/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
+++ b/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
@@ -116,14 +116,14 @@ public final class ThrowingEx {
 	/**
 	 * Rethrows errors, wraps and returns everything else as a runtime exception.
 	 *
+	 * <pre>{@code
 	 * try {
 	 *     doSomething();
 	 * } catch (Throwable e) {
 	 *     throw asRuntimeRethrowError(e);
 	 * }
-	 * ```
-	 *
-	 * */
+	 * }</pre>
+	 */
 	static RuntimeException asRuntimeRethrowError(Throwable e) {
 		if (e instanceof Error) {
 			throw (Error) e;

--- a/lib/src/main/java/com/diffplug/spotless/annotations/Internal.java
+++ b/lib/src/main/java/com/diffplug/spotless/annotations/Internal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Signifies that a `public` API is actually an implementation detail, and should be treated as if it
- * were `private`.
+ * Signifies that a {@code public} API is actually an implementation detail, and should be treated as if it
+ * were {@code private}.
  *
  * The user of the API should be warned that it may unexpectedly disappear in future versions of
  * Spotless. Usually the best place to put this warning is in the API's class JavaDoc.

--- a/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class ClangFormatStep {
 	private State createState() throws IOException, InterruptedException {
 		String howToInstall = "" +
 				"You can download clang-format from https://releases.llvm.org and " +
-				"then point Spotless to it with `pathToExe('/path/to/clang-format')` " +
+				"then point Spotless to it with {@code pathToExe('/path/to/clang-format')} " +
 				"or you can use your platform's package manager:" +
 				"\n  win:   choco install llvm --version {version}  (try dropping version if it fails)" +
 				"\n  mac:   brew install clang-format (TODO: how to specify version?)" +
@@ -79,7 +79,7 @@ public class ClangFormatStep {
 				.pathToExe(pathToExe)
 				.fixCantFind(howToInstall)
 				.fixWrongVersion(
-						"You can tell Spotless to use the version you already have with `clangFormat('{versionFound}')`" +
+						"You can tell Spotless to use the version you already have with {@code clangFormat('{versionFound}')}" +
 								"or you can download the currently specified version, {version}.\n" + howToInstall)
 				.confirmVersionAndGetAbsolutePath();
 		return new State(this, exeAbsPath);

--- a/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import com.diffplug.spotless.LineEnding;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class PipeStepPair {
-	/** The two steps will be named `<name>In` and `<name>Out`. */
+	/** The two steps will be named {@code <name>In} and {@code <name>Out}. */
 	public static Builder named(String name) {
 		return new Builder(name);
 	}

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -94,7 +94,7 @@ public class GoogleJavaFormatStep {
 		}
 	}
 
-	/** On JRE 11+, returns `1.9`. On earlier JREs, returns `1.7`. */
+	/** On JRE 11+, returns {@code 1.9}. On earlier JREs, returns {@code 1.7}. */
 	public static String defaultVersion() {
 		return JRE_VERSION >= 11 ? LATEST_VERSION_JRE_11 : LATEST_VERSION_JRE_8;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,8 +63,8 @@ public class BlackStep {
 		String trackingIssue = "\n  github issue to handle this better: https://github.com/diffplug/spotless/issues/674";
 		String exeAbsPath = ForeignExe.nameAndVersion("black", version)
 				.pathToExe(pathToExe)
-				.fixCantFind("Try running `pip install black=={version}`, or else tell Spotless where it is with `black().pathToExe('path/to/executable')`" + trackingIssue)
-				.fixWrongVersion("Try running `pip install --force-reinstall black=={version}`, or else specify `black('{versionFound}')` to Spotless" + trackingIssue)
+				.fixCantFind("Try running {@code pip install black=={version}}, or else tell Spotless where it is with {@code black().pathToExe('path/to/executable')}" + trackingIssue)
+				.fixWrongVersion("Try running {@code pip install --force-reinstall black=={version}}, or else specify {@code black('{versionFound}')} to Spotless" + trackingIssue)
 				.confirmVersionAndGetAbsolutePath();
 		return new State(this, exeAbsPath);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -632,7 +632,7 @@ public class FormatExtension {
 	}
 
 	/**
-	 * ```gradle
+	 * <pre>{@code
 	 * spotless {
 	 *   format 'examples', {
 	 *     target '*.md'
@@ -640,7 +640,7 @@ public class FormatExtension {
 	 *       prettier().config(['parser': 'javascript'])
 	 *     }
 	 *     ...
-	 * ```
+	 * }</pre>
 	 */
 	public void withinBlocks(String name, String open, String close, Action<FormatExtension> configure) {
 		withinBlocks(name, open, close, FormatExtension.class, configure);
@@ -650,7 +650,7 @@ public class FormatExtension {
 	 * Same as {@link #withinBlocks(String, String, String, Action)}, except you can specify
 	 * any language-specific subclass of {@link FormatExtension} to get language-specific steps.
 	 *
-	 * ```gradle
+	 * <pre>{@code
 	 * spotless {
 	 *   format 'examples', {
 	 *     target '*.md'
@@ -658,7 +658,7 @@ public class FormatExtension {
 	 *       googleJavaFormat()
 	 *     }
 	 *     ...
-	 * ```
+	 * }</pre>
 	 */
 	public <T extends FormatExtension> void withinBlocks(String name, String open, String close, Class<T> clazz, Action<T> configure) {
 		withinBlocksHelper(PipeStepPair.named(name).openClose(open, close), clazz, configure);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -62,7 +62,7 @@ import com.diffplug.spotless.npm.PrettierFormatterStep;
 
 import groovy.lang.Closure;
 
-/** Adds a `spotless{Name}Check` and `spotless{Name}Apply` task. */
+/** Adds a {@code spotless{Name}Check} and {@code spotless{Name}Apply} task. */
 public class FormatExtension {
 	final SpotlessExtension spotless;
 	final List<Action<FormatExtension>> lazyActions = new ArrayList<>();
@@ -311,17 +311,17 @@ public class FormatExtension {
 	}
 
 	/**
-	 * An optional performance optimization if you are using any of the `custom`
-	 * methods.  If you aren't explicitly calling `custom`, then this method
+	 * An optional performance optimization if you are using any of the {@code custom}
+	 * methods.  If you aren't explicitly calling {@code custom}, then this method
 	 * has no effect.
 	 *
 	 * Spotless tracks what files have changed from run to run, so that it can run faster
 	 * by only checking files which have changed, or whose formatting steps have changed.
-	 * If you use the `custom` methods, then gradle can never mark
-	 * your files as `up-to-date`, because it can't know if perhaps the behavior of your
+	 * If you use the {@code custom} methods, then gradle can never mark
+	 * your files as {@code up-to-date}, because it can't know if perhaps the behavior of your
 	 * custom function has changed.
 	 *
-	 * If you set `bumpThisNumberIfACustomStepChanges( <some number> )`, then spotless will
+	 * If you set {@code bumpThisNumberIfACustomStepChanges( <some number> )}, then spotless will
 	 * assume that the custom rules have not changed if the number has not changed.  If a
 	 * custom rule does change, then you must bump the number so that spotless will know
 	 * that it must recheck the files it has already checked.
@@ -396,7 +396,7 @@ public class FormatExtension {
 
 	/**
 	 * Created by {@link FormatExtension#licenseHeader(String, String)} or {@link FormatExtension#licenseHeaderFile(Object, String)}.
-	 * For most language-specific formats (e.g. java, scala, etc.) you can omit the second `delimiter` argument, because it is supplied
+	 * For most language-specific formats (e.g. java, scala, etc.) you can omit the second {@code delimiter} argument, because it is supplied
 	 * automatically ({@link HasBuiltinDelimiterForLicense}).
 	 */
 	public class LicenseHeaderConfig {
@@ -429,7 +429,7 @@ public class FormatExtension {
 
 		/**
 		 * @param updateYearWithLatest
-		 *           Will turn `2004` into `2004-2020`, and `2004-2019` into `2004-2020`
+		 *           Will turn {@code 2004} into {@code 2004-2020}, and {@code 2004-2019} into {@code 2004-2020}
 		 *           Default value is false, unless {@link SpotlessExtensionImpl#ratchetFrom(String)} is used, in which case default value is true.
 		 */
 		public LicenseHeaderConfig updateYearWithLatest(boolean updateYearWithLatest) {
@@ -697,7 +697,7 @@ public class FormatExtension {
 		this.togglePair = PipeStepPair.named(PipeStepPair.defaultToggleName()).openClose(off, on).buildPair();
 	}
 
-	/** Disables formatting between `spotless:off` and `spotless:on`. */
+	/** Disables formatting between {@code spotless:off} and {@code spotless:on}. */
 	public void toggleOffOn() {
 		toggleOffOn(PipeStepPair.defaultToggleOff(), PipeStepPair.defaultToggleOn());
 	}
@@ -743,12 +743,12 @@ public class FormatExtension {
 	 * Creates an independent {@link SpotlessApply} for (very) unusual circumstances.
 	 *
 	 * Most users will not want this method.  In the rare case that you want to create
-	 * a `SpotlessApply` which is independent of the normal Spotless machinery, this will
+	 * a {@code SpotlessApply} which is independent of the normal Spotless machinery, this will
 	 * let you do that.
 	 *
-	 * The returned task will not be hooked up to the global `spotlessApply`, and there will be no corresponding `check` task.
+	 * The returned task will not be hooked up to the global {@code spotlessApply}, and there will be no corresponding {@code check} task.
 	 *
-	 * NOTE: does not respect the rarely-used [`spotlessFiles` property](https://github.com/diffplug/spotless/blob/b7f8c551a97dcb92cc4b0ee665448da5013b30a3/plugin-gradle/README.md#can-i-apply-spotless-to-specific-files).
+	 * NOTE: does not respect the rarely-used [{@code spotlessFiles} property](https://github.com/diffplug/spotless/blob/b7f8c551a97dcb92cc4b0ee665448da5013b30a3/plugin-gradle/README.md#can-i-apply-spotless-to-specific-files).
 	 */
 	public SpotlessApply createIndependentApplyTask(String taskName) {
 		// create and setup the task

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -632,7 +632,7 @@ public class FormatExtension {
 	}
 
 	/**
-	 * <pre>{@code
+	 * <pre>
 	 * spotless {
 	 *   format 'examples', {
 	 *     target '*.md'
@@ -640,7 +640,7 @@ public class FormatExtension {
 	 *       prettier().config(['parser': 'javascript'])
 	 *     }
 	 *     ...
-	 * }</pre>
+	 * </pre>
 	 */
 	public void withinBlocks(String name, String open, String close, Action<FormatExtension> configure) {
 		withinBlocks(name, open, close, FormatExtension.class, configure);
@@ -650,7 +650,7 @@ public class FormatExtension {
 	 * Same as {@link #withinBlocks(String, String, String, Action)}, except you can specify
 	 * any language-specific subclass of {@link FormatExtension} to get language-specific steps.
 	 *
-	 * <pre>{@code
+	 * <pre>
 	 * spotless {
 	 *   format 'examples', {
 	 *     target '*.md'
@@ -658,7 +658,7 @@ public class FormatExtension {
 	 *       googleJavaFormat()
 	 *     }
 	 *     ...
-	 * }</pre>
+	 * </pre>
 	 */
 	public <T extends FormatExtension> void withinBlocks(String name, String open, String close, Class<T> clazz, Action<T> configure) {
 		withinBlocksHelper(PipeStepPair.named(name).openClose(open, close), clazz, configure);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -193,16 +193,16 @@ public abstract class SpotlessExtension {
 
 	boolean enforceCheck = true;
 
-	/** Returns `true` if Gradle's `check` task should run `spotlessCheck`; `false` otherwise. */
+	/** Returns {@code true} if Gradle's {@code check} task should run {@code spotlessCheck}; {@code false} otherwise. */
 	public boolean isEnforceCheck() {
 		return enforceCheck;
 	}
 
 	/**
-	 * Configures Gradle's `check` task to run `spotlessCheck` if `true`,
-	 * but to not do so if `false`.
+	 * Configures Gradle's {@code check} task to run {@code spotlessCheck} if {@code true},
+	 * but to not do so if {@code false}.
 	 *
-	 * `true` by default.
+	 * {@code true} by default.
 	 */
 	public void setEnforceCheck(boolean enforceCheck) {
 		this.enforceCheck = enforceCheck;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -35,7 +35,7 @@ public class SpotlessPlugin implements Plugin<Project> {
 		if (project.hasProperty(SPOTLESS_MODERN)) {
 			project.getLogger().warn("'spotlessModern' has no effect as of Spotless 5.0, recommend removing it.");
 		}
-		// make sure there's a `clean` task
+		// make sure there's a {@code clean} task
 		project.getPlugins().apply(BasePlugin.class);
 
 		// setup the extension

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class SpotlessTaskImpl extends SpotlessTask {
 			// Remove previous output if it exists
 			Files.deleteIfExists(output.toPath());
 		} else if (dirtyState.didNotConverge()) {
-			getLogger().warn("Skipping '" + input + "' because it does not converge.  Run `spotlessDiagnose` to understand why");
+			getLogger().warn("Skipping '" + input + "' because it does not converge.  Run {@code spotlessDiagnose} to understand why");
 		} else {
 			Path parentDir = output.toPath().getParent();
 			if (parentDir == null) {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SelfTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SelfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class SelfTest {
 		return project;
 	}
 
-	/** Runs against the `spotlessSelfApply.gradle` file. */
+	/** Runs against the {@code spotlessSelfApply.gradle} file. */
 	static void runWithTestKit(String taskType) throws Exception {
 		GradleRunner.create()
 				.withPluginClasspath()

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,10 +45,10 @@ import com.diffplug.spotless.ResourceHarness;
 
 public class MavenIntegrationHarness extends ResourceHarness {
 	/**
-	 * To run tests in the IDE, run `gradlew :plugin-maven:changelogPrint`, then
-	 * put the last version it prints into `SPOTLESS_MAVEN_VERSION_IDE`.  From now
-	 * on, if you run `gradlew :plugin-maven:runMavenBuild`, then you can run tests
-	 * in the IDE and they will run against the results of the last `runMavenBuild`
+	 * To run tests in the IDE, run {@code gradlew :plugin-maven:changelogPrint}, then
+	 * put the last version it prints into {@code SPOTLESS_MAVEN_VERSION_IDE}.  From now
+	 * on, if you run {@code gradlew :plugin-maven:runMavenBuild}, then you can run tests
+	 * in the IDE and they will run against the results of the last {@code runMavenBuild}
 	 */
 	private static final String SPOTLESS_MAVEN_VERSION_IDE = null;
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,8 +10,6 @@ pluginManagement {
 		id 'com.gradle.plugin-publish'             version '0.14.0'
 		// https://github.com/gradle-nexus/publish-plugin/releases
 		id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
-		// https://github.com/mnlipp/jdrupes-mdoclet/releases
-		id 'org.jdrupes.mdoclet'                   version '1.0.10'
 		// https://github.com/spotbugs/spotbugs-gradle-plugin/releases
 		id 'com.github.spotbugs'                   version '4.7.0'
 		// https://github.com/diffplug/spotless-changelog
@@ -23,7 +21,6 @@ plugins {
 	id 'com.diffplug.eclipse.resourcefilters'  apply false
 	id 'com.gradle.plugin-publish'             apply false
 	id 'io.github.gradle-nexus.publish-plugin' apply false
-	id 'org.jdrupes.mdoclet'                   apply false
 	id 'com.github.spotbugs'                   apply false
 	id 'com.diffplug.spotless-changelog'       apply false
 }

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 
-/** An api for testing a `FormatterStep` that doesn't depend on the File path. DO NOT ADD FILE SUPPORT TO THIS, use {@link StepHarnessWithFile} if you need that. */
+/** An api for testing a {@code FormatterStep} that doesn't depend on the File path. DO NOT ADD FILE SUPPORT TO THIS, use {@link StepHarnessWithFile} if you need that. */
 public class StepHarness implements AutoCloseable {
 	private final FormatterFunc formatter;
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 
-/** An api for testing a `FormatterStep` that depends on the File path. */
+/** An api for testing a {@code FormatterStep} that depends on the File path. */
 public class StepHarnessWithFile implements AutoCloseable {
 	private final FormatterFunc formatter;
 


### PR DESCRIPTION
I think this should fix #775.

The problem was that the doclet we used to put markdown into our javadoc required JDK8, so we just disabled the javadoc task on non-JDK8 machines. Rather than figure out how to get the doclet working on JDK11 or change our publishing JDK, I just removed the doclet and replaced the markdown-style code ticks with javadoc-style `{@code` blocks. I wish javadoc supported markdown, but it's not worth fighting the ecosystem over it.