### PR TITLE
Clean-up eclipse-jdt tests.

### DIFF
--- a/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
+++ b/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
@@ -15,96 +15,88 @@
  */
 package com.diffplug.spotless.extra.eclipse.java;
 
-import static com.diffplug.spotless.extra.eclipse.base.SpotlessEclipseFramework.LINE_DELIMITER;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Properties;
-import java.util.function.Consumer;
 
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.diffplug.spotless.FormatterProperties;
+import com.diffplug.spotless.ResourceHarness;
+
 /** Eclipse JDT wrapper integration tests */
-class EclipseJdtFormatterStepImplTest {
+class EclipseJdtFormatterStepImplTest extends ResourceHarness {
 
-	private final static String UNFORMATTED = "package com.diffplug.gradle.spotless;\n" +
-			"public class C {\n" +
-			"  static void hello() {" +
-			"    System.out.println(\"Hello World!\");\n" +
-			"  }\n" +
-			"}".replaceAll("\n", LINE_DELIMITER);
-	private final static String FORMATTED = "package com.diffplug.gradle.spotless;\n" +
-			"public class C {\n" +
-			"\tstatic void hello() {\n" +
-			"\t\tSystem.out.println(\"Hello World!\");\n" +
-			"\t}\n" +
-			"}".replaceAll("\n", LINE_DELIMITER);
+	private static String UNFORMATTED;
+	private static String FORMATTED;
 
-	private final static String PRE_UNFORMATTED = "/**<pre>void f(){}</pre>*/\n".replaceAll("\n", LINE_DELIMITER);
-	private final static String PRE_FORMATTED = "/**\n * <pre>\n * void f() {\n * }\n * </pre>\n */\n".replaceAll("\n", LINE_DELIMITER);
+	@BeforeAll
+	static void beforeAll() throws IOException {
+		UNFORMATTED = getTestResource("java/eclipse/JavaCodeUnformatted.test");
+		FORMATTED = getTestResource("java/eclipse/JavaCodeFormatted.test");
+	}
+
+	private Properties config;
+
+	@BeforeEach
+	void beforeEach() throws IOException {
+		File sttingsFile = createTestFile("java/eclipse/formatter.xml");
+		config = FormatterProperties.from(sttingsFile).getProperties();
+	}
 
 	private final static String ILLEGAL_CHAR = Character.toString((char) 254);
 
 	@Test
-	void defaultFormat() throws Throwable {
-		String output = format(UNFORMATTED, config -> {});
-		assertEquals(FORMATTED,
-				output, "Unexpected formatting with default preferences.");
+	void nominal() throws Throwable {
+		assertEquals(FORMATTED, format(UNFORMATTED));
 	}
 
-	/**
-	 * The exception handling has changed sine about JDT 4.10.
-	 * Before that version, JDT caught very internal parser error.
-	 * The latest behavior is in line with Eclipse-Groovy.
-	 * CDT however (still) catches parser exceptions in the formatter step.
-	 * Spotless anyhow provides possibilities to change exception behavior.
-	 * Furthermore it is assumed that Spotless runs on compile-able code.
-	 */
-	public void invalidFormat() throws Throwable {
+	@Test
+	public void invalidSyntax() throws Throwable {
 		try {
-			String output = format(FORMATTED.replace("void hello() {", "void hello()  "), config -> {});
-			assertTrue(output.contains("void hello()  " + LINE_DELIMITER), "Incomplete Java not formatted on best effort basis.");
+			String invalidSyntax = FORMATTED.replace("{", "");
+			assertEquals(invalidSyntax, format(invalidSyntax));
 		} catch (IndexOutOfBoundsException e) {
 			/*
 			 * Some JDT versions throw exception, but this changed again in later versions.
-			 * Anyhow, exceptions are acceptable, since Spotless should fromat valid Java code.
+			 * Anyhow, exceptions are acceptable, since Spotless should format valid Java code.
 			 */
 		}
 	}
 
 	@Test
 	void invalidCharater() throws Throwable {
-		String output = format(FORMATTED.replace("void hello() {", "void hello()" + ILLEGAL_CHAR + " {"), config -> {});
-		assertTrue(output.contains("void hello()" + ILLEGAL_CHAR + " {" + LINE_DELIMITER), "Invalid charater not formatted on best effort basis.");
+		String invalidInput = UNFORMATTED + ILLEGAL_CHAR;
+		assertEquals(invalidInput, format(invalidInput));
 	}
 
 	@Test
 	void invalidConfiguration() throws Throwable {
-		String output = format(FORMATTED, config -> {
-			config.setProperty(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
-			config.setProperty(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, "noInteger");
-		});
-		assertEquals(FORMATTED.replace("\t", "    "),
-				output, "Invalid indentation configuration not replaced by default value (4 spaces)");
+		config.setProperty(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
+		config.setProperty(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, "noInteger");
+		String defaultTabReplacement = "    ";
+		assertEquals(FORMATTED.replace("\t", defaultTabReplacement), format(FORMATTED));
 	}
 
 	@Test
-	/**	Test that an internal code formatter can be created to format the Java code within HTML pre-tags. (see also Spotless issue #191) */
-	void internalCodeFormatter() throws Throwable {
-		String output = format(PRE_UNFORMATTED + UNFORMATTED, config -> {
-			config.setProperty(
-					DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_HEADER,
-					DefaultCodeFormatterConstants.TRUE);
-		});
-		assertEquals(PRE_FORMATTED + FORMATTED,
-				output, "Code within HTML <pre> tag not formatted.");
+	void htmlPreTag() throws Throwable {
+		config.clear();
+		config.setProperty(
+				DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_HEADER,
+				DefaultCodeFormatterConstants.TRUE);
+		String formatted = getTestResource("java/eclipse/HtmlPreTagFormatted.test");
+		String unformatted = getTestResource("java/eclipse/HtmlPreTagUnformatted.test");
+		assertEquals(formatted, format(unformatted), "Failed to create internal code formatter. See Spotless issue #191");
 	}
 
-	private static String format(final String input, final Consumer<Properties> config) throws Exception {
-		Properties properties = new Properties();
-		config.accept(properties);
-		EclipseJdtFormatterStepImpl formatter = new EclipseJdtFormatterStepImpl(properties);
+	private String format(final String input) throws Exception {
+		EclipseJdtFormatterStepImpl formatter = new EclipseJdtFormatterStepImpl(config);
 		return formatter.format(input);
 	}
 

--- a/testlib/src/main/resources/java/eclipse/HtmlPreTagFormatted.test
+++ b/testlib/src/main/resources/java/eclipse/HtmlPreTagFormatted.test
@@ -1,0 +1,9 @@
+public interface Java {
+	/**
+	 * <pre>
+	 * void f() {
+	 * }
+	 * </pre>
+	 */
+	void f();
+}

--- a/testlib/src/main/resources/java/eclipse/HtmlPreTagUnformatted.test
+++ b/testlib/src/main/resources/java/eclipse/HtmlPreTagUnformatted.test
@@ -1,0 +1,4 @@
+public interface Java {
+	/**<pre>void f(){}</pre>*/
+    void f();
+}


### PR DESCRIPTION
For historical reasons the Spotless Eclipse plugin tests never used `:testlib`.
Recent problems with the latest `:eclipse-jdt` shows that we need some more tests.
Hence I clean-up a little bit.