### PR TITLE
Enable reproducible builds

### DIFF
--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -182,3 +182,8 @@ if (!version.endsWith('-SNAPSHOT')) {
 		}
 	}
 }
+
+tasks.withType(AbstractArchiveTask).configureEach {
+  preserveFileTimestamps = false
+  reproducibleFileOrder = true
+}


### PR DESCRIPTION
To ensure that this project can be correctly reproduced by an
independent build of the project, we should enable reproducible builds
in Gradle, across all projects.
