### PR TITLE
Added `wildcardsLast` option for Java `importOrder` in Maven

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Added `wildcardsLast` option for Java `importOrder` ([#956](https://github.com/diffplug/spotless/pull/956))
 
 ## [2.16.0] - 2021-10-02
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,10 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
 * Added `wildcardsLast` option for Java `importOrder` ([#956](https://github.com/diffplug/spotless/pull/956))
 
 ## [2.16.0] - 2021-10-02
-
 ### Added
 * Added support for JBDI bind list params in sql formatter ([#955](https://github.com/diffplug/spotless/pull/955))
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -179,6 +179,7 @@ any other maven phase (i.e. compile) then it can be configured as below;
 
     <importOrder /> <!-- standard import order -->
     <importOrder>  <!-- or a custom ordering -->
+      <wildcardsLast>false</wildcardsLast> <!-- Optional, default false. Sort wildcard import after specific imports -->
       <order>java,javax,org,com,com.diffplug,</order>  <!-- or use <file>${project.basedir}/eclipse.importorder</file> -->
       <!-- You probably want an empty string at the end - all of the
            imports you didn't specify explicitly will go there. -->

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,17 +31,20 @@ public class ImportOrder implements FormatterStepFactory {
 	@Parameter
 	private String order;
 
+	@Parameter
+	private boolean wildcardsLast = false;
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		if (file != null ^ order != null) {
 			if (file != null) {
 				File importsFile = config.getFileLocator().locateFile(file);
-				return ImportOrderStep.forJava().createFrom(importsFile);
+				return ImportOrderStep.forJava().createFrom(wildcardsLast, importsFile);
 			} else {
-				return ImportOrderStep.forJava().createFrom(order.split(",", -1));
+				return ImportOrderStep.forJava().createFrom(wildcardsLast, order.split(",", -1));
 			}
 		} else if (file == null && order == null) {
-			return ImportOrderStep.forJava().createFrom();
+			return ImportOrderStep.forJava().createFrom(wildcardsLast);
 		} else {
 			throw new IllegalArgumentException("Must specify exactly one of 'file' or 'order'.");
 		}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ImportOrderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ImportOrderTest.java
@@ -45,6 +45,15 @@ class ImportOrderTest extends MavenIntegrationHarness {
 		runTest("java/importsorter/JavaCodeSortedImportsDefault.test");
 	}
 
+	@Test
+	void wildcardsLast() throws Exception {
+		writePomWithJavaSteps(
+				"<importOrder>",
+				"  <wildcardsLast>true</wildcardsLast>",
+				"</importOrder>");
+		runTest("java/importsorter/JavaCodeSortedImportsWildcardsLast.test");
+	}
+
 	private void runTest() throws Exception {
 		runTest("java/importsorter/JavaCodeSortedImports.test");
 	}


### PR DESCRIPTION
Follow up to #954, bringing wildcardsLast option for importOrder step to the maven plugin.