### PR TITLE
Up-to-date index for Maven plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ output = [
 '| Toggle with [`spotless:off` and `spotless:on`](plugin-gradle/#spotlessoff-and-spotlesson) | {{yes}}    | {{yes}}      | {{no}}       | {{no}}  |',
 '| [Ratchet from](https://github.com/diffplug/spotless/tree/main/plugin-gradle#ratchet) `origin/main` or other git ref | {{yes}}    | {{yes}}      | {{no}}       | {{no}}  |',
 '| Define [line endings using git](https://github.com/diffplug/spotless/tree/main/plugin-gradle#line-endings-and-encodings-invisible-stuff) | {{yes}}    | {{yes}}      | {{yes}}       | {{no}}  |',
-'| Fast incremental format and up-to-date check   | {{yes}}      | {{no}}       | {{no}}       | {{no}}  |',
+'| Fast incremental format and up-to-date check   | {{yes}}      | {{yes}}      | {{no}}       | {{no}}  |',
 '| Fast format on fresh checkout using buildcache | {{yes}}      | {{no}}       | {{no}}       | {{no}}  |',
 lib('generic.EndWithNewlineStep')                +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
 lib('generic.IndentStep')                        +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
@@ -81,7 +81,7 @@ extra('wtp.EclipseWtpFormatterStep')             +'{{yes}}       | {{yes}}      
 | Toggle with [`spotless:off` and `spotless:on`](plugin-gradle/#spotlessoff-and-spotlesson) | :+1:    | :+1:      | :white_large_square:       | :white_large_square:  |
 | [Ratchet from](https://github.com/diffplug/spotless/tree/main/plugin-gradle#ratchet) `origin/main` or other git ref | :+1:    | :+1:      | :white_large_square:       | :white_large_square:  |
 | Define [line endings using git](https://github.com/diffplug/spotless/tree/main/plugin-gradle#line-endings-and-encodings-invisible-stuff) | :+1:    | :+1:      | :+1:       | :white_large_square:  |
-| Fast incremental format and up-to-date check   | :+1:      | :white_large_square:       | :white_large_square:       | :white_large_square:  |
+| Fast incremental format and up-to-date check   | :+1:      | :+1:      | :white_large_square:       | :white_large_square:  |
 | Fast format on fresh checkout using buildcache | :+1:      | :white_large_square:       | :white_large_square:       | :white_large_square:  |
 | [`generic.EndWithNewlineStep`](lib/src/main/java/com/diffplug/spotless/generic/EndWithNewlineStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`generic.IndentStep`](lib/src/main/java/com/diffplug/spotless/generic/IndentStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ artifactIdGradle=spotless-plugin-gradle
 # Build requirements
 VER_JAVA=1.8
 VER_SPOTBUGS=4.5.0
+VER_JSR_305=3.0.2
 
 # Dependencies provided by Spotless plugin
 VER_SLF4J=[1.6,2.0[

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -35,5 +35,5 @@ tasks.named('spotbugsMain') {
 dependencies {
 	compileOnly 'net.jcip:jcip-annotations:1.0'
 	compileOnly "com.github.spotbugs:spotbugs-annotations:${VER_SPOTBUGS}"
-	compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+	compileOnly "com.google.code.findbugs:jsr305:${VER_JSR_305}"
 }

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Incremental up-to-date checking ([#935](https://github.com/diffplug/spotless/pull/935)).
 
 ## [2.17.7] - 2021-12-16
 ### Fixed

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -900,6 +900,47 @@ If your project has not been rigorous with copyright headers, and you'd like to 
 
 <a name="ratchet"></a>
 
+## Incremental up-to-date checking and formatting
+
+**This feature is turned off by default.**
+
+Execution of `spotless:check` and `spotless:apply` for large projects can take time.
+By default, Spotless Maven plugin needs to read and format each source file.
+Repeated executions of `spotless:check` or `spotless:apply` are completely independent.
+
+If your project has many source files managed by Spotless and formatting takes a long time, you can
+enable incremental up-to-date checking with the following configuration:
+
+```xml
+<configuration>
+  <upToDateChecking>
+    <enabled>true</enabled>
+  </upToDateChecking>
+  <!-- ... define formats ... -->
+</configuration>
+```
+
+With up-to-date checking enabled, Spotless creates an index file in the `target` directory.
+The index file contains source file paths and corresponding last modified timestamps.
+It allows Spotless to skip already formatted files that have not changed.
+
+**Note:** the index file is located in the `target` directory. Executing `mvn clean` will delete
+the index file, and Spotless will need to check/format all the source files.
+
+Spotless will remove the index file when up-to-date checking is explicitly turned off with the
+following configuration:
+
+```xml
+<configuration>
+  <upToDateChecking>
+    <enabled>false</enabled>
+  </upToDateChecking>
+  <!-- ... define formats ... -->
+</configuration>
+```
+
+Consider using this configuration if you experience issues with up-to-date checking.
+
 ## How can I enforce formatting gradually? (aka "ratchet")
 
 If your project is not currently enforcing formatting, then it can be a noisy transition.  Having a giant commit where every single file gets changed makes the history harder to read.  To address this, you can use the `ratchet` feature:

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -161,6 +161,7 @@ task createPomXml(dependsOn: installLocalDependencies) {
 			mavenApiVersion           : VER_MAVEN_API,
 			eclipseAetherVersion      : VER_ECLIPSE_AETHER,
 			spotlessLibVersion        : libVersion,
+			jsr305Version             : VER_JSR_305,
 			additionalDependencies    : additionalDependencies
 		]
 

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -79,6 +79,7 @@ dependencies {
 
 	compileOnly "org.apache.maven:maven-plugin-api:${VER_MAVEN_API}"
 	compileOnly "org.apache.maven.plugin-tools:maven-plugin-annotations:${VER_MAVEN_API}"
+	compileOnly "org.apache.maven:maven-core:${VER_MAVEN_API}"
 	compileOnly "org.eclipse.aether:aether-api:${VER_ECLIPSE_AETHER}"
 	compileOnly "org.eclipse.aether:aether-util:${VER_ECLIPSE_AETHER}"
 
@@ -95,6 +96,7 @@ dependencies {
 	testImplementation "org.apache.maven:maven-plugin-api:${VER_MAVEN_API}"
 	testImplementation "org.eclipse.aether:aether-api:${VER_ECLIPSE_AETHER}"
 	testImplementation "org.codehaus.plexus:plexus-resources:${VER_PLEXUS_RESOURCES}"
+	testImplementation "org.apache.maven:maven-core:${VER_MAVEN_API}"
 }
 
 task cleanMavenProjectDir(type: Delete) { delete MAVEN_PROJECT_DIR }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -320,7 +320,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private UpToDateChecker createUpToDateChecker(Iterable<Formatter> formatters) {
-		if (upToDateChecking.isEnabled()) {
+		if (upToDateChecking != null && upToDateChecking.isEnabled()) {
 			getLog().info("Up-to-date checking enabled");
 			return UpToDateChecker.forProject(project, formatters, getLog());
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -324,6 +324,6 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 			getLog().info("Up-to-date checking enabled");
 			return UpToDateChecker.forProject(project, formatters, getLog());
 		}
-		return UpToDateChecker.noop();
+		return UpToDateChecker.noop(project, getLog());
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -60,6 +60,7 @@ import com.diffplug.spotless.maven.generic.Format;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
 import com.diffplug.spotless.maven.groovy.Groovy;
 import com.diffplug.spotless.maven.incremental.UpToDateChecker;
+import com.diffplug.spotless.maven.incremental.UpToDateChecking;
 import com.diffplug.spotless.maven.java.Java;
 import com.diffplug.spotless.maven.kotlin.Kotlin;
 import com.diffplug.spotless.maven.pom.Pom;
@@ -156,9 +157,8 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter(property = LicenseHeaderStep.spotlessSetLicenseHeaderYearsFromGitHistory)
 	private String setLicenseHeaderYearsFromGitHistory;
 
-	// todo: check naming convensions for plugin properties
-	@Parameter(property = "spotless.upToDateCheckingEnabled", defaultValue = "false")
-	private boolean upToDateCheckingEnabled;
+	@Parameter
+	private UpToDateChecking upToDateChecking;
 
 	protected abstract void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException;
 
@@ -320,7 +320,8 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private UpToDateChecker createUpToDateChecker(Iterable<Formatter> formatters) {
-		if (upToDateCheckingEnabled) {
+		if (upToDateChecking.isEnabled()) {
+			getLog().info("Up-to-date checking enabled");
 			return UpToDateChecker.forProject(project, formatters, getLog());
 		}
 		return UpToDateChecker.noop();

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Parameter;
@@ -71,10 +72,10 @@ public abstract class FormatterFactory {
 		return excludes == null ? emptySet() : Sets.newHashSet(excludes);
 	}
 
-	public final Formatter newFormatter(List<File> filesToFormat, FormatterConfig config) {
+	public final Formatter newFormatter(Supplier<Iterable<File>> filesToFormat, FormatterConfig config) {
 		Charset formatterEncoding = encoding(config);
 		LineEnding formatterLineEndings = lineEndings(config);
-		LineEnding.Policy formatterLineEndingPolicy = formatterLineEndings.createPolicy(config.getFileLocator().getBaseDir(), () -> filesToFormat);
+		LineEnding.Policy formatterLineEndingPolicy = formatterLineEndings.createPolicy(config.getFileLocator().getBaseDir(), filesToFormat);
 
 		FormatterStepConfig stepConfig = stepConfig(formatterEncoding, config);
 		List<FormatterStepFactory> factories = gatherStepFactories(config.getGlobalStepFactories(), stepFactories);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
@@ -17,27 +17,27 @@ package com.diffplug.spotless.maven;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.diffplug.spotless.Formatter;
 
 class FormattersHolder implements AutoCloseable {
 
-	private final Map<Formatter, List<File>> formatterToFiles;
+	private final Map<Formatter, Supplier<Iterable<File>>> formatterToFiles;
 
-	private FormattersHolder(Map<Formatter, List<File>> formatterToFiles) {
+	FormattersHolder(Map<Formatter, Supplier<Iterable<File>>> formatterToFiles) {
 		this.formatterToFiles = formatterToFiles;
 	}
 
-	static FormattersHolder create(Map<FormatterFactory, List<File>> formatterFactoryToFiles, FormatterConfig config) {
-		Map<Formatter, List<File>> formatterToFiles = new HashMap<>();
+	static FormattersHolder create(Map<FormatterFactory, Supplier<Iterable<File>>> formatterFactoryToFiles, FormatterConfig config) {
+		Map<Formatter, Supplier<Iterable<File>>> formatterToFiles = new HashMap<>();
 		try {
-			for (Entry<FormatterFactory, List<File>> entry : formatterFactoryToFiles.entrySet()) {
+			for (Entry<FormatterFactory, Supplier<Iterable<File>>> entry : formatterFactoryToFiles.entrySet()) {
 				FormatterFactory formatterFactory = entry.getKey();
-				List<File> files = entry.getValue();
+				Supplier<Iterable<File>> files = entry.getValue();
 
 				Formatter formatter = formatterFactory.newFormatter(files, config);
 				formatterToFiles.put(formatter, files);
@@ -58,7 +58,7 @@ class FormattersHolder implements AutoCloseable {
 		return formatterToFiles.keySet();
 	}
 
-	Map<Formatter, List<File>> getFormattersWithFiles() {
+	Map<Formatter, Supplier<Iterable<File>>> getFormattersWithFiles() {
 		return formatterToFiles;
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.diffplug.spotless.Formatter;
+
+class FormattersHolder implements AutoCloseable {
+
+	private final Map<Formatter, List<File>> formatterToFiles;
+
+	private FormattersHolder(Map<Formatter, List<File>> formatterToFiles) {
+		this.formatterToFiles = formatterToFiles;
+	}
+
+	static FormattersHolder create(Map<FormatterFactory, List<File>> formatterFactoryToFiles, FormatterConfig config) {
+		Map<Formatter, List<File>> formatterToFiles = new HashMap<>();
+		try {
+			for (Entry<FormatterFactory, List<File>> entry : formatterFactoryToFiles.entrySet()) {
+				FormatterFactory formatterFactory = entry.getKey();
+				List<File> files = entry.getValue();
+
+				Formatter formatter = formatterFactory.newFormatter(files, config);
+				formatterToFiles.put(formatter, files);
+			}
+		} catch (RuntimeException openError) {
+			try {
+				close(formatterToFiles.keySet());
+			} catch (Exception closeError) {
+				openError.addSuppressed(closeError);
+			}
+			throw openError;
+		}
+
+		return new FormattersHolder(formatterToFiles);
+	}
+
+	Iterable<Formatter> getFormatters() {
+		return formatterToFiles.keySet();
+	}
+
+	Map<Formatter, List<File>> getFormattersWithFiles() {
+		return formatterToFiles;
+	}
+
+	@Override
+	public void close() {
+		try {
+			close(formatterToFiles.keySet());
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to close formatters", e);
+		}
+	}
+
+	private static void close(Set<Formatter> formatters) throws Exception {
+		Exception error = null;
+		for (Formatter formatter : formatters) {
+			try {
+				formatter.close();
+			} catch (Exception e) {
+				if (error == null) {
+					error = e;
+				} else {
+					error.addSuppressed(e);
+				}
+			}
+		}
+		if (error != null) {
+			throw error;
+		}
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/PluginException.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/PluginException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+class PluginException extends RuntimeException {
+
+	PluginException(String message) {
+		super(message);
+	}
+
+	PluginException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	MojoExecutionException asMojoExecutionException() {
+		return new MojoExecutionException(getMessage(), getCause());
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
@@ -32,24 +32,22 @@ import com.diffplug.spotless.maven.incremental.UpToDateChecker;
 public class SpotlessApplyMojo extends AbstractSpotlessMojo {
 
 	@Override
-	protected void process(Iterable<File> files, Formatter formatter) throws MojoExecutionException {
-		try (UpToDateChecker upToDateChecker = createUpToDateChecker()) {
-			for (File file : files) {
-				if (upToDateChecker.isUpToDate(file)) {
-					continue;
-				}
-
-				try {
-					PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
-					if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
-						dirtyState.writeCanonicalTo(file);
-					}
-				} catch (IOException e) {
-					throw new MojoExecutionException("Unable to format file " + file, e);
-				}
-
-				upToDateChecker.setUpToDate(file);
+	protected void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
+		for (File file : files) {
+			if (upToDateChecker.isUpToDate(file)) {
+				continue;
 			}
+
+			try {
+				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
+				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
+					dirtyState.writeCanonicalTo(file);
+				}
+			} catch (IOException e) {
+				throw new MojoExecutionException("Unable to format file " + file, e);
+			}
+
+			upToDateChecker.setUpToDate(file);
 		}
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
@@ -35,6 +35,9 @@ public class SpotlessApplyMojo extends AbstractSpotlessMojo {
 	protected void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
 		for (File file : files) {
 			if (upToDateChecker.isUpToDate(file.toPath())) {
+				if (getLog().isDebugEnabled()) {
+					getLog().debug("Spotless will not format an up-to-date file: " + file);
+				}
 				continue;
 			}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
@@ -34,7 +34,7 @@ public class SpotlessApplyMojo extends AbstractSpotlessMojo {
 	@Override
 	protected void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
 		for (File file : files) {
-			if (upToDateChecker.isUpToDate(file)) {
+			if (upToDateChecker.isUpToDate(file.toPath())) {
 				continue;
 			}
 
@@ -47,7 +47,7 @@ public class SpotlessApplyMojo extends AbstractSpotlessMojo {
 				throw new MojoExecutionException("Unable to format file " + file, e);
 			}
 
-			upToDateChecker.setUpToDate(file);
+			upToDateChecker.setUpToDate(file.toPath());
 		}
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -37,22 +37,20 @@ import com.diffplug.spotless.maven.incremental.UpToDateChecker;
 public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 
 	@Override
-	protected void process(Iterable<File> files, Formatter formatter) throws MojoExecutionException {
+	protected void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
 		List<File> problemFiles = new ArrayList<>();
-		try (UpToDateChecker upToDateChecker = createUpToDateChecker()) {
-			for (File file : files) {
-				if (upToDateChecker.isUpToDate(file)) {
-					continue;
-				}
+		for (File file : files) {
+			if (upToDateChecker.isUpToDate(file)) {
+				continue;
+			}
 
-				try {
-					PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
-					if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
-						problemFiles.add(file);
-					}
-				} catch (IOException e) {
-					throw new MojoExecutionException("Unable to format file " + file, e);
+			try {
+				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
+				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
+					problemFiles.add(file);
 				}
+			} catch (IOException e) {
+				throw new MojoExecutionException("Unable to format file " + file, e);
 			}
 		}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -40,7 +40,7 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 	protected void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
 		List<File> problemFiles = new ArrayList<>();
 		for (File file : files) {
-			if (upToDateChecker.isUpToDate(file)) {
+			if (upToDateChecker.isUpToDate(file.toPath())) {
 				continue;
 			}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -41,6 +41,9 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 		List<File> problemFiles = new ArrayList<>();
 		for (File file : files) {
 			if (upToDateChecker.isUpToDate(file.toPath())) {
+				if (getLog().isDebugEnabled()) {
+					getLog().debug("Spotless will not check an up-to-date file: " + file);
+				}
 				continue;
 			}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -48,8 +48,9 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					problemFiles.add(file);
+				} else {
+					upToDateChecker.setUpToDate(file.toPath());
 				}
-				// todo: else - mark file as up-to-date?
 			} catch (IOException e) {
 				throw new MojoExecutionException("Unable to format file " + file, e);
 			}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -49,6 +49,7 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					problemFiles.add(file);
 				}
+				// todo: else - mark file as up-to-date?
 			} catch (IOException e) {
 				throw new MojoExecutionException("Unable to format file " + file, e);
 			}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -40,7 +40,6 @@ import org.apache.maven.plugin.logging.Log;
 
 import com.diffplug.common.annotations.VisibleForTesting;
 
-// todo: FileTime -> Instant can be a lossy conversion
 class FileIndex {
 
 	private static final String SEPARATOR = " ";

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -32,8 +32,9 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.TreeMap;
+
+import javax.annotation.Nullable;
 
 import org.apache.maven.plugin.logging.Log;
 
@@ -101,12 +102,13 @@ class FileIndex {
 		}
 	}
 
-	Optional<Instant> getLastModifiedTime(Path file) {
+	@Nullable
+	Instant getLastModifiedTime(Path file) {
 		if (!file.startsWith(projectDir)) {
-			return Optional.empty();
+			return null;
 		}
 		Path relativeFile = projectDir.relativize(file);
-		return Optional.ofNullable(fileToLastModifiedTime.get(relativeFile));
+		return fileToLastModifiedTime.get(relativeFile);
 	}
 
 	void setLastModifiedTime(Path file, Instant time) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -81,6 +81,19 @@ class FileIndex {
 		}
 	}
 
+	static void delete(FileIndexConfig config, Log log) {
+		Path indexFile = config.getIndexFile();
+		boolean deleted = false;
+		try {
+			deleted = Files.deleteIfExists(indexFile);
+		} catch (IOException e) {
+			log.warn("Unable to delete the index file: " + indexFile, e);
+		}
+		if (deleted) {
+			log.info("Deleted the index file: " + indexFile);
+		}
+	}
+
 	Optional<Instant> getLastModifiedTime(Path file) {
 		if (!file.startsWith(projectDir)) {
 			return Optional.empty();

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.newBufferedReader;
+import static java.nio.file.Files.newBufferedWriter;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import org.apache.maven.plugin.logging.Log;
+
+// todo: use TrieMap for fileToLastModifiedTime with String keys
+// todo: FileTime -> Instant can be a lossy conversion
+// todo: add unit tests
+class FileIndex {
+
+	private static final String INDEX_FILE_NAME = "spotless-index";
+	private static final String SEPARATOR = " ";
+
+	private final PluginFingerprint pluginFingerprint;
+	private final Path baseDir;
+	private final Map<Path, Instant> fileToLastModifiedTime;
+	private boolean updated;
+
+	private FileIndex(PluginFingerprint pluginFingerprint, Path baseDir, Map<Path, Instant> fileToLastModifiedTime) {
+		this.pluginFingerprint = pluginFingerprint;
+		this.baseDir = baseDir;
+		this.fileToLastModifiedTime = fileToLastModifiedTime;
+	}
+
+	static FileIndex read(Path baseDir, PluginFingerprint pluginFingerprint, Log log) {
+		Path indexFile = indexFile(baseDir);
+		if (Files.notExists(indexFile)) {
+			log.info("Index file does not exist. Fallback to an empty index");
+			return emptyIndex(baseDir, pluginFingerprint);
+		}
+
+		try (BufferedReader reader = newBufferedReader(indexFile, UTF_8)) {
+			PluginFingerprint actualPluginFingerprint = PluginFingerprint.from(reader.readLine());
+			if (!pluginFingerprint.equals(actualPluginFingerprint)) {
+				log.info("Fingerprint mismatch in the index file. Fallback to an empty index");
+				return emptyIndex(baseDir, pluginFingerprint);
+			} else {
+				Map<Path, Instant> fileToLastModifiedTime = readFileToLastModifiedTime(reader, baseDir, log);
+				return new FileIndex(pluginFingerprint, baseDir, fileToLastModifiedTime);
+			}
+		} catch (IOException e) {
+			log.warn("Error reading the index file. Fallback to an empty index", e);
+			return emptyIndex(baseDir, pluginFingerprint);
+		}
+	}
+
+	Optional<Instant> getLastModifiedTime(Path file) {
+		if (!file.startsWith(baseDir)) {
+			return Optional.empty();
+		}
+		Path relativeFile = baseDir.relativize(file);
+		return Optional.ofNullable(fileToLastModifiedTime.get(relativeFile));
+	}
+
+	void setLastModifiedTime(Path file, Instant time) {
+		Path relativeFile = baseDir.relativize(file);
+		fileToLastModifiedTime.put(relativeFile, time);
+		updated = true;
+	}
+
+	void write() {
+		if (!updated) {
+			return;
+		}
+
+		Path indexFile = indexFile(baseDir);
+		try (PrintWriter writer = new PrintWriter(newBufferedWriter(indexFile, UTF_8, CREATE, TRUNCATE_EXISTING))) {
+			writer.println(pluginFingerprint.value());
+
+			for (Entry<Path, Instant> entry : fileToLastModifiedTime.entrySet()) {
+				writer.print(entry.getKey() + SEPARATOR + entry.getValue());
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Unable to write the index", e);
+		}
+	}
+
+	private static Map<Path, Instant> readFileToLastModifiedTime(BufferedReader reader, Path baseDir, Log log) throws IOException {
+		Map<Path, Instant> fileToLastModifiedTime = new TreeMap<>();
+		String line;
+		while ((line = reader.readLine()) != null) {
+			int separatorIndex = line.lastIndexOf(SEPARATOR);
+			if (separatorIndex == -1) {
+				throw new IOException("Incorrect index file. No separator found in '" + line + "'");
+			}
+
+			Path relativeFile = Paths.get(line.substring(0, separatorIndex));
+			Path absoluteFile = baseDir.resolve(relativeFile);
+			if (Files.notExists(absoluteFile)) {
+				log.info("File stored in the index does not exist: " + relativeFile);
+			} else {
+				Instant lastModifiedTime;
+				try {
+					lastModifiedTime = Instant.parse(line.substring(separatorIndex));
+				} catch (Exception e) {
+					throw new IOException("Incorrect index file. Unable to parse last modified time from '" + line + "'", e);
+				}
+				fileToLastModifiedTime.put(relativeFile, lastModifiedTime);
+			}
+		}
+		return fileToLastModifiedTime;
+	}
+
+	private static Path indexFile(Path baseDir) {
+		return baseDir.resolve(INDEX_FILE_NAME);
+	}
+
+	private static FileIndex emptyIndex(Path baseDir, PluginFingerprint pluginFingerprint) {
+		return new FileIndex(pluginFingerprint, baseDir, new TreeMap<>());
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -139,8 +139,12 @@ class FileIndex {
 	}
 
 	private void ensureParentDirExists() {
+		Path parentDir = indexFile.getParent();
+		if (parentDir == null) {
+			throw new IllegalStateException("Index file does not have a parent dir: " + indexFile);
+		}
 		try {
-			Files.createDirectories(indexFile.getParent());
+			Files.createDirectories(parentDir);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Unable to create parent directory for the index file: " + indexFile, e);
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -100,11 +100,7 @@ class FileIndex {
 			return;
 		}
 
-		try {
-			Files.createDirectories(indexFile.getParent());
-		} catch (IOException e) {
-			throw new UncheckedIOException("Unable to create parent directory for the index file: " + indexFile, e);
-		}
+		ensureParentDirExists();
 		try (PrintWriter writer = new PrintWriter(newBufferedWriter(indexFile, UTF_8, CREATE, TRUNCATE_EXISTING))) {
 			writer.println(pluginFingerprint.value());
 
@@ -113,6 +109,14 @@ class FileIndex {
 			}
 		} catch (IOException e) {
 			throw new UncheckedIOException("Unable to write the index", e);
+		}
+	}
+
+	private void ensureParentDirExists() {
+		try {
+			Files.createDirectories(indexFile.getParent());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Unable to create parent directory for the index file: " + indexFile, e);
 		}
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -66,13 +66,14 @@ class FileIndex {
 		}
 
 		try (BufferedReader reader = newBufferedReader(indexFile, UTF_8)) {
-			PluginFingerprint actualPluginFingerprint = PluginFingerprint.from(reader.readLine());
-			if (!config.getPluginFingerprint().equals(actualPluginFingerprint)) {
+			PluginFingerprint computedFingerprint = config.getPluginFingerprint();
+			PluginFingerprint storedFingerprint = PluginFingerprint.from(reader.readLine());
+			if (!computedFingerprint.equals(storedFingerprint)) {
 				log.info("Fingerprint mismatch in the index file. Fallback to an empty index");
 				return emptyIndex(config);
 			} else {
 				Map<Path, Instant> fileToLastModifiedTime = readFileToLastModifiedTime(reader, config.getProjectDir(), log);
-				return new FileIndex(indexFile, config.getPluginFingerprint(), fileToLastModifiedTime, config.getProjectDir());
+				return new FileIndex(indexFile, computedFingerprint, fileToLastModifiedTime, config.getProjectDir());
 			}
 		} catch (IOException e) {
 			log.warn("Error reading the index file. Fallback to an empty index", e);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndexConfig.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndexConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import java.nio.file.Path;
+
+import org.apache.maven.project.MavenProject;
+
+class FileIndexConfig {
+
+	private static final String INDEX_FILE_NAME = "spotless-index";
+
+	private final MavenProject project;
+	private final PluginFingerprint pluginFingerprint;
+
+	FileIndexConfig(MavenProject project, PluginFingerprint pluginFingerprint) {
+		this.project = project;
+		this.pluginFingerprint = pluginFingerprint;
+	}
+
+	Path getProjectDir() {
+		return project.getBasedir().toPath();
+	}
+
+	Path getIndexFile() {
+		Path targetDir = getProjectDir().resolve(project.getBuild().getDirectory());
+		return targetDir.resolve(INDEX_FILE_NAME);
+	}
+
+	PluginFingerprint getPluginFingerprint() {
+		return pluginFingerprint;
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndexConfig.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndexConfig.java
@@ -26,6 +26,10 @@ class FileIndexConfig {
 	private final MavenProject project;
 	private final PluginFingerprint pluginFingerprint;
 
+	FileIndexConfig(MavenProject project) {
+		this(project, PluginFingerprint.empty());
+	}
+
 	FileIndexConfig(MavenProject project, PluginFingerprint pluginFingerprint) {
 		this.project = project;
 		this.pluginFingerprint = pluginFingerprint;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
@@ -39,9 +39,8 @@ class IndexBasedChecker implements UpToDateChecker {
 
 	static IndexBasedChecker create(MavenProject project, Iterable<Formatter> formatters, Log log) {
 		PluginFingerprint pluginFingerprint = PluginFingerprint.from(project, formatters);
-		// todo: does this produce the correct dir?
-		Path buildDir = project.getBasedir().toPath().resolve(project.getBuild().getDirectory());
-		FileIndex fileIndex = FileIndex.read(buildDir, pluginFingerprint, log);
+		FileIndexConfig indexConfig = new FileIndexConfig(project, pluginFingerprint);
+		FileIndex fileIndex = FileIndex.read(indexConfig, log);
 		return new IndexBasedChecker(fileIndex);
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
@@ -26,14 +26,15 @@ import java.util.Optional;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
+import com.diffplug.common.annotations.VisibleForTesting;
 import com.diffplug.spotless.Formatter;
 
-// todo: add unit tests
 class IndexBasedChecker implements UpToDateChecker {
 
 	private final FileIndex index;
 
-	private IndexBasedChecker(FileIndex index) {
+	@VisibleForTesting
+	IndexBasedChecker(FileIndex index) {
 		this.index = index;
 	}
 
@@ -53,16 +54,14 @@ class IndexBasedChecker implements UpToDateChecker {
 			return false;
 		}
 
-		Instant currentLastModifiedTime = lastModifiedTime(path);
 		Instant storedLastModifiedTime = storedLastModifiedTimeOptional.get();
-		return currentLastModifiedTime.isAfter(storedLastModifiedTime);
+		return storedLastModifiedTime.equals(lastModifiedTime(path));
 	}
 
 	@Override
 	public void setUpToDate(File file) {
 		Path path = file.toPath();
-		Instant currentLastModifiedTime = lastModifiedTime(path);
-		index.setLastModifiedTime(path, currentLastModifiedTime);
+		index.setLastModifiedTime(path, lastModifiedTime(path));
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
+import com.diffplug.spotless.Formatter;
+
 // todo: add unit tests
 class IndexBasedChecker implements UpToDateChecker {
 
@@ -35,8 +37,8 @@ class IndexBasedChecker implements UpToDateChecker {
 		this.index = index;
 	}
 
-	static IndexBasedChecker create(MavenProject project, Log log) {
-		PluginFingerprint pluginFingerprint = PluginFingerprint.from(project);
+	static IndexBasedChecker create(MavenProject project, Iterable<Formatter> formatters, Log log) {
+		PluginFingerprint pluginFingerprint = PluginFingerprint.from(project, formatters);
 		// todo: does this produce the correct dir?
 		Path buildDir = project.getBasedir().toPath().resolve(project.getBuild().getDirectory());
 		FileIndex fileIndex = FileIndex.read(buildDir, pluginFingerprint, log);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
@@ -15,11 +15,11 @@
  */
 package com.diffplug.spotless.maven.incremental;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -46,16 +46,14 @@ class IndexBasedChecker implements UpToDateChecker {
 	}
 
 	@Override
-	public boolean isUpToDate(File file) {
-		Path path = file.toPath();
-		Instant storedLastModifiedTime = index.getLastModifiedTime(path);
-		return Objects.equals(storedLastModifiedTime, lastModifiedTime(path));
+	public boolean isUpToDate(Path file) {
+		Instant storedLastModifiedTime = index.getLastModifiedTime(file);
+		return Objects.equals(storedLastModifiedTime, lastModifiedTime(file));
 	}
 
 	@Override
-	public void setUpToDate(File file) {
-		Path path = file.toPath();
-		index.setLastModifiedTime(path, lastModifiedTime(path));
+	public void setUpToDate(Path file) {
+		index.setLastModifiedTime(file, lastModifiedTime(file));
 	}
 
 	@Override
@@ -63,9 +61,11 @@ class IndexBasedChecker implements UpToDateChecker {
 		index.write();
 	}
 
+	// todo: FileTime -> Instant can be a lossy conversion
 	private static Instant lastModifiedTime(Path path) {
 		try {
-			return Files.getLastModifiedTime(path).toInstant();
+			FileTime lastModifiedTime = Files.getLastModifiedTime(path);
+			return lastModifiedTime.toInstant();
 		} catch (IOException e) {
 			throw new UncheckedIOException("Unable to get last modified date for " + path, e);
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
+// todo: add unit tests
+class IndexBasedChecker implements UpToDateChecker {
+
+	private final FileIndex index;
+
+	private IndexBasedChecker(FileIndex index) {
+		this.index = index;
+	}
+
+	static IndexBasedChecker create(MavenProject project, Log log) {
+		PluginFingerprint pluginFingerprint = PluginFingerprint.from(project);
+		// todo: does this produce the correct dir?
+		Path buildDir = project.getBasedir().toPath().resolve(project.getBuild().getDirectory());
+		FileIndex fileIndex = FileIndex.read(buildDir, pluginFingerprint, log);
+		return new IndexBasedChecker(fileIndex);
+	}
+
+	@Override
+	public boolean isUpToDate(File file) {
+		Path path = file.toPath();
+
+		Optional<Instant> storedLastModifiedTimeOptional = index.getLastModifiedTime(path);
+		if (!storedLastModifiedTimeOptional.isPresent()) {
+			return false;
+		}
+
+		Instant currentLastModifiedTime = lastModifiedTime(path);
+		Instant storedLastModifiedTime = storedLastModifiedTimeOptional.get();
+		return currentLastModifiedTime.isAfter(storedLastModifiedTime);
+	}
+
+	@Override
+	public void setUpToDate(File file) {
+		Path path = file.toPath();
+		Instant currentLastModifiedTime = lastModifiedTime(path);
+		index.setLastModifiedTime(path, currentLastModifiedTime);
+	}
+
+	@Override
+	public void close() {
+		index.write();
+	}
+
+	private static Instant lastModifiedTime(Path path) {
+		try {
+			return Files.getLastModifiedTime(path).toInstant();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Unable to get last modified date for " + path, e);
+		}
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/IndexBasedChecker.java
@@ -21,7 +21,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Optional;
+import java.util.Objects;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
@@ -48,14 +48,8 @@ class IndexBasedChecker implements UpToDateChecker {
 	@Override
 	public boolean isUpToDate(File file) {
 		Path path = file.toPath();
-
-		Optional<Instant> storedLastModifiedTimeOptional = index.getLastModifiedTime(path);
-		if (!storedLastModifiedTimeOptional.isPresent()) {
-			return false;
-		}
-
-		Instant storedLastModifiedTime = storedLastModifiedTimeOptional.get();
-		return storedLastModifiedTime.equals(lastModifiedTime(path));
+		Instant storedLastModifiedTime = index.getLastModifiedTime(path);
+		return Objects.equals(storedLastModifiedTime, lastModifiedTime(path));
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import java.io.File;
+
+class NoopChecker implements UpToDateChecker {
+
+	static final NoopChecker INSTANCE = new NoopChecker();
+
+	private NoopChecker() {}
+
+	@Override
+	public boolean isUpToDate(File file) {
+		return false;
+	}
+
+	@Override
+	public void setUpToDate(File file) {}
+
+	@Override
+	public void close() {}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
@@ -15,7 +15,7 @@
  */
 package com.diffplug.spotless.maven.incremental;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
@@ -31,12 +31,12 @@ class NoopChecker implements UpToDateChecker {
 	}
 
 	@Override
-	public boolean isUpToDate(File file) {
+	public boolean isUpToDate(Path file) {
 		return false;
 	}
 
 	@Override
-	public void setUpToDate(File file) {}
+	public void setUpToDate(Path file) {}
 
 	@Override
 	public void close() {}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/NoopChecker.java
@@ -17,11 +17,18 @@ package com.diffplug.spotless.maven.incremental;
 
 import java.io.File;
 
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
 class NoopChecker implements UpToDateChecker {
 
-	static final NoopChecker INSTANCE = new NoopChecker();
-
 	private NoopChecker() {}
+
+	static NoopChecker create(MavenProject project, Log log) {
+		FileIndexConfig indexConfig = new FileIndexConfig(project);
+		FileIndex.delete(indexConfig, log);
+		return new NoopChecker();
+	}
 
 	@Override
 	public boolean isUpToDate(File file) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/ObjectDigestOutputStream.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/ObjectDigestOutputStream.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+class ObjectDigestOutputStream extends ObjectOutputStream {
+
+	private final MessageDigest messageDigest;
+
+	private ObjectDigestOutputStream(DigestOutputStream out) throws IOException {
+		super(out);
+		messageDigest = out.getMessageDigest();
+	}
+
+	static ObjectDigestOutputStream create() throws IOException {
+		return new ObjectDigestOutputStream(createDigestOutputStream());
+	}
+
+	byte[] digest() {
+		return messageDigest.digest();
+	}
+
+	private static DigestOutputStream createDigestOutputStream() {
+		OutputStream nullOutputStream = new OutputStream() {
+			@Override
+			public void write(int b) {}
+		};
+
+		MessageDigest result;
+		try {
+			result = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 digest algorithm not available", e);
+		}
+
+		return new DigestOutputStream(nullOutputStream, result);
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Objects;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+
+class PluginFingerprint {
+
+	private static final String SPOTLESS_PLUGIN_KEY = "com.diffplug.spotless:spotless-maven-plugin";
+
+	private final String value;
+
+	private PluginFingerprint(String value) {
+		this.value = value;
+	}
+
+	static PluginFingerprint from(MavenProject project) {
+		Plugin spotlessPlugin = project.getPlugin(SPOTLESS_PLUGIN_KEY);
+		byte[] serialized = serialize(spotlessPlugin);
+		byte[] digest = digest(serialized);
+		String value = Base64.getEncoder().encodeToString(digest);
+		return new PluginFingerprint(value);
+	}
+
+	static PluginFingerprint from(String value) {
+		return new PluginFingerprint(value);
+	}
+
+	String value() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		PluginFingerprint that = (PluginFingerprint) o;
+		return value.equals(that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(value);
+	}
+
+	@Override
+	public String toString() {
+		return "PluginFingerprint[" + value + "]";
+	}
+
+	private static byte[] digest(byte[] bytes) {
+		try {
+			return MessageDigest.getInstance("SHA-256").digest(bytes);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 digest algorithm not available", e);
+		}
+	}
+
+	private static byte[] serialize(Plugin plugin) {
+		try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+				ObjectOutputStream objectStream = new ObjectOutputStream(byteStream)) {
+			objectStream.writeObject(plugin);
+			objectStream.flush();
+			return byteStream.toByteArray();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Unable to serialize plugin " + plugin, e);
+		}
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
@@ -46,6 +46,10 @@ class PluginFingerprint {
 		return new PluginFingerprint(value);
 	}
 
+	static PluginFingerprint empty() {
+		return new PluginFingerprint("");
+	}
+
 	String value() {
 		return value;
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
@@ -30,8 +30,8 @@ public interface UpToDateChecker extends AutoCloseable {
 
 	void close();
 
-	static UpToDateChecker noop() {
-		return NoopChecker.INSTANCE;
+	static UpToDateChecker noop(MavenProject project, Log log) {
+		return NoopChecker.create(project, log);
 	}
 
 	static UpToDateChecker forProject(MavenProject project, Iterable<Formatter> formatters, Log log) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
@@ -15,7 +15,7 @@
  */
 package com.diffplug.spotless.maven.incremental;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
@@ -24,9 +24,9 @@ import com.diffplug.spotless.Formatter;
 
 public interface UpToDateChecker extends AutoCloseable {
 
-	boolean isUpToDate(File file);
+	boolean isUpToDate(Path file);
 
-	void setUpToDate(File file);
+	void setUpToDate(Path file);
 
 	void close();
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import java.io.File;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
+public interface UpToDateChecker extends AutoCloseable {
+
+	boolean isUpToDate(File file);
+
+	void setUpToDate(File file);
+
+	void close();
+
+	static UpToDateChecker noop() {
+		return NoopChecker.INSTANCE;
+	}
+
+	static UpToDateChecker forProject(MavenProject project, Log log) {
+		return IndexBasedChecker.create(project, log);
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
@@ -20,6 +20,8 @@ import java.io.File;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
+import com.diffplug.spotless.Formatter;
+
 public interface UpToDateChecker extends AutoCloseable {
 
 	boolean isUpToDate(File file);
@@ -32,7 +34,7 @@ public interface UpToDateChecker extends AutoCloseable {
 		return NoopChecker.INSTANCE;
 	}
 
-	static UpToDateChecker forProject(MavenProject project, Log log) {
-		return IndexBasedChecker.create(project, log);
+	static UpToDateChecker forProject(MavenProject project, Iterable<Formatter> formatters, Log log) {
+		return IndexBasedChecker.create(project, formatters, log);
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecking.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecking.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class UpToDateChecking {
+
+	@Parameter
+	private boolean enabled;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -59,6 +59,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	private static final String MODULES = "modules";
 	private static final String MODULE_NAME = "name";
 	private static final String CHILD_ID = "childId";
+	private static final int REMOTE_DEBUG_PORT = 5005;
 
 	private final MustacheFactory mustacheFactory = new DefaultMustacheFactory();
 
@@ -151,6 +152,15 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		return MavenRunner.create()
 				.withProjectDir(rootFolder())
 				.withLocalRepository(new File(getSystemProperty(LOCAL_MAVEN_REPOSITORY_DIR)));
+	}
+
+	/**
+	 * Useful for local development. Allows debugging the Spotless Maven Plugin remotely.
+	 * Effectively translates into running {@code mvnDebug} on port 5005. The forked JVM will be
+	 * suspended until the debugger connects.
+	 */
+	protected MavenRunner mavenRunnerWithRemoteDebug() throws IOException {
+		return mavenRunner().withRemoteDebug(REMOTE_DEBUG_PORT);
 	}
 
 	protected MultiModuleProjectCreator multiModuleProject() {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -157,8 +157,12 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		return new MultiModuleProjectCreator();
 	}
 
-	private String createPomXmlContent(String[] executions, String[] configuration) throws IOException {
-		Map<String, Object> params = buildPomXmlParams(executions, configuration, null);
+	protected String createPomXmlContent(String[] executions, String[] configuration) throws IOException {
+		return createPomXmlContent(null, executions, configuration);
+	}
+
+	protected String createPomXmlContent(String pluginVersion, String[] executions, String[] configuration) throws IOException {
+		Map<String, Object> params = buildPomXmlParams(pluginVersion, executions, configuration, null);
 		return createPomXmlContent("/pom-test.xml.mustache", params);
 	}
 
@@ -172,9 +176,9 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		}
 	}
 
-	private static Map<String, Object> buildPomXmlParams(String[] executions, String[] configuration, String[] modules) {
+	private static Map<String, Object> buildPomXmlParams(String pluginVersion, String[] executions, String[] configuration, String[] modules) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(SPOTLESS_MAVEN_PLUGIN_VERSION, getSystemProperty(SPOTLESS_MAVEN_PLUGIN_VERSION));
+		params.put(SPOTLESS_MAVEN_PLUGIN_VERSION, pluginVersion == null ? getSystemProperty(SPOTLESS_MAVEN_PLUGIN_VERSION) : pluginVersion);
 
 		if (configuration != null) {
 			params.put(CONFIGURATION, String.join("\n", configuration));
@@ -265,7 +269,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 			modulesList.addAll(subProjects.keySet());
 			String[] modules = modulesList.toArray(new String[0]);
 
-			Map<String, Object> rootPomParams = buildPomXmlParams(null, configuration, modules);
+			Map<String, Object> rootPomParams = buildPomXmlParams(null, null, configuration, modules);
 			setFile("pom.xml").toContent(createPomXmlContent("/multi-module/pom-parent.xml.mustache", rootPomParams));
 		}
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexConfigTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexConfigTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+
+class FileIndexConfigTest {
+
+	@Test
+	void returnsCorrectProjectDir() {
+		FileIndexConfig config = new FileIndexConfig(mavenProject(), PluginFingerprint.from("foo"));
+
+		assertThat(config.getProjectDir()).isEqualTo(Paths.get("projectDir"));
+	}
+
+	@Test
+	void returnsCorrectIndexFile() {
+		FileIndexConfig config = new FileIndexConfig(mavenProject(), PluginFingerprint.from("foo"));
+
+		assertThat(config.getIndexFile())
+				.isEqualTo(Paths.get("projectDir", "target", "spotless-index"));
+	}
+
+	@Test
+	void returnsCorrectPluginFingerprint() {
+		FileIndexConfig config = new FileIndexConfig(mavenProject(), PluginFingerprint.from("foo"));
+
+		assertThat(config.getPluginFingerprint()).isEqualTo(PluginFingerprint.from("foo"));
+	}
+
+	@Test
+	void returnsEmptyPluginFingerprint() {
+		FileIndexConfig config = new FileIndexConfig(mavenProject());
+
+		assertThat(config.getPluginFingerprint()).isEqualTo(PluginFingerprint.from(""));
+	}
+
+	private static MavenProject mavenProject() {
+		MavenProject project = new MavenProject();
+		project.setFile(new File("projectDir", "pom.xml"));
+		Build build = new Build();
+		build.setDirectory("target");
+		project.setBuild(build);
+		return project;
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexHarness.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+abstract class FileIndexHarness {
+
+	protected static final PluginFingerprint FINGERPRINT = PluginFingerprint.from("foo");
+
+	protected final FileIndexConfig config = mock(FileIndexConfig.class);
+	protected final Log log = mock(Log.class);
+
+	protected Path tempDir;
+
+	@BeforeEach
+	void beforeEach(@TempDir Path tempDir) throws Exception {
+		this.tempDir = tempDir;
+
+		Path projectDir = tempDir.resolve("my-project");
+		Files.createDirectory(projectDir);
+		when(config.getProjectDir()).thenReturn(projectDir);
+
+		Path indexFile = projectDir.resolve("target").resolve("spotless-index");
+		when(config.getIndexFile()).thenReturn(indexFile);
+
+		when(config.getPluginFingerprint()).thenReturn(FINGERPRINT);
+	}
+
+	protected List<Path> createSourceFilesAndWriteIndexFile(PluginFingerprint fingerprint, String... files) throws IOException {
+		List<String> lines = new ArrayList<>();
+		lines.add(fingerprint.value());
+
+		List<Path> sourceFiles = new ArrayList<>();
+		for (String file : files) {
+			Path path = createSourceFile(file);
+			lines.add(file + " " + Files.getLastModifiedTime(path).toInstant());
+			sourceFiles.add(path);
+		}
+
+		writeIndexFile(lines.toArray(new String[0]));
+		return sourceFiles;
+	}
+
+	protected void writeIndexFile(String... lines) throws IOException {
+		Files.createDirectory(config.getIndexFile().getParent());
+		Files.createFile(config.getIndexFile());
+		Files.write(config.getIndexFile(), Arrays.asList(lines), UTF_8, APPEND);
+	}
+
+	protected Path createSourceFile(String name) throws IOException {
+		Path file = config.getProjectDir().resolve(name);
+		Files.createFile(file);
+		return file;
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -251,5 +252,15 @@ class FileIndexTest extends FileIndexHarness {
 
 		FileIndex index3 = FileIndex.read(config, log);
 		assertThat(index3.size()).isEqualTo(2);
+	}
+
+	@Test
+	void writeFailsWhenIndexFilesDoesNotHaveParentDir() {
+		when(config.getIndexFile()).thenReturn(Paths.get("file-without-parent"));
+		FileIndex index = FileIndex.read(config, log);
+		assertThat(index.size()).isZero();
+
+		assertThatThrownBy(index::write).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Index file does not have a parent dir");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
@@ -28,7 +28,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -106,7 +105,7 @@ class FileIndexTest extends FileIndexHarness {
 		FileIndex index = FileIndex.read(config, log);
 
 		assertThat(index.size()).isOne();
-		assertThat(index.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+		assertThat(index.getLastModifiedTime(sourceFile)).isEqualTo(Files.getLastModifiedTime(sourceFile).toInstant());
 		verifyNoInteractions(log);
 	}
 
@@ -118,7 +117,7 @@ class FileIndexTest extends FileIndexHarness {
 
 		assertThat(index.size()).isEqualTo(3);
 		for (Path sourceFile : sourceFiles) {
-			assertThat(index.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+			assertThat(index.getLastModifiedTime(sourceFile)).isEqualTo(Files.getLastModifiedTime(sourceFile).toInstant());
 		}
 		verifyNoInteractions(log);
 	}
@@ -152,8 +151,8 @@ class FileIndexTest extends FileIndexHarness {
 		index1.write();
 
 		FileIndex index2 = FileIndex.read(config, log);
-		assertThat(index2.getLastModifiedTime(sourceFile3)).contains(modifiedTime3);
-		assertThat(index2.getLastModifiedTime(sourceFile4)).contains(modifiedTime4);
+		assertThat(index2.getLastModifiedTime(sourceFile3)).isEqualTo(modifiedTime3);
+		assertThat(index2.getLastModifiedTime(sourceFile4)).isEqualTo(modifiedTime4);
 	}
 
 	@Test
@@ -168,7 +167,7 @@ class FileIndexTest extends FileIndexHarness {
 
 		assertThat(config.getIndexFile().getParent()).exists();
 		FileIndex index2 = FileIndex.read(config, log);
-		assertThat(index2.getLastModifiedTime(sourceFile)).contains(modifiedTime);
+		assertThat(index2.getLastModifiedTime(sourceFile)).isEqualTo(modifiedTime);
 	}
 
 	@Test
@@ -198,7 +197,7 @@ class FileIndexTest extends FileIndexHarness {
 
 		FileIndex index = FileIndex.read(config, log);
 
-		assertThat(index.getLastModifiedTime(nonProjectFile)).isEmpty();
+		assertThat(index.getLastModifiedTime(nonProjectFile)).isNull();
 	}
 
 	@Test
@@ -208,7 +207,7 @@ class FileIndexTest extends FileIndexHarness {
 
 		FileIndex index = FileIndex.read(config, log);
 
-		assertThat(index.getLastModifiedTime(unknownSourceFile)).isEmpty();
+		assertThat(index.getLastModifiedTime(unknownSourceFile)).isNull();
 	}
 
 	@Test
@@ -224,14 +223,14 @@ class FileIndexTest extends FileIndexHarness {
 		Path sourceFile = createSourceFilesAndWriteIndexFile(FINGERPRINT, "source.txt").get(0);
 		FileIndex index = FileIndex.read(config, log);
 
-		Optional<Instant> oldTimeOptional = index.getLastModifiedTime(sourceFile);
-		assertThat(oldTimeOptional).isPresent();
+		Instant oldTime = index.getLastModifiedTime(sourceFile);
+		assertThat(oldTime).isNotNull();
 
 		Instant newTime = Instant.now().plusSeconds(42);
-		assertThat(oldTimeOptional.get()).isNotEqualTo(newTime);
+		assertThat(oldTime).isNotEqualTo(newTime);
 
 		index.setLastModifiedTime(sourceFile, newTime);
-		assertThat(index.getLastModifiedTime(sourceFile)).contains(newTime);
+		assertThat(index.getLastModifiedTime(sourceFile)).isEqualTo(newTime);
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+class FileIndexTest {
+
+	private final FileIndexConfig config = mock(FileIndexConfig.class);
+	private final Log log = mock(Log.class);
+
+	private Path tempDir;
+
+	@BeforeEach
+	void beforeEach(@TempDir Path tempDir) throws Exception {
+		this.tempDir = tempDir;
+
+		Path projectDir = tempDir.resolve("my-project");
+		Files.createDirectory(projectDir);
+		when(config.getProjectDir()).thenReturn(projectDir);
+
+		Path indexFile = projectDir.resolve("target").resolve("spotless-index");
+		when(config.getIndexFile()).thenReturn(indexFile);
+
+		when(config.getPluginFingerprint()).thenReturn(PluginFingerprint.from("foo"));
+	}
+
+	@Test
+	void readFallsBackToEmptyIndexWhenIndexFileDoesNotExist() {
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isZero();
+		verify(log).info("Index file does not exist. Fallback to an empty index");
+	}
+
+	@Test
+	void readFallsBackToEmptyIndexWhenIndexFileIsEmpty() throws Exception {
+		writeIndexFile();
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isZero();
+		verify(log).info("Index file is empty. Fallback to an empty index");
+	}
+
+	@Test
+	void readFallsBackToEmptyIndexOnFingerprintMismatch() throws Exception {
+		createSourceFilesAndWriteIndexFile("bar", "source1.txt", "source2.txt");
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isZero();
+		verify(log).info("Fingerprint mismatch in the index file. Fallback to an empty index");
+	}
+
+	@Test
+	void readFallsBackToEmptyIndexWhenIncorrectSeparator() throws Exception {
+		createSourceFile("source.txt");
+		writeIndexFile(config.getPluginFingerprint().value(), "source.txt|" + Instant.now());
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isZero();
+		ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+		verify(log).warn(eq("Error reading the index file. Fallback to an empty index"), errorCaptor.capture());
+		assertThat(errorCaptor.getValue()).hasMessageContaining("Incorrect index file. No separator found");
+	}
+
+	@Test
+	void readFallsBackToEmptyIndexWhenUnparseableTimestamp() throws Exception {
+		createSourceFile("source.txt");
+		writeIndexFile(config.getPluginFingerprint().value(), "source.txt 12345-bad-instant");
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isZero();
+		ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+		verify(log).warn(eq("Error reading the index file. Fallback to an empty index"), errorCaptor.capture());
+		assertThat(errorCaptor.getValue()).hasMessageContaining("Incorrect index file. Unable to parse last modified time");
+	}
+
+	@Test
+	void readEmptyIndex() throws Exception {
+		writeIndexFile("foo");
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isZero();
+		verifyNoInteractions(log);
+	}
+
+	@Test
+	void readIndexWithSingleEntry() throws Exception {
+		Path sourceFile = createSourceFilesAndWriteIndexFile("foo", "source.txt").get(0);
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isOne();
+		assertThat(index.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+		verifyNoInteractions(log);
+	}
+
+	@Test
+	void readIndexWithMultipleEntries() throws Exception {
+		List<Path> sourceFiles = createSourceFilesAndWriteIndexFile("foo", "source1.txt", "source2.txt", "source3.txt");
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.size()).isEqualTo(3);
+		for (Path sourceFile : sourceFiles) {
+			assertThat(index.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+		}
+		verifyNoInteractions(log);
+	}
+
+	@Test
+	void writeIndexWithoutUpdatesDoesNotUpdateTheFile() throws Exception {
+		createSourceFilesAndWriteIndexFile("foo", "source.txt");
+		FileTime modifiedTimeBeforeRead = Files.getLastModifiedTime(config.getIndexFile());
+
+		FileIndex index = FileIndex.read(config, log);
+		FileTime modifiedTimeAfterRead = Files.getLastModifiedTime(config.getIndexFile());
+
+		index.write();
+		FileTime modifiedTimeAfterWrite = Files.getLastModifiedTime(config.getIndexFile());
+
+		assertThat(modifiedTimeAfterRead).isEqualTo(modifiedTimeBeforeRead);
+		assertThat(modifiedTimeAfterWrite).isEqualTo(modifiedTimeAfterRead);
+	}
+
+	@Test
+	void writeIndexContainingUpdates() throws Exception {
+		createSourceFilesAndWriteIndexFile("foo", "source1.txt", "source2.txt");
+		Path sourceFile3 = createSourceFile("source3.txt");
+		Path sourceFile4 = createSourceFile("source4.txt");
+		Instant modifiedTime3 = Instant.now();
+		Instant modifiedTime4 = Instant.now().plusSeconds(42);
+
+		FileIndex index1 = FileIndex.read(config, log);
+		index1.setLastModifiedTime(sourceFile3, modifiedTime3);
+		index1.setLastModifiedTime(sourceFile4, modifiedTime4);
+		index1.write();
+
+		FileIndex index2 = FileIndex.read(config, log);
+		assertThat(index2.getLastModifiedTime(sourceFile3)).contains(modifiedTime3);
+		assertThat(index2.getLastModifiedTime(sourceFile4)).contains(modifiedTime4);
+	}
+
+	@Test
+	void writeIndexWhenParentDirDoesNotExist() throws Exception {
+		assertThat(config.getIndexFile().getParent()).doesNotExist();
+		FileIndex index1 = FileIndex.read(config, log);
+		Path sourceFile = createSourceFile("source.txt");
+		Instant modifiedTime = Instant.now();
+		index1.setLastModifiedTime(sourceFile, modifiedTime);
+
+		index1.write();
+
+		assertThat(config.getIndexFile().getParent()).exists();
+		FileIndex index2 = FileIndex.read(config, log);
+		assertThat(index2.getLastModifiedTime(sourceFile)).contains(modifiedTime);
+	}
+
+	@Test
+	void deleteNonExistingIndex() {
+		FileIndex.delete(config, log);
+
+		verifyNoInteractions(log);
+	}
+
+	@Test
+	void deleteExistingIndex() throws Exception {
+		createSourceFilesAndWriteIndexFile("foo", "source1.txt", "source2.txt");
+		assertThat(config.getIndexFile()).exists();
+
+		FileIndex.delete(config, log);
+
+		verify(log).info(contains("Deleted the index file"));
+		assertThat(config.getIndexFile()).doesNotExist();
+	}
+
+	@Test
+	void getLastModifiedTimeReturnsEmptyOptionalForNonProjectFile() throws Exception {
+		createSourceFilesAndWriteIndexFile("foo", "source.txt");
+		Path nonProjectDir = tempDir.resolve("some-other-project");
+		Files.createDirectory(nonProjectDir);
+		Path nonProjectFile = Files.createFile(nonProjectDir.resolve("some-other-source.txt"));
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.getLastModifiedTime(nonProjectFile)).isEmpty();
+	}
+
+	@Test
+	void getLastModifiedTimeReturnsEmptyOptionalForUnknownFile() throws Exception {
+		createSourceFilesAndWriteIndexFile("foo", "source.txt");
+		Path unknownSourceFile = createSourceFile("unknown-source.txt");
+
+		FileIndex index = FileIndex.read(config, log);
+
+		assertThat(index.getLastModifiedTime(unknownSourceFile)).isEmpty();
+	}
+
+	@Test
+	void setLastModifiedTimeThrowsForNonProjectFile() throws Exception {
+		FileIndex index = FileIndex.read(config, log);
+		Path nonProjectFile = Paths.get("non-project-file");
+
+		assertThatThrownBy(() -> index.setLastModifiedTime(nonProjectFile, Instant.now())).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void setLastModifiedTimeUpdatesModifiedTime() throws Exception {
+		Path sourceFile = createSourceFilesAndWriteIndexFile("foo", "source.txt").get(0);
+		FileIndex index = FileIndex.read(config, log);
+
+		Optional<Instant> oldTimeOptional = index.getLastModifiedTime(sourceFile);
+		assertThat(oldTimeOptional).isPresent();
+
+		Instant newTime = Instant.now().plusSeconds(42);
+		assertThat(oldTimeOptional.get()).isNotEqualTo(newTime);
+
+		index.setLastModifiedTime(sourceFile, newTime);
+		assertThat(index.getLastModifiedTime(sourceFile)).contains(newTime);
+	}
+
+	@Test
+	void rewritesIndexFileThatReferencesNonExistingFile() throws Exception {
+		List<Path> sourceFiles = createSourceFilesAndWriteIndexFile("foo", "source1.txt", "source2.txt");
+		Path nonExistingSourceFile = config.getProjectDir().resolve("non-existing-source.txt");
+		FileIndex index1 = FileIndex.read(config, log);
+		assertThat(index1.size()).isEqualTo(2);
+
+		index1.setLastModifiedTime(nonExistingSourceFile, Instant.now());
+		assertThat(index1.size()).isEqualTo(3);
+		index1.write();
+
+		FileIndex index2 = FileIndex.read(config, log);
+		verify(log).info("File stored in the index does not exist: " + nonExistingSourceFile.getFileName());
+		assertThat(index2.size()).isEqualTo(2);
+		index2.write();
+
+		FileIndex index3 = FileIndex.read(config, log);
+		assertThat(index3.size()).isEqualTo(2);
+	}
+
+	private List<Path> createSourceFilesAndWriteIndexFile(String fingerprint, String... files)
+			throws IOException {
+		List<String> lines = new ArrayList<>();
+		lines.add(fingerprint);
+
+		List<Path> sourceFiles = new ArrayList<>();
+		for (String file : files) {
+			Path path = createSourceFile(file);
+			lines.add(file + " " + Files.getLastModifiedTime(path).toInstant());
+			sourceFiles.add(path);
+		}
+
+		writeIndexFile(lines.toArray(new String[0]));
+		return sourceFiles;
+	}
+
+	private void writeIndexFile(String... lines) throws IOException {
+		Files.createDirectory(config.getIndexFile().getParent());
+		Files.createFile(config.getIndexFile());
+		Files.write(config.getIndexFile(), Arrays.asList(lines), UTF_8, APPEND);
+	}
+
+	private Path createSourceFile(String name) throws IOException {
+		Path file = config.getProjectDir().resolve(name);
+		Files.createFile(file);
+		return file;
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
@@ -37,9 +37,9 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 	}
 
 	@Test
-	void isUpToDateReturnsFalseForUnknownFile() {
-		File unknownFile = new File("unknown-file.txt");
-		assertThat(checker.isUpToDate(unknownFile)).isFalse();
+	void isUpToDateReturnsFalseForUnknownFile() throws Exception {
+		Path sourceFile = createSourceFile("source.txt");
+		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
 	}
 
 	@Test
@@ -77,24 +77,24 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 	@Test
 	void setUpToDateUpdatesTheIndex() throws Exception {
 		Path sourceFile = createSourceFile("source.txt");
-		assertThat(index.getLastModifiedTime(sourceFile)).isEmpty();
+		assertThat(index.getLastModifiedTime(sourceFile)).isNull();
 		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
 
 		checker.setUpToDate(sourceFile.toFile());
 
-		assertThat(index.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+		assertThat(index.getLastModifiedTime(sourceFile)).isEqualTo(Files.getLastModifiedTime(sourceFile).toInstant());
 		assertThat(checker.isUpToDate(sourceFile.toFile())).isTrue();
 	}
 
 	@Test
 	void closeWritesTheIndex() throws Exception {
 		Path sourceFile = createSourceFile("source.txt");
-		assertThat(index.getLastModifiedTime(sourceFile)).isEmpty();
+		assertThat(index.getLastModifiedTime(sourceFile)).isNull();
 
 		checker.setUpToDate(sourceFile.toFile());
 		checker.close();
 
 		FileIndex newIndex = FileIndex.read(config, log);
-		assertThat(newIndex.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+		assertThat(newIndex.getLastModifiedTime(sourceFile)).isEqualTo(Files.getLastModifiedTime(sourceFile).toInstant());
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
@@ -32,7 +32,7 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 	@BeforeEach
 	void beforeEach() {
 		index = FileIndex.read(config, log);
-		checker = new IndexBasedChecker(index);
+		checker = new IndexBasedChecker(index, log);
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
@@ -17,7 +17,6 @@ package com.diffplug.spotless.maven.incremental;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -39,7 +38,7 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 	@Test
 	void isUpToDateReturnsFalseForUnknownFile() throws Exception {
 		Path sourceFile = createSourceFile("source.txt");
-		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
+		assertThat(checker.isUpToDate(sourceFile)).isFalse();
 	}
 
 	@Test
@@ -48,7 +47,7 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 		Instant modifiedTime = Files.getLastModifiedTime(sourceFile).toInstant();
 		index.setLastModifiedTime(sourceFile, modifiedTime);
 
-		assertThat(checker.isUpToDate(sourceFile.toFile())).isTrue();
+		assertThat(checker.isUpToDate(sourceFile)).isTrue();
 	}
 
 	@Test
@@ -57,7 +56,7 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 		Instant modifiedTime = Files.getLastModifiedTime(sourceFile).toInstant().minusSeconds(42);
 		index.setLastModifiedTime(sourceFile, modifiedTime);
 
-		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
+		assertThat(checker.isUpToDate(sourceFile)).isFalse();
 	}
 
 	/**
@@ -71,19 +70,19 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 		Instant modifiedTime = Files.getLastModifiedTime(sourceFile).toInstant().plusSeconds(42);
 		index.setLastModifiedTime(sourceFile, modifiedTime);
 
-		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
+		assertThat(checker.isUpToDate(sourceFile)).isFalse();
 	}
 
 	@Test
 	void setUpToDateUpdatesTheIndex() throws Exception {
 		Path sourceFile = createSourceFile("source.txt");
 		assertThat(index.getLastModifiedTime(sourceFile)).isNull();
-		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
+		assertThat(checker.isUpToDate(sourceFile)).isFalse();
 
-		checker.setUpToDate(sourceFile.toFile());
+		checker.setUpToDate(sourceFile);
 
 		assertThat(index.getLastModifiedTime(sourceFile)).isEqualTo(Files.getLastModifiedTime(sourceFile).toInstant());
-		assertThat(checker.isUpToDate(sourceFile.toFile())).isTrue();
+		assertThat(checker.isUpToDate(sourceFile)).isTrue();
 	}
 
 	@Test
@@ -91,7 +90,7 @@ class IndexBasedCheckerTest extends FileIndexHarness {
 		Path sourceFile = createSourceFile("source.txt");
 		assertThat(index.getLastModifiedTime(sourceFile)).isNull();
 
-		checker.setUpToDate(sourceFile.toFile());
+		checker.setUpToDate(sourceFile);
 		checker.close();
 
 		FileIndex newIndex = FileIndex.read(config, log);

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/IndexBasedCheckerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IndexBasedCheckerTest extends FileIndexHarness {
+
+	private FileIndex index;
+	private IndexBasedChecker checker;
+
+	@BeforeEach
+	void beforeEach() {
+		index = FileIndex.read(config, log);
+		checker = new IndexBasedChecker(index);
+	}
+
+	@Test
+	void isUpToDateReturnsFalseForUnknownFile() {
+		File unknownFile = new File("unknown-file.txt");
+		assertThat(checker.isUpToDate(unknownFile)).isFalse();
+	}
+
+	@Test
+	void isUpToDateReturnsTrueWhenOnDiskFileIsSameAsInTheIndex() throws Exception {
+		Path sourceFile = createSourceFile("source.txt");
+		Instant modifiedTime = Files.getLastModifiedTime(sourceFile).toInstant();
+		index.setLastModifiedTime(sourceFile, modifiedTime);
+
+		assertThat(checker.isUpToDate(sourceFile.toFile())).isTrue();
+	}
+
+	@Test
+	void isUpToDateReturnsFalseWhenOnDiskFileIsNewerThanInTheIndex() throws Exception {
+		Path sourceFile = createSourceFile("source.txt");
+		Instant modifiedTime = Files.getLastModifiedTime(sourceFile).toInstant().minusSeconds(42);
+		index.setLastModifiedTime(sourceFile, modifiedTime);
+
+		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
+	}
+
+	/**
+	 * This test checks a bit of a weird case when file's last modified time in the index is greater
+	 * than file's last modified time on-disk. This should not happen because of how the index is
+	 * used. To be on the safe side, we consider the file to be out of date if this ever happens.
+	 */
+	@Test
+	void isUpToDateReturnsFalseWhenOnDiskFileIsOlderThanInTheIndex() throws Exception {
+		Path sourceFile = createSourceFile("source.txt");
+		Instant modifiedTime = Files.getLastModifiedTime(sourceFile).toInstant().plusSeconds(42);
+		index.setLastModifiedTime(sourceFile, modifiedTime);
+
+		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
+	}
+
+	@Test
+	void setUpToDateUpdatesTheIndex() throws Exception {
+		Path sourceFile = createSourceFile("source.txt");
+		assertThat(index.getLastModifiedTime(sourceFile)).isEmpty();
+		assertThat(checker.isUpToDate(sourceFile.toFile())).isFalse();
+
+		checker.setUpToDate(sourceFile.toFile());
+
+		assertThat(index.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+		assertThat(checker.isUpToDate(sourceFile.toFile())).isTrue();
+	}
+
+	@Test
+	void closeWritesTheIndex() throws Exception {
+		Path sourceFile = createSourceFile("source.txt");
+		assertThat(index.getLastModifiedTime(sourceFile)).isEmpty();
+
+		checker.setUpToDate(sourceFile.toFile());
+		checker.close();
+
+		FileIndex newIndex = FileIndex.read(config, log);
+		assertThat(newIndex.getLastModifiedTime(sourceFile)).contains(Files.getLastModifiedTime(sourceFile).toInstant());
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.FormatExceptionPolicyStrict;
+import com.diffplug.spotless.Formatter;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.LineEnding;
+import com.diffplug.spotless.ResourceHarness;
+
+class NoopCheckerTest extends ResourceHarness {
+
+	private MavenProject project;
+	private Path indexFile;
+	private File existingSourceFile;
+	private File nonExistingSourceFile;
+
+	@BeforeEach
+	void beforeEach() throws Exception {
+		project = buildMavenProject();
+		indexFile = new FileIndexConfig(project).getIndexFile();
+		existingSourceFile = new File(project.getBasedir(), "existing.txt");
+		Files.write(existingSourceFile.toPath(), "foo".getBytes(UTF_8), CREATE_NEW);
+		nonExistingSourceFile = new File(project.getBasedir(), "non-existing.txt");
+	}
+
+	@Test
+	void deletesExistingIndexFileWhenCreated() {
+		Log log = mock(Log.class);
+		try (UpToDateChecker realChecker = UpToDateChecker.forProject(project, singletonList(dummyFormatter()), log)) {
+			realChecker.setUpToDate(existingSourceFile);
+		}
+		assertThat(indexFile).exists();
+
+		try (UpToDateChecker noopChecker = UpToDateChecker.noop(project, log)) {
+			assertThat(noopChecker).isNotNull();
+		}
+		assertThat(indexFile).doesNotExist();
+		verify(log).info("Deleted the index file: " + indexFile);
+	}
+
+	@Test
+	void doesNothingWhenIndexFileDoesNotExist() {
+		assertThat(indexFile).doesNotExist();
+
+		Log log = mock(Log.class);
+		try (UpToDateChecker noopChecker = UpToDateChecker.noop(project, log)) {
+			assertThat(noopChecker).isNotNull();
+		}
+		assertThat(indexFile).doesNotExist();
+		verifyNoInteractions(log);
+	}
+
+	@Test
+	void neverUpToDate() {
+		try (UpToDateChecker noopChecker = UpToDateChecker.noop(project, mock(Log.class))) {
+			assertThat(noopChecker.isUpToDate(existingSourceFile)).isFalse();
+			assertThat(noopChecker.isUpToDate(nonExistingSourceFile)).isFalse();
+		}
+	}
+
+	private MavenProject buildMavenProject() throws IOException {
+		File projectDir = newFolder("project");
+		File targetDir = new File(projectDir, "target");
+		File pomFile = new File(projectDir, "pom.xml");
+
+		assertThat(targetDir.mkdir()).isTrue();
+		assertThat(pomFile.createNewFile()).isTrue();
+
+		MavenProject project = new MavenProject();
+		project.setFile(pomFile);
+		Build build = new Build();
+		build.setDirectory(targetDir.getName());
+		project.setBuild(build);
+		return project;
+	}
+
+	private static Formatter dummyFormatter() {
+		return Formatter.builder()
+				.rootDir(Paths.get(""))
+				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
+				.encoding(UTF_8)
+				.steps(singletonList(mock(FormatterStep.class, withSettings().serializable())))
+				.exceptionPolicy(new FormatExceptionPolicyStrict())
+				.build();
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
@@ -46,16 +46,16 @@ class NoopCheckerTest extends ResourceHarness {
 
 	private MavenProject project;
 	private Path indexFile;
-	private File existingSourceFile;
-	private File nonExistingSourceFile;
+	private Path existingSourceFile;
+	private Path nonExistingSourceFile;
 
 	@BeforeEach
 	void beforeEach() throws Exception {
 		project = buildMavenProject();
 		indexFile = new FileIndexConfig(project).getIndexFile();
-		existingSourceFile = new File(project.getBasedir(), "existing.txt");
-		Files.write(existingSourceFile.toPath(), "foo".getBytes(UTF_8), CREATE_NEW);
-		nonExistingSourceFile = new File(project.getBasedir(), "non-existing.txt");
+		existingSourceFile = project.getBasedir().toPath().resolve("existing.txt");
+		Files.write(existingSourceFile, "foo".getBytes(UTF_8), CREATE_NEW);
+		nonExistingSourceFile = project.getBasedir().toPath().resolve("non-existing.txt");
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+class PluginFingerprintTest extends MavenIntegrationHarness {
+
+	private static final String VERSION_1 = "1.0.0";
+	private static final String VERSION_2 = "2.0.0";
+
+	private static final String[] EXECUTION_1 = {
+			"<execution>",
+			"  <id>check</id>",
+			"  <goals>",
+			"    <goal>check</goal>",
+			"  </goals>",
+			"</execution>"
+	};
+	private static final String[] EXECUTION_2 = {};
+
+	private static final String[] CONFIGURATION_1 = {
+			"<googleJavaFormat>",
+			"  <version>1.2</version>",
+			"</googleJavaFormat>"
+	};
+	private static final String[] CONFIGURATION_2 = {
+			"<googleJavaFormat>",
+			"  <version>1.8</version>",
+			"  <reflowLongStrings>true</reflowLongStrings>",
+			"</googleJavaFormat>"
+	};
+
+	@Test
+	void sameFingerprint() throws Exception {
+		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
+		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
+
+		MavenProject project1 = mavenProject(xml1);
+		MavenProject project2 = mavenProject(xml2);
+
+		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1);
+		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2);
+
+		assertEquals(fingerprint1, fingerprint2);
+	}
+
+	@Test
+	void differentFingerprintForDifferentPluginVersion() throws Exception {
+		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
+		String xml2 = createPomXmlContent(VERSION_2, EXECUTION_1, CONFIGURATION_1);
+
+		MavenProject project1 = mavenProject(xml1);
+		MavenProject project2 = mavenProject(xml2);
+
+		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1);
+		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2);
+
+		assertNotEquals(fingerprint1, fingerprint2);
+	}
+
+	@Test
+	void differentFingerprintForDifferentExecution() throws Exception {
+		String xml1 = createPomXmlContent(VERSION_2, EXECUTION_1, CONFIGURATION_1);
+		String xml2 = createPomXmlContent(VERSION_2, EXECUTION_2, CONFIGURATION_1);
+
+		MavenProject project1 = mavenProject(xml1);
+		MavenProject project2 = mavenProject(xml2);
+
+		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1);
+		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2);
+
+		assertNotEquals(fingerprint1, fingerprint2);
+	}
+
+	@Test
+	void differentFingerprintForDifferentConfiguration() throws Exception {
+		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_2, CONFIGURATION_2);
+		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_2, CONFIGURATION_1);
+
+		MavenProject project1 = mavenProject(xml1);
+		MavenProject project2 = mavenProject(xml2);
+
+		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1);
+		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2);
+
+		assertNotEquals(fingerprint1, fingerprint2);
+	}
+
+	private static MavenProject mavenProject(String xml) throws Exception {
+		return new MavenProject(readPom(xml));
+	}
+
+	private static Model readPom(String xml) throws Exception {
+		byte[] bytes = xml.getBytes(UTF_8);
+		try (XmlStreamReader xmlReader = ReaderFactory.newXmlReader(new ByteArrayInputStream(bytes))) {
+			MavenXpp3Reader pomReader = new MavenXpp3Reader();
+			return pomReader.read(xmlReader);
+		}
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
@@ -17,8 +17,7 @@ package com.diffplug.spotless.maven.incremental;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Paths;
@@ -78,7 +77,7 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
 
-		assertEquals(fingerprint1, fingerprint2);
+		assertThat(fingerprint1).isEqualTo(fingerprint2);
 	}
 
 	@Test
@@ -92,7 +91,7 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
 
-		assertNotEquals(fingerprint1, fingerprint2);
+		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
 	}
 
 	@Test
@@ -106,7 +105,7 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
 
-		assertNotEquals(fingerprint1, fingerprint2);
+		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
 	}
 
 	@Test
@@ -120,7 +119,7 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
 
-		assertNotEquals(fingerprint1, fingerprint2);
+		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
 	}
 
 	@Test
@@ -140,7 +139,7 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, formatters1);
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, formatters2);
 
-		assertNotEquals(fingerprint1, fingerprint2);
+		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
 	}
 
 	@Test
@@ -158,7 +157,14 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, formatters1);
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, formatters2);
 
-		assertNotEquals(fingerprint1, fingerprint2);
+		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
+	}
+
+	@Test
+	void emptyFingerprint() {
+		PluginFingerprint fingerprint = PluginFingerprint.empty();
+
+		assertThat(fingerprint.value()).isEmpty();
 	}
 
 	private static MavenProject mavenProject(String xml) throws Exception {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+import com.diffplug.spotless.maven.MavenRunner.Result;
+
+class UpToDateCheckingTest extends MavenIntegrationHarness {
+
+	@Test
+	void enableUpToDateChecking() throws Exception {
+		writePom(
+				"<java>",
+				"  <googleJavaFormat/>",
+				"</java>",
+				"<upToDateChecking>",
+				"  <enabled>true</enabled>",
+				"</upToDateChecking>");
+
+		String output = runTest("java/googlejavaformat/JavaCodeFormatted18.test");
+
+		assertThat(output).contains("Up-to-date checking enabled");
+	}
+
+	private String runTest(String targetResource) throws Exception {
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		Result result = mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource(targetResource);
+		return result.output();
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
@@ -17,33 +17,188 @@ package com.diffplug.spotless.maven.incremental;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
-import com.diffplug.spotless.maven.MavenRunner.Result;
+import com.diffplug.spotless.maven.MavenRunner;
 
 class UpToDateCheckingTest extends MavenIntegrationHarness {
 
 	@Test
+	void upToDateCheckingDisabledByDefault() throws Exception {
+		writePom(
+				"<java>",
+				"  <googleJavaFormat/>",
+				"</java>");
+
+		List<File> files = writeUnformattedFiles(1);
+		String output = runSpotlessApply();
+
+		assertThat(output).doesNotContain("Up-to-date checking enabled");
+		assertFormatted(files);
+	}
+
+	@Test
 	void enableUpToDateChecking() throws Exception {
+		writePomWithUpToDateCheckingEnabled(true);
+
+		List<File> files = writeUnformattedFiles(1);
+		String output = runSpotlessApply();
+
+		assertThat(output).contains("Up-to-date checking enabled");
+		assertFormatted(files);
+	}
+
+	@Test
+	void disableUpToDateChecking() throws Exception {
+		writePomWithUpToDateCheckingEnabled(false);
+
+		List<File> files = writeUnformattedFiles(1);
+		String output = runSpotlessApply();
+
+		assertThat(output).doesNotContain("Up-to-date checking enabled");
+		assertFormatted(files);
+	}
+
+	@Test
+	void spotlessApplyRecordsCorrectlyFormattedFiles() throws Exception {
+		writePomWithUpToDateCheckingEnabled(true);
+		List<File> files = writeFormattedFiles(5);
+
+		String applyOutput1 = runSpotlessApply();
+		assertSpotlessApplyDidNotSkipAnyFiles(applyOutput1);
+		assertFormatted(files);
+
+		String applyOutput2 = runSpotlessApply();
+		assertSpotlessApplySkipped(files, applyOutput2);
+
+		String checkOutput = runSpotlessCheck();
+		assertSpotlessCheckSkipped(files, checkOutput);
+	}
+
+	@Test
+	void spotlessApplyRecordsUnformattedFiles() throws Exception {
+		writePomWithUpToDateCheckingEnabled(true);
+		List<File> files = writeUnformattedFiles(4);
+
+		String applyOutput1 = runSpotlessApply();
+		assertSpotlessApplyDidNotSkipAnyFiles(applyOutput1);
+		assertFormatted(files);
+
+		String applyOutput2 = runSpotlessApply();
+		assertSpotlessApplySkipped(files, applyOutput2);
+
+		String checkOutput = runSpotlessCheck();
+		assertSpotlessCheckSkipped(files, checkOutput);
+	}
+
+	@Test
+	void spotlessCheckRecordsCorrectlyFormattedFiles() throws Exception {
+		writePomWithUpToDateCheckingEnabled(true);
+		List<File> files = writeFormattedFiles(7);
+
+		String checkOutput1 = runSpotlessCheck();
+		assertSpotlessCheckDidNotSkipAnyFiles(checkOutput1);
+
+		String checkOutput2 = runSpotlessCheck();
+		assertSpotlessCheckSkipped(files, checkOutput2);
+
+		String applyOutput = runSpotlessApply();
+		assertSpotlessApplySkipped(files, applyOutput);
+	}
+
+	@Test
+	void spotlessCheckRecordsUnformattedFiles() throws Exception {
+		writePomWithUpToDateCheckingEnabled(true);
+		List<File> files = writeUnformattedFiles(6);
+
+		String checkOutput1 = runSpotlessCheckOnUnformattedFiles();
+		assertSpotlessCheckDidNotSkipAnyFiles(checkOutput1);
+
+		String checkOutput2 = runSpotlessCheckOnUnformattedFiles();
+		assertSpotlessCheckDidNotSkipAnyFiles(checkOutput2);
+
+		String applyOutput = runSpotlessApply();
+		assertSpotlessApplyDidNotSkipAnyFiles(applyOutput);
+		assertFormatted(files);
+
+		String checkOutput3 = runSpotlessCheck();
+		assertSpotlessCheckSkipped(files, checkOutput3);
+	}
+
+	private void writePomWithUpToDateCheckingEnabled(boolean enabled) throws IOException {
 		writePom(
 				"<java>",
 				"  <googleJavaFormat/>",
 				"</java>",
 				"<upToDateChecking>",
-				"  <enabled>true</enabled>",
+				"  <enabled>" + enabled + "</enabled>",
 				"</upToDateChecking>");
-
-		String output = runTest("java/googlejavaformat/JavaCodeFormatted18.test");
-
-		assertThat(output).contains("Up-to-date checking enabled");
 	}
 
-	private String runTest(String targetResource) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/googlejavaformat/JavaCodeUnformatted.test");
-		Result result = mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(targetResource);
-		return result.output();
+	private List<File> writeFormattedFiles(int count) throws IOException {
+		return writeFiles("java/googlejavaformat/JavaCodeFormatted18.test", "formatted", count);
+	}
+
+	private List<File> writeUnformattedFiles(int count) throws IOException {
+		return writeFiles("java/googlejavaformat/JavaCodeUnformatted.test", "unformatted", count);
+	}
+
+	private List<File> writeFiles(String resource, String suffix, int count) throws IOException {
+		List<File> result = new ArrayList<>(count);
+		for (int i = 0; i < count; i++) {
+			String path = "src/main/java/test_" + suffix + "_" + i + ".java";
+			File file = setFile(path).toResource(resource);
+			result.add(file);
+		}
+		return result;
+	}
+
+	private String runSpotlessApply() throws Exception {
+		return mavenRunnerForGoal("apply").runNoError().output();
+	}
+
+	private String runSpotlessCheck() throws Exception {
+		return mavenRunnerForGoal("check").runNoError().output();
+	}
+
+	private String runSpotlessCheckOnUnformattedFiles() throws Exception {
+		return mavenRunnerForGoal("check").runHasError().output();
+	}
+
+	private MavenRunner mavenRunnerForGoal(String goal) throws IOException {
+		// -X enables debug logging
+		return mavenRunner().withArguments("-X", "spotless:" + goal);
+	}
+
+	private void assertFormatted(List<File> files) throws IOException {
+		for (File file : files) {
+			assertFile(file).sameAsResource("java/googlejavaformat/JavaCodeFormatted18.test");
+		}
+	}
+
+	private void assertSpotlessApplyDidNotSkipAnyFiles(String applyOutput) {
+		assertThat(applyOutput).doesNotContain("Spotless will not format");
+	}
+
+	private void assertSpotlessCheckDidNotSkipAnyFiles(String checkOutput) {
+		assertThat(checkOutput).doesNotContain("Spotless will not format");
+	}
+
+	private void assertSpotlessApplySkipped(List<File> files, String applyOutput) {
+		for (File file : files) {
+			assertThat(applyOutput).contains("Spotless will not format an up-to-date file: " + file);
+		}
+	}
+
+	private void assertSpotlessCheckSkipped(List<File> files, String checkOutput) {
+		for (File file : files) {
+			assertThat(checkOutput).contains("Spotless will not check an up-to-date file: " + file);
+		}
 	}
 }

--- a/plugin-maven/src/test/resources/pom-build.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-build.xml.mustache
@@ -23,6 +23,7 @@
     <maven.api.version>{{mavenApiVersion}}</maven.api.version>
     <eclipse.aether.version>{{eclipseAetherVersion}}</eclipse.aether.version>
     <spotless.lib.version>{{spotlessLibVersion}}</spotless.lib.version>
+    <jsr305.version>{{jsr305Version}}</jsr305.version>
   </properties>
 
   <dependencies>
@@ -54,6 +55,12 @@
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-util</artifactId>
       <version>${eclipse.aether.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${jsr305.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/plugin-maven/src/test/resources/pom-build.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-build.xml.mustache
@@ -28,6 +28,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven.api.version}</version>
       <scope>provided</scope>


### PR DESCRIPTION
POC of a component that allows the Maven plugin to skip already formatted and unchanged files. The code is not production-ready and probably does not work. It is only to illustrate the approach and gather feedback.

A new `UpToDateChecker` maintains an index file in the build directory (`<project>/target`). The index file has the following structure:

```
<source file 1> <last modified time 1>
<source file 2> <last modified time 2>
...
<source file n> <last modified time n>
```

`UpToDateChecker` loads or creates an index file at creation time into an in-memory map.

Method `#isUpToDate(File)` checks the file's current last modified time against the last modified time from the in-memory map.

Method `#setUpToDate(File)` updates or adds the file and its last modified time to the in-memory map.

Method `#close()` writes the complete in-memory map into the index file.

Spotless apply goal uses `UpToDateChecker` to determine if a file needs to be formatted. It also notifies the checker if the file has was formatted.