### PR TITLE
Add support for JDBI bind list params.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Added
+* Added support for JBDI bind list params in sql formatter ([#955](https://github.com/diffplug/spotless/pull/955))
+
 ## [2.18.0] - 2021-09-30
 ### Added
 * Added support for custom JSR223 formatters ([#945](https://github.com/diffplug/spotless/pull/945))

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -138,6 +138,13 @@ public class SQLTokenizedFormatter {
 				argList.remove(index + 1);
 				argList.remove(index + 1);
 			}
+
+			// JDBI bind list
+			if (tokenString.equals("<") && t1.getType() == TokenType.NAME && token2String.equals(">")) {
+				t0.setString(t0.getString() + t1.getString() + t2.getString());
+				argList.remove(index + 1);
+				argList.remove(index + 1);
+			}
 		}
 
 		int indent = 0;

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Added
+* Added support for JBDI bind list params in sql formatter ([#955](https://github.com/diffplug/spotless/pull/955))
+
 ## [5.15.2] - 2021-09-27
 ### Changed
 * Added support and bump Eclipse formatter default versions to `4.21` for `eclipse-cdt`, `eclipse-jdt`, `eclipse-wtp`. Change is only applied for JVM 11+.

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Added
+* Added support for JBDI bind list params in sql formatter ([#955](https://github.com/diffplug/spotless/pull/955))
+
 ## [2.15.0] - 2021-09-30
 ### Added
 * Added support for custom JSR223 formatters ([#945](https://github.com/diffplug/spotless/pull/945))

--- a/testlib/src/main/resources/sql/dbeaver/full.clean
+++ b/testlib/src/main/resources/sql/dbeaver/full.clean
@@ -51,6 +51,7 @@ WHERE
             table3.name = 'Foo Bar'
             AND table3.type = 'unknown_type'
             AND table3.param =:aParam
+            AND table3.listParam IN(<listParam>)
     )
 GROUP BY
     table1.id,

--- a/testlib/src/main/resources/sql/dbeaver/full.dirty
+++ b/testlib/src/main/resources/sql/dbeaver/full.dirty
@@ -9,5 +9,5 @@ DELETE FROM TABLE1 WHERE a=1;
 UPDATE TABLE1 SET a=2 WHERE a=1;
 
 SELECT table1.id, table2.number, SUM(table1.amount) FROM table1 INNER JOIN table2 ON table.id = table2.table1_id
-WHERE table1.id IN (SELECT table1_id FROM table3 WHERE table3.name = 'Foo Bar' and table3.type = 'unknown_type' And        table3.param = :aParam)
+WHERE table1.id IN (SELECT table1_id FROM table3 WHERE table3.name = 'Foo Bar' and table3.type = 'unknown_type' And        table3.param = :aParam aNd table3.listParam IN ( <listParam > ))
 GROUP BY table1.id, table2.number ORDER BY table1.id;

--- a/testlib/src/main/resources/sql/dbeaver/jdbi-params.clean
+++ b/testlib/src/main/resources/sql/dbeaver/jdbi-params.clean
@@ -1,0 +1,7 @@
+SELECT
+    *
+FROM
+    TABLE
+    WHERE
+        id IN(<ids>)
+        AND user_id =:user_id;

--- a/testlib/src/main/resources/sql/dbeaver/jdbi-params.dirty
+++ b/testlib/src/main/resources/sql/dbeaver/jdbi-params.dirty
@@ -1,0 +1,1 @@
+SELECT * FROM table WHERE id IN (<ids>) AND user_id = :user_id;

--- a/testlib/src/test/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStepTest.java
@@ -35,7 +35,8 @@ class DBeaverSQLFormatterStepTest extends ResourceHarness {
 				.testResource("sql/dbeaver/full.dirty", "sql/dbeaver/full.clean")
 				.testResource("sql/dbeaver/V1_initial.sql.dirty", "sql/dbeaver/V1_initial.sql.clean")
 				.testResource("sql/dbeaver/alter-table.dirty", "sql/dbeaver/alter-table.clean")
-				.testResource("sql/dbeaver/create.dirty", "sql/dbeaver/create.clean");
+				.testResource("sql/dbeaver/create.dirty", "sql/dbeaver/create.clean")
+			    .testResource("sql/dbeaver/jdbi-params.dirty", "sql/dbeaver/jdbi-params.clean");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStepTest.java
@@ -36,7 +36,7 @@ class DBeaverSQLFormatterStepTest extends ResourceHarness {
 				.testResource("sql/dbeaver/V1_initial.sql.dirty", "sql/dbeaver/V1_initial.sql.clean")
 				.testResource("sql/dbeaver/alter-table.dirty", "sql/dbeaver/alter-table.clean")
 				.testResource("sql/dbeaver/create.dirty", "sql/dbeaver/create.clean")
-			    .testResource("sql/dbeaver/jdbi-params.dirty", "sql/dbeaver/jdbi-params.clean");
+				.testResource("sql/dbeaver/jdbi-params.dirty", "sql/dbeaver/jdbi-params.clean");
 	}
 
 	@Test


### PR DESCRIPTION
JDBI bind list params are in the format: `IN(<ids>)`. Previously the formatter would break these up:

```
IN(
  < ids >
)
```

Which breaks the JDBI integration. This will no longer happen in the case that there is a `<` then a NAME type token then `>`
