### PR TITLE
doc: enhance importOrderFile method doc

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -142,11 +142,14 @@ If you're stuck on an older version of Gradle, `id 'com.diffplug.gradle.spotless
 ```gradle
 spotless {
   java {
-    importOrder() // standard import order
+    // Use the default importOrder configuration
+    importOrder()
+    // optional: you can specify import groups directly
+    // note: You probably want an empty string at the end - all of the imports you didn't specify explicitly will go there.
     importOrder('java', 'javax', 'com.acme', '')
-    // You probably want an empty string at the end - all of the
-    // imports you didn't specify explicitly will go there.
-    importOrderFile(eclipse-import-order.txt) // import order file as exported from eclipse
+    // optional: instead of specifying import groups directly you can specify a config file
+    // export config file: https://github.com/diffplug/spotless/blob/main/ECLIPSE_SCREENSHOTS.md#creating-spotlessimportorder
+    importOrderFile('eclipse-import-order.txt') // import order file as exported from eclipse
 
     removeUnusedImports()
 
@@ -210,11 +213,14 @@ The groovy formatter's default behavior is to format all `.groovy` and `.java` f
 apply plugin: 'groovy'
 spotless {
   groovy {
-    importOrder() // standard import order
+    // Use the default importOrder configuration
+    importOrder()
+    // optional: you can specify import groups directly
+    // note: You probably want an empty string at the end - all of the imports you didn't specify explicitly will go there.
     importOrder('java', 'javax', 'com.acme', '')
-    // You probably want an empty string at the end - all of the
-    // imports you didn't specify explicitly will go there.
-    importOrderFile(eclipse-import-order.txt) // import order file as exported from eclipse
+    // optional: instead of specifying import groups directly you can specify a config file
+    // export config file: https://github.com/diffplug/spotless/blob/main/ECLIPSE_SCREENSHOTS.md#creating-spotlessimportorder
+    importOrderFile('eclipse-import-order.txt') // import order file as exported from eclipse
 
     excludeJava() // excludes all Java sources within the Groovy source dirs from formatting
     // the Groovy Eclipse formatter extends the Java Eclipse formatter,

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -143,9 +143,10 @@ If you're stuck on an older version of Gradle, `id 'com.diffplug.gradle.spotless
 spotless {
   java {
     importOrder() // standard import order
-    importOrder('java', 'javax', 'com.acme', '') // or importOrderFile
+    importOrder('java', 'javax', 'com.acme', '')
     // You probably want an empty string at the end - all of the
     // imports you didn't specify explicitly will go there.
+    importOrderFile(eclipse-import-order.txt) // import order file as exported from eclipse
 
     removeUnusedImports()
 
@@ -210,7 +211,10 @@ apply plugin: 'groovy'
 spotless {
   groovy {
     importOrder() // standard import order
-    importOrder('java', 'javax', 'com.acme', '') // or importOrderFile
+    importOrder('java', 'javax', 'com.acme', '')
+    // You probably want an empty string at the end - all of the
+    // imports you didn't specify explicitly will go there.
+    importOrderFile(eclipse-import-order.txt) // import order file as exported from eclipse
 
     excludeJava() // excludes all Java sources within the Groovy source dirs from formatting
     // the Groovy Eclipse formatter extends the Java Eclipse formatter,


### PR DESCRIPTION
Hello guys,
thanks for the awesome work.

I recently tried to include an `importOrderFile` for java formatting. For me it was not clear from the documentation that I need to explicitly use the method `importOrderFile(filePath)` instead of `importOrder(filePath)`.

For anyone stumbling into the same issue it would be great to directly see how to use the different methods. I tried to use the same pattern as for the `eclipse('4.17').configFile('eclipse-prefs.xml')` option. ([Doc](https://github.com/diffplug/spotless/tree/main/plugin-gradle#eclipse-jdt))

I hope this PR is sufficient since it does not change any code. If there needs to be additional documentation in the plugin `CHANGES.md` please point me to it and I'll happily do it.
