### PR TITLE
Fixup our CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ anchors:
           path: plugin-gradle/build/test-results/test
 jobs:
   # gradlew spotlessCheck assemble testClasses
-  assemble_testClasses: 
+  assemble_testClasses:
     <<: *env_gradle_large
     steps:
       - checkout
@@ -102,11 +102,11 @@ jobs:
           name: gradlew npmTest
           command: ./gradlew npmTest --build-cache
       - store_test_results:
-          path: testlib/build/test-results/npm
+          path: testlib/build/test-results/NpmTest
       - store_test_results:
-          path: plugin-maven/build/test-results/npm
+          path: plugin-maven/build/test-results/NpmTest
       - store_test_results:
-          path: plugin-gradle/build/test-results/npm
+          path: plugin-gradle/build/test-results/NpmTest
   test_windows:
     executor:
       name: win/default
@@ -114,7 +114,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install 
+          name: install
           command: choco install ojdkbuild8
       - run:
           name: gradlew check
@@ -129,9 +129,9 @@ jobs:
           name: gradlew npmTest
           command: gradlew npmTest --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
       - store_test_results:
-          path: testlib/build/test-results/npm
+          path: testlib/build/test-results/NpmTest
       - store_test_results:
-          path: plugin-gradle/build/test-results/npm
+          path: plugin-gradle/build/test-results/NpmTest
   changelog_print:
     << : *env_gradle
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,10 @@ jobs:
       - checkout
       - run:
           name: install
-          command: choco install ojdkbuild8
+          command: choco install ojdkbuild8 -params 'installdir=c:\\java8'
+      - run:
+          name: JAVA_HOME
+          command: setx JAVA_HOME "C:\java8"
       - run:
           name: gradlew check
           command: gradlew check --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,23 @@ jobs:
           path: plugin-maven/build/test-results/NpmTest
       - store_test_results:
           path: plugin-gradle/build/test-results/NpmTest
+      - run:
+          name: gradlew check
+          command: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew check --build-cache
+      - store_test_results:
+          path: testlib/build/test-results/test
+      - store_test_results:
+          path: lib-extra/build/test-results/test
+      - store_test_results:
+          path: plugin-gradle/build/test-results/test
+      - store_test_results:
+          path: lib/build/spotbugs
+      - store_test_results:
+          path: lib-extra/build/spotbugs
+      - store_test_results:
+          path: testlib/build/spotbugs
+      - store_test_results:
+          path: plugin-gradle/build/spotbugs
   test_windows:
     executor:
       name: win/default
@@ -114,14 +131,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install
-          command: choco install ojdkbuild8 -params 'installdir=c:\\java8'
-      - run:
-          name: JAVA_HOME
-          command: setx JAVA_HOME "C:\java8"
-      - run:
-          name: gradlew check
-          command: gradlew check --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
+          name: gradlew test
+          command: gradlew test --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
       - store_test_results:
           path: testlib/build/test-results/test
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,13 @@ jobs:
           path: lib-extra/build/test-results/test
       - store_test_results:
           path: plugin-gradle/build/test-results/test
-      - store_test_results:
+      - store_artifacts:
           path: lib/build/spotbugs
-      - store_test_results:
+      - store_artifacts:
           path: lib-extra/build/spotbugs
-      - store_test_results:
+      - store_artifacts:
           path: testlib/build/spotbugs
-      - store_test_results:
+      - store_artifacts:
           path: plugin-gradle/build/spotbugs
   test_windows:
     executor:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * `DiffMessageFormatter` can now generate messages based on a folder of cleaned files, as an alternative to a `Formatter` ([#982](https://github.com/diffplug/spotless/pull/982)).
+### Fixed
+* Fix CI and various spotbugs nits ([#988](https://github.com/diffplug/spotless/pull/988)).
 
 ## [2.19.2] - 2021-10-26
 ### Changed

--- a/gradle/special-tests.gradle
+++ b/gradle/special-tests.gradle
@@ -6,7 +6,7 @@ def special = [
 	'Clang'
 ]
 
-boolean isCiServer = true
+boolean isCiServer = System.getenv().containsKey("CI")
 tasks.named('test') {
 	// See com.diffplug.spotless.tag package for available JUnit 5 @Tag annotations
 	useJUnitPlatform {
@@ -14,7 +14,7 @@ tasks.named('test') {
 	}
 	if (isCiServer) {
 		retry {
-			maxRetries = 2
+			maxRetries = 1
 			maxFailures = 2
 		}
 	}

--- a/gradle/special-tests.gradle
+++ b/gradle/special-tests.gradle
@@ -1,13 +1,22 @@
+apply plugin: 'org.gradle.test-retry'
+
 def special = [
 	'Npm',
 	'Black',
 	'Clang'
 ]
 
+boolean isCiServer = true
 tasks.named('test') {
 	// See com.diffplug.spotless.tag package for available JUnit 5 @Tag annotations
 	useJUnitPlatform {
 		excludeTags special as String[]
+	}
+	if (isCiServer) {
+		retry {
+			maxRetries = 2
+			maxFailures = 2
+		}
 	}
 }
 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -102,7 +102,6 @@ public final class DiffMessageFormatter {
 
 		@Override
 		public String getFormatted(File file, String rawUnix) {
-			Path relative = rootDir.relativize(file.toPath());
 			Path clean = cleanDir.resolve(rootDir.relativize(file.toPath()));
 			byte[] content = Errors.rethrow().get(() -> Files.readAllBytes(clean));
 			return new String(content, encoding);

--- a/lib/src/main/java/com/diffplug/spotless/Jvm.java
+++ b/lib/src/main/java/com/diffplug/spotless/Jvm.java
@@ -242,7 +242,7 @@ public final class Jvm {
 
 			private static <V> int[] convert(V versionObject) {
 				try {
-					return Arrays.asList(versionObject.toString().split("\\.")).stream().mapToInt(s -> Integer.valueOf(s)).toArray();
+					return Arrays.asList(versionObject.toString().split("\\.")).stream().mapToInt(Integer::parseInt).toArray();
 				} catch (Exception e) {
 					throw new IllegalArgumentException(String.format("Not a semantic version: %s", versionObject), e);
 				}

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.java;
 
+import java.io.Serializable;
 import java.util.*;
 
 import javax.annotation.Nullable;
@@ -256,7 +257,9 @@ final class ImportSorterImpl {
 		return null;
 	}
 
-	private static class OrderingComparator implements Comparator<String> {
+	private static class OrderingComparator implements Comparator<String>, Serializable {
+		private static final long serialVersionUID = 1;
+
 		private final boolean wildcardsLast;
 
 		private OrderingComparator(boolean wildcardsLast) {

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -85,7 +85,7 @@ public class PrettierFormatterStep {
 				PrettierRestService restService = new PrettierRestService(prettierRestServer.getBaseUrl());
 				String prettierConfigOptions = restService.resolveConfig(this.prettierConfig.getPrettierConfigPath(), this.prettierConfig.getOptions());
 				return Closeable.ofDangerous(() -> endServer(restService, prettierRestServer), new PrettierFilePathPassingFormatterFunc(prettierConfigOptions, restService));
-			} catch (Exception e) {
+			} catch (IOException e) {
 				throw ThrowingEx.asRuntime(e);
 			}
 		}

--- a/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class TsFmtFormatterStep {
 				ServerProcessInfo tsfmtRestServer = npmRunServer();
 				TsFmtRestService restService = new TsFmtRestService(tsfmtRestServer.getBaseUrl());
 				return Closeable.ofDangerous(() -> endServer(restService, tsfmtRestServer), input -> restService.format(input, tsFmtOptions));
-			} catch (Exception e) {
+			} catch (IOException e) {
 				throw ThrowingEx.asRuntime(e);
 			}
 		}

--- a/lib/src/main/java/com/diffplug/spotless/pom/SortPomStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/pom/SortPomStep.java
@@ -30,13 +30,13 @@ public class SortPomStep {
 
 	private SortPomStep() {}
 
-	private SortPomCfg cfg;
-
 	public static FormatterStep create(SortPomCfg cfg, Provisioner provisioner) {
 		return FormatterStep.createLazy(NAME, () -> new State(cfg, provisioner), State::createFormat);
 	}
 
 	static class State implements Serializable {
+		private static final long serialVersionUID = 1;
+
 		SortPomCfg cfg;
 		JarState jarState;
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
 		id 'com.diffplug.spotless-changelog'       version '2.2.0'
 		// https://github.com/diffplug/goomph/blob/main/CHANGES.md
 		id 'com.diffplug.p2.asmaven'               version '3.33.2'
-    // https://github.com/gradle/test-retry-gradle-plugin/releases
+		// https://github.com/gradle/test-retry-gradle-plugin/releases
 		id 'org.gradle.test-retry'                 version '1.3.1'
 	}
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,8 @@ pluginManagement {
 		id 'com.github.spotbugs'                   version '4.7.8'
 		// https://github.com/diffplug/spotless-changelog
 		id 'com.diffplug.spotless-changelog'       version '2.2.0'
+		// https://github.com/gradle/test-retry-gradle-plugin/releases
+		id 'org.gradle.test-retry'                 version '1.3.1'
 	}
 }
 plugins {
@@ -17,6 +19,7 @@ plugins {
 	id 'io.github.gradle-nexus.publish-plugin' apply false
 	id 'com.github.spotbugs'                   apply false
 	id 'com.diffplug.spotless-changelog'       apply false
+	id 'org.gradle.test-retry'                 apply false
 }
 if (System.env['CI'] != null) {
 	// use the remote buildcache on all CI builds

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -124,6 +124,7 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@EnabledForJreRange(min = JAVA_11) // google-java-format requires JRE 11+
 	void equalityGroupArtifact() throws Exception {
 		new SerializableEqualityTester() {
 			String groupArtifact = GoogleJavaFormatStep.defaultGroupArtifact();


### PR DESCRIPTION
We had various CI rot issues as documented in #930, all fixed here. In particular:

- we now run tests against Java 8 again
- we run spotbugs again
- we retry test failures on CI
- we store npm test results on Circle, as well as spotbugs results

Also fixed-up some spotbugs findings - a few unused fields and unused temp variables.