### PR TITLE
SpotlessTaskService (towards configuration-cache)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* `DiffMessageFormatter` can now generate messages based on a folder of cleaned files, as an alternative to a `Formatter` ([#982](https://github.com/diffplug/spotless/pull/982)).
 
 ## [2.19.2] - 2021-10-26
 ### Changed

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -16,13 +16,13 @@ spotless {
 		// the rootProject doesn't have any java
 		java {
 			ratchetFrom 'origin/main'
-			custom 'noInternalDeps', noInternalDepsClosure
 			bumpThisNumberIfACustomStepChanges(1)
 			licenseHeaderFile rootProject.file('gradle/spotless.license')
 			importOrderFile   rootProject.file('gradle/spotless.importorder')
 			eclipse().configFile rootProject.file('gradle/spotless.eclipseformat.xml')
 			trimTrailingWhitespace()
 			removeUnusedImports()
+			custom 'noInternalDeps', noInternalDepsClosure
 		}
 	}
 	groovyGradle {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,8 +164,7 @@ public final class DiffMessageFormatter {
 	private static String diff(Builder builder, File file) throws IOException {
 		String raw = new String(Files.readAllBytes(file.toPath()), builder.formatter.getEncoding());
 		String rawUnix = LineEnding.toUnix(raw);
-		String formattedUnix;
-		formattedUnix = PaddedCell.check(builder.formatter, file, rawUnix).canonical();
+		String formattedUnix = PaddedCell.check(builder.formatter, file, rawUnix).canonical();
 
 		if (rawUnix.equals(formattedUnix)) {
 			// the formatting is fine, so it's a line-ending issue

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -174,20 +174,6 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	@Override
-	public boolean equals(Object other) {
-		if (other instanceof FileSignature) {
-			return Arrays.equals(signatures, ((FileSignature) other).signatures);
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public int hashCode() {
-		return Arrays.hashCode(signatures);
-	}
-
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 	private static final class Sig implements Serializable {
 		private static final long serialVersionUID = 6727302747168655222L;
@@ -206,21 +192,6 @@ public final class FileSignature implements Serializable {
 			this.size = size;
 			this.hash = hash;
 			this.lastModified = lastModified;
-		}
-
-		@Override
-		public boolean equals(Object other) {
-			if (other instanceof Sig) {
-				Sig o = (Sig) other;
-				return name.equals(o.name) && size == o.size && Arrays.equals(hash, o.hash);
-			} else {
-				return false;
-			}
-		}
-
-		@Override
-		public int hashCode() {
-			return Arrays.hashCode(hash) | name.hashCode();
 		}
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -174,6 +174,20 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof FileSignature) {
+			return Arrays.equals(signatures, ((FileSignature) other).signatures);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Arrays.hashCode(signatures);
+	}
+
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 	private static final class Sig implements Serializable {
 		private static final long serialVersionUID = 6727302747168655222L;
@@ -192,6 +206,21 @@ public final class FileSignature implements Serializable {
 			this.size = size;
 			this.hash = hash;
 			this.lastModified = lastModified;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (other instanceof Sig) {
+				Sig o = (Sig) other;
+				return name.equals(o.name) && size == o.size && Arrays.equals(hash, o.hash);
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			return Arrays.hashCode(hash) | name.hashCode();
 		}
 	}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * **BREAKING** Previously, many projects required `buildscript { repositories { mavenCentral() }}` at the top of their root project, because Spotless resolved its dependencies using the buildscript repositories. Spotless now resolves its dependencies from the normal project repositories of the root project, which means that you can remove the `buildscript {}` block, but you still need `repositories { mavenCentral() }` (or similar) in the root project.
+* **BREAKING** `createIndepentApplyTask(String taskName)` now requires that `taskName` does not end with `Apply`
 * Bump minimum required Gradle from `6.1` to `6.1.1`.
 
 ## [5.17.1] - 2021-10-26

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -758,7 +758,8 @@ public class FormatExtension {
 	 */
 	public SpotlessApply createIndependentApplyTask(String taskName) {
 		// create and setup the task
-		SpotlessTask spotlessTask = spotless.project.getTasks().create(taskName + "Helper", SpotlessTaskImpl.class);
+		SpotlessTaskImpl spotlessTask = spotless.project.getTasks().create(taskName + "Helper", SpotlessTaskImpl.class);
+		spotlessTask.getTaskService().set(spotless.getTaskService());
 		setupTask(spotlessTask);
 		// enforce the clean ordering
 		Task clean = spotless.project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME);
@@ -766,7 +767,7 @@ public class FormatExtension {
 		// create the apply task
 		SpotlessApply applyTask = spotless.project.getTasks().create(taskName, SpotlessApply.class);
 		applyTask.setSpotlessOutDirectory(spotlessTask.getOutputDirectory());
-		applyTask.linkSource(spotlessTask);
+		applyTask.getTaskService().set(spotless.getTaskService());
 		applyTask.dependsOn(spotlessTask);
 
 		return applyTask;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -770,7 +770,7 @@ public class FormatExtension {
 		spotlessTask.mustRunAfter(clean);
 		// create the apply task
 		SpotlessApply applyTask = spotless.project.getTasks().create(taskName, SpotlessApply.class);
-		applyTask.setSpotlessOutDirectory(spotlessTask.getOutputDirectory());
+		applyTask.getSpotlessOutDirectory().set(spotlessTask.getOutputDirectory());
 		applyTask.getTaskService().set(spotless.getTaskService());
 		applyTask.dependsOn(spotlessTask);
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -763,7 +763,7 @@ public class FormatExtension {
 		Preconditions.checkArgument(!taskName.endsWith(SpotlessExtension.APPLY), "Task name must not end with " + SpotlessExtension.APPLY);
 		// create and setup the task
 		SpotlessTaskImpl spotlessTask = spotless.project.getTasks().create(taskName + SpotlessTaskService.INDEPENDENT_HELPER, SpotlessTaskImpl.class);
-		spotlessTask.getTaskService().set(spotless.getTaskService());
+		spotlessTask.init(spotless.getTaskService());
 		setupTask(spotlessTask);
 		// enforce the clean ordering
 		Task clean = spotless.project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -770,8 +770,7 @@ public class FormatExtension {
 		spotlessTask.mustRunAfter(clean);
 		// create the apply task
 		SpotlessApply applyTask = spotless.project.getTasks().create(taskName, SpotlessApply.class);
-		applyTask.getSpotlessOutDirectory().set(spotlessTask.getOutputDirectory());
-		applyTask.getTaskService().set(spotless.getTaskService());
+		applyTask.init(spotlessTask);
 		applyTask.dependsOn(spotlessTask);
 
 		return applyTask;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -40,6 +40,7 @@ import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.BasePlugin;
 
+import com.diffplug.common.base.Preconditions;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -754,11 +755,14 @@ public class FormatExtension {
 	 *
 	 * The returned task will not be hooked up to the global {@code spotlessApply}, and there will be no corresponding {@code check} task.
 	 *
+	 * The task name must not end with `Apply`.
+	 *
 	 * NOTE: does not respect the rarely-used <a href="https://github.com/diffplug/spotless/blob/b7f8c551a97dcb92cc4b0ee665448da5013b30a3/plugin-gradle/README.md#can-i-apply-spotless-to-specific-files">{@code spotlessFiles} property</a>.
 	 */
 	public SpotlessApply createIndependentApplyTask(String taskName) {
+		Preconditions.checkArgument(!taskName.endsWith(SpotlessExtension.APPLY), "Task name must not end with " + SpotlessExtension.APPLY);
 		// create and setup the task
-		SpotlessTaskImpl spotlessTask = spotless.project.getTasks().create(taskName + "Helper", SpotlessTaskImpl.class);
+		SpotlessTaskImpl spotlessTask = spotless.project.getTasks().create(taskName + SpotlessTaskService.INDEPENDENT_HELPER, SpotlessTaskImpl.class);
 		spotlessTask.getTaskService().set(spotless.getTaskService());
 		setupTask(spotlessTask);
 		// enforce the clean ordering

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
@@ -19,7 +19,6 @@ import java.io.File;
 
 import javax.annotation.Nullable;
 
-import org.gradle.api.Project;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.tooling.events.FinishEvent;
@@ -28,15 +27,15 @@ import org.gradle.tooling.events.OperationCompletionListener;
 import com.diffplug.spotless.extra.GitRatchet;
 
 /** Gradle implementation of GitRatchet. */
-public abstract class GitRatchetGradle extends GitRatchet<Project> implements BuildService<BuildServiceParameters.None>, OperationCompletionListener {
+public abstract class GitRatchetGradle extends GitRatchet<File> implements BuildService<BuildServiceParameters.None>, OperationCompletionListener {
 	@Override
-	protected File getDir(Project project) {
-		return project.getProjectDir();
+	protected File getDir(File project) {
+		return project;
 	}
 
 	@Override
-	protected @Nullable Project getParent(Project project) {
-		return project.getParent();
+	protected @Nullable File getParent(File project) {
+		return project.getParentFile();
 	}
 
 	@Override

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class IdeHook {
 		System.err.println("IS CLEAN");
 	}
 
-	static void performHook(SpotlessTask spotlessTask) {
+	static void performHook(SpotlessTaskImpl spotlessTask) {
 		String path = (String) spotlessTask.getProject().property(PROPERTY);
 		File file = new File(path);
 		if (!file.isAbsolute()) {
@@ -43,7 +43,7 @@ class IdeHook {
 		if (spotlessTask.getTarget().contains(file)) {
 			try (Formatter formatter = spotlessTask.buildFormatter()) {
 				if (spotlessTask.ratchet != null) {
-					if (spotlessTask.ratchet.isClean(spotlessTask.getProject(), spotlessTask.rootTreeSha, file)) {
+					if (spotlessTask.ratchet.isClean(spotlessTask.getProjectDir().get().getAsFile(), spotlessTask.rootTreeSha, file)) {
 						dumpIsClean();
 						return;
 					}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SerializableMisc.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SerializableMisc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class SerializableMisc {
 		}
 	}
 
-	static <T extends Serializable> T fromFile(Class<T> clazz, File file) {
+	static <T> T fromFile(Class<T> clazz, File file) {
 		try (InputStream input = Files.asByteSource(file).openBufferedStream()) {
 			return fromStream(clazz, input);
 		} catch (IOException e) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -20,26 +20,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
-import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 
-import com.diffplug.common.base.Preconditions;
-
-public abstract class SpotlessApply extends DefaultTask {
-	@Internal
-	abstract Property<SpotlessTaskService> getTaskService();
-
-	private String getSourceTaskPath() {
-		String path = getPath();
-		Preconditions.checkArgument(path.endsWith(SpotlessExtension.APPLY));
-		return path.substring(0, path.length() - SpotlessExtension.APPLY.length());
-	}
-
+public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
 	private File spotlessOutDirectory;
 
 	@Internal
@@ -56,7 +43,7 @@ public abstract class SpotlessApply extends DefaultTask {
 		getTaskService().get().registerApply(this);
 		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
 		if (files.isEmpty()) {
-			getState().setDidWork(getTaskService().get().getSourceDidWork(getSourceTaskPath()));
+			getState().setDidWork(getSourceDidWork());
 		} else {
 			files.visit(new FileVisitor() {
 				@Override

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -23,25 +23,13 @@ import java.nio.file.StandardCopyOption;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 
 public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
-	private File spotlessOutDirectory;
-
-	@Internal
-	public File getSpotlessOutDirectory() {
-		return spotlessOutDirectory;
-	}
-
-	public void setSpotlessOutDirectory(File spotlessOutDirectory) {
-		this.spotlessOutDirectory = spotlessOutDirectory;
-	}
-
 	@TaskAction
 	public void performAction() {
 		getTaskService().get().registerApplyAlreadyRan(this);
-		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
+		ConfigurableFileTree files = getProject().fileTree(getSpotlessOutDirectory().get());
 		if (files.isEmpty()) {
 			getState().setDidWork(getSourceDidWork());
 		} else {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -40,7 +40,7 @@ public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
 
 	@TaskAction
 	public void performAction() {
-		getTaskService().get().registerApply(this);
+		getTaskService().get().registerApplyAlreadyRan(this);
 		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
 		if (files.isEmpty()) {
 			getState().setDidWork(getSourceDidWork());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -42,7 +42,7 @@ public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
 				@Override
 				public void visitFile(FileVisitDetails fileVisitDetails) {
 					String path = fileVisitDetails.getPath();
-					File originalSource = new File(getProject().getProjectDir(), path);
+					File originalSource = new File(getProjectDir().get().getAsFile(), path);
 					try {
 						getLogger().debug("Copying " + fileVisitDetails.getFile() + " to " + originalSource);
 						Files.copy(fileVisitDetails.getFile().toPath(), originalSource.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -29,7 +29,7 @@ public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
 	@TaskAction
 	public void performAction() {
 		getTaskService().get().registerApplyAlreadyRan(this);
-		ConfigurableFileTree files = getProject().fileTree(getSpotlessOutDirectory().get());
+		ConfigurableFileTree files = getConfigCacheWorkaround().fileTree().from(getSpotlessOutDirectory().get());
 		if (files.isEmpty()) {
 			getState().setDidWork(sourceDidWork());
 		} else {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -31,7 +31,7 @@ public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
 		getTaskService().get().registerApplyAlreadyRan(this);
 		ConfigurableFileTree files = getProject().fileTree(getSpotlessOutDirectory().get());
 		if (files.isEmpty()) {
-			getState().setDidWork(getSourceDidWork());
+			getState().setDidWork(sourceDidWork());
 		} else {
 			files.visit(new FileVisitor() {
 				@Override

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -67,7 +67,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 				@Override
 				public void visitFile(FileVisitDetails fileVisitDetails) {
 					String path = fileVisitDetails.getPath();
-					File originalSource = new File(getProject().getProjectDir(), path);
+					File originalSource = new File(getProjectDir().get().getAsFile(), path);
 					try {
 						// read the file on disk
 						byte[] userFile = Files.readAllBytes(originalSource.toPath());
@@ -100,7 +100,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 				throw new GradleException(DiffMessageFormatter.builder()
 						.runToFix("Run '" + calculateGradleCommand() + " " + getTaskPathPrefix() + "spotlessApply' to fix these violations.")
 						.formatterFolder(
-								getProject().getRootDir().toPath(),
+								getProjectDir().get().getAsFile().toPath(),
 								getSpotlessOutDirectory().get().toPath(),
 								getEncoding().get())
 						.problemFiles(problemFiles)
@@ -109,10 +109,18 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 		}
 	}
 
+	@Internal
+	abstract Property<String> getProjectPath();
+
+	@Override
+	void init(SpotlessTaskImpl impl) {
+		super.init(impl);
+		getProjectPath().set(getProject().getPath());
+	}
+
 	private String getTaskPathPrefix() {
-		return getProject().getPath().equals(":")
-				? ":"
-				: getProject().getPath() + ":";
+		String path = getProjectPath().get();
+		return path.equals(":") ? ":" : path + ":";
 	}
 
 	private static String calculateGradleCommand() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -46,7 +46,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 	private void performAction(boolean isTest) throws IOException {
 		ConfigurableFileTree files = getProject().fileTree(getSpotlessOutDirectory().get());
 		if (files.isEmpty()) {
-			getState().setDidWork(getSourceDidWork());
+			getState().setDidWork(sourceDidWork());
 		} else if (!isTest && applyHasRun()) {
 			// if our matching apply has already run, then we don't need to do anything
 			getState().setDidWork(false);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -116,6 +116,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 	void init(SpotlessTaskImpl impl) {
 		super.init(impl);
 		getProjectPath().set(getProject().getPath());
+		getEncoding().set(impl.getEncoding());
 	}
 
 	private String getTaskPathPrefix() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -50,7 +50,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 	}
 
 	private void performAction(boolean isTest) throws IOException {
-		ConfigurableFileTree files = getProject().fileTree(getSpotlessOutDirectory().get());
+		ConfigurableFileTree files = getConfigCacheWorkaround().fileTree().from(getSpotlessOutDirectory().get());
 		if (files.isEmpty()) {
 			getState().setDidWork(sourceDidWork());
 		} else if (!isTest && applyHasRun()) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -28,7 +28,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 
 import com.diffplug.spotless.FileSignature;
@@ -37,17 +36,6 @@ import com.diffplug.spotless.ThrowingEx;
 import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 
 public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
-	private File spotlessOutDirectory;
-
-	@Internal
-	public File getSpotlessOutDirectory() {
-		return spotlessOutDirectory;
-	}
-
-	public void setSpotlessOutDirectory(File spotlessOutDirectory) {
-		this.spotlessOutDirectory = spotlessOutDirectory;
-	}
-
 	public void performActionTest() {
 		performAction(true);
 	}
@@ -58,7 +46,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 	}
 
 	private void performAction(boolean isTest) {
-		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
+		ConfigurableFileTree files = getProject().fileTree(getSpotlessOutDirectory().get());
 		if (files.isEmpty()) {
 			getState().setDidWork(getApplyDidWork());
 		} else if (!isTest && applyHasRun()) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -61,7 +61,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 		ConfigurableFileTree files = getProject().fileTree(spotlessOutDirectory);
 		if (files.isEmpty()) {
 			getState().setDidWork(getApplyDidWork());
-		} else if (!isTest && applyWasInGraph()) {
+		} else if (!isTest && applyHasRun()) {
 			// if our matching apply has already run, then we don't need to do anything
 			getState().setDidWork(false);
 		} else {
@@ -105,7 +105,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 			});
 			if (!problemFiles.isEmpty()) {
 				Collections.sort(problemFiles);
-				try (Formatter formatter = buildFormatter()) {
+				try (Formatter formatter = buildFormatterForCheck()) {
 					throw formatViolationsFor(formatter, problemFiles);
 				}
 			}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -18,7 +18,6 @@ package com.diffplug.gradle.spotless;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +28,8 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 
 import com.diffplug.spotless.FileSignature;
@@ -36,6 +37,9 @@ import com.diffplug.spotless.ThrowingEx;
 import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 
 public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
+	@Internal
+	public abstract Property<String> getEncoding();
+
 	public void performActionTest() throws IOException {
 		performAction(true);
 	}
@@ -98,7 +102,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 						.formatterFolder(
 								getProject().getRootDir().toPath(),
 								getSpotlessOutDirectory().get().toPath(),
-								StandardCharsets.UTF_8.name())
+								getEncoding().get())
 						.problemFiles(problemFiles)
 						.getMessage());
 			}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -48,7 +48,7 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 	private void performAction(boolean isTest) {
 		ConfigurableFileTree files = getProject().fileTree(getSpotlessOutDirectory().get());
 		if (files.isEmpty()) {
-			getState().setDidWork(getApplyDidWork());
+			getState().setDidWork(getSourceDidWork());
 		} else if (!isTest && applyHasRun()) {
 			// if our matching apply has already run, then we don't need to do anything
 			getState().setDidWork(false);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -18,6 +18,7 @@ package com.diffplug.gradle.spotless;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +33,7 @@ import org.gradle.api.tasks.TaskAction;
 
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.ThrowingEx;
+import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 
 public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 	public void performActionTest() throws IOException {
@@ -91,9 +93,14 @@ public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 			});
 			if (!problemFiles.isEmpty()) {
 				Collections.sort(problemFiles);
-				String errMsg = errorMsgForCheck(problemFiles, "Run '" + calculateGradleCommand() + " " + getTaskPathPrefix() + "spotlessApply' to fix these violations.");
-				throw new GradleException(errMsg);
-
+				throw new GradleException(DiffMessageFormatter.builder()
+						.runToFix("Run '" + calculateGradleCommand() + " " + getTaskPathPrefix() + "spotlessApply' to fix these violations.")
+						.formatterFolder(
+								getProject().getRootDir().toPath(),
+								getSpotlessOutDirectory().get().toPath(),
+								StandardCharsets.UTF_8.name())
+						.problemFiles(problemFiles)
+						.getMessage());
 			}
 		}
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 
 import com.diffplug.spotless.LineEnding;
 
@@ -45,6 +46,8 @@ public abstract class SpotlessExtension {
 	protected SpotlessExtension(Project project) {
 		this.project = requireNonNull(project);
 	}
+
+	abstract Provider<SpotlessTaskService> getTaskService();
 
 	abstract RegisterDependenciesTask getRegisterDependenciesTask();
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -112,8 +112,10 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		});
 
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
-			task.getSpotlessOutDirectory().set(spotlessTask.get().getOutputDirectory());
+			SpotlessTask source = spotlessTask.get();
+			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
 			task.getTaskService().set(taskService);
+			task.getEncoding().set(source.getEncoding());
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -78,7 +78,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		// create the SpotlessTask
 		String taskName = EXTENSION + SpotlessPlugin.capitalize(name);
 		TaskProvider<SpotlessTaskImpl> spotlessTask = tasks.register(taskName, SpotlessTaskImpl.class, task -> {
-			task.getTaskService().set(taskService);
+			task.init(taskService);
 			task.setEnabled(!isIdeHook);
 			// clean removes the SpotlessCache, so we have to run after clean
 			task.mustRunAfter(cleanTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -112,10 +112,9 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
 			SpotlessTaskImpl source = spotlessTask.get();
-			task.init(spotlessTask.get());
-			task.getEncoding().set(source.getEncoding());
+			task.init(source);
 			task.setEnabled(!isIdeHook);
-			task.dependsOn(spotlessTask);
+			task.dependsOn(source);
 
 			// if the user runs both, make sure that apply happens first,
 			task.mustRunAfter(applyTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 public class SpotlessExtensionImpl extends SpotlessExtension {
 	private final TaskProvider<RegisterDependenciesTask> registerDependenciesTask;
+	private final Provider<SpotlessTaskService> taskService;
 
 	public SpotlessExtensionImpl(Project project) {
 		super(project);
@@ -52,6 +54,13 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 						.configure(task -> task.dependsOn(rootCheckTask));
 			}
 		});
+
+		taskService = project.getGradle().getSharedServices().registerIfAbsent("SpotlessTaskService", SpotlessTaskService.class, spec -> {});
+	}
+
+	@Override
+	Provider<SpotlessTaskService> getTaskService() {
+		return taskService;
 	}
 
 	final TaskProvider<?> rootCheckTask, rootApplyTask, rootDiagnoseTask;
@@ -69,6 +78,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		// create the SpotlessTask
 		String taskName = EXTENSION + SpotlessPlugin.capitalize(name);
 		TaskProvider<SpotlessTaskImpl> spotlessTask = tasks.register(taskName, SpotlessTaskImpl.class, task -> {
+			task.getTaskService().set(taskService);
 			task.setEnabled(!isIdeHook);
 			// clean removes the SpotlessCache, so we have to run after clean
 			task.mustRunAfter(cleanTask);
@@ -87,10 +97,10 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 
 		// create the check and apply control tasks
 		TaskProvider<SpotlessApply> applyTask = tasks.register(taskName + APPLY, SpotlessApply.class, task -> {
+			task.getTaskService().set(taskService);
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
 			task.setSpotlessOutDirectory(spotlessTask.get().getOutputDirectory());
-			task.linkSource(spotlessTask.get());
 		});
 		rootApplyTask.configure(task -> {
 			task.dependsOn(applyTask);
@@ -102,10 +112,10 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		});
 
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
+			task.getTaskService().set(taskService);
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
 			task.setSpotlessOutDirectory(spotlessTask.get().getOutputDirectory());
-			task.source = spotlessTask.get();
 
 			// if the user runs both, make sure that apply happens first,
 			task.mustRunAfter(applyTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -97,10 +97,10 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 
 		// create the check and apply control tasks
 		TaskProvider<SpotlessApply> applyTask = tasks.register(taskName + APPLY, SpotlessApply.class, task -> {
+			task.getSpotlessOutDirectory().set(spotlessTask.get().getOutputDirectory());
 			task.getTaskService().set(taskService);
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
-			task.setSpotlessOutDirectory(spotlessTask.get().getOutputDirectory());
 		});
 		rootApplyTask.configure(task -> {
 			task.dependsOn(applyTask);
@@ -112,10 +112,10 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		});
 
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
+			task.getSpotlessOutDirectory().set(spotlessTask.get().getOutputDirectory());
 			task.getTaskService().set(taskService);
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
-			task.setSpotlessOutDirectory(spotlessTask.get().getOutputDirectory());
 
 			// if the user runs both, make sure that apply happens first,
 			task.mustRunAfter(applyTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -97,8 +97,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 
 		// create the check and apply control tasks
 		TaskProvider<SpotlessApply> applyTask = tasks.register(taskName + APPLY, SpotlessApply.class, task -> {
-			task.getSpotlessOutDirectory().set(spotlessTask.get().getOutputDirectory());
-			task.getTaskService().set(taskService);
+			task.init(spotlessTask.get());
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);
 		});
@@ -112,9 +111,8 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		});
 
 		TaskProvider<SpotlessCheck> checkTask = tasks.register(taskName + CHECK, SpotlessCheck.class, task -> {
-			SpotlessTask source = spotlessTask.get();
-			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
-			task.getTaskService().set(taskService);
+			SpotlessTaskImpl source = spotlessTask.get();
+			task.init(spotlessTask.get());
 			task.getEncoding().set(source.getEncoding());
 			task.setEnabled(!isIdeHook);
 			task.dependsOn(spotlessTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -80,9 +81,13 @@ public abstract class SpotlessTask extends DefaultTask {
 
 	public void setupRatchet(GitRatchetGradle gitRatchet, String ratchetFrom) {
 		ratchet = gitRatchet;
-		rootTreeSha = gitRatchet.rootTreeShaOf(getProject(), ratchetFrom);
-		subtreeSha = gitRatchet.subtreeShaOf(getProject(), rootTreeSha);
+		File projectDir = getProjectDir().get().getAsFile();
+		rootTreeSha = gitRatchet.rootTreeShaOf(projectDir, ratchetFrom);
+		subtreeSha = gitRatchet.subtreeShaOf(projectDir, rootTreeSha);
 	}
+
+	@Internal
+	abstract DirectoryProperty getProjectDir();
 
 	@Internal
 	GitRatchetGradle getRatchet() {
@@ -163,7 +168,7 @@ public abstract class SpotlessTask extends DefaultTask {
 		return Formatter.builder()
 				.lineEndingsPolicy(lineEndingsPolicy)
 				.encoding(Charset.forName(encoding))
-				.rootDir(getProject().getRootDir().toPath())
+				.rootDir(getProjectDir().get().getAsFile().toPath())
 				.steps(steps)
 				.exceptionPolicy(exceptionPolicy)
 				.build();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,14 +43,6 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
 public class SpotlessTask extends DefaultTask {
-	SpotlessApply applyTask;
-
-	/** Internal use only, allows coordination between check and apply when they are in the same build */
-	@Internal
-	SpotlessApply getApplyTask() {
-		return applyTask;
-	}
-
 	// set by SpotlessExtension, but possibly overridden by FormatExtension
 	protected String encoding = "UTF-8";
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -42,7 +42,7 @@ import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
-public class SpotlessTask extends DefaultTask {
+public abstract class SpotlessTask extends DefaultTask {
 	// set by SpotlessExtension, but possibly overridden by FormatExtension
 	protected String encoding = "UTF-8";
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -23,7 +23,9 @@ import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.ChangeType;
 import org.gradle.work.FileChange;
@@ -34,9 +36,13 @@ import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.PaddedCell;
 
 @CacheableTask
-public class SpotlessTaskImpl extends SpotlessTask {
+public abstract class SpotlessTaskImpl extends SpotlessTask {
+	@Internal
+	abstract Property<SpotlessTaskService> getTaskService();
+
 	@TaskAction
 	public void performAction(InputChanges inputs) throws Exception {
+		getTaskService().get().registerSource(this);
 		if (target == null) {
 			throw new GradleException("You must specify 'Iterable<File> target'");
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -86,7 +86,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 		File output = getOutputFile(input);
 		getLogger().debug("Applying format to " + input + " and writing to " + output);
 		PaddedCell.DirtyState dirtyState;
-		if (ratchet != null && ratchet.isClean(getProject(), rootTreeSha, input)) {
+		if (ratchet != null && ratchet.isClean(getProjectDir().get().getAsFile(), rootTreeSha, input)) {
 			dirtyState = PaddedCell.isClean();
 		} else {
 			dirtyState = PaddedCell.calculateDirtyState(formatter, input);
@@ -118,12 +118,13 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 	}
 
 	private File getOutputFile(File input) {
-		String outputFileName = FormatExtension.relativize(getProject().getProjectDir(), input);
+		File projectDir = getProjectDir().get().getAsFile();
+		String outputFileName = FormatExtension.relativize(projectDir, input);
 		if (outputFileName == null) {
 			throw new IllegalArgumentException(StringPrinter.buildString(printer -> {
-				printer.println("Spotless error! All target files must be within the project root. In project " + getProject().getPath());
-				printer.println("  root dir: " + getProject().getProjectDir().getAbsolutePath());
-				printer.println("    target: " + input.getAbsolutePath());
+				printer.println("Spotless error! All target files must be within the project root.");
+				printer.println("  project dir: " + projectDir.getAbsolutePath());
+				printer.println("       target: " + input.getAbsolutePath());
 			}));
 		}
 		return new File(outputDirectory, outputFileName);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -24,8 +24,10 @@ import java.nio.file.StandardCopyOption;
 import javax.inject.Inject;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
@@ -40,14 +42,22 @@ import com.diffplug.spotless.PaddedCell;
 @CacheableTask
 public abstract class SpotlessTaskImpl extends SpotlessTask {
 	@Internal
-	abstract Property<SpotlessTaskService> getTaskService();
+	abstract Property<SpotlessTaskService> getTakService();
+
+	@Internal
+	abstract DirectoryProperty getProjectDir();
+
+	void init(Provider<SpotlessTaskService> service) {
+		getTakService().set(service);
+		getProjectDir().set(getProject().getProjectDir());
+	}
 
 	@Inject
 	protected abstract FileSystemOperations getFs();
 
 	@TaskAction
 	public void performAction(InputChanges inputs) throws Exception {
-		getTaskService().get().registerSourceAlreadyRan(this);
+		getTakService().get().registerSourceAlreadyRan(this);
 		if (target == null) {
 			throw new GradleException("You must specify 'Iterable<File> target'");
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -42,13 +42,13 @@ import com.diffplug.spotless.PaddedCell;
 @CacheableTask
 public abstract class SpotlessTaskImpl extends SpotlessTask {
 	@Internal
-	abstract Property<SpotlessTaskService> getTakService();
+	abstract Property<SpotlessTaskService> getTaskService();
 
 	@Internal
 	abstract DirectoryProperty getProjectDir();
 
 	void init(Provider<SpotlessTaskService> service) {
-		getTakService().set(service);
+		getTaskService().set(service);
 		getProjectDir().set(getProject().getProjectDir());
 	}
 
@@ -57,7 +57,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 
 	@TaskAction
 	public void performAction(InputChanges inputs) throws Exception {
-		getTakService().get().registerSourceAlreadyRan(this);
+		getTaskService().get().registerSourceAlreadyRan(this);
 		if (target == null) {
 			throw new GradleException("You must specify 'Iterable<File> target'");
 		}
@@ -122,7 +122,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 		String outputFileName = FormatExtension.relativize(projectDir, input);
 		if (outputFileName == null) {
 			throw new IllegalArgumentException(StringPrinter.buildString(printer -> {
-				printer.println("Spotless error! All target files must be within the project root.");
+				printer.println("Spotless error! All target files must be within the project dir.");
 				printer.println("  project dir: " + projectDir.getAbsolutePath());
 				printer.println("       target: " + input.getAbsolutePath());
 			}));

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -42,7 +42,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 
 	@TaskAction
 	public void performAction(InputChanges inputs) throws Exception {
-		getTaskService().get().registerSource(this);
+		getTaskService().get().registerSourceAlreadyRan(this);
 		if (target == null) {
 			throw new GradleException("You must specify 'Iterable<File> target'");
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.BuildService;
@@ -59,12 +60,16 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		@Internal
 		abstract Property<SpotlessTaskService> getTaskService();
 
+		@Internal
+		abstract DirectoryProperty getProjectDir();
+
 		@Inject
 		protected abstract ObjectFactory getConfigCacheWorkaround();
 
 		void init(SpotlessTaskImpl impl) {
 			getSpotlessOutDirectory().set(impl.getOutputDirectory());
-			getTaskService().set(impl.getTaskService());
+			getTaskService().set(impl.getTakService());
+			getProjectDir().set(impl.getProjectDir());
 		}
 
 		String sourceTaskPath() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -53,7 +53,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 	}
 
 	public void registerApplyAlreadyRan(SpotlessApply task) {
-		apply.put(task.getSourceTaskPath(), task);
+		apply.put(task.sourceTaskPath(), task);
 	}
 
 	static String INDEPENDENT_HELPER = "Helper";
@@ -65,7 +65,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		@Internal
 		abstract Property<SpotlessTaskService> getTaskService();
 
-		String getSourceTaskPath() {
+		String sourceTaskPath() {
 			String path = getPath();
 			if (this instanceof SpotlessApply) {
 				if (path.endsWith(SpotlessExtension.APPLY)) {
@@ -85,8 +85,8 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 			return getTaskService().get();
 		}
 
-		public boolean getSourceDidWork() {
-			SpotlessTask sourceTask = service().source.get(getSourceTaskPath());
+		protected boolean sourceDidWork() {
+			SpotlessTask sourceTask = service().source.get(sourceTaskPath());
 			if (sourceTask != null) {
 				return sourceTask.getDidWork();
 			} else {
@@ -94,12 +94,12 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 			}
 		}
 
-		public boolean applyHasRun() {
-			return service().apply.containsKey(getSourceTaskPath());
+		protected boolean applyHasRun() {
+			return service().apply.containsKey(sourceTaskPath());
 		}
 
-		String errorMsgForCheck(List<File> problemFiles, String runToFix) throws IOException {
-			SpotlessTask task = service().source.get(getSourceTaskPath());
+		protected String errorMsgForCheck(List<File> problemFiles, String runToFix) throws IOException {
+			SpotlessTask task = service().source.get(sourceTaskPath());
 			((SpotlessCheck) this).getSpotlessOutDirectory();
 			if (task != null) {
 				try (Formatter formatter = task.buildFormatter()) {
@@ -125,7 +125,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 			if (cached != null && cached.getKey().equals(key)) {
 				return cached.getValue();
 			} else {
-				throw new IllegalStateException(getPath() + " is running but " + getSourceTaskPath() + " was up-to-date and didn't run");
+				throw new IllegalStateException(getPath() + " is running but " + sourceTaskPath() + " was up-to-date and didn't run");
 			}
 		}
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,6 +51,9 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 	static String INDEPENDENT_HELPER = "Helper";
 
 	public static abstract class ClientTask extends DefaultTask {
+		@Internal
+		abstract Property<File> getSpotlessOutDirectory();
+
 		@Internal
 		abstract Property<SpotlessTaskService> getTaskService();
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import com.diffplug.spotless.Formatter;
+
+public abstract class SpotlessTaskService implements BuildService<BuildServiceParameters.None> {
+	private Map<String, SpotlessApply> apply = new HashMap<>();
+	private Map<String, SpotlessTask> source = new HashMap<>();
+
+	public void registerSource(SpotlessTask task) {
+		source.put(task.getPath(), task);
+	}
+
+	public void registerApply(SpotlessApply task) {
+		apply.put(task.getPath(), task);
+	}
+
+	public boolean getSourceDidWork(String sourceTaskPath) {
+		SpotlessTask sourceTask = source.get(sourceTaskPath);
+		if (sourceTask != null) {
+			return sourceTask.getDidWork();
+		} else {
+			return false;
+		}
+	}
+
+	public boolean getApplyDidWork(String applyTaskPath) {
+		SpotlessApply applyTask = apply.get(applyTaskPath);
+		if (applyTask != null) {
+			return applyTask.getDidWork();
+		} else {
+			return false;
+		}
+	}
+
+	public boolean applyWasInGraph(String applyTaskPath) {
+		return apply.containsKey(applyTaskPath);
+	}
+
+	public Formatter buildFormatter(String sourceTaskPath) {
+		SpotlessTask task = Objects.requireNonNull(source.get(sourceTaskPath));
+		return task.buildFormatter();
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -48,6 +48,8 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		apply.put(task.getSourceTaskPath(), task);
 	}
 
+	static String INDEPENDENT_HELPER = "Helper";
+
 	public static abstract class ClientTask extends DefaultTask {
 		@Internal
 		abstract Property<SpotlessTaskService> getTaskService();
@@ -55,8 +57,11 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		String getSourceTaskPath() {
 			String path = getPath();
 			if (this instanceof SpotlessApply) {
-				Preconditions.checkArgument(path.endsWith(SpotlessExtension.APPLY));
-				return path.substring(0, path.length() - SpotlessExtension.APPLY.length());
+				if (path.endsWith(SpotlessExtension.APPLY)) {
+					return path.substring(0, path.length() - SpotlessExtension.APPLY.length());
+				} else {
+					return path + INDEPENDENT_HELPER;
+				}
 			} else if (this instanceof SpotlessCheck) {
 				Preconditions.checkArgument(path.endsWith(SpotlessExtension.CHECK));
 				return path.substring(0, path.length() - SpotlessExtension.CHECK.length());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -20,7 +20,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
@@ -49,12 +52,15 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 
 	static String INDEPENDENT_HELPER = "Helper";
 
-	public static abstract class ClientTask extends DefaultTask {
+	static abstract class ClientTask extends DefaultTask {
 		@Internal
 		abstract Property<File> getSpotlessOutDirectory();
 
 		@Internal
 		abstract Property<SpotlessTaskService> getTaskService();
+
+		@Inject
+		protected abstract ObjectFactory getConfigCacheWorkaround();
 
 		String sourceTaskPath() {
 			String path = getPath();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -62,6 +62,11 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		@Inject
 		protected abstract ObjectFactory getConfigCacheWorkaround();
 
+		void init(SpotlessTaskImpl impl) {
+			getSpotlessOutDirectory().set(impl.getOutputDirectory());
+			getTaskService().set(impl.getTaskService());
+		}
+
 		String sourceTaskPath() {
 			String path = getPath();
 			if (this instanceof SpotlessApply) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -16,11 +16,8 @@
 package com.diffplug.gradle.spotless;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.gradle.api.DefaultTask;
@@ -31,10 +28,6 @@ import org.gradle.api.tasks.Internal;
 
 import com.diffplug.common.base.Preconditions;
 import com.diffplug.common.base.Unhandled;
-import com.diffplug.common.collect.Maps;
-import com.diffplug.spotless.FileSignature;
-import com.diffplug.spotless.Formatter;
-import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 
 /**
  * Allows the check and apply tasks to coordinate
@@ -47,8 +40,6 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
 
 	public void registerSourceAlreadyRan(SpotlessTask task) {
-		// if there's a registered source, we can wipe the cache
-		cachePut(task.getOutputDirectory(), null, null);
 		source.put(task.getPath(), task);
 	}
 
@@ -97,50 +88,5 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		protected boolean applyHasRun() {
 			return service().apply.containsKey(sourceTaskPath());
 		}
-
-		protected String errorMsgForCheck(List<File> problemFiles, String runToFix) throws IOException {
-			SpotlessTask task = service().source.get(sourceTaskPath());
-			((SpotlessCheck) this).getSpotlessOutDirectory();
-			if (task != null) {
-				try (Formatter formatter = task.buildFormatter()) {
-					String msg = DiffMessageFormatter.builder()
-							.runToFix(runToFix)
-							.formatter(formatter)
-							.problemFiles(problemFiles)
-							.getMessage();
-					cachePut(FileSignature.signAsList(problemFiles), msg);
-					return msg;
-				}
-			} else {
-				return cacheGet(FileSignature.signAsList(problemFiles));
-			}
-		}
-
-		private void cachePut(FileSignature key, String msg) {
-			SpotlessTaskService.cachePut(getSpotlessOutDirectory().get(), key, msg);
-		}
-
-		private String cacheGet(FileSignature key) {
-			Map.Entry<FileSignature, String> cached = SerializableMisc.fromFile(Map.Entry.class, getCacheFile(getSpotlessOutDirectory().get()));
-			if (cached != null && cached.getKey().equals(key)) {
-				return cached.getValue();
-			} else {
-				throw new IllegalStateException(getPath() + " is running but " + sourceTaskPath() + " was up-to-date and didn't run");
-			}
-		}
-	}
-
-	private static void cachePut(File spotlessOut, FileSignature key, String msg) {
-		File cacheFile = getCacheFile(spotlessOut);
-		if (key == null) {
-			cacheFile.delete();
-		} else {
-			SerializableMisc.toFile((Serializable) Maps.immutableEntry(key, msg), cacheFile);
-		}
-	}
-
-	private static File getCacheFile(File spotlessOut) {
-		File parent = spotlessOut.getParentFile();
-		return new File(parent, spotlessOut.getName() + "-errorMsg");
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -86,15 +86,6 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 			}
 		}
 
-		public boolean getApplyDidWork() {
-			SpotlessApply applyTask = service().apply.get(getSourceTaskPath());
-			if (applyTask != null) {
-				return applyTask.getDidWork();
-			} else {
-				return false;
-			}
-		}
-
 		public boolean applyHasRun() {
 			return service().apply.containsKey(getSourceTaskPath());
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -68,7 +68,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 
 		void init(SpotlessTaskImpl impl) {
 			getSpotlessOutDirectory().set(impl.getOutputDirectory());
-			getTaskService().set(impl.getTakService());
+			getTaskService().set(impl.getTaskService());
 			getProjectDir().set(impl.getProjectDir());
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import org.assertj.core.api.Assertions;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildServiceParameters;
 import org.junit.jupiter.api.Test;
 
@@ -41,12 +42,12 @@ class DiffMessageFormatterTest extends ResourceHarness {
 
 	private class Bundle {
 		Project project = TestProvisioner.gradleProject(rootFolder());
-		SpotlessTaskService taskService = new SpotlessTaskService() {
+		Provider<SpotlessTaskService> taskService = GradleIntegrationHarness.providerOf(new SpotlessTaskService() {
 			@Override
 			public BuildServiceParameters.None getParameters() {
 				return null;
 			}
-		};
+		});
 
 		File file;
 		SpotlessTaskImpl task;
@@ -61,7 +62,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 
 		private SpotlessTaskImpl createFormatTask(String name) {
 			SpotlessTaskImpl task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name), SpotlessTaskImpl.class);
-			task.getTaskService().set(taskService);
+			task.init(taskService);
 			task.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 			task.setTarget(Collections.singletonList(file));
 			return task;

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -67,18 +67,16 @@ class DiffMessageFormatterTest extends ResourceHarness {
 			return task;
 		}
 
-		private SpotlessCheck createCheckTask(String name, SpotlessTask source) {
+		private SpotlessCheck createCheckTask(String name, SpotlessTaskImpl source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
-			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
-			task.getTaskService().set(taskService);
+			task.init(source);
 			task.getEncoding().set(StandardCharsets.UTF_8.name());
 			return task;
 		}
 
-		private SpotlessApply createApplyTask(String name, SpotlessTask source) {
+		private SpotlessApply createApplyTask(String name, SpotlessTaskImpl source) {
 			SpotlessApply task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Apply", SpotlessApply.class);
-			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
-			task.getTaskService().set(taskService);
+			task.init(source);
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -17,7 +17,6 @@ package com.diffplug.gradle.spotless;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -71,7 +70,6 @@ class DiffMessageFormatterTest extends ResourceHarness {
 		private SpotlessCheck createCheckTask(String name, SpotlessTaskImpl source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
 			task.init(source);
-			task.getEncoding().set(StandardCharsets.UTF_8.name());
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -17,6 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -70,6 +71,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
 			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
 			task.getTaskService().set(taskService);
+			task.getEncoding().set(StandardCharsets.UTF_8.name());
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -68,15 +68,15 @@ class DiffMessageFormatterTest extends ResourceHarness {
 
 		private SpotlessCheck createCheckTask(String name, SpotlessTask source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
+			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
 			task.getTaskService().set(taskService);
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
 			return task;
 		}
 
 		private SpotlessApply createApplyTask(String name, SpotlessTask source) {
 			SpotlessApply task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Apply", SpotlessApply.class);
+			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
 			task.getTaskService().set(taskService);
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.Collections;
 
 import org.gradle.api.Project;
+import org.gradle.api.services.BuildServiceParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,12 @@ class FormatTaskTest extends ResourceHarness {
 		Project project = TestProvisioner.gradleProject(rootFolder());
 		spotlessTask = project.getTasks().create("spotlessTaskUnderTest", SpotlessTaskImpl.class);
 		spotlessTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
+		spotlessTask.getTaskService().set(new SpotlessTaskService() {
+			@Override
+			public BuildServiceParameters.None getParameters() {
+				return null;
+			}
+		});
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -36,12 +36,12 @@ class FormatTaskTest extends ResourceHarness {
 		Project project = TestProvisioner.gradleProject(rootFolder());
 		spotlessTask = project.getTasks().create("spotlessTaskUnderTest", SpotlessTaskImpl.class);
 		spotlessTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
-		spotlessTask.getTaskService().set(new SpotlessTaskService() {
+		spotlessTask.init(GradleIntegrationHarness.providerOf(new SpotlessTaskService() {
 			@Override
 			public BuildServiceParameters.None getParameters() {
 				return null;
 			}
-		});
+		}));
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
@@ -57,17 +57,16 @@ class GradleIncrementalResolutionTest extends GradleIntegrationHarness {
 		// check will run against all three the first time.
 		checkRanAgainst("abc");
 		// Subsequent runs will use the cached error message
-		checkRanAgainstNoneButError().contains("Caused by: org.gradle.api.GradleException: The following files had format violations:\n" +
-				"    b.md\n" +
-				"        @@ -1 +1 @@\n" +
-				"        -B\n" +
-				"        +b");
-		checkRanAgainstNoneButError().contains("Caused by: org.gradle.api.GradleException: The following files had format violations:\n" +
-				"    b.md\n" +
-				"        @@ -1 +1 @@\n" +
-				"        -B\n" +
-				"        +b");
-
+		checkRanAgainstNoneButError().contains("> The following files had format violations:\n" +
+				"      b.md\n" +
+				"          @@ -1 +1 @@\n" +
+				"          -B\n" +
+				"          +b");
+		checkRanAgainstNoneButError().contains("> The following files had format violations:\n" +
+				"      b.md\n" +
+				"          @@ -1 +1 @@\n" +
+				"          -B\n" +
+				"          +b");
 		// apply will simply copy outputs the first time: no formatters executed
 		applyRanAgainst("");
 		// the second time, it will only run on the file that was changed by apply

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
@@ -26,7 +26,6 @@ import java.util.TreeSet;
 
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
-import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.Errors;
@@ -137,8 +136,7 @@ class GradleIncrementalResolutionTest extends GradleIntegrationHarness {
 		String console = StringPrinter.buildString(Errors.rethrow().wrap(printer -> {
 			boolean expectFailure = task.equals("spotlessCheck") && !isClean();
 			if (expectFailure) {
-				BuildResult b = gradleRunner().withArguments(task, "--stacktrace").forwardStdOutput(printer.toWriter()).forwardStdError(printer.toWriter()).buildAndFail();
-				//				System.err.println(b.getOutput());
+				gradleRunner().withArguments(task).forwardStdOutput(printer.toWriter()).forwardStdError(printer.toWriter()).buildAndFail();
 			} else {
 				gradleRunner().withArguments(task).forwardStdOutput(printer.toWriter()).build();
 			}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
@@ -24,6 +24,9 @@ import java.util.Locale;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.Assertions;
+import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.Errors;
@@ -53,10 +56,18 @@ class GradleIncrementalResolutionTest extends GradleIntegrationHarness {
 		writeState("aBc");
 		assertState("aBc");
 		// check will run against all three the first time.
-		// Subsequent runs will only run the formatter on the bad file (in order to generate the failure message)
 		checkRanAgainst("abc");
-		checkRanAgainst("b");
-		checkRanAgainst("b");
+		// Subsequent runs will use the cached error message
+		checkRanAgainstNoneButError().contains("Caused by: org.gradle.api.GradleException: The following files had format violations:\n" +
+				"    b.md\n" +
+				"        @@ -1 +1 @@\n" +
+				"        -B\n" +
+				"        +b");
+		checkRanAgainstNoneButError().contains("Caused by: org.gradle.api.GradleException: The following files had format violations:\n" +
+				"    b.md\n" +
+				"        @@ -1 +1 @@\n" +
+				"        -B\n" +
+				"        +b");
 
 		// apply will simply copy outputs the first time: no formatters executed
 		applyRanAgainst("");
@@ -69,8 +80,12 @@ class GradleIncrementalResolutionTest extends GradleIntegrationHarness {
 		writeState("Abc");
 		// then check runs against just the changed file
 		checkRanAgainst("a");
-		// even after failing
-		checkRanAgainst("a");
+		// even after failing once the error is still there
+		checkRanAgainstNoneButError().contains("> The following files had format violations:\n" +
+				"      a.md\n" +
+				"          @@ -1 +1 @@\n" +
+				"          -A\n" +
+				"          +a");
 		// and so does apply
 		applyRanAgainst();
 		applyRanAgainst("a");
@@ -112,12 +127,18 @@ class GradleIncrementalResolutionTest extends GradleIntegrationHarness {
 		taskRanAgainst("spotlessCheck", ranAgainst);
 	}
 
-	private void taskRanAgainst(String task, String... ranAgainst) throws IOException {
+	private AbstractStringAssert<?> checkRanAgainstNoneButError() throws IOException {
+		String console = taskRanAgainst("spotlessCheck");
+		return Assertions.assertThat(console);
+	}
+
+	private String taskRanAgainst(String task, String... ranAgainst) throws IOException {
 		pauseForFilesystem();
 		String console = StringPrinter.buildString(Errors.rethrow().wrap(printer -> {
 			boolean expectFailure = task.equals("spotlessCheck") && !isClean();
 			if (expectFailure) {
-				gradleRunner().withArguments(task).forwardStdOutput(printer.toWriter()).buildAndFail();
+				BuildResult b = gradleRunner().withArguments(task, "--stacktrace").forwardStdOutput(printer.toWriter()).forwardStdError(printer.toWriter()).buildAndFail();
+				//				System.err.println(b.getOutput());
 			} else {
 				gradleRunner().withArguments(task).forwardStdOutput(printer.toWriter()).build();
 			}
@@ -130,6 +151,7 @@ class GradleIncrementalResolutionTest extends GradleIntegrationHarness {
 			}
 		}
 		assertEquals(concat(Arrays.asList(ranAgainst)), concat(added));
+		return console;
 	}
 
 	private String concat(Iterable<String> iterable) {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -24,6 +24,7 @@ import java.util.ListIterator;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.gradle.api.provider.Provider;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
@@ -57,6 +58,10 @@ public class GradleIntegrationHarness extends ResourceHarness {
 				this.version = version;
 			}
 		}
+	}
+
+	public static <T> Provider<T> providerOf(T value) {
+		return org.gradle.api.internal.provider.Providers.of(value);
 	}
 
 	/**

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -48,7 +48,7 @@ class PaddedCellTaskTest extends ResourceHarness {
 		};
 		File file;
 		File outputFile;
-		SpotlessTaskImpl task;
+		SpotlessTaskImpl source;
 		SpotlessCheck check;
 		SpotlessApply apply;
 
@@ -56,10 +56,10 @@ class PaddedCellTaskTest extends ResourceHarness {
 			this.name = name;
 			file = setFile("src/test." + name).toContent("CCC");
 			FormatterStep step = FormatterStep.createNeverUpToDate(name, function);
-			task = createFormatTask(name, step);
-			check = createCheckTask(name, task);
-			apply = createApplyTask(name, task);
-			outputFile = new File(task.getOutputDirectory() + "/src", file.getName());
+			source = createFormatTask(name, step);
+			check = createCheckTask(name, source);
+			apply = createApplyTask(name, source);
+			outputFile = new File(source.getOutputDirectory() + "/src", file.getName());
 		}
 
 		private SpotlessTaskImpl createFormatTask(String name, FormatterStep step) {
@@ -71,18 +71,16 @@ class PaddedCellTaskTest extends ResourceHarness {
 			return task;
 		}
 
-		private SpotlessCheck createCheckTask(String name, SpotlessTask source) {
+		private SpotlessCheck createCheckTask(String name, SpotlessTaskImpl source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
-			task.getTaskService().set(taskService);
-			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
+			task.init(source);
 			task.getEncoding().set(StandardCharsets.UTF_8.name());
 			return task;
 		}
 
-		private SpotlessApply createApplyTask(String name, SpotlessTask source) {
+		private SpotlessApply createApplyTask(String name, SpotlessTaskImpl source) {
 			SpotlessApply task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Apply", SpotlessApply.class);
-			task.getTaskService().set(taskService);
-			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
+			task.init(source);
 			return task;
 		}
 
@@ -97,21 +95,21 @@ class PaddedCellTaskTest extends ResourceHarness {
 
 		void diagnose() throws IOException {
 			SpotlessDiagnoseTask diagnose = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Diagnose", SpotlessDiagnoseTask.class);
-			diagnose.source = task;
+			diagnose.source = source;
 			diagnose.performAction();
 		}
 
 		void format() throws Exception {
-			Tasks.execute(task);
+			Tasks.execute(source);
 		}
 
 		void apply() throws Exception {
-			Tasks.execute(task);
+			Tasks.execute(source);
 			apply.performAction();
 		}
 
 		void check() throws Exception {
-			Tasks.execute(task);
+			Tasks.execute(source);
 			check.performActionTest();
 		}
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -73,14 +73,14 @@ class PaddedCellTaskTest extends ResourceHarness {
 		private SpotlessCheck createCheckTask(String name, SpotlessTask source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
 			task.getTaskService().set(taskService);
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
+			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
 			return task;
 		}
 
 		private SpotlessApply createApplyTask(String name, SpotlessTask source) {
 			SpotlessApply task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Apply", SpotlessApply.class);
 			task.getTaskService().set(taskService);
-			task.setSpotlessOutDirectory(source.getOutputDirectory());
+			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.gradle.api.Project;
+import org.gradle.api.services.BuildServiceParameters;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +39,12 @@ class PaddedCellTaskTest extends ResourceHarness {
 	private class Bundle {
 		String name;
 		Project project = TestProvisioner.gradleProject(rootFolder());
+		SpotlessTaskService taskService = new SpotlessTaskService() {
+			@Override
+			public BuildServiceParameters.None getParameters() {
+				return null;
+			}
+		};
 		File file;
 		File outputFile;
 		SpotlessTaskImpl task;
@@ -56,6 +63,7 @@ class PaddedCellTaskTest extends ResourceHarness {
 
 		private SpotlessTaskImpl createFormatTask(String name, FormatterStep step) {
 			SpotlessTaskImpl task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name), SpotlessTaskImpl.class);
+			task.getTaskService().set(taskService);
 			task.addStep(step);
 			task.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 			task.setTarget(Collections.singletonList(file));
@@ -64,14 +72,14 @@ class PaddedCellTaskTest extends ResourceHarness {
 
 		private SpotlessCheck createCheckTask(String name, SpotlessTask source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
-			task.source = source;
+			task.getTaskService().set(taskService);
 			task.setSpotlessOutDirectory(source.getOutputDirectory());
 			return task;
 		}
 
 		private SpotlessApply createApplyTask(String name, SpotlessTask source) {
 			SpotlessApply task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Apply", SpotlessApply.class);
-			task.linkSource(source);
+			task.getTaskService().set(taskService);
 			task.setSpotlessOutDirectory(source.getOutputDirectory());
 			return task;
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildServiceParameters;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -40,12 +41,12 @@ class PaddedCellTaskTest extends ResourceHarness {
 	private class Bundle {
 		String name;
 		Project project = TestProvisioner.gradleProject(rootFolder());
-		SpotlessTaskService taskService = new SpotlessTaskService() {
+		Provider<SpotlessTaskService> taskService = GradleIntegrationHarness.providerOf(new SpotlessTaskService() {
 			@Override
 			public BuildServiceParameters.None getParameters() {
 				return null;
 			}
-		};
+		});
 		File file;
 		File outputFile;
 		SpotlessTaskImpl source;
@@ -64,7 +65,7 @@ class PaddedCellTaskTest extends ResourceHarness {
 
 		private SpotlessTaskImpl createFormatTask(String name, FormatterStep step) {
 			SpotlessTaskImpl task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name), SpotlessTaskImpl.class);
-			task.getTaskService().set(taskService);
+			task.init(taskService);
 			task.addStep(step);
 			task.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
 			task.setTarget(Collections.singletonList(file));

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -75,7 +74,6 @@ class PaddedCellTaskTest extends ResourceHarness {
 		private SpotlessCheck createCheckTask(String name, SpotlessTaskImpl source) {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
 			task.init(source);
-			task.getEncoding().set(StandardCharsets.UTF_8.name());
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -74,6 +75,7 @@ class PaddedCellTaskTest extends ResourceHarness {
 			SpotlessCheck task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name) + "Check", SpotlessCheck.class);
 			task.getTaskService().set(taskService);
 			task.getSpotlessOutDirectory().set(source.getOutputDirectory());
+			task.getEncoding().set(StandardCharsets.UTF_8.name());
 			return task;
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
@@ -45,8 +45,6 @@ class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 						"> Task :spotlessInternalRegisterDependencies\n")
 				.contains("> Task :sub:spotlessJava\n" +
 						"> Task :sub:spotlessJavaCheck\n" +
-						"> Task :sub:spotlessCheck\n" +
-						"\n" +
-						"BUILD SUCCESSFUL");
+						"> Task :sub:spotlessCheck\n");
 	}
 }


### PR DESCRIPTION
This PR is a step towards support for the configuration-cache, but it is not the full thing. It is intended to produce no changes in behavior, and just move us off of the forbidden APIs.

IMO it's a bummer. `ObjectFactory` does fileTrees, and `FileSystemOperations` does deleting, and if you want to know your project directory you've got to break code navigation / dataflow analysis and store it into your own bespoke property and hope that the name you pick isn't too different from what future PR contributors expect. I did quite a bit of refactoring to try to simplify as much as I could, but this PR basically just adds 300 lines of boilerplate.