### PR TITLE
Consolidate skip behavior

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+ * [skip bug](https://github.com/diffplug/spotless/issues/968) if ratchetFrom is specified, the build will still fail in if no Git repository is found, even if `skip` is true.
 
 ## [2.17.1] - 2021-10-13
 ### Fixed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -73,6 +73,12 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Component
 	private ResourceManager resourceManager;
 
+	@Parameter(defaultValue = "${mojoExecution.goal}", required = true, readonly = true)
+	private String goal;
+
+	@Parameter(property = "spotless.check.skip", defaultValue = "false")
+	private boolean skip;
+
 	@Parameter(defaultValue = "${repositorySystemSession}", required = true, readonly = true)
 	private RepositorySystemSession repositorySystemSession;
 
@@ -147,6 +153,11 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private void execute(FormatterFactory formatterFactory) throws MojoExecutionException {
+		if (skip) {
+			getLog().info(String.format("Spotless %s skipped", goal));
+			return;
+		}
+
 		FormatterConfig config = getFormatterConfig();
 		List<File> files = collectFiles(formatterFactory, config);
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.PaddedCell;
@@ -30,16 +29,9 @@ import com.diffplug.spotless.PaddedCell;
  */
 @Mojo(name = "apply", threadSafe = true)
 public class SpotlessApplyMojo extends AbstractSpotlessMojo {
-	@Parameter(property = "spotless.apply.skip", defaultValue = "false")
-	private boolean skip;
 
 	@Override
 	protected void process(Iterable<File> files, Formatter formatter) throws MojoExecutionException {
-		if (skip) {
-			getLog().info("Spotless apply skipped");
-			return;
-		}
-
 		for (File file : files) {
 			try {
 				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.List;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.PaddedCell;
@@ -36,16 +35,8 @@ import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 
-	@Parameter(property = "spotless.check.skip", defaultValue = "false")
-	private boolean skip;
-
 	@Override
 	protected void process(Iterable<File> files, Formatter formatter) throws MojoExecutionException {
-		if (skip) {
-			getLog().info("Spotless check skipped");
-			return;
-		}
-
 		List<File> problemFiles = new ArrayList<>();
 		for (File file : files) {
 			try {


### PR DESCRIPTION
Fix for failure of plugin when both `ratchetFrom` and `skip=true` are specified if no Git repository is present, as is sometimes the case for CI or Docker builds.

Fix for #968 