### PR TITLE
Treat warnings as errors in _ext projects.

### DIFF
--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseFramework.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,6 +146,7 @@ public final class SpotlessEclipseFramework {
 	 * @throws BundleException Throws exception in case the setup failed.
 	 * @deprecated  Use {@link #setup(SpotlessEclipseConfig)} instead.
 	 */
+	@Deprecated
 	public synchronized static boolean setup() throws BundleException {
 		return setup(plugins -> plugins.applyDefault());
 	}
@@ -159,6 +160,7 @@ public final class SpotlessEclipseFramework {
 	 * @throws BundleException Throws exception in case the setup failed.
 	 * @deprecated  Use {@link #setup(SpotlessEclipseConfig)} instead.
 	 */
+	@Deprecated
 	public synchronized static boolean setup(Consumer<SpotlessEclipsePluginConfig> plugins) throws BundleException {
 		return setup(config -> config.applyDefault(), plugins);
 	}
@@ -172,6 +174,7 @@ public final class SpotlessEclipseFramework {
 	 * @throws BundleException Throws exception in case the setup failed.
 	 * @deprecated  Use {@link #setup(SpotlessEclipseConfig)} instead.
 	 */
+	@Deprecated
 	public synchronized static boolean setup(Consumer<SpotlessEclipseServiceConfig> config, Consumer<SpotlessEclipsePluginConfig> plugins) throws BundleException {
 		return setup(core -> core.applyDefault(), config, plugins);
 	}
@@ -186,6 +189,7 @@ public final class SpotlessEclipseFramework {
 	 * @throws BundleException Throws exception in case the setup failed.
 	 * @deprecated  Use {@link #setup(SpotlessEclipseConfig)} instead.
 	 */
+	@Deprecated
 	public synchronized static boolean setup(Consumer<SpotlessEclipseCoreConfig> core, Consumer<SpotlessEclipseServiceConfig> services, Consumer<SpotlessEclipsePluginConfig> plugins) throws BundleException {
 		if (null != INSTANCE) {
 			return false;

--- a/_ext/eclipse-jdt/src/main/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImpl.java
+++ b/_ext/eclipse-jdt/src/main/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImpl.java
@@ -56,6 +56,7 @@ public class EclipseJdtFormatterStepImpl {
 	}
 
 	/** @deprecated  Use {@link #format(String, File)} instead. */
+	@Deprecated
 	public String format(String raw) throws Exception {
 		return format(raw, new File(""));
 	}

--- a/_ext/gradle/java-setup.gradle
+++ b/_ext/gradle/java-setup.gradle
@@ -8,10 +8,11 @@ apply from: rootProject.file('gradle/java-setup.gradle')
 // Allow declaration of api/compile dependencies
 apply plugin: 'java-library'
 
-// Show warning locations
+// Show warning locations, fail on warnings
 tasks.withType(JavaCompile) {
 	options.compilerArgs << "-Xlint:unchecked"
 	options.compilerArgs << "-Xlint:deprecation"
+	options.compilerArgs << "-Werror"
 }
 
 //Currently testlib is not used by _ext. Hence the external dependencies are added here.


### PR DESCRIPTION
Please remind me. There was no reason not to mark things as deprecated was there? I probably just forgot it.