### PR TITLE
Attempted workaround for git worktree issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
  * [module-info formatting](https://github.com/diffplug/spotless/pull/958) in `eclipse-jdt` versions `4.20` and `4.21`. Note that the problem also affects older versions.
+ * Added workaround to support projects using git worktrees ([#965](https://github.com/diffplug/spotless/pull/965))
 
 ## [2.19.0] - 2021-10-02
 * Added `wildcardsLast` option for Java `ImportOrderStep` ([#954](https://github.com/diffplug/spotless/pull/954))
@@ -22,7 +23,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [2.18.0] - 2021-09-30
 ### Added
 * Added support for custom JSR223 formatters ([#945](https://github.com/diffplug/spotless/pull/945))
-* Added support for formating and sorting Maven POMs ([#946](https://github.com/diffplug/spotless/pull/946))
+* Added support for formatting and sorting Maven POMs ([#946](https://github.com/diffplug/spotless/pull/946))
 
 ## [2.17.0] - 2021-09-27
 ### Added

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -168,8 +168,7 @@ public final class GitAttributesLineEndings {
 			//////////////////////////
 			// REPO-SPECIFIC VALUES //
 			//////////////////////////
-			FileRepositoryBuilder builder = new FileRepositoryBuilder();
-			builder.findGitDir(projectDir);
+			FileRepositoryBuilder builder = GitWorkarounds.fileRepositoryBuilderForProject(projectDir);
 			if (builder.getGitDir() != null) {
 				workTree = builder.getWorkTree();
 				repoConfig = new FileBasedConfig(userConfig, new File(builder.getGitDir(), Constants.CONFIG), FS.DETECTED);

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -17,8 +17,6 @@ package com.diffplug.spotless.extra;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -182,37 +180,13 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 		return null;
 	}
 
-	/**
-	 * When populating a new submodule directory with "git submodule init", the $GIT_DIR meta-information directory
-	 * for submodules is created inside $GIT_DIR/modules// directory of the super-project
-	 * and referenced via the git-file mechanism.
-	 */
-	private static @Nullable File getDotGitDir(File dir, String dotGit) {
-		File dotGitPath = new File(dir, dotGit);
-
-		if (dotGitPath.isDirectory()) {
-			return dotGitPath;
-		} else if (dotGitPath.isFile()) {
-			try {
-				String relativePath = new String(Files.readAllBytes(dotGitPath.toPath()), StandardCharsets.UTF_8)
-						.split(":")[1].trim();
-				return getDotGitDir(dir, relativePath);
-			} catch (IOException e) {
-				System.err.println("failed to parse git meta: " + e.getMessage());
-				return null;
-			}
-		} else {
-			return null;
-		}
-	}
-
 	private static boolean isGitRoot(File dir) {
-		File dotGit = getDotGitDir(dir, Constants.DOT_GIT);
+		File dotGit = GitWorkarounds.getDotGitDir(dir);
 		return dotGit != null && RepositoryCache.FileKey.isGitRepository(dotGit, FS.DETECTED);
 	}
 
 	static Repository createRepo(File dir) throws IOException {
-		return FileRepositoryBuilder.create(getDotGitDir(dir, Constants.DOT_GIT));
+		return FileRepositoryBuilder.create(GitWorkarounds.getDotGitDir(dir));
 	}
 
 	/**

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020-2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.extra;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+/**
+ * Utility methods for Git workarounds.
+ */
+public class GitWorkarounds {
+	private GitWorkarounds() {}
+
+	/**
+	 * Finds the .git directory for the given project directory.
+	 *
+	 * Ordinarily one would just use JGit for this, but it doesn't support worktrees properly.
+	 * So this applies an additional workaround for that.
+	 *
+	 * @param projectDir the project directory.
+	 * @return the path to the .git directory.
+	 */
+	static @Nullable File getDotGitDir(File projectDir) {
+		return fileRepositoryBuilderForProject(projectDir).getGitDir();
+	}
+
+	/**
+	 * Creates a {@link FileRepositoryBuilder} for the given project directory.
+	 *
+	 * This applies a workaround for JGit not supporting worktrees properly.
+	 *
+	 * @param projectDir the project directory.
+	 * @return the builder.
+	 */
+	static FileRepositoryBuilder fileRepositoryBuilderForProject(File projectDir) {
+		FileRepositoryBuilder builder = new FileRepositoryBuilder();
+		builder.findGitDir(projectDir);
+		File gitDir = builder.getGitDir();
+		if (gitDir != null) {
+			builder.setGitDir(resolveRealGitDirIfWorktreeDir(gitDir));
+		}
+		return builder;
+	}
+
+	/**
+	 * If the dir is a worktree directory (typically .git/worktrees/something) then
+	 * returns the actual .git directory.
+	 *
+	 * @param dir the directory which may be a worktree directory or may be a .git directory.
+	 * @return the .git directory.
+	 */
+	private static File resolveRealGitDirIfWorktreeDir(File dir) {
+		File pointerFile = new File(dir, "gitdir");
+		if (pointerFile.isFile()) {
+			try {
+				String content = new String(Files.readAllBytes(pointerFile.toPath()), StandardCharsets.UTF_8).trim();
+				return new File(content);
+			} catch (IOException e) {
+				System.err.println("failed to parse git meta: " + e.getMessage());
+				return dir;
+			}
+		} else {
+			return dir;
+		}
+	}
+}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -8,6 +8,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ### Fixed
  * [module-info formatting](https://github.com/diffplug/spotless/pull/958) in `eclipse-jdt` versions `4.20` and `4.21`. Note that the problem also affects older versions.
+ * Added workaround to support projects using git worktrees ([#965](https://github.com/diffplug/spotless/pull/965))
 
 ## [5.16.0] - 2021-10-02
 * Added `wildcardsLast()` option for Java `importOrder` ([#954](https://github.com/diffplug/spotless/pull/954))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
  * [module-info formatting](https://github.com/diffplug/spotless/pull/958) in `eclipse-jdt` versions `4.20` and `4.21`. Note that the problem also affects older versions.
+ * Added workaround to support projects using git worktrees ([#965](https://github.com/diffplug/spotless/pull/965))
 
 ## [2.17.0] - 2021-10-04
 ### Added
@@ -17,7 +18,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [2.15.0] - 2021-09-30
 ### Added
 * Added support for custom JSR223 formatters ([#945](https://github.com/diffplug/spotless/pull/945))
-* Added support for formating and sorting Maven POMs ([#946](https://github.com/diffplug/spotless/pull/946))
+* Added support for formatting and sorting Maven POMs ([#946](https://github.com/diffplug/spotless/pull/946))
 
 ## [2.14.0] - 2021-09-27
 ### Added


### PR DESCRIPTION
If the directory found as the git dir contains a file called `gitdir`, attempts to resolve it to find the actual git directory.

(Not quite sure how to unit test because it's not like I can use JGit to create a worktree for the test given that it doesn't support the feature!)

For issue #75 or my issue #964