### PR TITLE
Apply eclipse-jdt-4.8.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+ * [module-info formatting](https://github.com/diffplug/spotless/pull/958) in `eclipse-jdt` versions `4.20` and `4.21`. Note that the problem also affects older versions.
 
 ## [2.19.0] - 2021-10-02
 * Added `wildcardsLast` option for Java `ImportOrderStep` ([#954](https://github.com/diffplug/spotless/pull/954))

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -50,7 +50,8 @@ public final class EclipseJdtFormatterStep {
 		Class<?> formatterClazz = getClass(state);
 		Object formatter = formatterClazz.getConstructor(Properties.class).newInstance(state.getPreferences());
 		Method method = formatterClazz.getMethod(FORMATTER_METHOD, String.class);
-		return JVM_SUPPORT.suggestLaterVersionOnError(state.getSemanticVersion(), input -> (String) method.invoke(formatter, input));
+		FormatterFunc formatterFunc = getFormatterFunc(formatter, method);
+		return JVM_SUPPORT.suggestLaterVersionOnError(state.getSemanticVersion(), formatterFunc);
 	}
 
 	private static Class<?> getClass(State state) {
@@ -58,5 +59,12 @@ public final class EclipseJdtFormatterStep {
 			return state.loadClass(FORMATTER_CLASS);
 		}
 		return state.loadClass(FORMATTER_CLASS_OLD);
+	}
+
+	private static FormatterFunc getFormatterFunc(Object formatter, Method method) {
+		if (1 == method.getParameterCount()) {
+			return input -> (String) method.invoke(formatter, input);
+		}
+		return (FormatterFunc.NeedsFile) (input, file) -> (String) method.invoke(formatter, input, file);
 	}
 }

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.20.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.20.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on JDT version 4.20.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_20 to determine core version.
-com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.1
 com.diffplug.spotless:spotless-eclipse-base:3.5.0
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.21.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.21.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on JDT version 4.21.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_21 to determine core version.
-com.diffplug.spotless:spotless-eclipse-jdt:4.8.0
+com.diffplug.spotless:spotless-eclipse-jdt:4.8.1
 com.diffplug.spotless:spotless-eclipse-base:3.5.0
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepTest.java
@@ -26,7 +26,7 @@ import com.diffplug.spotless.extra.eclipse.EclipseResourceHarness;
 
 class EclipseJdtFormatterStepTest extends EclipseResourceHarness {
 	private final static String NON_SEMANTIC_ECLIPSE_VERSION = "4.7.3a";
-	private final static Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support("Oldest Version").add(8, "4.6.1");
+	private final static Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support("Oldest Version").add(8, "4.6.1").add(11, "4.20.0");
 	private final static String INPUT = "package p; class C{}";
 	private final static String EXPECTED = "package p;\nclass C {\n}";
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+ * [module-info formatting](https://github.com/diffplug/spotless/pull/958) in `eclipse-jdt` versions `4.20` and `4.21`. Note that the problem also affects older versions.
 
 ## [5.16.0] - 2021-10-02
 * Added `wildcardsLast()` option for Java `importOrder` ([#954](https://github.com/diffplug/spotless/pull/954))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+ * [module-info formatting](https://github.com/diffplug/spotless/pull/958) in `eclipse-jdt` versions `4.20` and `4.21`. Note that the problem also affects older versions.
 
 ## [2.17.0] - 2021-10-04
 ### Added


### PR DESCRIPTION
The new version fixes module-info formatting.
See #958 for details.