### PR TITLE
Support google-java-format's skip-reflowing-long-strings option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for `google-java-format`'s `skip-reflowing-long-strings` option ([#929](https://github.com/diffplug/spotless/pull/929))
 
 ## [2.15.3] - 2021-08-20
 ### Changed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for `google-java-format`'s `skip-reflowing-long-strings` option ([#929](https://github.com/diffplug/spotless/pull/929))
 
 ## [5.14.3] - 2021-08-20
 ### Changed

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -112,7 +112,7 @@ spotless {
     // don't need to set target, it is inferred from java
 
     // apply a specific flavor of google-java-format
-    googleJavaFormat('1.8').aosp()
+    googleJavaFormat('1.8').aosp().reflowLongStrings()
     // make sure every file has the following copyright header.
     // optionally, Spotless can set copyright years by digging
     // through git history (see "license" section below)
@@ -176,9 +176,9 @@ spotless {
 spotless {
   java {
     googleJavaFormat()
-    // optional: you can specify a specific version and/or switch to AOSP style
+    // optional: you can specify a specific version and/or switch to AOSP style and/or reflow long strings (requires at least 1.8)
     //
-    googleJavaFormat('1.7').aosp()
+    googleJavaFormat('1.8').aosp().reflowLongStrings()
 ```
 
 ### eclipse jdt

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -90,6 +90,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	public class GoogleJavaFormatConfig {
 		final String version;
 		String style;
+		boolean reflowLongStrings;
 
 		GoogleJavaFormatConfig(String version) {
 			this.version = Objects.requireNonNull(version);
@@ -97,19 +98,31 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			addStep(createStep());
 		}
 
-		public void style(String style) {
+		public GoogleJavaFormatConfig style(String style) {
 			this.style = Objects.requireNonNull(style);
 			replaceStep(createStep());
+			return this;
 		}
 
-		public void aosp() {
-			style("AOSP");
+		public GoogleJavaFormatConfig aosp() {
+			return style("AOSP");
+		}
+
+		public GoogleJavaFormatConfig reflowLongStrings() {
+			return reflowLongStrings(true);
+		}
+
+		public GoogleJavaFormatConfig reflowLongStrings(boolean reflowLongStrings) {
+			this.reflowLongStrings = reflowLongStrings;
+			replaceStep(createStep());
+			return this;
 		}
 
 		private FormatterStep createStep() {
 			return GoogleJavaFormatStep.create(version,
 					style,
-					provisioner());
+					provisioner(),
+					reflowLongStrings);
 		}
 	}
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for `google-java-format`'s `skip-reflowing-long-strings` option ([#929](https://github.com/diffplug/spotless/pull/929))
 
 ## [2.12.3] - 2021-08-20
 ### Changed

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -105,10 +105,11 @@ To use it in your pom, just [add the Spotless dependency](https://search.maven.o
     <java>
       <!-- no need to specify files, inferred automatically, but you can if you want -->
 
-      <!-- apply a specific flavor of google-java-format -->
+      <!-- apply a specific flavor of google-java-format and reflow long strings -->
       <googleJavaFormat>
         <version>1.8</version>
         <style>AOSP</style>
+        <reflowLongStrings>true</reflowLongStrings>
       </googleJavaFormat>
 
       <!-- make sure every file has the following copyright header.
@@ -201,8 +202,9 @@ any other maven phase (i.e. compile) then it can be configured as below;
 
 ```xml
 <googleJavaFormat>
-  <version>1.7</version> <!-- optional -->
-  <style>GOOGLE</style>  <!-- or AOSP (optional) -->
+  <version>1.8</version>                      <!-- optional -->
+  <style>GOOGLE</style>                       <!-- or AOSP (optional) -->
+  <reflowLongStrings>true</reflowLongStrings> <!-- optional (requires at least 1.8) -->
 </googleJavaFormat>
 ```
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/GoogleJavaFormat.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/GoogleJavaFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,14 @@ public class GoogleJavaFormat implements FormatterStepFactory {
 	@Parameter
 	private String style;
 
+	@Parameter
+	private Boolean reflowLongStrings;
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		String version = this.version != null ? this.version : GoogleJavaFormatStep.defaultVersion();
 		String style = this.style != null ? this.style : GoogleJavaFormatStep.defaultStyle();
-		return GoogleJavaFormatStep.create(version, style, config.getProvisioner());
+		boolean reflowLongStrings = this.reflowLongStrings != null ? this.reflowLongStrings : GoogleJavaFormatStep.defaultReflowLongStrings();
+		return GoogleJavaFormatStep.create(version, style, config.getProvisioner(), reflowLongStrings);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/GoogleJavaFormatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/GoogleJavaFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.diffplug.spotless.maven.java;
 
 import org.junit.Test;
 
+import com.diffplug.spotless.JreVersion;
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
 
 public class GoogleJavaFormatTest extends MavenIntegrationHarness {
@@ -39,6 +40,18 @@ public class GoogleJavaFormatTest extends MavenIntegrationHarness {
 				"</googleJavaFormat>");
 
 		runTest("java/googlejavaformat/JavaCodeFormattedAOSP.test");
+	}
+
+	@Test
+	public void specificVersionReflowLongStrings() throws Exception {
+		JreVersion.assume11OrGreater();
+		writePomWithJavaSteps(
+				"<googleJavaFormat>",
+				"  <version>1.8</version>",
+				"  <reflowLongStrings>true</reflowLongStrings>",
+				"</googleJavaFormat>");
+
+		runTest("java/googlejavaformat/JavaCodeFormattedReflowLongStrings.test");
 	}
 
 	private void runTest(String targetResource) throws Exception {

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormatted.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormatted.test
@@ -4,7 +4,8 @@ import mylib.UsedB;
 
 public class Java {
   public static void main(String[] args) {
-    System.out.println("hello");
+    System.out.println(
+        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
     UsedB.someMethod();
     UsedA.someMethod();
   }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormatted18.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormatted18.test
@@ -3,7 +3,8 @@ import mylib.UsedB;
 
 public class Java {
   public static void main(String[] args) {
-    System.out.println("hello");
+    System.out.println(
+        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
     UsedB.someMethod();
     UsedA.someMethod();
   }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormattedAOSP.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormattedAOSP.test
@@ -4,7 +4,8 @@ import mylib.UsedB;
 
 public class Java {
     public static void main(String[] args) {
-        System.out.println("hello");
+        System.out.println(
+                "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
         UsedB.someMethod();
         UsedA.someMethod();
     }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormattedReflowLongStrings.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeFormattedReflowLongStrings.test
@@ -1,0 +1,12 @@
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+  public static void main(String[] args) {
+    System.out.println(
+        "A very very very very very very very very very very very very very very very very very"
+            + " very very very very long string that goes beyond the 100-character line length.");
+    UsedB.someMethod();
+    UsedA.someMethod();
+  }
+}

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeUnformatted.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeUnformatted.test
@@ -5,7 +5,7 @@ import mylib.UsedA;
 
 public class Java {
 public static void main(String[] args) {
-System.out.println("hello");
+System.out.println("A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
 UsedB.someMethod();
 UsedA.someMethod();
 }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicenseFormattedAOSP.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicenseFormattedAOSP.test
@@ -8,7 +8,8 @@ import mylib.UsedB;
 
 public class Java {
     public static void main(String[] args) {
-        System.out.println("hello");
+        System.out.println(
+                "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
         UsedB.someMethod();
         UsedA.someMethod();
     }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicenseFormattedReflowLongStrings.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicenseFormattedReflowLongStrings.test
@@ -9,7 +9,8 @@ import mylib.UsedB;
 public class Java {
   public static void main(String[] args) {
     System.out.println(
-        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+        "A very very very very very very very very very very very very very very very very very"
+            + " very very very very long string that goes beyond the 100-character line length.");
     UsedB.someMethod();
     UsedA.someMethod();
   }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicensePackageFormattedAOSP.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicensePackageFormattedAOSP.test
@@ -5,7 +5,8 @@ import mylib.UsedB;
 
 public class Java {
     public static void main(String[] args) {
-        System.out.println("hello");
+        System.out.println(
+                "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
         UsedB.someMethod();
         UsedA.someMethod();
     }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicensePackageFormattedReflowLongStrings.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicensePackageFormattedReflowLongStrings.test
@@ -6,7 +6,8 @@ import mylib.UsedB;
 public class Java {
   public static void main(String[] args) {
     System.out.println(
-        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+        "A very very very very very very very very very very very very very very very very very"
+            + " very very very very long string that goes beyond the 100-character line length.");
     UsedB.someMethod();
     UsedA.someMethod();
   }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicensePackageUnformatted.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicensePackageUnformatted.test
@@ -6,7 +6,7 @@ import mylib.UsedA;
 
 public class Java {
 public static void main(String[] args) {
-System.out.println("hello");
+System.out.println("A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
 UsedB.someMethod();
 UsedA.someMethod();
 }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicenseUnformatted.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithLicenseUnformatted.test
@@ -9,7 +9,7 @@ import mylib.UsedA;
 
 public class Java {
 public static void main(String[] args) {
-System.out.println("hello");
+System.out.println("A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
 UsedB.someMethod();
 UsedA.someMethod();
 }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageFormatted.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageFormatted.test
@@ -5,7 +5,8 @@ import mylib.UsedB;
 
 public class Java {
   public static void main(String[] args) {
-    System.out.println("hello");
+    System.out.println(
+        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
     UsedB.someMethod();
     UsedA.someMethod();
   }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageFormattedAOSP.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageFormattedAOSP.test
@@ -5,7 +5,8 @@ import mylib.UsedB;
 
 public class Java {
     public static void main(String[] args) {
-        System.out.println("hello");
+        System.out.println(
+                "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
         UsedB.someMethod();
         UsedA.someMethod();
     }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageFormattedReflowLongStrings.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageFormattedReflowLongStrings.test
@@ -6,7 +6,8 @@ import mylib.UsedB;
 public class Java {
   public static void main(String[] args) {
     System.out.println(
-        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+        "A very very very very very very very very very very very very very very very very very"
+            + " very very very very long string that goes beyond the 100-character line length.");
     UsedB.someMethod();
     UsedA.someMethod();
   }

--- a/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageUnformatted.test
+++ b/testlib/src/main/resources/java/googlejavaformat/JavaCodeWithPackageUnformatted.test
@@ -6,7 +6,7 @@ import mylib.UsedA;
 
 public class Java {
 public static void main(String[] args) {
-System.out.println("hello");
+System.out.println("A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
 UsedB.someMethod();
 UsedA.someMethod();
 }

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,29 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
+	public void behaviorWithReflowLongStrings() throws Exception {
+		try (StepHarness step = StepHarness.forStep(GoogleJavaFormatStep.create(GoogleJavaFormatStep.defaultVersion(), GoogleJavaFormatStep.defaultStyle(), TestProvisioner.mavenCentral(), true))) {
+			if (JreVersion.thisVm() < 11) {
+				step.testResourceException("java/googlejavaformat/JavaCodeUnformatted.test", throwable -> {
+					throwable.hasMessageStartingWith("You are running Spotless on JRE 8")
+							.hasMessageEndingWith(", which limits you to google-java-format 1.7\n"
+									+ "If you upgrade your build JVM to 11+, then you can use google-java-format 1.11.0, which may have fixed this problem.");
+				});
+			} else {
+				step.testResource("java/googlejavaformat/JavaCodeUnformatted.test", "java/googlejavaformat/JavaCodeFormattedReflowLongStrings.test")
+						.testResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test", "java/googlejavaformat/JavaCodeWithLicenseFormattedReflowLongStrings.test")
+						.testResource("java/googlejavaformat/JavaCodeWithLicensePackageUnformatted.test", "java/googlejavaformat/JavaCodeWithLicensePackageFormattedReflowLongStrings.test")
+						.testResource("java/googlejavaformat/JavaCodeWithPackageUnformatted.test", "java/googlejavaformat/JavaCodeWithPackageFormattedReflowLongStrings.test");
+			}
+		}
+	}
+
+	@Test
 	public void equality() throws Exception {
 		new SerializableEqualityTester() {
 			String version = "1.2";
 			String style = "";
+			boolean reflowLongStrings = false;
 
 			@Override
 			protected void setupTest(API api) {
@@ -98,12 +117,15 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 				// change the style, and it's different
 				style = "AOSP";
 				api.areDifferentThan();
+				// change the reflowLongStrings flag, and it's different
+				reflowLongStrings = true;
+				api.areDifferentThan();
 			}
 
 			@Override
 			protected FormatterStep create() {
 				String finalVersion = this.version;
-				return GoogleJavaFormatStep.create(finalVersion, style, TestProvisioner.mavenCentral());
+				return GoogleJavaFormatStep.create(finalVersion, style, TestProvisioner.mavenCentral(), reflowLongStrings);
 			}
 		}.testEquals();
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -36,7 +36,7 @@ public class GoogleJavaFormatStepTest extends ResourceHarness {
 				step.testResourceException("java/googlejavaformat/TextBlock.dirty", throwable -> {
 					throwable.hasMessageStartingWith("You are running Spotless on JRE 8")
 							.hasMessageEndingWith(", which limits you to google-java-format 1.7\n"
-									+ "If you upgrade your build JVM to 11+, then you can use google-java-format 1.9, which may have fixed this problem.");
+									+ "If you upgrade your build JVM to 11+, then you can use google-java-format 1.11.0, which may have fixed this problem.");
 				});
 			} else if (JreVersion.thisVm() < 13) {
 				step.testResourceException("java/googlejavaformat/TextBlock.dirty", throwable -> {


### PR DESCRIPTION
Add configuration option to switch the option of the googleJavaFormat step.
Default to not reflowing for backwards compatibility.
    
Fixes #924