### PR TITLE
 Remove the `removeFormat` method (fixes #653)

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Removed
+* **BREAKING** `removeFormat` (which has been broken since `5.0`) has been removed. Use `clearSteps()` as a workaround ([#653](https://github.com/diffplug/spotless/issues/653)).
+
 ## [5.17.1] - 2021-10-26
 ### Changed
 * Added support and bump Eclipse formatter default versions to `4.21` for `eclipse-groovy`. Change is only applied for JVM 11+.

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -182,15 +182,6 @@ public abstract class SpotlessExtension {
 		format(name, FormatExtension.class, closure);
 	}
 
-	/** Makes it possible to remove a format which was created earlier. */
-	public void removeFormat(String name) {
-		requireNonNull(name);
-		FormatExtension toRemove = formats.remove(name);
-		if (toRemove == null) {
-			project.getLogger().warn("Called removeFormat('" + name + "') but there was no such format.");
-		}
-	}
-
 	boolean enforceCheck = true;
 
 	/** Returns {@code true} if Gradle's {@code check} task should run {@code spotlessCheck}; {@code false} otherwise. */


### PR DESCRIPTION
`removeFormat` has been broken since `5.0`, and there is an easy workaround with `clearSteps()` (#653). This PR removes the broken method.

This is a breaking change (kinda, it's been accidentally broken for a long time). I'm putting this PR in the queue now because there are probably some smallish breaking changes on the way which are needed to resolve the dependency resolution weirdness that we've been struggling with for a long time. Since a `6.0` is on the way soon anyway, now is a good time to pile-in on any lingering debt.