### PR TITLE
Apply eclipse-jdt-4.8.1(2nd attempt)

### DIFF
--- a/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
+++ b/_ext/eclipse-jdt/src/test/java/com/diffplug/spotless/extra/eclipse/java/EclipseJdtFormatterStepImplTest.java
@@ -46,8 +46,8 @@ class EclipseJdtFormatterStepImplTest extends ResourceHarness {
 
 	@BeforeEach
 	void beforeEach() throws IOException {
-		File sttingsFile = createTestFile("java/eclipse/formatter.xml");
-		config = FormatterProperties.from(sttingsFile).getProperties();
+		File settingsFile = createTestFile("java/eclipse/formatter.xml");
+		config = FormatterProperties.from(settingsFile).getProperties();
 	}
 
 	private final static String ILLEGAL_CHAR = Character.toString((char) 254);
@@ -97,10 +97,8 @@ class EclipseJdtFormatterStepImplTest extends ResourceHarness {
 
 	@Test
 	void moduleInfo() throws Throwable {
-		config.clear();
-		config.setProperty(
-				DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_MODULE_STATEMENTS,
-				DefaultCodeFormatterConstants.createAlignmentValue(true, DefaultCodeFormatterConstants.WRAP_ONE_PER_LINE, DefaultCodeFormatterConstants.INDENT_BY_ONE));
+		File settingsFile = createTestFile("java/eclipse/ModuleInfo.prefs");
+		config = FormatterProperties.from(settingsFile).getProperties();
 		String formatted = getTestResource("java/eclipse/ModuleInfoFormatted.test");
 		String unformatted = getTestResource("java/eclipse/ModuleInfoUnformatted.test");
 		assertEquals(formatted, format(unformatted, "whatever/module-info.java"), "Jvm9 module info not formatted.");

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/eclipse/EclipseResourceHarness.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/eclipse/EclipseResourceHarness.java
@@ -43,6 +43,7 @@ import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
  */
 public class EclipseResourceHarness extends ResourceHarness {
 	private final EclipseBasedStepBuilder stepBuilder;
+	private final String fileName;
 	private final String input;
 	private final String expected;
 
@@ -50,10 +51,22 @@ public class EclipseResourceHarness extends ResourceHarness {
 	 * Create harness to be used for several versions of the formatter step
 	 * @param builder Eclipse Formatter step builder
 	 * @param unformatted Simple unformatted input
-	 * @param formatted
+	 * @param formatted Expected formatted output
 	 */
 	public EclipseResourceHarness(EclipseBasedStepBuilder builder, String unformatted, String formatted) {
+		this(builder, "someSourceFile", unformatted, formatted);
+	}
+
+	/**
+	 * Create harness to be used for several versions of the formatter step
+	 * @param builder Eclipse Formatter step builder
+	 * @param sourceFileName File name of the source file
+	 * @param unformatted Simple unformatted input
+	 * @param formatted Expected formatted output
+	 */
+	public EclipseResourceHarness(EclipseBasedStepBuilder builder, String sourceFileName, String unformatted, String formatted) {
 		stepBuilder = builder;
+		fileName = sourceFileName;
 		input = unformatted;
 		expected = formatted;
 	}
@@ -77,7 +90,7 @@ public class EclipseResourceHarness extends ResourceHarness {
 	 * @return Formatted string
 	 */
 	protected String format(String formatterVersion, File... settingsFiles) throws Exception {
-		File inputFile = setFile("someInputFile").toContent(input);
+		File inputFile = setFile(fileName).toContent(input);
 		stepBuilder.setVersion(formatterVersion);
 		stepBuilder.setPreferences(Arrays.asList(settingsFiles));
 		FormatterStep step = stepBuilder.build();

--- a/testlib/src/main/resources/java/eclipse/ModuleInfo.prefs
+++ b/testlib/src/main/resources/java/eclipse/ModuleInfo.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+#DefaultCodeFormatterConstants.createAlignmentValue(true, DefaultCodeFormatterConstants.WRAP_ONE_PER_LINE, DefaultCodeFormatterConstants.INDENT_BY_ONE)
+org.eclipse.jdt.core.formatter.alignment_for_module_statements=53


### PR DESCRIPTION
The new version fixes module-info formatting.

Fix in #960 was incomplete. Still the old interface version was used.
