### PR TITLE
Fixed module-info formatting in eclipse-jdt.

### DIFF
--- a/_ext/eclipse-jdt/CHANGES.md
+++ b/_ext/eclipse-jdt/CHANGES.md
@@ -3,6 +3,11 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `4.8.0`).
 
 ## [Unreleased]
+### Changed
+* Bumped minimum supported Eclipse JDT core version to 3.27.0
+* `format` interface requires source file information to distinguish module-info from compilation unit. Old interface marked as deprecated.
+### Fixed
+* Fixed module-info formatting. Previous versions did not recognized content and skipped formatting.
 
 ## [4.8.0] - 2018-07-19
 * Initial release!

--- a/_ext/eclipse-jdt/gradle.properties
+++ b/_ext/eclipse-jdt/gradle.properties
@@ -5,5 +5,5 @@ description=Eclipse's JDT formatter bundled for Spotless
 VER_JAVA=11
 
 # Compile
-VER_ECLIPSE_JDT_CORE=[3.12.0,4.0.0[
+VER_ECLIPSE_JDT_CORE=[3.13.0,4.0.0[
 VER_SPOTLESS_ECLISPE_BASE=[3.5.0,4.0.0[

--- a/_ext/eclipse-jdt/src/main/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImpl.java
+++ b/_ext/eclipse-jdt/src/main/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,13 @@
  */
 package com.diffplug.spotless.extra.eclipse.java;
 
+import java.io.File;
 import java.util.Properties;
 
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.text.edits.TextEdit;
@@ -53,8 +55,17 @@ public class EclipseJdtFormatterStepImpl {
 		}
 	}
 
+	/** @deprecated  Use {@link #format(String, File)} instead. */
 	public String format(String raw) throws Exception {
-		TextEdit edit = codeFormatter.format(CodeFormatter.K_COMPILATION_UNIT | CodeFormatter.F_INCLUDE_COMMENTS, raw, 0, raw.length(), 0, SpotlessEclipseFramework.LINE_DELIMITER);
+		return format(raw, new File(""));
+	}
+
+	/** Formatting Java string, distinguishing module-info and compilation unit by file name */
+	public String format(String raw, File file) throws Exception {
+		int kind = (file.getName().equals(IModule.MODULE_INFO_JAVA) ? CodeFormatter.K_MODULE_INFO
+				: CodeFormatter.K_COMPILATION_UNIT) | CodeFormatter.F_INCLUDE_COMMENTS;
+
+		TextEdit edit = codeFormatter.format(kind, raw, 0, raw.length(), 0, SpotlessEclipseFramework.LINE_DELIMITER);
 		if (edit == null) {
 			throw new IllegalArgumentException("Invalid java syntax for formatting.");
 		} else {

--- a/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
+++ b/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
@@ -95,9 +95,24 @@ class EclipseJdtFormatterStepImplTest extends ResourceHarness {
 		assertEquals(formatted, format(unformatted), "Failed to create internal code formatter. See Spotless issue #191");
 	}
 
+	@Test
+	void moduleInfo() throws Throwable {
+		config.clear();
+		config.setProperty(
+				DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_MODULE_STATEMENTS,
+				DefaultCodeFormatterConstants.createAlignmentValue(true, DefaultCodeFormatterConstants.WRAP_ONE_PER_LINE, DefaultCodeFormatterConstants.INDENT_BY_ONE));
+		String formatted = getTestResource("java/eclipse/ModuleInfoFormatted.test");
+		String unformatted = getTestResource("java/eclipse/ModuleInfoUnformatted.test");
+		assertEquals(formatted, format(unformatted, "whatever/module-info.java"), "Jvm9 module info not formatted.");
+	}
+
 	private String format(final String input) throws Exception {
+		return format(input, "");
+	}
+
+	private String format(final String input, final String fileName) throws Exception {
 		EclipseJdtFormatterStepImpl formatter = new EclipseJdtFormatterStepImpl(config);
-		return formatter.format(input);
+		return formatter.format(input, new File(fileName));
 	}
 
 }

--- a/testlib/src/main/resources/java/eclipse/ModuleInfoFormatted.test
+++ b/testlib/src/main/resources/java/eclipse/ModuleInfoFormatted.test
@@ -1,0 +1,6 @@
+module foo.bar {
+	provides test.Service
+		with
+		foo.bar.Service1,
+		foo.bar.Service2;
+}

--- a/testlib/src/main/resources/java/eclipse/ModuleInfoUnformatted.test
+++ b/testlib/src/main/resources/java/eclipse/ModuleInfoUnformatted.test
@@ -1,0 +1,5 @@
+module foo.bar
+{
+	provides test.Service
+			with foo.bar.Service1, foo.bar.Service2;
+}


### PR DESCRIPTION
Since JDT Core 3.13, the module-info formatting is distinguished by filename.
This PR still uses `spotless-eclipse-base` 3.5 and therefore requires JVM 11.