### PR TITLE
Resolve dependencies per-project

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changed
-* **BREAKING** Previously, many projects required `buildscript { repositories { mavenCentral() }}` at the top of their root project, because Spotless resolved its dependencies using the buildscript repositories. Spotless now resolves its dependencies from the normal project repositories of the root project, which means that you can remove the `buildscript {}` block, but you still need `repositories { mavenCentral() }` (or similar) in the root project.
+* **BREAKING** Previously, many projects required `buildscript { repositories { mavenCentral() }}` at the top of their root project, because Spotless resolved its dependencies using the buildscript repositories. Spotless now resolves its dependencies from the normal project repositories of each project with a `spotless {...}` block. This means that you can remove the `buildscript {}` block, but you still need a `repositories { mavenCentral() }` (or similar) in each project which is using Spotless.
 * **BREAKING** `createIndepentApplyTask(String taskName)` now requires that `taskName` does not end with `Apply`
 * Bump minimum required Gradle from `6.1` to `6.1.1`.
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -75,7 +75,7 @@ public class FormatExtension {
 	}
 
 	protected final Provisioner provisioner() {
-		return spotless.getRegisterDependenciesTask().rootProvisioner;
+		return GradleProvisioner.forProject(spotless.project);
 	}
 
 	private String formatName() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -737,7 +737,7 @@ public class FormatExtension {
 			spotless.getRegisterDependenciesTask().hookSubprojectTask(task);
 		}
 		if (getRatchetFrom() != null) {
-			task.setupRatchet(spotless.getRegisterDependenciesTask().getGitRatchet().get(), getRatchetFrom());
+			task.setupRatchet(getRatchetFrom());
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -733,9 +733,7 @@ public class FormatExtension {
 		}
 		task.setSteps(steps);
 		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> totalTarget));
-		if (spotless.project != spotless.project.getRootProject()) {
-			spotless.getRegisterDependenciesTask().hookSubprojectTask(task);
-		}
+		spotless.getRegisterDependenciesTask().hookSubprojectTask(task);
 		if (getRatchetFrom() != null) {
 			task.setupRatchet(getRatchetFrom());
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -763,7 +763,7 @@ public class FormatExtension {
 		Preconditions.checkArgument(!taskName.endsWith(SpotlessExtension.APPLY), "Task name must not end with " + SpotlessExtension.APPLY);
 		// create and setup the task
 		SpotlessTaskImpl spotlessTask = spotless.project.getTasks().create(taskName + SpotlessTaskService.INDEPENDENT_HELPER, SpotlessTaskImpl.class);
-		spotlessTask.init(spotless.getTaskService());
+		spotlessTask.init(spotless.getRegisterDependenciesTask().getTaskService());
 		setupTask(spotlessTask);
 		// enforce the clean ordering
 		Task clean = spotless.project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -75,7 +75,7 @@ public class FormatExtension {
 	}
 
 	protected final Provisioner provisioner() {
-		return GradleProvisioner.forProject(spotless.project);
+		return spotless.getRegisterDependenciesTask().getTaskService().get().provisionerFor(spotless.project);
 	}
 
 	private String formatName() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GitRatchetGradle.java
@@ -19,15 +19,10 @@ import java.io.File;
 
 import javax.annotation.Nullable;
 
-import org.gradle.api.services.BuildService;
-import org.gradle.api.services.BuildServiceParameters;
-import org.gradle.tooling.events.FinishEvent;
-import org.gradle.tooling.events.OperationCompletionListener;
-
 import com.diffplug.spotless.extra.GitRatchet;
 
 /** Gradle implementation of GitRatchet. */
-public abstract class GitRatchetGradle extends GitRatchet<File> implements BuildService<BuildServiceParameters.None>, OperationCompletionListener {
+public class GitRatchetGradle extends GitRatchet<File> {
 	@Override
 	protected File getDir(File project) {
 		return project;
@@ -36,10 +31,5 @@ public abstract class GitRatchetGradle extends GitRatchet<File> implements Build
 	@Override
 	protected @Nullable File getParent(File project) {
 		return project.getParentFile();
-	}
-
-	@Override
-	public void onFinish(FinishEvent finishEvent) {
-		// NOOP
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -15,59 +15,20 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.io.File;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 
-import com.diffplug.common.base.Preconditions;
 import com.diffplug.common.collect.ImmutableList;
 import com.diffplug.spotless.Provisioner;
 
 /** Should be package-private. */
 class GradleProvisioner {
 	private GradleProvisioner() {}
-
-	/** The provisioner used for the root project. */
-	static class RootProvisioner implements Provisioner {
-		private final Project rootProject;
-		private final Map<Request, Set<File>> cache = new HashMap<>();
-
-		RootProvisioner(Project rootProject) {
-			Preconditions.checkArgument(rootProject == rootProject.getRootProject());
-			this.rootProject = rootProject;
-		}
-
-		@Override
-		public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates) {
-			Request req = new Request(withTransitives, mavenCoordinates);
-			Set<File> result;
-			synchronized (cache) {
-				result = cache.get(req);
-			}
-			if (result != null) {
-				return result;
-			} else {
-				synchronized (cache) {
-					result = cache.get(req);
-					if (result != null) {
-						return result;
-					} else {
-						result = GradleProvisioner.forProject(rootProject).provisionWithTransitives(req.withTransitives, req.mavenCoords);
-						cache.put(req, result);
-						return result;
-					}
-				}
-			}
-		}
-	}
 
 	static Provisioner forProject(Project project) {
 		Objects.requireNonNull(project);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -43,10 +43,13 @@ class GradleProvisioner {
 				config.setTransitive(withTransitives);
 				return config.resolve();
 			} catch (Exception e) {
-				String projName = project.getPath();
+				String projName = project.getPath().substring(1).replace(':', '/');
+				if (!projName.isEmpty()) {
+					projName = projName + "/";
+				}
 				logger.log(
 						Level.SEVERE,
-						"You probably need to add a repository containing the '" + mavenCoords + "' artifact in the 'build.gradle' of the " + projName + " project.\n" +
+						"You need to add a repository containing the '" + mavenCoords + "' artifact in '" + projName + "build.gradle'.\n" +
 								"E.g.: 'repositories { mavenCentral() }'",
 						e);
 				throw e;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
@@ -42,8 +42,8 @@ class IdeHook {
 		}
 		if (spotlessTask.getTarget().contains(file)) {
 			try (Formatter formatter = spotlessTask.buildFormatter()) {
-				if (spotlessTask.ratchet != null) {
-					if (spotlessTask.ratchet.isClean(spotlessTask.getProjectDir().get().getAsFile(), spotlessTask.rootTreeSha, file)) {
+				if (spotlessTask.getRatchet() != null) {
+					if (spotlessTask.getRatchet().isClean(spotlessTask.getProjectDir().get().getAsFile(), spotlessTask.getRootTreeSha(), file)) {
 						dumpIsClean();
 						return;
 					}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -18,16 +18,12 @@ package com.diffplug.gradle.spotless;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -35,7 +31,6 @@ import org.gradle.build.event.BuildEventsListenerRegistry;
 
 import com.diffplug.common.base.Preconditions;
 import com.diffplug.common.io.Files;
-import com.diffplug.spotless.FormatterStep;
 
 /**
  * NOT AN END-USER TASK, DO NOT USE FOR ANYTHING!
@@ -50,26 +45,17 @@ import com.diffplug.spotless.FormatterStep;
 public abstract class RegisterDependenciesTask extends DefaultTask {
 	static final String TASK_NAME = "spotlessInternalRegisterDependencies";
 
-	@Input
-	public List<FormatterStep> getSteps() {
-		List<FormatterStep> allSteps = new ArrayList<>();
-		TaskExecutionGraph taskGraph = getProject().getGradle().getTaskGraph();
-		tasks.stream()
-				.filter(taskGraph::hasTask)
-				.sorted()
-				.forEach(task -> allSteps.addAll(task.getSteps()));
-		return allSteps;
-	}
-
-	private List<SpotlessTask> tasks = new ArrayList<>();
-
-	@Internal
-	public List<SpotlessTask> getTasks() {
-		return tasks;
-	}
-
 	void hookSubprojectTask(SpotlessTask task) {
-		tasks.add(task);
+		// TODO: in the future, we might use this hook to add an optional perf improvement
+		// spotlessRoot {
+		//    java { googleJavaFormat('1.2') }
+		//    ...etc
+		// }
+		// The point would be to reuse configurations from the root project,
+		// with the restriction that you have to declare every formatter in
+		// the root, and you'd get an error if you used a formatter somewhere
+		// which you didn't declare in the root. That's a problem for the future
+		// though, not today!
 		task.dependsOn(this);
 	}
 
@@ -80,17 +66,9 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 		return unitOutput;
 	}
 
-	GradleProvisioner.RootProvisioner rootProvisioner;
-
-	@Internal
-	public GradleProvisioner.RootProvisioner getRootProvisioner() {
-		return rootProvisioner;
-	}
-
 	void setup() {
 		Preconditions.checkArgument(getProject().getRootProject() == getProject(), "Can only be used on the root project");
 		unitOutput = new File(getProject().getBuildDir(), "tmp/spotless-register-dependencies");
-		rootProvisioner = new GradleProvisioner.RootProvisioner(getProject());
 		Provider<GitRatchetGradle> gitRatchetProvider = getProject().getGradle().getSharedServices().registerIfAbsent("GitRatchetGradle", GitRatchetGradle.class, unused -> {});
 		getBuildEventsListenerRegistry().onTaskCompletion(gitRatchetProvider);
 		getGitRatchet().set(gitRatchetProvider);
@@ -99,7 +77,7 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 	@TaskAction
 	public void trivialFunction() throws IOException {
 		Files.createParentDirs(unitOutput);
-		Files.write(Integer.toString(getSteps().size()), unitOutput, StandardCharsets.UTF_8);
+		Files.write(Integer.toString(1), unitOutput, StandardCharsets.UTF_8);
 	}
 
 	@Internal

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -72,8 +72,7 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 
 		BuildServiceRegistry buildServices = getProject().getGradle().getSharedServices();
 		getTaskService().set(buildServices.registerIfAbsent("SpotlessTaskService", SpotlessTaskService.class, spec -> {}));
-		getGitRatchet().set(buildServices.registerIfAbsent("GitRatchetGradle", GitRatchetGradle.class, unused -> {}));
-		getBuildEventsListenerRegistry().onTaskCompletion(getGitRatchet());
+		getBuildEventsListenerRegistry().onTaskCompletion(getTaskService());
 	}
 
 	@TaskAction
@@ -83,10 +82,7 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 	}
 
 	@Internal
-	public abstract Property<SpotlessTaskService> getTaskService();
-
-	@Internal
-	public abstract Property<GitRatchetGradle> getGitRatchet();
+	abstract Property<SpotlessTaskService> getTaskService();
 
 	@Inject
 	protected abstract BuildEventsListenerRegistry getBuildEventsListenerRegistry();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
-import org.gradle.api.provider.Provider;
 
 import com.diffplug.spotless.LineEnding;
 
@@ -46,8 +45,6 @@ public abstract class SpotlessExtension {
 	protected SpotlessExtension(Project project) {
 		this.project = requireNonNull(project);
 	}
-
-	abstract Provider<SpotlessTaskService> getTaskService();
 
 	abstract RegisterDependenciesTask getRegisterDependenciesTask();
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -19,13 +19,11 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 public class SpotlessExtensionImpl extends SpotlessExtension {
 	private final TaskProvider<RegisterDependenciesTask> registerDependenciesTask;
-	private final Provider<SpotlessTaskService> taskService;
 
 	public SpotlessExtensionImpl(Project project) {
 		super(project);
@@ -54,13 +52,6 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 						.configure(task -> task.dependsOn(rootCheckTask));
 			}
 		});
-
-		taskService = project.getGradle().getSharedServices().registerIfAbsent("SpotlessTaskService", SpotlessTaskService.class, spec -> {});
-	}
-
-	@Override
-	Provider<SpotlessTaskService> getTaskService() {
-		return taskService;
 	}
 
 	final TaskProvider<?> rootCheckTask, rootApplyTask, rootDiagnoseTask;
@@ -78,7 +69,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		// create the SpotlessTask
 		String taskName = EXTENSION + SpotlessPlugin.capitalize(name);
 		TaskProvider<SpotlessTaskImpl> spotlessTask = tasks.register(taskName, SpotlessTaskImpl.class, task -> {
-			task.init(taskService);
+			task.init(getRegisterDependenciesTask().getTaskService());
 			task.setEnabled(!isIdeHook);
 			// clean removes the SpotlessCache, so we have to run after clean
 			task.mustRunAfter(cleanTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -69,9 +69,9 @@ public abstract class SpotlessTask extends DefaultTask {
 
 	/*** API which performs git up-to-date tasks. */
 	@Nullable
-	GitRatchetGradle ratchet;
+	private GitRatchetGradle ratchet;
 	/** The sha of the tree at repository root, used for determining if an individual *file* is clean according to git. */
-	ObjectId rootTreeSha;
+	private ObjectId rootTreeSha;
 	/**
 	 * The sha of the tree at the root of *this project*, used to determine if the git baseline has changed within this folder.
 	 * Using a more fine-grained tree (rather than the project root) allows Gradle to mark more subprojects as up-to-date

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -29,6 +29,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -44,6 +45,9 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
 public abstract class SpotlessTask extends DefaultTask {
+	@Internal
+	abstract Property<SpotlessTaskService> getTaskService();
+
 	// set by SpotlessExtension, but possibly overridden by FormatExtension
 	protected String encoding = "UTF-8";
 
@@ -79,11 +83,11 @@ public abstract class SpotlessTask extends DefaultTask {
 	 */
 	private transient ObjectId subtreeSha = ObjectId.zeroId();
 
-	public void setupRatchet(GitRatchetGradle gitRatchet, String ratchetFrom) {
-		ratchet = gitRatchet;
+	public void setupRatchet(String ratchetFrom) {
+		ratchet = getTaskService().get().getRatchet();
 		File projectDir = getProjectDir().get().getAsFile();
-		rootTreeSha = gitRatchet.rootTreeShaOf(projectDir, ratchetFrom);
-		subtreeSha = gitRatchet.subtreeShaOf(projectDir, rootTreeSha);
+		rootTreeSha = ratchet.rootTreeShaOf(projectDir, ratchetFrom);
+		subtreeSha = ratchet.subtreeShaOf(projectDir, rootTreeSha);
 	}
 
 	@Internal

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -56,7 +56,7 @@ public abstract class SpotlessTask extends DefaultTask {
 		this.encoding = Objects.requireNonNull(encoding);
 	}
 
-	protected LineEnding.Policy lineEndingsPolicy;
+	protected transient LineEnding.Policy lineEndingsPolicy;
 
 	@Input
 	public LineEnding.Policy getLineEndingsPolicy() {
@@ -69,15 +69,15 @@ public abstract class SpotlessTask extends DefaultTask {
 
 	/*** API which performs git up-to-date tasks. */
 	@Nullable
-	private GitRatchetGradle ratchet;
+	private transient GitRatchetGradle ratchet;
 	/** The sha of the tree at repository root, used for determining if an individual *file* is clean according to git. */
-	private ObjectId rootTreeSha;
+	private transient ObjectId rootTreeSha;
 	/**
 	 * The sha of the tree at the root of *this project*, used to determine if the git baseline has changed within this folder.
 	 * Using a more fine-grained tree (rather than the project root) allows Gradle to mark more subprojects as up-to-date
 	 * compared to using the project root.
 	 */
-	private ObjectId subtreeSha = ObjectId.zeroId();
+	private transient ObjectId subtreeSha = ObjectId.zeroId();
 
 	public void setupRatchet(GitRatchetGradle gitRatchet, String ratchetFrom) {
 		ratchet = gitRatchet;
@@ -139,7 +139,7 @@ public abstract class SpotlessTask extends DefaultTask {
 		return outputDirectory;
 	}
 
-	protected List<FormatterStep> steps = new ArrayList<>();
+	protected transient List<FormatterStep> steps = new ArrayList<>();
 
 	@Input
 	public List<FormatterStep> getSteps() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Internal;
@@ -41,9 +40,6 @@ import com.diffplug.spotless.PaddedCell;
 
 @CacheableTask
 public abstract class SpotlessTaskImpl extends SpotlessTask {
-	@Internal
-	abstract Property<SpotlessTaskService> getTaskService();
-
 	@Internal
 	abstract DirectoryProperty getProjectDir();
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -83,7 +83,8 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 				}
 			}
 		} else {
-			throw new GradleException("Spotless doesn't support configuration cache yet");
+			throw new GradleException("Spotless doesn't support configuration cache yet.\n" +
+					"Rerun with --no-configuration-cache");
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -50,7 +50,6 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 	void init(Provider<SpotlessTaskService> service) {
 		getTaskService().set(service);
 		getProjectDir().set(getProject().getProjectDir());
-		service.get().registerSourceCreated(this);
 	}
 
 	@Inject
@@ -69,7 +68,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 			Files.createDirectories(outputDirectory.toPath());
 		}
 
-		if (getTaskService().get().sourceWasCreatedThisBuild(this)) {
+		if (lineEndingsPolicy != null) {
 			try (Formatter formatter = buildFormatter()) {
 				for (FileChange fileChange : inputs.getFileChanges(target)) {
 					File input = fileChange.getFile();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -92,7 +92,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 		File output = getOutputFile(input);
 		getLogger().debug("Applying format to " + input + " and writing to " + output);
 		PaddedCell.DirtyState dirtyState;
-		if (ratchet != null && ratchet.isClean(getProjectDir().get().getAsFile(), rootTreeSha, input)) {
+		if (getRatchet() != null && getRatchet().isClean(getProjectDir().get().getAsFile(), getRootTreeSha(), input)) {
 			dirtyState = PaddedCell.isClean();
 		} else {
 			dirtyState = PaddedCell.calculateDirtyState(formatter, input);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -42,7 +42,6 @@ import com.diffplug.spotless.Provisioner;
  * apply already did).
  */
 public abstract class SpotlessTaskService implements BuildService<BuildServiceParameters.None> {
-	private final Map<String, SpotlessTask> sourceCreated = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, SpotlessApply> apply = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
@@ -51,14 +50,6 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		return provisioner.computeIfAbsent(project.getPath(), unused -> {
 			return GradleProvisioner.newDedupingProvisioner(project);
 		});
-	}
-
-	void registerSourceCreated(SpotlessTask spotlessTask) {
-		sourceCreated.put(spotlessTask.getPath(), spotlessTask);
-	}
-
-	boolean sourceWasCreatedThisBuild(SpotlessTask spotlessTask) {
-		return sourceCreated.containsKey(spotlessTask.getPath());
 	}
 
 	void registerSourceAlreadyRan(SpotlessTask task) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -32,6 +33,7 @@ import org.gradle.api.tasks.Internal;
 
 import com.diffplug.common.base.Preconditions;
 import com.diffplug.common.base.Unhandled;
+import com.diffplug.spotless.Provisioner;
 
 /**
  * Allows the check and apply tasks to coordinate
@@ -42,6 +44,13 @@ import com.diffplug.common.base.Unhandled;
 public abstract class SpotlessTaskService implements BuildService<BuildServiceParameters.None> {
 	private final Map<String, SpotlessApply> apply = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
+	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
+
+	public Provisioner provisionerFor(Project project) {
+		return provisioner.computeIfAbsent(project.getPath(), unused -> {
+			return GradleProvisioner.newDedupingProvisioner(project);
+		});
+	}
 
 	public void registerSourceAlreadyRan(SpotlessTask task) {
 		source.put(task.getPath(), task);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -42,21 +42,30 @@ import com.diffplug.spotless.Provisioner;
  * apply already did).
  */
 public abstract class SpotlessTaskService implements BuildService<BuildServiceParameters.None> {
+	private final Map<String, SpotlessTask> sourceCreated = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, SpotlessApply> apply = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
 
-	public Provisioner provisionerFor(Project project) {
+	Provisioner provisionerFor(Project project) {
 		return provisioner.computeIfAbsent(project.getPath(), unused -> {
 			return GradleProvisioner.newDedupingProvisioner(project);
 		});
 	}
 
-	public void registerSourceAlreadyRan(SpotlessTask task) {
+	void registerSourceCreated(SpotlessTask spotlessTask) {
+		sourceCreated.put(spotlessTask.getPath(), spotlessTask);
+	}
+
+	boolean sourceWasCreatedThisBuild(SpotlessTask spotlessTask) {
+		return sourceCreated.containsKey(spotlessTask.getPath());
+	}
+
+	void registerSourceAlreadyRan(SpotlessTask task) {
 		source.put(task.getPath(), task);
 	}
 
-	public void registerApplyAlreadyRan(SpotlessApply task) {
+	void registerApplyAlreadyRan(SpotlessApply task) {
 		apply.put(task.sourceTaskPath(), task);
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -83,7 +83,7 @@ public class GradleIntegrationHarness extends ResourceHarness {
 		setFile(".gitattributes").toContent("* text eol=lf");
 	}
 
-	protected final GradleRunner gradleRunner() throws IOException {
+	protected GradleRunner gradleRunner() throws IOException {
 		return GradleRunner.create()
 				.withGradleVersion(GradleVersionSupport.MINIMUM.version)
 				.withProjectDir(rootFolder())

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectAfterEvaluate.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectAfterEvaluate.java
@@ -25,13 +25,13 @@ class MultiProjectAfterEvaluate extends GradleIntegrationHarness {
 	@Test
 	void failureDoesntTriggerAll() throws IOException {
 		setFile("settings.gradle").toLines("include 'sub'");
-		setFile("build.gradle").toLines("repositories { mavenCentral() }");
 		setFile("sub/build.gradle")
 				.toLines(
 						"plugins {",
 						"  id 'com.diffplug.spotless'",
 						"  id 'java'",
 						"}",
+						"repositories { mavenCentral() }",
 						"spotless { java { googleJavaFormat() } }");
 		String output = gradleRunner().withArguments("spotlessApply", "--warning-mode", "all").build().getOutput().replace("\r\n", "\n");
 		Assertions.assertThat(output).doesNotContain("Using method Project#afterEvaluate(Action) when the project is already evaluated has been deprecated.");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 	@Test
-	void registerDependencies() throws IOException {
+	void duplicateConfigs() throws IOException {
 		setFile("settings.gradle")
 				.toLines("include 'sub'");
 		setFile("sub/build.gradle").toLines(
@@ -32,6 +32,10 @@ class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 				"spotless {",
 				"  java {",
 				"    target 'src/main/java/**/*.java'",
+				"    googleJavaFormat('1.2')",
+				"  }",
+				"  format 'javaDupe', com.diffplug.gradle.spotless.JavaExtension, {",
+				"    target 'src/boop/java/**/*.java'",
 				"    googleJavaFormat('1.2')",
 				"  }",
 				"}");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
@@ -43,9 +43,13 @@ class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 		setFile("gradle.properties").toLines();
 		String newestSupported = gradleRunner().withArguments("spotlessCheck").build().getOutput();
 		Assertions.assertThat(newestSupported.replace("\r", ""))
-				.startsWith("> Task :spotlessInternalRegisterDependencies\n")
-				.contains("> Task :sub:spotlessJava\n" +
-						"> Task :sub:spotlessJavaCheck\n" +
+				.startsWith(
+						"> Task :spotlessInternalRegisterDependencies\n")
+				.contains(
+						"> Task :sub:spotlessJava\n",
+						"> Task :sub:spotlessJavaCheck\n",
+						"> Task :sub:spotlessJavaDupe\n",
+						"> Task :sub:spotlessJavaDupeCheck\n",
 						"> Task :sub:spotlessCheck\n");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
@@ -25,12 +25,10 @@ class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 	void registerDependencies() throws IOException {
 		setFile("settings.gradle")
 				.toLines("include 'sub'");
-		setFile("build.gradle").toLines(
-				"plugins { id 'com.diffplug.spotless' }",
-				"repositories { mavenCentral() }");
 		setFile("sub/build.gradle").toLines(
-				"apply plugin: 'com.diffplug.spotless'",
+				"plugins { id 'com.diffplug.spotless' }",
 				"",
+				"repositories { mavenCentral() }",
 				"spotless {",
 				"  java {",
 				"    target 'src/main/java/**/*.java'",
@@ -41,8 +39,7 @@ class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 		setFile("gradle.properties").toLines();
 		String newestSupported = gradleRunner().withArguments("spotlessCheck").build().getOutput();
 		Assertions.assertThat(newestSupported.replace("\r", ""))
-				.startsWith("> Task :spotlessCheck UP-TO-DATE\n" +
-						"> Task :spotlessInternalRegisterDependencies\n")
+				.startsWith("> Task :spotlessInternalRegisterDependencies\n")
 				.contains("> Task :sub:spotlessJava\n" +
 						"> Task :sub:spotlessJavaCheck\n" +
 						"> Task :sub:spotlessCheck\n");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
@@ -88,7 +88,7 @@ class UpToDateTest extends GradleIntegrationHarness {
 		// the format task is UP-TO-DATE (same inputs), but the apply tasks will run again
 		pauseForFilesystem();
 		BuildResult buildResult = gradleRunner().withArguments("spotlessApply").build();
-		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.UP_TO_DATE)).containsExactly(":spotlessMisc");
+		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.UP_TO_DATE)).containsExactly(":spotlessInternalRegisterDependencies", ":spotlessMisc");
 		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.SUCCESS)).containsExactly(":spotlessMiscApply", ":spotlessApply");
 		assertFile("README.md").hasContent("abc");
 


### PR DESCRIPTION
- In Spotless 5.x, we resolved all dependencies from the "buildscript" repositories of the root project.
- In #980 we kept resolving from the root project only.
- And in this PR we start to resolve dependencies from the normal child projects themselves.

That leads to a lot of duplication, but there is a clear path to recentralize from here if we want to get that performance back. After this PR, spotless can build and run without any warnings from configuration cache. However, it doesn't *actually* work, and many things will break if you try to do it, although it's surprising how many things do work.

But if you aren't using configuration-cache and you just have a giant multi-module project which has been barfing on our root-project synchronization, this PR is the ultimate fix to #941.