### PR TITLE
Fix temporary workspace deletion on JVM shutdown (#967)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * Added support and bump Eclipse formatter default versions to `4.21` for `eclipse-groovy`. Change is only applied for JVM 11+.
 
+### Fixed
+ * Temporary workspace deletion for Eclipse based formatters on JVM shutdown ([#967](https://github.com/diffplug/spotless/issues/967)). Change is only applied for Eclipse versions using JVM 11+, no back-port to older versions is planned.
+
 ## [2.19.1] - 2021-10-13
 ### Fixed
  * [module-info formatting](https://github.com/diffplug/spotless/pull/958) in `eclipse-jdt` versions `4.20` and `4.21`. Note that the problem also affects older versions.

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.20.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.20.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on CDT version 10.3 (see https://www.eclipse.org/cdt/)
 com.diffplug.spotless:spotless-eclipse-cdt:10.3.0
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 com.ibm.icu:icu4j:67.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.21.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_cdt_formatter/v4.21.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on CDT version 10.4 (see https://www.eclipse.org/cdt/)
 com.diffplug.spotless:spotless-eclipse-cdt:10.4.0
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 com.ibm.icu:icu4j:67.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.20.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.20.0.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.20.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_20 to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.1
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 net.jcip:jcip-annotations:1.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.21.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_jdt_formatter/v4.21.0.lockfile
@@ -1,7 +1,7 @@
 # Spotless formatter based on JDT version 4.21.0 (see https://projects.eclipse.org/projects/eclipse.jdt)
 # Compare tag in M2 pom with https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/log/?h=R4_21 to determine core version.
 com.diffplug.spotless:spotless-eclipse-jdt:4.8.1
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 net.jcip:jcip-annotations:1.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.20.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.20.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Eclipse-WTP version 3.22 (see https://www.eclipse.org/webtools/)
 com.diffplug.spotless:spotless-eclipse-wtp:3.22.0
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 com.ibm.icu:icu4j:67.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.21.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters/v4.21.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Eclipse-WTP version 3.23 (see https://www.eclipse.org/webtools/)
 com.diffplug.spotless:spotless-eclipse-wtp:3.23.0
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 com.ibm.icu:icu4j:67.1

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.20.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.20.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Groovy-Eclipse version 4.2.0 (see https://github.com/groovy/groovy-eclipse/releases)
 com.diffplug.spotless:spotless-eclipse-groovy:4.2.0
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 net.jcip:jcip-annotations:1.0

--- a/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.21.0.lockfile
+++ b/lib-extra/src/main/resources/com/diffplug/spotless/extra/groovy_eclipse_formatter/v4.21.0.lockfile
@@ -1,6 +1,6 @@
 # Spotless formatter based on Groovy-Eclipse version 4.3.0 (see https://github.com/groovy/groovy-eclipse/releases)
 com.diffplug.spotless:spotless-eclipse-groovy:4.3.0
-com.diffplug.spotless:spotless-eclipse-base:3.5.0
+com.diffplug.spotless:spotless-eclipse-base:3.5.2
 com.github.spotbugs:spotbugs-annotations:4.0.2
 com.google.code.findbugs:jsr305:3.0.2
 net.jcip:jcip-annotations:1.0

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,6 +6,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * Added support and bump Eclipse formatter default versions to `4.21` for `eclipse-groovy`. Change is only applied for JVM 11+.
 
+### Fixed
+ * Temporary workspace deletion for Eclipse based formatters on JVM shutdown ([#967](https://github.com/diffplug/spotless/issues/967)). Change is only applied for Eclipse versions using JVM 11+, no back-port to older versions is planned.
+
 ## [5.17.0] - 2021-10-13
 ### Added
 * Added support for calling local binary formatters ([#963](https://github.com/diffplug/spotless/pull/963))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -9,6 +9,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
  * Revert change from 2.17.2 regarding [skip bug](https://github.com/diffplug/spotless/pull/969) because fixing the skip bug caused inconsistent behavior between `check.skip` and `apply.skip`.
  * [skip bug](https://github.com/diffplug/spotless/issues/968) if ratchetFrom is specified, the build will still fail in if no Git repository is found, even if `skip` is true (new fix).
 
+### Fixed
+ * Temporary workspace deletion for Eclipse based formatters on JVM shutdown ([#967](https://github.com/diffplug/spotless/issues/967)). Change is only applied for Eclipse versions using JVM 11+, no back-port to older versions is planned.
+
 ## [2.17.2] - 2021-10-14
 ### Fixed
  * [skip bug](https://github.com/diffplug/spotless/issues/968) if ratchetFrom is specified, the build will still fail in if no Git repository is found, even if `skip` is true.


### PR DESCRIPTION
Applies 42ffbe908c1436fb0ba310f2d43b623e4281daf9 and 49b3e3ea7f84964f68677382dec2d8ceab3853e8, which fixes #967 to all Eclipse formatters using `spotless-eclipse.base:3.5.x`. Back port for `spotless-eclipse.base:3.4.x` (JVM 8) is not planned.
