### PR TITLE
Provide common Java version detection

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/Jvm.java
+++ b/lib/src/main/java/com/diffplug/spotless/Jvm.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2016-2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/** Java virtual machine helper */
+public final class Jvm {
+	private static final int JAVA_VERSION;
+
+	static {
+		String jre = System.getProperty("java.version");
+		if (jre.startsWith("1.8")) {
+			JAVA_VERSION = 8;
+		} else {
+			Matcher matcher = Pattern.compile("(\\d+)").matcher(jre);
+			if (!matcher.find()) {
+				throw new IllegalArgumentException("Expected " + jre + " to start with an integer");
+			}
+			JAVA_VERSION = Integer.parseInt(matcher.group(1));
+			if (JAVA_VERSION <= 8) {
+				throw new IllegalArgumentException("Expected " + jre + " to start with an integer greater than 8");
+			}
+		}
+	}
+
+	/** @return the major version of this VM, e.g. 8, 9, 10, 11, 13, etc. */
+	public static int version() {
+		return JAVA_VERSION;
+	}
+
+	/**
+	 * Utility to map constraints of formatter to this JVM
+	 * @param <V> Version type of formatter
+	 */
+	public static class Support<V> {
+		private final NavigableMap<Integer, V> java2formatterVersion;
+		private final String formatterName;
+		private final Comparator<? super V> formatterVersionComparator;
+		private Integer requiredJavaVersion;
+
+		private Support(String fromatterName) {
+			this(fromatterName, null);
+		}
+
+		private Support(String formatterName, @Nullable Comparator<? super V> formatterVersionComparator) {
+			java2formatterVersion = new TreeMap<Integer, V>();
+			this.formatterName = formatterName;
+			if (null == formatterVersionComparator) {
+				this.formatterVersionComparator = new SemanticVersionComparator<V>();
+			} else {
+				this.formatterVersionComparator = formatterVersionComparator;
+			}
+			requiredJavaVersion = 0;
+		}
+
+		/**
+		 * Add supported formatter version
+		 * @param minimumJavaVersion Minimum Java version required
+		 * @param maxFormatterVersion Maximum formatter version supported by the Java version
+		 * @return this
+		 */
+		public Support<V> add(int minimumJavaVersion, V maxFormatterVersion) {
+			Objects.requireNonNull(maxFormatterVersion);
+			java2formatterVersion.put(minimumJavaVersion, maxFormatterVersion);
+			requiredJavaVersion = java2formatterVersion.floorKey(Jvm.version());
+			return this;
+		}
+
+		/** @return Latest formatter version supported by this JVM */
+		public V getLatestFormatterVersion() {
+			V latestFormatterVersion = java2formatterVersion.get(requiredJavaVersion);
+			if (null == latestFormatterVersion) {
+				throw new UnsupportedClassVersionError("Unsupported JVM: " + toString());
+			}
+			return latestFormatterVersion;
+		}
+
+		/**
+		 * Assert the formatter is supported
+		 * @param formatterVersion Formatter version
+		 */
+		public void assertFormatterSupported(V formatterVersion) throws Exception {
+			Objects.requireNonNull(formatterVersion);
+			if (formatterVersionComparator.compare(formatterVersion, getLatestFormatterVersion()) > 0) {
+				throw new UnsupportedClassVersionError(String.format("Unsupported formatter version %s: %s", formatterVersion, toString()));
+			}
+		}
+
+		/**
+		 * Suggest to use a later formatter version if formatting fails
+		 * @param formatterVersion Formatter version
+		 * @param originalFunc Formatter function
+		 * @return Wrapped formatter function. Adding hint about later versions to exceptions.
+		 */
+		public FormatterFunc suggestLaterVersionOnError(V formatterVersion, FormatterFunc originalFunc) {
+			if (formatterVersionComparator.compare(formatterVersion, getLatestFormatterVersion()) < 0) {
+				return new FormatterFuncWrapper(String.format("You are not using latest version for Java %d and later. Try to upgrade to %s version %s, which may have fixed this problem.", requiredJavaVersion, formatterName, getLatestFormatterVersion()), originalFunc);
+			} else if (java2formatterVersion.lastKey() > Jvm.version()) {
+				Integer nextJavaVersion = java2formatterVersion.higherKey(Jvm.version());
+				V nextFormatterVersion = java2formatterVersion.get(nextJavaVersion);
+				return new FormatterFuncWrapper(String.format("You are running Spotless on JRE %1$d, which limits you to %2$s %3$s.%nIf you upgrade your build JVM to %4$d+, then you can use %2$s %5$s, which may have fixed this problem.", Jvm.version(), formatterName, formatterVersion, nextJavaVersion, nextFormatterVersion), originalFunc);
+			}
+			return originalFunc;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("Java version %d not supported by %s %s.%n", Jvm.version(), formatterName) +
+					java2formatterVersion.entrySet().stream().map(
+							entry -> String.format("- Version %s requires Java version %d", entry.getValue().toString(), entry.getKey())).collect(Collectors.joining(System.lineSeparator()));
+		}
+
+		@SuppressFBWarnings("SE_COMPARATOR_SHOULD_BE_SERIALIZABLE")
+		private static class SemanticVersionComparator<V> implements Comparator<V> {
+
+			@Override
+			public int compare(V version0, V version1) {
+				Integer[] version0Items = convert(version0);
+				Integer[] version1Items = convert(version1);
+				int numberOfElements = version0Items.length > version1Items.length ? version0Items.length : version1Items.length;
+				version0Items = Arrays.copyOf(version0Items, numberOfElements);
+				version1Items = Arrays.copyOf(version1Items, numberOfElements);
+				for (int i = 0; i < numberOfElements; i++) {
+					if (version0Items[i] > version1Items[i]) {
+						return 1;
+					} else if (version1Items[i] > version0Items[i]) {
+						return -1;
+					}
+				}
+				return 0;
+			}
+
+			private static <V> Integer[] convert(V versionObject) {
+				try {
+					Objects.requireNonNull(versionObject);
+					return Arrays.asList(versionObject.toString().split("\\.")).stream().map(s -> Integer.valueOf(s)).toArray(Integer[]::new);
+				} catch (Exception e) {
+					throw new IllegalArgumentException(String.format("Not a semantic version: %s", versionObject), e);
+				}
+			}
+		};
+
+		private static class FormatterFuncWrapper implements FormatterFunc {
+			private final String hintLaterVersion;
+			private final FormatterFunc originalFunc;
+
+			FormatterFuncWrapper(String hintLaterVersion, FormatterFunc originalFunc) {
+				this.hintLaterVersion = hintLaterVersion;
+				this.originalFunc = originalFunc;
+			}
+
+			@Override
+			public String apply(String unix, File file) throws Exception {
+				try {
+					return originalFunc.apply(unix, file);
+				} catch (Exception e) {
+					throw new Exception(hintLaterVersion, e);
+				}
+			}
+
+			@Override
+			public String apply(String input) throws Exception {
+				try {
+					return originalFunc.apply(input);
+				} catch (Exception e) {
+					throw new Exception(hintLaterVersion, e);
+				}
+			}
+
+		};
+
+	}
+
+	/**
+	 * Creates a map of JVM requirements for a formatter
+	 * @param <V> Version type of the formatter (V#toString() must correspond to a semantic version, separated by dots)
+	 * @param formatterName Name of the formatter
+	 * @return Empty map of supported formatters
+	 */
+	public static <V> Support<V> support(String formatterName) {
+		return new Support<V>(formatterName);
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -84,7 +84,7 @@ public class GoogleJavaFormatStep {
 				State::createFormat);
 	}
 
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.7").add(11, "1.11.0");
+	static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.7").add(11, "1.11.0");
 
 	/** Get default formatter version */
 	public static String defaultVersion() {

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -78,7 +78,7 @@ public class GoogleJavaFormatStep {
 
 	/** Get default formatter version */
 	public static String defaultVersion() {
-		return JVM_SUPPORT.getLatestFormatterVersion();
+		return JVM_SUPPORT.getRecommendedFormatterVersion();
 	}
 
 	public static String defaultStyle() {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import com.diffplug.common.base.StringPrinter;
 import com.diffplug.common.tree.TreeDef;
 import com.diffplug.common.tree.TreeStream;
 import com.diffplug.spotless.FileSignature;
-import com.diffplug.spotless.JreVersion;
+import com.diffplug.spotless.Jvm;
 import com.diffplug.spotless.ResourceHarness;
 
 public class GradleIntegrationHarness extends ResourceHarness {
@@ -44,10 +44,10 @@ public class GradleIntegrationHarness extends ResourceHarness {
 		final String version;
 
 		GradleVersionSupport(String version) {
-			if (JreVersion.thisVm() >= 15) {
+			if (Jvm.version() >= 15) {
 				// the first version with support for Java 15+
 				this.version = "6.7";
-			} else if (JreVersion.thisVm() >= 14) {
+			} else if (Jvm.version() >= 14) {
 				// the first version with support for Java 14+
 				this.version = "6.3";
 			} else {

--- a/testlib/src/main/java/com/diffplug/spotless/JreVersion.java
+++ b/testlib/src/main/java/com/diffplug/spotless/JreVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,44 +15,28 @@
  */
 package com.diffplug.spotless;
 
-import java.util.function.IntPredicate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import static org.junit.Assume.assumeTrue;
 
 public class JreVersion {
 	private JreVersion() {}
 
-	/** Returns the major version of this VM, e.g. 8, 9, 10, 11, 13, etc. */
+	/**
+	 * @return the major version of this VM, e.g. 8, 9, 10, 11, 13, etc.
+	 * @deprecated Use {@link com.diffplug.spotless.Jvm#version()} instead.
+	 */
 	public static int thisVm() {
-		String jre = System.getProperty("java.version");
-		if (jre.startsWith("1.8")) {
-			return 8;
-		} else {
-			Matcher matcher = Pattern.compile("(\\d+)").matcher(jre);
-			if (!matcher.find()) {
-				throw new IllegalArgumentException("Expected " + jre + " to start with an integer");
-			}
-			int version = Integer.parseInt(matcher.group(1));
-			if (version <= 8) {
-				throw new IllegalArgumentException("Expected " + jre + " to start with an integer greater than 8");
-			}
-			return version;
-		}
-	}
-
-	private static void assume(IntPredicate versionTest) {
-		org.junit.Assume.assumeTrue(versionTest.test(thisVm()));
+		return Jvm.version();
 	}
 
 	public static void assume11OrGreater() {
-		assume(v -> v >= 11);
+		assumeTrue(Jvm.version() >= 11);
 	}
 
 	public static void assume11OrLess() {
-		assume(v -> v <= 11);
+		assumeTrue(Jvm.version() <= 11);
 	}
 
 	public static void assumeLessThan15() {
-		assume(v -> v < 15);
+		assumeTrue(Jvm.version() < 15);
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JvmTest {
+
+	private static final String TEST_NAME = "My Test Formatter";
+	private Jvm.Support<String> testSupport;
+
+	@Before
+	public void initialize() {
+		testSupport = Jvm.support(TEST_NAME);
+	}
+
+	@Test
+	public void supportAddConfig() {
+		Integer differentVersions[] = {0, 1, 2};
+		Arrays.asList(differentVersions).stream().forEach(v -> testSupport.add(v + Jvm.version(), v.toString()));
+		Arrays.asList(differentVersions).stream().forEach(v -> assertThat(testSupport.toString(), containsString(String.format("Version %d", v))));
+		assertThat(testSupport.toString(), containsString(String.format("%s alternatives", TEST_NAME)));
+		testSupport.verifyConfiguration();
+	}
+
+	@Test
+	public void supportConfigChecks() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			testSupport.add(1, "Not a semantic version");
+		});
+
+		testSupport.add(1, "0.1").add(2, "1").verifyConfiguration(); //correct behavior
+		Arrays.<Consumer<Jvm.Support<String>>> asList(
+				s -> {
+					s.add(1, "0.1").add(1, "1.0");
+				}, //forgot to adapt JVM version
+				s -> {
+					s.add(1, "0.1").add(2, "0.1");
+				}, //forgot to adapt formatter version
+				s -> {
+					s.add(1, "1.0").add(2, "0.1");
+				}, //higher formatter version requires lower Java version
+				s -> {
+					s.add(2, "0.1").add(1, "1.0");
+				} //lower formatter version requires higher Java version
+		).stream().forEach(configuration -> {
+			Jvm.Support<String> support = Jvm.support(TEST_NAME);
+			configuration.accept(support);
+			assertThrows(AssertionError.class, () -> {
+				support.verifyConfiguration();
+			});
+		});
+	}
+
+	@Test
+	public void supportEmptyConfiguration() {
+		try {
+			testSupport.verifyConfiguration();
+		} catch (AssertionError e) {
+			fail("Empty configuration should be valid: " + e.toString());
+		}
+
+		assertNull("No formatter version is configured", testSupport.getRecommendedFormatterVersion());
+
+		testSupport.assertFormatterSupported("0.1");
+
+		Exception expected = new Exception("Some test exception");
+		Exception actual = assertThrows(Exception.class, () -> {
+			testSupport.suggestLaterVersionOnError("0.0", unused -> {
+				throw expected;
+			}).apply("");
+		});
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void supportListsMinimumJvmIfOnlyHigherJvmSupported() {
+		int higherJvmVersion = Jvm.version() + 1;
+		Exception testException = new Exception("Some test exception");
+		testSupport.add(higherJvmVersion, "1.2.3");
+		testSupport.add(higherJvmVersion + 1, "2.2.3");
+
+		assertNull("No formatter version is supported", testSupport.getRecommendedFormatterVersion());
+
+		for (String fmtVersion : Arrays.asList("1.2", "1.2.3")) {
+			String proposal = assertThrows(Exception.class, () -> {
+				testSupport.assertFormatterSupported(fmtVersion);
+			}).getMessage();
+			assertThat(proposal, containsString(String.format("on JVM %d", Jvm.version())));
+			assertThat(proposal, containsString(String.format("%s %s requires JVM %d+", TEST_NAME, fmtVersion, higherJvmVersion)));
+			assertThat(proposal, containsString(String.format("try %s alternatives", TEST_NAME)));
+
+			proposal = assertThrows(Exception.class, () -> {
+				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
+					throw testException;
+				}).apply("");
+			}).getMessage();
+			assertThat(proposal, containsString(String.format("on JVM %d", Jvm.version())));
+			assertThat(proposal, containsString(String.format("%s %s requires JVM %d+", TEST_NAME, fmtVersion, higherJvmVersion)));
+			assertThat(proposal, containsString(String.format("try %s alternatives", TEST_NAME)));
+		}
+
+		for (String fmtVersion : Arrays.asList("1.2.4", "2")) {
+			String proposal = assertThrows(Exception.class, () -> {
+				testSupport.assertFormatterSupported(fmtVersion);
+			}).getMessage();
+			assertThat(proposal, containsString(String.format("%s %s requires JVM %d+", TEST_NAME, fmtVersion, higherJvmVersion + 1)));
+
+			proposal = assertThrows(Exception.class, () -> {
+				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
+					throw testException;
+				}).apply("");
+			}).getMessage();
+			assertThat(proposal, containsString(String.format("%s %s requires JVM %d+", TEST_NAME, fmtVersion, higherJvmVersion + 1)));
+		}
+	}
+
+	@Test
+	public void supportProposesFormatterUpgrade() {
+		int requiredJvm = Jvm.version() - 1;
+		testSupport.add(Jvm.version() - 2, "1");
+		testSupport.add(requiredJvm, "2");
+		testSupport.add(Jvm.version() + 1, "3");
+		for (String fmtVersion : Arrays.asList("0", "1", "1.9")) {
+			testSupport.assertFormatterSupported(fmtVersion);
+
+			String proposal = assertThrows(Exception.class, () -> {
+				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
+					throw new Exception("Some test exception");
+				}).apply("");
+			}).getMessage();
+			assertThat(proposal, containsString("not using latest version"));
+			assertThat(proposal, containsString(String.format("on JVM %d+", requiredJvm)));
+			assertThat(proposal, containsString(String.format("upgrade to %s %s", TEST_NAME, "2")));
+		}
+	}
+
+	@Test
+	public void supportProposesJvmUpgrade() {
+		testSupport.add(Jvm.version(), "1");
+		int higherJvm = Jvm.version() + 3;
+		testSupport.add(higherJvm, "2");
+		testSupport.add(higherJvm + 1, "3");
+		for (String fmtVersion : Arrays.asList("1", "1.0")) {
+			String proposal = assertThrows(Exception.class, () -> {
+				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
+					throw new Exception("Some test exception");
+				}).apply("");
+			}).getMessage();
+			assertThat(proposal, containsString(String.format("on JVM %d", Jvm.version())));
+			assertThat(proposal, containsString(String.format("limits you to %s %s", TEST_NAME, "1")));
+			assertThat(proposal, containsString(String.format("upgrade your JVM to %d+", higherJvm)));
+			assertThat(proposal, containsString(String.format("then you can use %s %s", TEST_NAME, "2")));
+		}
+	}
+
+	@Test
+	public void supportAllowsExperimentalVersions() {
+		testSupport.add(Jvm.version(), "1.0");
+		for (String fmtVersion : Arrays.asList("1", "2.0")) {
+			testSupport.assertFormatterSupported(fmtVersion);
+
+			Exception testException = new Exception("Some test exception");
+			Exception exception = assertThrows(Exception.class, () -> {
+				testSupport.suggestLaterVersionOnError(fmtVersion, unused -> {
+					throw testException;
+				}).apply("");
+			});
+			assertEquals(testException, exception);
+		}
+	}
+
+}

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -35,8 +35,8 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 		try (StepHarness step = StepHarness.forStep(GoogleJavaFormatStep.create(TestProvisioner.mavenCentral()))) {
 			if (Jvm.version() < 11) {
 				step.testResourceException("java/googlejavaformat/TextBlock.dirty", throwable -> {
-					throwable.hasMessageStartingWith("You are running Spotless on JRE 8, which limits you to google-java-format 1.7.")
-							.hasMessageEndingWith("If you upgrade your build JVM to 11+, then you can use google-java-format 1.11.0, which may have fixed this problem.");
+					throwable.hasMessageStartingWith("You are running Spotless on JVM 8, which limits you to google-java-format 1.7.")
+							.hasMessageEndingWith("If you upgrade your JVM to 11+, then you can use google-java-format 1.11.0, which may have fixed this problem.");
 				});
 			} else if (Jvm.version() < 13) {
 				step.testResourceException("java/googlejavaformat/TextBlock.dirty", throwable -> {

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -32,11 +32,6 @@ import com.diffplug.spotless.TestProvisioner;
 public class GoogleJavaFormatStepTest extends ResourceHarness {
 
 	@Test
-	public void verifyJvmSupport() {
-		GoogleJavaFormatStep.JVM_SUPPORT.verifyConfiguration();
-	}
-
-	@Test
 	public void jvm13Features() throws Exception {
 		assumeTrue(Jvm.version() >= 13);
 		try (StepHarness step = StepHarness.forStep(GoogleJavaFormatStep.create(TestProvisioner.mavenCentral()))) {

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JreVersion;
+import com.diffplug.spotless.Jvm;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
@@ -32,19 +33,18 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 	@Test
 	public void suggestJre11() throws Exception {
 		try (StepHarness step = StepHarness.forStep(GoogleJavaFormatStep.create(TestProvisioner.mavenCentral()))) {
-			if (JreVersion.thisVm() < 11) {
+			if (Jvm.version() < 11) {
 				step.testResourceException("java/googlejavaformat/TextBlock.dirty", throwable -> {
-					throwable.hasMessageStartingWith("You are running Spotless on JRE 8")
-							.hasMessageEndingWith(", which limits you to google-java-format 1.7\n"
-									+ "If you upgrade your build JVM to 11+, then you can use google-java-format 1.9, which may have fixed this problem.");
+					throwable.hasMessageStartingWith("You are running Spotless on JRE 8, which limits you to google-java-format 1.7.")
+							.hasMessageEndingWith("If you upgrade your build JVM to 11+, then you can use google-java-format 1.11.0, which may have fixed this problem.");
 				});
-			} else if (JreVersion.thisVm() < 13) {
+			} else if (Jvm.version() < 13) {
 				step.testResourceException("java/googlejavaformat/TextBlock.dirty", throwable -> {
 					throwable.isInstanceOf(InvocationTargetException.class)
 							.extracting(exception -> exception.getCause().getMessage()).asString().contains("7:18: error: unclosed string literal");
 				});
 			} else {
-				// JreVersion.thisVm() >= 13
+				// Jvm.version() >= 13
 				step.testResource("java/googlejavaformat/TextBlock.dirty", "java/googlejavaformat/TextBlock.clean");
 			}
 		}


### PR DESCRIPTION
The approach of `GoogleJavaFormatter` to provide default versions depending of the JRE Java version has been extracted to a generic class. The code duplicated in `testlib` JRE has been removed.

Furthermore the approach has been extended:
- It allows to check whether a formatter version is supported by the current JRE. This approach allows to provide proposals about other formatter versions to the user. 
- It provides version proposals not requiring a JRE upgrade if possible.

For these extensions the amount of code has been increased. It needs to be discussed whether the benefit is worth the increase of code complexity. 