### PR TITLE
Customize artifact of google java format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Added support and bump Eclipse formatter default versions to `4.21` for `eclipse-cdt`, `eclipse-jdt`, `eclipse-wtp`. Change is only applied for JVM 11+.
+* Added `groupArtifact` option for `google-java-format` ([#944](https://github.com/diffplug/spotless/pull/944))
 
 ## [2.16.1] - 2021-09-20
 ### Changed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Added support and bump Eclipse formatter default versions to `4.21` for `eclipse-cdt`, `eclipse-jdt`, `eclipse-wtp`. Change is only applied for JVM 11+.
+* Added `groupArtifact` option for `google-java-format` ([#944](https://github.com/diffplug/spotless/pull/944))
 
 ## [5.15.1] - 2021-09-20
 ### Changed

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -180,9 +180,10 @@ spotless {
 spotless {
   java {
     googleJavaFormat()
-    // optional: you can specify a specific version and/or switch to AOSP style and/or reflow long strings (requires at least 1.8)
-    //
-    googleJavaFormat('1.8').aosp().reflowLongStrings()
+    // optional: you can specify a specific version and/or switch to AOSP style
+    //   and/or reflow long strings (requires at least 1.8)
+    //   and/or use custom group artifact (you probably don't need this)
+    googleJavaFormat('1.8').aosp().reflowLongStrings().groupArtifact('com.google.googlejavaformat:google-java-format')
 ```
 
 ### eclipse jdt

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -89,13 +89,21 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 	public class GoogleJavaFormatConfig {
 		final String version;
+		String groupArtifact;
 		String style;
 		boolean reflowLongStrings;
 
 		GoogleJavaFormatConfig(String version) {
 			this.version = Objects.requireNonNull(version);
+			this.groupArtifact = GoogleJavaFormatStep.defaultGroupArtifact();
 			this.style = GoogleJavaFormatStep.defaultStyle();
 			addStep(createStep());
+		}
+
+		public GoogleJavaFormatConfig groupArtifact(String groupArtifact) {
+			this.groupArtifact = Objects.requireNonNull(groupArtifact);
+			replaceStep(createStep());
+			return this;
 		}
 
 		public GoogleJavaFormatConfig style(String style) {
@@ -119,7 +127,9 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		}
 
 		private FormatterStep createStep() {
-			return GoogleJavaFormatStep.create(version,
+			return GoogleJavaFormatStep.create(
+					groupArtifact,
+					version,
 					style,
 					provisioner(),
 					reflowLongStrings);

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Added support and bump Eclipse formatter default versions to `4.21` for `eclipse-cdt`, `eclipse-jdt`, `eclipse-wtp`. Change is only applied for JVM 11+.
+* Added `groupArtifact` option for `google-java-format` ([#944](https://github.com/diffplug/spotless/pull/944))
 
 ## [2.13.1] - 2021-09-20
 ### Changed

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -205,6 +205,8 @@ any other maven phase (i.e. compile) then it can be configured as below;
   <version>1.8</version>                      <!-- optional -->
   <style>GOOGLE</style>                       <!-- or AOSP (optional) -->
   <reflowLongStrings>true</reflowLongStrings> <!-- optional (requires at least 1.8) -->
+  <!-- optional: custom group artifact (you probably don't need this) -->
+  <groupArtifact>com.google.googlejavaformat:google-java-format</groupArtifact>
 </googleJavaFormat>
 ```
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/GoogleJavaFormat.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/GoogleJavaFormat.java
@@ -24,6 +24,9 @@ import com.diffplug.spotless.maven.FormatterStepFactory;
 
 public class GoogleJavaFormat implements FormatterStepFactory {
 	@Parameter
+	private String groupArtifact;
+
+	@Parameter
 	private String version;
 
 	@Parameter
@@ -34,9 +37,10 @@ public class GoogleJavaFormat implements FormatterStepFactory {
 
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
+		String groupArtifact = this.groupArtifact != null ? this.groupArtifact : GoogleJavaFormatStep.defaultGroupArtifact();
 		String version = this.version != null ? this.version : GoogleJavaFormatStep.defaultVersion();
 		String style = this.style != null ? this.style : GoogleJavaFormatStep.defaultStyle();
 		boolean reflowLongStrings = this.reflowLongStrings != null ? this.reflowLongStrings : GoogleJavaFormatStep.defaultReflowLongStrings();
-		return GoogleJavaFormatStep.create(version, style, config.getProvisioner(), reflowLongStrings);
+		return GoogleJavaFormatStep.create(groupArtifact, version, style, config.getProvisioner(), reflowLongStrings);
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -84,6 +84,16 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
+	void behaviorWithCustomGroupArtifact() throws Exception {
+		FormatterStep step = GoogleJavaFormatStep.create(GoogleJavaFormatStep.defaultGroupArtifact(), "1.2", GoogleJavaFormatStep.defaultStyle(), TestProvisioner.mavenCentral(), false);
+		StepHarness.forStep(step)
+				.testResource("java/googlejavaformat/JavaCodeUnformatted.test", "java/googlejavaformat/JavaCodeFormatted.test")
+				.testResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test", "java/googlejavaformat/JavaCodeWithLicenseFormatted.test")
+				.testResource("java/googlejavaformat/JavaCodeWithLicensePackageUnformatted.test", "java/googlejavaformat/JavaCodeWithLicensePackageFormatted.test")
+				.testResource("java/googlejavaformat/JavaCodeWithPackageUnformatted.test", "java/googlejavaformat/JavaCodeWithPackageFormatted.test");
+	}
+
+	@Test
 	void equality() throws Exception {
 		new SerializableEqualityTester() {
 			String version = "1.2";
@@ -109,6 +119,30 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 			protected FormatterStep create() {
 				String finalVersion = this.version;
 				return GoogleJavaFormatStep.create(finalVersion, style, TestProvisioner.mavenCentral(), reflowLongStrings);
+			}
+		}.testEquals();
+	}
+
+	@Test
+	void equalityGroupArtifact() throws Exception {
+		new SerializableEqualityTester() {
+			String groupArtifact = GoogleJavaFormatStep.defaultGroupArtifact();
+			String version = "1.11.0";
+			String style = "";
+			boolean reflowLongStrings = false;
+
+			@Override
+			protected void setupTest(API api) {
+				// same version == same
+				api.areDifferentThan();
+				// change the groupArtifact, and it's different
+				groupArtifact = "io.opil:google-java-format";
+				api.areDifferentThan();
+			}
+
+			@Override
+			protected FormatterStep create() {
+				return GoogleJavaFormatStep.create(groupArtifact, version, style, TestProvisioner.mavenCentral(), reflowLongStrings);
 			}
 		}.testEquals();
 	}


### PR DESCRIPTION
Add `artifact` option to `GoogleJavaFormatStep`.

The Google Java Format is not friendly for lambda. I've managed a customized artifact to improve it. This PR allows user to integrate home-brewed GJF with spotless.
