### PR TITLE
Fix bug in Spotless 6.0 related to ktlint bundling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changed
+* Bumped default ktlint from `0.43.0` to `0.43.2`.
 * Converted `ktlint` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
 
 ## [2.20.1] - 2021-12-01

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -37,7 +37,7 @@ public class KtLintStep {
 	// prevent direct instantiation
 	private KtLintStep() {}
 
-	private static final String DEFAULT_VERSION = "0.43.0";
+	private static final String DEFAULT_VERSION = "0.43.2";
 	static final String NAME = "ktlint";
 	static final String PACKAGE_PRE_0_32 = "com.github.shyiko";
 	static final String PACKAGE = "com.pinterest";

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,9 +3,12 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changed
+* Bumped default ktlint from `0.43.0` to `0.43.2`.
+### Fixed
+* Fixed problem with ktlint dependency variants ([#993](https://github.com/diffplug/spotless/issues/993))
 
 ## [6.0.1] - 2021-12-01
-
 ### Changed
 * Added `named` option to `licenseHeader` to support alternate license header within same format (like java) ([872](https://github.com/diffplug/spotless/issues/872)).
 * Added `onlyIfContentMatches` option to `licenseHeader` to skip license header application  based on source file content pattern ([#650](https://github.com/diffplug/spotless/issues/650)).

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Bundling;
 
 import com.diffplug.common.collect.ImmutableList;
 import com.diffplug.spotless.Provisioner;
@@ -76,6 +77,9 @@ class GradleProvisioner {
 						.forEach(config.getDependencies()::add);
 				config.setDescription(mavenCoords.toString());
 				config.setTransitive(withTransitives);
+				config.attributes(attr -> {
+					attr.attribute(Bundling.BUNDLING_ATTRIBUTE, project.getObjects().named(Bundling.class, Bundling.EXTERNAL));
+				});
 				return config.resolve();
 			} catch (Exception e) {
 				String projName = project.getPath().substring(1).replace(':', '/');

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,9 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* Bumped default ktlint from `0.43.0` to `0.43.2`.
 
 ## [2.17.5] - 2021-12-01
-
 ### Changed
 * Bump jgit version ([#992](https://github.com/diffplug/spotless/pull/992)).
   * jgit `5.10.0.202012080955-r` -> `5.13.0.202109080827-r`

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -31,6 +31,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.attributes.Bundling;
 import org.gradle.testfixtures.ProjectBuilder;
 
 import com.diffplug.common.base.Errors;
@@ -68,6 +69,9 @@ public class TestProvisioner {
 			Configuration config = project.getConfigurations().detachedConfiguration(deps);
 			config.setTransitive(withTransitives);
 			config.setDescription(mavenCoords.toString());
+			config.attributes(attr -> {
+				attr.attribute(Bundling.BUNDLING_ATTRIBUTE, project.getObjects().named(Bundling.class, Bundling.EXTERNAL));
+			});
 			try {
 				return config.resolve();
 			} catch (ResolveException e) {

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.spotless.kotlin;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -29,18 +28,15 @@ import com.diffplug.spotless.TestProvisioner;
  * causes these problems. The root is still a gradle bug, but in the meantime we don't
  * need to hold up *every* PR with this: https://github.com/gradle/gradle/issues/11752
  */
-@Disabled
 class KtLintStepTest extends ResourceHarness {
 	@Test
 	void behavior() throws Exception {
-		// Must use jcenter (GONE) because `com.andreapivetta.kolor:kolor:0.0.2` isn't available on mavenCentral.
-		// It is a dependency of ktlint.
 		FormatterStep step = KtLintStep.create(TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
+					assertion.hasMessage("Error on line: 1, column: 2\n" +
 							"Wildcard import");
 				});
 	}


### PR DESCRIPTION
- Bump default ktlint from `0.43.0` -> `0.43.2`
- Fix problem with ktlint dependency variants (#993)