### PR TITLE
Java importOrder support for sorting wildcards last

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Added `wildcardsLast` option for Java `ImportOrderStep` ([#954](https://github.com/diffplug/spotless/pull/954))
 
 ## [2.18.0] - 2021-09-30
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,8 +73,8 @@ public final class ImportOrderStep {
 
 	private FormatterStep createFrom(boolean wildcardsLast, Supplier<List<String>> importOrder) {
 		return FormatterStep.createLazy("importOrder",
-			() -> new State(importOrder.get(), lineFormat, wildcardsLast),
-			State::toFormatter);
+				() -> new State(importOrder.get(), lineFormat, wildcardsLast),
+				State::toFormatter);
 	}
 
 	private static List<String> getImportOrder(File importsFile) {

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -36,6 +36,8 @@ import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 
 public final class ImportOrderStep {
+	private static final boolean WILDCARDS_LAST_DEFAULT = false;
+
 	private final String lineFormat;
 
 	public static ImportOrderStep forGroovy() {
@@ -51,7 +53,7 @@ public final class ImportOrderStep {
 	}
 
 	public FormatterStep createFrom(String... importOrder) {
-		return createFrom(false, importOrder);
+		return createFrom(WILDCARDS_LAST_DEFAULT, importOrder);
 	}
 
 	public FormatterStep createFrom(boolean wildcardsLast, String... importOrder) {
@@ -61,7 +63,7 @@ public final class ImportOrderStep {
 	}
 
 	public FormatterStep createFrom(File importsFile) {
-		return createFrom(false, importsFile);
+		return createFrom(WILDCARDS_LAST_DEFAULT, importsFile);
 	}
 
 	public FormatterStep createFrom(boolean wildcardsLast, File importsFile) {

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
@@ -29,9 +29,11 @@ final class ImportSorter {
 	static final String N = "\n";
 
 	private final List<String> importsOrder;
+	private final boolean wildcardsLast;
 
-	ImportSorter(List<String> importsOrder) {
+	ImportSorter(List<String> importsOrder, boolean wildcardsLast) {
 		this.importsOrder = new ArrayList<>(importsOrder);
+		this.wildcardsLast = wildcardsLast;
 	}
 
 	String format(String raw, String lineFormat) {
@@ -79,7 +81,7 @@ final class ImportSorter {
 		}
 		scanner.close();
 
-		List<String> sortedImports = ImportSorterImpl.sort(imports, importsOrder, lineFormat);
+		List<String> sortedImports = ImportSorterImpl.sort(imports, importsOrder, wildcardsLast, lineFormat);
 		return applyImportsToDocument(raw, firstImportLine, lastImportLine, sortedImports);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Added `wildcardsLast()` option for Java `importOrder` ([#954](https://github.com/diffplug/spotless/pull/954))
 
 ## [5.15.2] - 2021-09-27
 ### Changed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -100,8 +100,8 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			ImportOrderStep importOrderStep = ImportOrderStep.forJava();
 
 			return importOrderFile != null
-				? importOrderStep.createFrom(wildcardsLast, getProject().file(importOrderFile))
-				: importOrderStep.createFrom(wildcardsLast, importOrder);
+					? importOrderStep.createFrom(wildcardsLast, getProject().file(importOrderFile))
+					: importOrderStep.createFrom(wildcardsLast, importOrder);
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -87,7 +87,11 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 		/** Sorts wildcard imports after non-wildcard imports, instead of before. */
 		public ImportOrderConfig wildcardsLast() {
-			wildcardsLast = true;
+			return wildcardsLast(true);
+		}
+
+		public ImportOrderConfig wildcardsLast(boolean wildcardsLast) {
+			this.wildcardsLast = wildcardsLast;
 			replaceStep(createStep());
 			return this;
 		}

--- a/testlib/src/main/resources/java/importsorter/JavaCodeImportComments.test
+++ b/testlib/src/main/resources/java/importsorter/JavaCodeImportComments.test
@@ -7,8 +7,14 @@ import java.lang.Runnable;
 import org.comments.be
 import org.comments.removed
 */
-import static java.lang.Runnable.*; 
+import static java.lang.Runnable.*;
 /*
 import other.multiline.comments
-import will.be.removed.too */ 
+import will.be.removed.too */
 import static com.foo.Bar
+import java.awt.*;
+import java.util.*;
+import java.util.List;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static org.hamcrest.Matchers.*;

--- a/testlib/src/main/resources/java/importsorter/JavaCodeSortedImports.test
+++ b/testlib/src/main/resources/java/importsorter/JavaCodeSortedImports.test
@@ -1,9 +1,15 @@
+import java.awt.*;
 import java.lang.Runnable;
 import java.lang.Thread;
+import java.util.*;
+import java.util.List;
 
 import org.dooda.Didoo;
 
 import static java.lang.Exception.*;
 import static java.lang.Runnable.*;
+import static org.hamcrest.Matchers.*;
 
 import static com.foo.Bar;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;

--- a/testlib/src/main/resources/java/importsorter/JavaCodeSortedImportsWildcardsLast.test
+++ b/testlib/src/main/resources/java/importsorter/JavaCodeSortedImportsWildcardsLast.test
@@ -1,6 +1,6 @@
 import static com.foo.Bar;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.lang.Exception.*;
 import static java.lang.Runnable.*;
 import static org.hamcrest.Matchers.*;
@@ -8,6 +8,6 @@ import static org.hamcrest.Matchers.*;
 import java.awt.*;
 import java.lang.Runnable;
 import java.lang.Thread;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 import org.dooda.Didoo;

--- a/testlib/src/main/resources/java/importsorter/JavaCodeUnsortedImports.test
+++ b/testlib/src/main/resources/java/importsorter/JavaCodeUnsortedImports.test
@@ -1,7 +1,13 @@
 import static java.lang.Exception.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import org.dooda.Didoo;
+import java.util.List;
 import java.lang.Thread;
+import java.util.*;
 import java.lang.Runnable;
+import static org.hamcrest.Matchers.*;
 
 import static java.lang.Runnable.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.foo.Bar
+import java.awt.*;

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -47,6 +47,12 @@ class ImportOrderStepTest extends ResourceHarness {
 	}
 
 	@Test
+	void sortImportsWildcardsLast() throws Throwable {
+		FormatterStep step = ImportOrderStep.forJava().createFrom(true);
+		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImportsWildcardsLast.test");
+	}
+
+	@Test
 	void removeDuplicates() throws Throwable {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
 		assertOnResources(step, "java/importsorter/JavaCodeSortedDuplicateImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");


### PR DESCRIPTION
Adds support for sorting wildcards after non-wildcards in the import list. Gradle config like so:

```
importOrder('java', 'javax', 'com.acme', '').wildcardsLast()
```

Not implemented here: Maven plugin support

Fixes #879.


![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and the build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
