### PR TITLE
Add native markdown formatting for maven

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for Markdown with `flexmark` at `0.62.2` ([#1011](https://github.com/diffplug/spotless/pull/1011)).
 
 ## [2.20.3] - 2021-12-15
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ lib('kotlin.KtLintStep')                         +'{{yes}}       | {{yes}}      
 lib('kotlin.KtfmtStep')                          +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
 lib('kotlin.DiktatStep')                         +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
 lib('markdown.FreshMarkStep')                    +'{{yes}}       | {{no}}       | {{no}}       | {{no}}  |',
+lib('markdown.FlexmarkStep')                     +'{{no}}        | {{yes}}      | {{no}}       | {{no}}  |',
 lib('npm.PrettierFormatterStep')                 +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
 lib('npm.TsFmtFormatterStep')                    +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
 lib('pom.SortPomStepStep')                       +'{{no}}        | {{yes}}      | {{no}}       | {{no}}  |',
@@ -103,6 +104,7 @@ extra('wtp.EclipseWtpFormatterStep')             +'{{yes}}       | {{yes}}      
 | [`kotlin.KtfmtStep`](lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`kotlin.DiktatStep`](lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`markdown.FreshMarkStep`](lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java) | :+1:       | :white_large_square:       | :white_large_square:       | :white_large_square:  |
+| [`markdown.FlexmarkStep`](lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java) | :white_large_square:        | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`npm.PrettierFormatterStep`](lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`npm.TsFmtFormatterStep`](lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`pom.SortPomStepStep`](lib/src/main/java/com/diffplug/spotless/pom/SortPomStepStep.java) | :white_large_square:        | :+1:      | :white_large_square:       | :white_large_square:  |

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,7 +8,8 @@ apply from: rootProject.file('gradle/java-publish.gradle')
 
 def NEEDS_GLUE = [
 	'sortPom',
-	'ktlint'
+	'ktlint',
+	'flexmark'
 ]
 for (glue in NEEDS_GLUE) {
 	sourceSets.register(glue) {
@@ -32,6 +33,9 @@ dependencies {
 	ktlintCompileOnly "com.pinterest:ktlint:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-core:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-standard:$VER_KTLINT"
+
+	// used for markdown formatting
+	flexmarkCompileOnly 'com.vladsch.flexmark:flexmark-all:0.62.2'
 }
 
 // we'll hold the core lib to a high standard

--- a/lib/src/flexmark/java/com/diffplug/spotless/glue/markdown/FlexmarkFormatterFunc.java
+++ b/lib/src/flexmark/java/com/diffplug/spotless/glue/markdown/FlexmarkFormatterFunc.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.glue.markdown;
+
+import com.vladsch.flexmark.formatter.Formatter;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.parser.ParserEmulationProfile;
+import com.vladsch.flexmark.parser.PegdownExtensions;
+import com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.data.MutableDataHolder;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+
+import com.diffplug.spotless.FormatterFunc;
+
+/**
+ * The formatter function for <a href="https://github.com/vsch/flexmark-java">flexmark-java</a>.
+ */
+public class FlexmarkFormatterFunc implements FormatterFunc {
+
+	/**
+	 * The emulation profile is used by both the parser and the formatter and generally determines the markdown flavor.
+	 * COMMONMARK is the default defined by flexmark-java.
+	 */
+	private static final String DEFAULT_EMULATION_PROFILE = "COMMONMARK";
+
+	private final Parser parser;
+	private final Formatter formatter;
+
+	public FlexmarkFormatterFunc() {
+		// flexmark-java has a separate parser and renderer (formatter)
+		// this is build from the example in https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter
+
+		// The emulation profile generally determines the markdown flavor. We use the same one for both the parser and
+		// the formatter, to make sure this formatter func is idempotent.
+		final ParserEmulationProfile emulationProfile = ParserEmulationProfile.valueOf(DEFAULT_EMULATION_PROFILE);
+
+		final MutableDataHolder parserOptions = createParserOptions(emulationProfile);
+		final MutableDataHolder formatterOptions = createFormatterOptions(parserOptions, emulationProfile);
+
+		parser = Parser.builder(parserOptions).build();
+		formatter = Formatter.builder(formatterOptions).build();
+	}
+
+	/**
+	 * Creates the parser options.
+	 * See: https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter#options
+	 *
+	 * @param emulationProfile the emulation profile (or flavor of markdown) the parser should use
+	 * @return the created parser options
+	 */
+	private static MutableDataHolder createParserOptions(ParserEmulationProfile emulationProfile) {
+		final MutableDataHolder parserOptions = PegdownOptionsAdapter.flexmarkOptions(PegdownExtensions.ALL).toMutable();
+		parserOptions.set(Parser.PARSER_EMULATION_PROFILE, emulationProfile);
+		return parserOptions;
+	}
+
+	/**
+	 * Creates the formatter options, copies the parser extensions and changes defaults that make sense for a formatter.
+	 * See: https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter#options
+	 *
+	 * @param parserOptions the options used for the parser
+	 * @param emulationProfile the emulation profile (or flavor of markdown) the formatter should use
+	 * @return the created formatter options
+	 */
+	private static MutableDataHolder createFormatterOptions(MutableDataHolder parserOptions, ParserEmulationProfile emulationProfile) {
+		final MutableDataHolder formatterOptions = new MutableDataSet();
+		formatterOptions.set(Parser.EXTENSIONS, Parser.EXTENSIONS.get(parserOptions));
+		formatterOptions.set(Formatter.FORMATTER_EMULATION_PROFILE, emulationProfile);
+		return formatterOptions;
+	}
+
+	@Override
+	public String apply(String input) throws Exception {
+		final Document parsedMarkdown = parser.parse(input);
+		return formatter.render(parsedMarkdown);
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -115,7 +115,7 @@ public class GoogleJavaFormatStep {
 	static final class State implements Serializable {
 		private static final long serialVersionUID = 1L;
 
-		/** The jar that contains the eclipse formatter. */
+		/** The jar that contains the formatter. */
 		final JarState jarState;
 		final String stepName;
 		final String version;

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -82,7 +82,7 @@ public class KtLintStep {
 		/** Are the files being linted Kotlin script files. */
 		private final boolean isScript;
 		private final String pkg;
-		/** The jar that contains the eclipse formatter. */
+		/** The jar that contains the formatter. */
 		final JarState jarState;
 		private final TreeMap<String, String> userData;
 		private final boolean useParams;

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -108,7 +108,7 @@ public class KtfmtStep {
 		 * Option that allows to apply formatting options to perform a 4 spaces block and continuation indent.
 		 */
 		private final Style style;
-		/** The jar that contains the eclipse formatter. */
+		/** The jar that contains the formatter. */
 		final JarState jarState;
 
 		State(String version, Provisioner provisioner, Style style) throws IOException {

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
@@ -16,8 +16,7 @@
 package com.diffplug.spotless.markdown;
 
 import java.io.Serializable;
-import java.lang.reflect.Array;
-import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
@@ -33,13 +32,6 @@ public class FlexmarkStep {
 	private static final String DEFAULT_VERSION = "0.62.2";
 	private static final String NAME = "flexmark-java";
 	private static final String MAVEN_COORDINATE = "com.vladsch.flexmark:flexmark-all:";
-
-	/**
-	 * The emulation profile is used by both the parser and the formatter and generally determines the markdown flavor.
-	 * COMMONMARK is the default defined by flexmark-java. It's defined here so it can be used in both the parser and
-	 * the formatter, to keep the step idempotent.
-	 */
-	private static final String DEFAULT_EMULATION_PROFILE = "COMMONMARK";
 
 	/** Creates a formatter step for the default version. */
 	public static FormatterStep create(Provisioner provisioner) {
@@ -70,87 +62,9 @@ public class FlexmarkStep {
 
 		FormatterFunc createFormat() throws Exception {
 			final ClassLoader classLoader = jarState.getClassLoader();
-
-			// flexmark-java has a separate parser and renderer (formatter)
-			// this is build from the example in https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter
-
-			// first we need to create the parser and find the parse method
-			final Class<?> parserClazz = classLoader.loadClass("com.vladsch.flexmark.parser.Parser");
-			final Class<?> parserBuilderClazz = classLoader.loadClass("com.vladsch.flexmark.parser.Parser$Builder");
-			final Class<?> parserEmulationProfileClazz = classLoader.loadClass("com.vladsch.flexmark.parser.ParserEmulationProfile");
-			final Class<?> dataHolderClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.DataHolder");
-			final Class<?> dataKeyClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.DataKey");
-			final Object parserEmulationProfile = parserEmulationProfileClazz.getField(DEFAULT_EMULATION_PROFILE).get(null);
-			final Object parserOptions = buildParserOptions(classLoader, parserClazz, dataHolderClazz, dataKeyClazz, parserEmulationProfile);
-			final Object parserBuilder = parserClazz.getMethod("builder", dataHolderClazz).invoke(null, parserOptions);
-			final Object parser = parserBuilderClazz.getMethod("build").invoke(parserBuilder);
-			final Method parseMethod = parserClazz.getMethod("parse", String.class);
-
-			// now we can create the formatter and find the render method
-			final Class<?> formatterClazz = classLoader.loadClass("com.vladsch.flexmark.formatter.Formatter");
-			final Class<?> nodeClazz = classLoader.loadClass("com.vladsch.flexmark.util.ast.Node");
-			final Class<?> formatterBuilderClazz = classLoader.loadClass("com.vladsch.flexmark.formatter.Formatter$Builder");
-			final Object formatterOptions = buildFormatterOptions(
-					classLoader, parserClazz, formatterClazz, dataKeyClazz, dataHolderClazz, parserOptions, parserEmulationProfile);
-			final Object formatterBuilder = formatterClazz.getMethod("builder", dataHolderClazz).invoke(null, formatterOptions);
-			final Object formatter = formatterBuilderClazz.getMethod("build").invoke(formatterBuilder);
-			final Method renderMethod = formatterClazz.getMethod("render", nodeClazz);
-
-			// the input must be parsed by the parser and then rendered by the formatter
-			return input -> (String) renderMethod.invoke(formatter, parseMethod.invoke(parser, input));
-		}
-
-		private Object buildParserOptions(
-				ClassLoader classLoader,
-				Class<?> parserClazz,
-				Class<?> dataHolderClazz,
-				Class<?> dataKeyClazz,
-				Object parserEmulationProfile) throws Exception {
-			final Class<?> pegdownOptionsAdapterClazz = classLoader.loadClass("com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter");
-			final Class<?> pegdownExtensionsClazz = classLoader.loadClass("com.vladsch.flexmark.parser.PegdownExtensions");
-			final Class<?> extensionClazz = classLoader.loadClass("com.vladsch.flexmark.util.misc.Extension");
-			final Class<?> mutableDataHolderClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.MutableDataHolder");
-
-			final int pegDownExtensionsConstantAll = pegdownExtensionsClazz.getField("ALL").getInt(null);
-			final Object extensions = Array.newInstance(extensionClazz, 0);
-			final Class<?> extensionArrayClazz = extensions.getClass();
-
-			final Object parserOptions = pegdownOptionsAdapterClazz
-					.getMethod("flexmarkOptions", Integer.TYPE, extensionArrayClazz)
-					.invoke(null, pegDownExtensionsConstantAll, extensions);
-			final Object mutableParserOptions = dataHolderClazz.getMethod("toMutable").invoke(parserOptions);
-			final Object parserEmulationProfileKey = parserClazz.getField("PARSER_EMULATION_PROFILE").get(null);
-			final Method mutableDataHolderSetMethod = mutableDataHolderClazz.getMethod("set", dataKeyClazz, Object.class);
-			mutableDataHolderSetMethod.invoke(mutableParserOptions, parserEmulationProfileKey, parserEmulationProfile);
-			return mutableParserOptions;
-		}
-
-		/**
-		 * Creates the formatter options, copies the parser extensions and changes defaults that make sense for a formatter.
-		 * See: https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter#options
-		 */
-		private Object buildFormatterOptions(
-				ClassLoader classLoader,
-				Class<?> parserClazz,
-				Class<?> formatterClazz,
-				Class<?> dataKeyClazz,
-				Class<?> dataHolderClazz,
-				Object parserOptions,
-				Object parserEmulationProfile) throws Exception {
-			final Class<?> mutableDataSetClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.MutableDataSet");
-			final Object formatterOptions = mutableDataSetClazz.getConstructor().newInstance();
-			final Method mutableDataSetMethodSet = mutableDataSetClazz.getMethod("set", dataKeyClazz, Object.class);
-
-			// copy the parser extensions like the example in https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter
-			final Object parserExtensions = parserClazz.getField("EXTENSIONS").get(null);
-			final Object copiedExtensions = dataKeyClazz.getMethod("get", dataHolderClazz).invoke(parserExtensions, parserOptions);
-			mutableDataSetMethodSet.invoke(formatterOptions, parserExtensions, copiedExtensions);
-
-			// use the same emulation profile for the parser and the formatted, to make sure the step is idempotent
-			final Object formatterEmulationProfile = formatterClazz.getField("FORMATTER_EMULATION_PROFILE").get(null);
-			mutableDataSetMethodSet.invoke(formatterOptions, formatterEmulationProfile, parserEmulationProfile);
-
-			return formatterOptions;
+			final Class<?> formatterFunc = classLoader.loadClass("com.diffplug.spotless.glue.markdown.FlexmarkFormatterFunc");
+			final Constructor<?> constructor = formatterFunc.getConstructor();
+			return (FormatterFunc) constructor.newInstance();
 		}
 
 	}

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2016-2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.markdown;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.JarState;
+import com.diffplug.spotless.Provisioner;
+
+/** A step for <a href="https://github.com/vsch/flexmark-java">flexmark-java</a>. */
+public class FlexmarkStep {
+	// prevent direct instantiation
+	private FlexmarkStep() {}
+
+	private static final String DEFAULT_VERSION = "0.62.2";
+	private static final String NAME = "flexmark-java";
+	private static final String MAVEN_COORDINATE = "com.vladsch.flexmark:flexmark-all:";
+
+	/**
+	 * The emulation profile is used by both the parser and the formatter and generally determines the markdown flavor.
+	 * COMMONMARK is the default defined by flexmark-java. It's defined here so it can be used in both the parser and
+	 * the formatter, to keep the step idempotent.
+	 */
+	private static final String DEFAULT_EMULATION_PROFILE = "COMMONMARK";
+
+	/** Creates a formatter step for the default version. */
+	public static FormatterStep create(Provisioner provisioner) {
+		return create(defaultVersion(), provisioner);
+	}
+
+	/** Creates a formatter step for the given version. */
+	public static FormatterStep create(String version, Provisioner provisioner) {
+		Objects.requireNonNull(version, "version");
+		Objects.requireNonNull(provisioner, "provisioner");
+		return FormatterStep.createLazy(NAME,
+				() -> new State(JarState.from(MAVEN_COORDINATE + version, provisioner)),
+				State::createFormat);
+	}
+
+	public static String defaultVersion() {
+		return DEFAULT_VERSION;
+	}
+
+	private static class State implements Serializable {
+		private static final long serialVersionUID = 1L;
+
+		final JarState jarState;
+
+		State(JarState jarState) {
+			this.jarState = jarState;
+		}
+
+		FormatterFunc createFormat() throws Exception {
+			final ClassLoader classLoader = jarState.getClassLoader();
+
+			// flexmark-java has a separate parser and renderer (formatter)
+			// this is build from the example in https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter
+
+			// first we need to create the parser and find the parse method
+			final Class<?> parserClazz = classLoader.loadClass("com.vladsch.flexmark.parser.Parser");
+			final Class<?> parserBuilderClazz = classLoader.loadClass("com.vladsch.flexmark.parser.Parser$Builder");
+			final Class<?> parserEmulationProfileClazz = classLoader.loadClass("com.vladsch.flexmark.parser.ParserEmulationProfile");
+			final Class<?> dataHolderClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.DataHolder");
+			final Class<?> dataKeyClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.DataKey");
+			final Object parserEmulationProfile = parserEmulationProfileClazz.getField(DEFAULT_EMULATION_PROFILE).get(null);
+			final Object parserOptions = buildParserOptions(classLoader, parserClazz, dataHolderClazz, dataKeyClazz, parserEmulationProfile);
+			final Object parserBuilder = parserClazz.getMethod("builder", dataHolderClazz).invoke(null, parserOptions);
+			final Object parser = parserBuilderClazz.getMethod("build").invoke(parserBuilder);
+			final Method parseMethod = parserClazz.getMethod("parse", String.class);
+
+			// now we can create the formatter and find the render method
+			final Class<?> formatterClazz = classLoader.loadClass("com.vladsch.flexmark.formatter.Formatter");
+			final Class<?> nodeClazz = classLoader.loadClass("com.vladsch.flexmark.util.ast.Node");
+			final Class<?> formatterBuilderClazz = classLoader.loadClass("com.vladsch.flexmark.formatter.Formatter$Builder");
+			final Object formatterOptions = buildFormatterOptions(
+					classLoader, parserClazz, formatterClazz, dataKeyClazz, dataHolderClazz, parserOptions, parserEmulationProfile);
+			final Object formatterBuilder = formatterClazz.getMethod("builder", dataHolderClazz).invoke(null, formatterOptions);
+			final Object formatter = formatterBuilderClazz.getMethod("build").invoke(formatterBuilder);
+			final Method renderMethod = formatterClazz.getMethod("render", nodeClazz);
+
+			// the input must be parsed by the parser and then rendered by the formatter
+			return input -> (String) renderMethod.invoke(formatter, parseMethod.invoke(parser, input));
+		}
+
+		private Object buildParserOptions(
+				ClassLoader classLoader,
+				Class<?> parserClazz,
+				Class<?> dataHolderClazz,
+				Class<?> dataKeyClazz,
+				Object parserEmulationProfile) throws Exception {
+			final Class<?> pegdownOptionsAdapterClazz = classLoader.loadClass("com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter");
+			final Class<?> pegdownExtensionsClazz = classLoader.loadClass("com.vladsch.flexmark.parser.PegdownExtensions");
+			final Class<?> extensionClazz = classLoader.loadClass("com.vladsch.flexmark.util.misc.Extension");
+			final Class<?> mutableDataHolderClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.MutableDataHolder");
+
+			final int pegDownExtensionsConstantAll = pegdownExtensionsClazz.getField("ALL").getInt(null);
+			final Object extensions = Array.newInstance(extensionClazz, 0);
+			final Class<?> extensionArrayClazz = extensions.getClass();
+
+			final Object parserOptions = pegdownOptionsAdapterClazz
+					.getMethod("flexmarkOptions", Integer.TYPE, extensionArrayClazz)
+					.invoke(null, pegDownExtensionsConstantAll, extensions);
+			final Object mutableParserOptions = dataHolderClazz.getMethod("toMutable").invoke(parserOptions);
+			final Object parserEmulationProfileKey = parserClazz.getField("PARSER_EMULATION_PROFILE").get(null);
+			final Method mutableDataHolderSetMethod = mutableDataHolderClazz.getMethod("set", dataKeyClazz, Object.class);
+			mutableDataHolderSetMethod.invoke(mutableParserOptions, parserEmulationProfileKey, parserEmulationProfile);
+			return mutableParserOptions;
+		}
+
+		/**
+		 * Creates the formatter options, copies the parser extensions and changes defaults that make sense for a formatter.
+		 * See: https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter#options
+		 */
+		private Object buildFormatterOptions(
+				ClassLoader classLoader,
+				Class<?> parserClazz,
+				Class<?> formatterClazz,
+				Class<?> dataKeyClazz,
+				Class<?> dataHolderClazz,
+				Object parserOptions,
+				Object parserEmulationProfile) throws Exception {
+			final Class<?> mutableDataSetClazz = classLoader.loadClass("com.vladsch.flexmark.util.data.MutableDataSet");
+			final Object formatterOptions = mutableDataSetClazz.getConstructor().newInstance();
+			final Method mutableDataSetMethodSet = mutableDataSetClazz.getMethod("set", dataKeyClazz, Object.class);
+
+			// copy the parser extensions like the example in https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter
+			final Object parserExtensions = parserClazz.getField("EXTENSIONS").get(null);
+			final Object copiedExtensions = dataKeyClazz.getMethod("get", dataHolderClazz).invoke(parserExtensions, parserOptions);
+			mutableDataSetMethodSet.invoke(formatterOptions, parserExtensions, copiedExtensions);
+
+			// use the same emulation profile for the parser and the formatted, to make sure the step is idempotent
+			final Object formatterEmulationProfile = formatterClazz.getField("FORMATTER_EMULATION_PROFILE").get(null);
+			mutableDataSetMethodSet.invoke(formatterOptions, formatterEmulationProfile, parserEmulationProfile);
+
+			return formatterOptions;
+		}
+
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
@@ -54,6 +54,7 @@ public class FlexmarkStep {
 	private static class State implements Serializable {
 		private static final long serialVersionUID = 1L;
 
+		/** The jar that contains the formatter. */
 		final JarState jarState;
 
 		State(JarState jarState) {

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
@@ -65,7 +65,7 @@ public class FreshMarkStep {
 	private static class State implements Serializable {
 		private static final long serialVersionUID = 1L;
 
-		/** The jar that contains the eclipse formatter. */
+		/** The jar that contains the formatter. */
 		final JarState jarState;
 		final NavigableMap<String, ?> properties;
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for Markdown with `flexmark` at `0.62.2` ([#1011](https://github.com/diffplug/spotless/pull/1011)).
 
 ## [2.17.7] - 2021-12-16
 ### Fixed

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -594,6 +594,7 @@ All configuration settings are optional, they are described in detail [here](htt
 <configuration>
   <markdown>
     <!-- These are the defaults, you can override if you want -->
+    <!-- Multi-module users should consider not including **/*.md in modules that contain submodules to make sure files are not formatted multiple times -->
     <includes>
       <include>*.md</include>
       <include>**/*.md</include>

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -593,10 +593,7 @@ All configuration settings are optional, they are described in detail [here](htt
 ```xml
 <configuration>
   <markdown>
-    <!-- These are the defaults, you can override if you want -->
-    <!-- Multi-module users should consider not including **/*.md in modules that contain submodules to make sure files are not formatted multiple times -->
-    <includes>
-      <include>*.md</include>
+    <includes> <!-- You have to set the target manually -->
       <include>**/*.md</include>
     </includes>
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -56,6 +56,7 @@ user@machine repo % mvn spotless:check
   - [Antlr4](#antlr4) ([antlr4formatter](#antlr4formatter))
   - [Sql](#sql) ([dbeaver](#dbeaver))
   - [Maven Pom](#maven-pom) ([sortPom](#sortpom))
+  - [Markdown](#markdown) ([flexmark](#flexmark))
   - [Typescript](#typescript) ([tsfmt](#tsfmt), [prettier](#prettier))
   - Multiple languages
     - [Prettier](#prettier) ([plugins](#prettier-plugins), [npm detection](#npm-detection), [`.npmrc` detection](#npmrc-detection))
@@ -584,6 +585,30 @@ All configuration settings are optional, they are described in detail [here](htt
   <sortExecutions>false</sortExecutions> <!-- Sort plugin executions -->
 </sortPom>
 ```
+
+## Markdown
+
+[code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java). [available steps](https://github.com/diffplug/spotless/tree/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown).
+
+```xml
+<configuration>
+  <markdown>
+    <!-- These are the defaults, you can override if you want -->
+    <includes>
+      <include>*.md</include>
+      <include>**/*.md</include>
+    </includes>
+
+    <flexmark/> <!-- has its own section below -->
+  </markdown>
+</configuration>
+```
+
+### Flexmark
+
+[homepage](https://github.com/vsch/flexmark-java). [code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Flexmark.java). Flexmark is a flexible Commonmark/Markdown parser that can be used to format Markdown files. It supports different [flavors of Markdown](https://github.com/vsch/flexmark-java#markdown-processor-emulation) and [many formatting options](https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter#options).
+
+Currently, none of the available options can be configured yet. It uses only the default options together with `COMMONMARK` as `FORMATTER_EMULATION_PROFILE`.
 
 <a name="applying-to-typescript-source"></a>
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -56,6 +56,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
 import com.diffplug.spotless.maven.groovy.Groovy;
 import com.diffplug.spotless.maven.java.Java;
 import com.diffplug.spotless.maven.kotlin.Kotlin;
+import com.diffplug.spotless.maven.markdown.Markdown;
 import com.diffplug.spotless.maven.pom.Pom;
 import com.diffplug.spotless.maven.python.Python;
 import com.diffplug.spotless.maven.scala.Scala;
@@ -140,6 +141,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	@Parameter
 	private Python python;
+
+	@Parameter
+	private Markdown markdown;
 
 	@Parameter(property = "spotlessFiles")
 	private String filePatterns;
@@ -290,7 +294,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private List<FormatterFactory> getFormatterFactories() {
-		return Stream.concat(formats.stream(), Stream.of(groovy, java, scala, kotlin, cpp, typescript, antlr4, pom, sql, python))
+		return Stream.concat(formats.stream(), Stream.of(groovy, java, scala, kotlin, cpp, typescript, antlr4, pom, sql, python, markdown))
 				.filter(Objects::nonNull)
 				.collect(toList());
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -264,7 +264,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		Set<String> configuredIncludes = formatterFactory.includes();
 		Set<String> includes = configuredIncludes.isEmpty() ? formatterFactory.defaultIncludes() : configuredIncludes;
 		if (includes.isEmpty()) {
-			throw new MojoExecutionException("You must specify some files to include, such as '<includes><include>src/**</include></includes>'");
+			throw new MojoExecutionException("You must specify some files to include, such as '<includes><include>src/**/*.blah</include></includes>'");
 		}
 		return includes;
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Flexmark.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Flexmark.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.markdown;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.markdown.FlexmarkStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+
+public class Flexmark implements FormatterStepFactory {
+
+	@Parameter
+	private String version;
+
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig config) {
+		String version = this.version != null ? this.version : FlexmarkStep.defaultVersion();
+		return FlexmarkStep.create(version, config.getProvisioner());
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
@@ -15,9 +15,9 @@
  */
 package com.diffplug.spotless.maven.markdown;
 
+import java.util.Collections;
 import java.util.Set;
 
-import com.diffplug.common.collect.ImmutableSet;
 import com.diffplug.spotless.maven.FormatterFactory;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
 
@@ -30,7 +30,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
 public class Markdown extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes() {
-		return ImmutableSet.of("*.md", "**/*.md");
+		return Collections.emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.markdown;
+
+import java.util.Set;
+
+import com.diffplug.common.collect.ImmutableSet;
+import com.diffplug.spotless.maven.FormatterFactory;
+import com.diffplug.spotless.maven.generic.LicenseHeader;
+
+/**
+ * A {@link FormatterFactory} implementation that corresponds to {@code <markdown>...</markdown>} configuration element.
+ * <p>
+ * It defines a formatter for Markdown files that can execute both language agnostic (e.g. {@link LicenseHeader})
+ * and markdown-specific (e.g. {@link Flexmark}) steps.
+ */
+public class Markdown extends FormatterFactory {
+	@Override
+	public Set<String> defaultIncludes() {
+		return ImmutableSet.of("*.md", "**/*.md");
+	}
+
+	@Override
+	public String licenseHeaderDelimiter() {
+		return null;
+	}
+
+	public void addFlexmark(Flexmark flexmark) {
+		addStepFactory(flexmark);
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -138,6 +138,10 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		writePom(groupWithSteps("pom", including("pom_test.xml"), steps));
 	}
 
+	protected void writePomWithMarkdownSteps(String... steps) throws IOException {
+		writePom(groupWithSteps("markdown", steps));
+	}
+
 	protected void writePom(String... configuration) throws IOException {
 		writePom(null, configuration);
 	}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -140,7 +140,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	}
 
 	protected void writePomWithMarkdownSteps(String... steps) throws IOException {
-		writePom(groupWithSteps("markdown", steps));
+		writePom(groupWithSteps("markdown", including("**/*.md"), steps));
 	}
 
 	protected void writePom(String... configuration) throws IOException {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/markdown/FlexmarkMavenTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/markdown/FlexmarkMavenTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.markdown;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+public class FlexmarkMavenTest extends MavenIntegrationHarness {
+
+	@Test
+	public void testFlexmarkWithDefaultConfig() throws Exception {
+		writePomWithMarkdownSteps("<flexmark />");
+
+		setFile("markdown_test.md").toResource("markdown/flexmark/FlexmarkUnformatted.md");
+		mavenRunner().withArguments("spotless:apply").runNoError().error();
+		assertFile("markdown_test.md").sameAsResource("markdown/flexmark/FlexmarkFormatted.md");
+	}
+
+}

--- a/testlib/src/main/resources/markdown/flexmark/FlexmarkFormatted.md
+++ b/testlib/src/main/resources/markdown/flexmark/FlexmarkFormatted.md
@@ -1,0 +1,64 @@
+# Heading
+
+-----
+
+paragraph text
+lazy continuation
+also note the empty line at the start of this file
+
+another paragraph, but this time it has many characters. So many in fact that it reaches over two hundred individual characters on just this one single line. Isn't that amazing? I'm also amazed that you're still reading this. High five!
+
+* list item
+- changed list item marker
+- with a space in front
+* back to the other list item marker
+
+> block quote
+> keeps going
+> lazy continuation
+
+```
+code block
+    with uneven indent
+       with uneven indent
+ indented code
+```
+
+~~~info
+  with uneven indent
+     with uneven indent
+indented code
+~~~
+
+with uneven indent
+with uneven indent
+indented text
+
+1. numbered item 1
+2. numbered item 2
+   1. numbered sub-item 1
+   2. numbered sub-item 2
+   3. numbered sub-item 3
+3. numbered item 3
+
+- bullet item 1
+- bullet item 2
+- bullet item 3
+
+1. numbered item 1
+2. numbered item 2
+3. numbered item 3
+   - bullet item 1
+   - bullet item 2
+   - bullet item 3
+     1. numbered sub-item 1
+     2. numbered sub-item 2
+     3. numbered sub-item 3
+
+## HEADER_CONNECTED_TO_HASH
+
+1 empty line between header and start of paragraph
+
+## HEADER WITH SPACES
+
+2 empty lines between header and start of paragraph

--- a/testlib/src/main/resources/markdown/flexmark/FlexmarkUnformatted.md
+++ b/testlib/src/main/resources/markdown/flexmark/FlexmarkUnformatted.md
@@ -1,0 +1,64 @@
+
+#Heading
+-----
+paragraph text
+lazy continuation
+also note the empty line at the start of this file
+
+another paragraph, but this time it has many characters. So many in fact that it reaches over two hundred individual characters on just this one single line. Isn't that amazing? I'm also amazed that you're still reading this. High five!
+
+* list item
+- changed list item marker
+-  with a space in front
+* back to the other list item marker
+
+> block quote
+> keeps going
+lazy continuation
+
+```
+code block
+    with uneven indent
+       with uneven indent
+ indented code
+```
+
+~~~info
+  with uneven indent
+     with uneven indent
+indented code
+~~~
+
+  with uneven indent
+     with uneven indent
+indented text
+
+1. numbered item 1
+1. numbered item 2
+    1. numbered sub-item 1
+    1. numbered sub-item 2
+    1. numbered sub-item 3
+1. numbered item 3
+
+- bullet item 1
+- bullet item 2
+- bullet item 3
+
+1. numbered item 1
+1. numbered item 2
+1. numbered item 3
+    - bullet item 1
+    - bullet item 2
+    - bullet item 3
+        1. numbered sub-item 1
+        1. numbered sub-item 2
+        1. numbered sub-item 3
+
+##HEADER_CONNECTED_TO_HASH
+
+1 empty line between header and start of paragraph
+
+## HEADER WITH SPACES
+
+
+2 empty lines between header and start of paragraph

--- a/testlib/src/test/java/com/diffplug/spotless/markdown/FlexmarkStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/markdown/FlexmarkStepTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.markdown;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.TestProvisioner;
+
+class FlexmarkStepTest {
+
+	@Test
+	void behavior() throws Exception {
+		StepHarness.forStep(FlexmarkStep.create(TestProvisioner.mavenCentral()))
+				.testResource(
+						"markdown/flexmark/FlexmarkUnformatted.md",
+						"markdown/flexmark/FlexmarkFormatted.md");
+	}
+}


### PR DESCRIPTION
This adds support for native formatting of markdown files, and enables it in Spotless for Maven.

## Why?
So far, spotless only supported markdown formatting using the general formatting rules and through the use of prettier. However, the general formatting rules can only do so much. In addition, prettier requires npm and nodejs, which can be an unwanted dependency for maven users. By natively supporting markdown formatting, maven users can now avoid the npm/nodejs requirement, while having the benefit of comprehensive markdown formatting.

## How?
This native support comes through the use of [flexmark-java](https://github.com/vsch/flexmark-java). A fork of commonmark-java that made it possible to parse many flavors of markdown into an AST and render it in some way. Among those renderers, there is the option to format to markdown. This renderer (or formatter) supports [many formatting options](https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter#options). I've selected a few reasonable ones to get started, but they are not configurable yet.

This changeset adds a basic usage of [flexmark-java as Markdown formatter](https://github.com/vsch/flexmark-java/wiki/Markdown-Formatter). It adds a new `<markdown>` tag to the spotless maven plugin configuration, and subsequently adds a new `<flexmark>` tag a level deeper. Like all formatters it directly supports the default configurations (e.g. `includes`).

## Usage
General usage looks like this:

```xml
<markdown>
  <flexmark />
<markdown>
```

By default it `includes` all `*.md` and `**/*.md` files. 

<!---
## I'd love your opinion on the following
Much of the code added here is simply the plumbing necessary to set up the parser and renderer. Due to spotless' lazy loading, this means a lot of class loading and usage of the reflection api. Although I don't mind it, it doesn't lead to very readable, nor maintainable code. If we want to support configurations for any of the many formatting rules supported by flexmark, we'll need to write more and more of such code. Specifically, because it uses so many library specific constants and enums. 

One idea to circumvent this would be to create a new maven project that can be lazy loaded by spotless. It would implement the usage of `flexmark-java`, so spotless doesn't have to. Something like:
```java
public class MarkdownFormatter {
  public MarkdownFormatter(Map<String, String> properties) { .. }
  public String format(String input) { ... }
}
```

Maybe this doesn't work, but I think it would (perhaps I'm missing something). The only downside to this that I see, is that it adds indirection. This could lead to potential problems with maintenance of that side-project and keeping things up to date with current versions. I'd love to hear what the spotless team thinks about this approach.

EDIT: I've commented this out, because this problem has been resolved by using the compile-only sourceset.
--->

Lastly, my thanks to everyone here. Spotless is a great tool. I've really been enjoying using it so far 🙌 

## Todo
 - [x] add topic to CHANGES.md files
 - [x] add documentation to README.md files

<!--- 
Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
--->