### PR TITLE
Fix conflicts between Spotless and Android re: `clean` task

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Spotless no longer applies `BasePlugin` ([#1014](https://github.com/diffplug/spotless/pull/1014)).
+  * This was done to ensure that any Spotless tasks would run after the `clean` task, but we found a way to do this without applying the `BasePlugin`. This resolves a conflict with the [Android Gradle template](https://issuetracker.google.com/issues/186924459) (fixes [#858](https://github.com/diffplug/spotless/issues/858)).
 
 ## [6.0.2] - 2021-12-05
 ### Changed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -37,8 +37,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.tasks.Delete;
 
 import com.diffplug.common.base.Preconditions;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
@@ -790,11 +788,7 @@ public class FormatExtension {
 		spotlessTask.init(spotless.getRegisterDependenciesTask().getTaskService());
 		setupTask(spotlessTask);
 		// clean removes the SpotlessCache, so we have to run after clean
-		spotless.project.getTasks().withType(Delete.class).configureEach(task -> {
-			if (task.getName().equals(BasePlugin.CLEAN_TASK_NAME)) {
-				spotlessTask.mustRunAfter(task);
-			}
-		});
+		SpotlessPlugin.configureCleanTask(spotless.project, spotlessTask::mustRunAfter);
 		// create the apply task
 		SpotlessApply applyTask = spotless.project.getTasks().create(taskName, SpotlessApply.class);
 		applyTask.init(spotlessTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -75,8 +75,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 			task.init(getRegisterDependenciesTask().getTaskService());
 			task.setEnabled(!isIdeHook);
 		});
-		// clean removes the SpotlessCache, so we have to run after clean
-		SpotlessPlugin.configureCleanTaskMustRunAfter(project, spotlessTask);
+		SpotlessPlugin.taskMustRunAfterClean(project, spotlessTask);
 		project.afterEvaluate(unused -> {
 			spotlessTask.configure(task -> {
 				// now that the task is being configured, we execute our actions
@@ -118,8 +117,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		TaskProvider<SpotlessDiagnoseTask> diagnoseTask = tasks.register(taskName + DIAGNOSE, SpotlessDiagnoseTask.class, task -> {
 			task.source = spotlessTask.get();
 		});
-		// clean removes the SpotlessCache, so we have to run after clean
-		SpotlessPlugin.configureCleanTaskMustRunAfter(project, diagnoseTask);
+		SpotlessPlugin.taskMustRunAfterClean(project, diagnoseTask);
 		rootDiagnoseTask.configure(task -> task.dependsOn(diagnoseTask));
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -17,6 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -47,8 +48,12 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 
 		project.afterEvaluate(unused -> {
 			if (enforceCheck) {
-				project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME)
-						.configure(task -> task.dependsOn(rootCheckTask));
+				try {
+					project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME)
+							.configure(task -> task.dependsOn(rootCheckTask));
+				} catch (ProjectConfigurationException e) {
+					// no action needed, it's okay if there's no `check` task
+				}
 			}
 		});
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -64,15 +65,18 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 	protected void createFormatTasks(String name, FormatExtension formatExtension) {
 		boolean isIdeHook = project.hasProperty(IdeHook.PROPERTY);
 		TaskContainer tasks = project.getTasks();
-		TaskProvider<?> cleanTask = tasks.named(BasePlugin.CLEAN_TASK_NAME);
 
 		// create the SpotlessTask
 		String taskName = EXTENSION + SpotlessPlugin.capitalize(name);
 		TaskProvider<SpotlessTaskImpl> spotlessTask = tasks.register(taskName, SpotlessTaskImpl.class, task -> {
 			task.init(getRegisterDependenciesTask().getTaskService());
 			task.setEnabled(!isIdeHook);
-			// clean removes the SpotlessCache, so we have to run after clean
-			task.mustRunAfter(cleanTask);
+		});
+		// clean removes the SpotlessCache, so we have to run after clean
+		tasks.withType(Delete.class).configureEach(clean -> {
+			if (clean.getName().equals(BasePlugin.CLEAN_TASK_NAME)) {
+				spotlessTask.configure(spotless -> spotless.mustRunAfter(clean));
+			}
 		});
 
 		project.afterEvaluate(unused -> {
@@ -115,7 +119,12 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		// create the diagnose task
 		TaskProvider<SpotlessDiagnoseTask> diagnoseTask = tasks.register(taskName + DIAGNOSE, SpotlessDiagnoseTask.class, task -> {
 			task.source = spotlessTask.get();
-			task.mustRunAfter(cleanTask);
+		});
+		// clean removes the SpotlessCache, so we have to run after clean
+		tasks.withType(Delete.class).configureEach(clean -> {
+			if (clean.getName().equals(BasePlugin.CLEAN_TASK_NAME)) {
+				diagnoseTask.configure(spotless -> spotless.mustRunAfter(clean));
+			}
 		});
 		rootDiagnoseTask.configure(task -> task.dependsOn(diagnoseTask));
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -17,7 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.ProjectConfigurationException;
+import org.gradle.api.UnknownTaskException;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -51,7 +51,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 				try {
 					project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME)
 							.configure(task -> task.dependsOn(rootCheckTask));
-				} catch (ProjectConfigurationException e) {
+				} catch (UnknownTaskException e) {
 					// no action needed, it's okay if there's no `check` task
 				}
 			}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -17,9 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -73,12 +71,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 			task.setEnabled(!isIdeHook);
 		});
 		// clean removes the SpotlessCache, so we have to run after clean
-		tasks.withType(Delete.class).configureEach(clean -> {
-			if (clean.getName().equals(BasePlugin.CLEAN_TASK_NAME)) {
-				spotlessTask.configure(spotless -> spotless.mustRunAfter(clean));
-			}
-		});
-
+		SpotlessPlugin.configureCleanTaskMustRunAfter(project, spotlessTask);
 		project.afterEvaluate(unused -> {
 			spotlessTask.configure(task -> {
 				// now that the task is being configured, we execute our actions
@@ -121,11 +114,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 			task.source = spotlessTask.get();
 		});
 		// clean removes the SpotlessCache, so we have to run after clean
-		tasks.withType(Delete.class).configureEach(clean -> {
-			if (clean.getName().equals(BasePlugin.CLEAN_TASK_NAME)) {
-				diagnoseTask.configure(spotless -> spotless.mustRunAfter(clean));
-			}
-		});
+		SpotlessPlugin.configureCleanTaskMustRunAfter(project, diagnoseTask);
 		rootDiagnoseTask.configure(task -> task.dependsOn(diagnoseTask));
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -61,7 +61,8 @@ public class SpotlessPlugin implements Plugin<Project> {
 		});
 	}
 
-	static void configureCleanTaskMustRunAfter(Project project, TaskProvider<?> task) {
+	/** clean removes the SpotlessCache, so we have to run after clean. */
+	static void taskMustRunAfterClean(Project project, TaskProvider<?> task) {
 		configureCleanTask(project, clean -> task.configure(spotless -> spotless.mustRunAfter(clean)));
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -63,7 +63,7 @@ public class SpotlessPlugin implements Plugin<Project> {
 
 	/** clean removes the SpotlessCache, so we have to run after clean. */
 	static void taskMustRunAfterClean(Project project, TaskProvider<?> task) {
-		configureCleanTask(project, clean -> task.configure(spotless -> spotless.mustRunAfter(clean)));
+		configureCleanTask(project, clean -> task.get().mustRunAfter(clean));
 	}
 
 	static String capitalize(String input) {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
@@ -64,11 +64,11 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"    }",
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
-		BuildResult spotlessCheckFailsGracefully = gradleRunner().withArguments("--stacktrace", "clean", "spotlessCheck").buildAndFail();
+		BuildResult spotlessCheckFailsGracefully = gradleRunner().withArguments("--stacktrace", "spotlessCheck").buildAndFail();
 		Assertions.assertThat(spotlessCheckFailsGracefully.getOutput()).contains("> The following files had format violations:");
 
-		gradleRunner().withArguments("--stacktrace", "clean", "spotlessApply").build();
-		gradleRunner().withArguments("--stacktrace", "clean", "spotlessCheck").build();
+		gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+		gradleRunner().withArguments("--stacktrace", "spotlessCheck").build();
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.kotlin;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -42,6 +43,7 @@ class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@Disabled
 	void worksShyiko() throws Exception {
 		// Must use jcenter (GONE) because `com.andreapivetta.kolor:kolor:0.0.2` isn't available on mavenCentral.
 		// It is a dependency of ktlint.


### PR DESCRIPTION
Spotless eagerly applies `BasePlugin` for the purpose of creating the `clean` task. This causes a problem for users who define their own `clean` task, which the Android template recommends.

Now we don't have to anymore, because we find it lazily (and [without triggering configuration](https://github.com/diffplug/spotless/blob/581215b965f7116b91a930e93d5d9d6ef7990f60/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java#L56-L62)) like so:

https://github.com/diffplug/spotless/blob/581215b965f7116b91a930e93d5d9d6ef7990f60/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java#L56-L62