### PR TITLE
Use static concurrent cache for dedupe.

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Fixed
+* Fixed concurrency issue with deduping of tool provisioners
+
 ## [6.0.2] - 2021-12-05
 ### Changed
 * Bumped default ktlint from `0.43.0` to `0.43.2`.

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -17,7 +17,6 @@ package com.diffplug.gradle.spotless;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -53,7 +52,7 @@ class GradleProvisioner {
 		public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates) {
 			Request req = new Request(withTransitives, mavenCoordinates);
 			return cache.computeIfAbsent(
-				req, r -> forProject(project).provisionWithTransitives(r.withTransitives, r.mavenCoords));
+					req, r -> forProject(project).provisionWithTransitives(r.withTransitives, r.mavenCoords));
 		}
 	}
 


### PR DESCRIPTION
- [X] a summary of the change
- either
    - [X] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

I first tried changing the Map to concurrent but it didn't fix the issue, making it static did though. If making it static has potential issues, an alternative might be something like attaching the provisioner to `Project` in `newDedupingProvisioner` to reference to dedupe the deduper itself, which was probably the root problem. I have left the map as concurrent though since I don't think Gradle's threading model is clear enough to safely use a non-concurrent one here.

I have run my build with a local snapshot and could confirm it passes with this change.

Fixes #1015 
