### PR TITLE
Fix spotbugs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,15 @@ anchors:
           path: lib-extra/build/test-results/test
       - store_test_results:
           path: plugin-gradle/build/test-results/test
+      - store_artifacts:
+          path: lib/build/spotbugs
+      - store_artifacts:
+          path: lib-extra/build/spotbugs
+      - store_artifacts:
+          path: testlib/build/spotbugs
+      - store_artifacts:
+          path: plugin-gradle/build/spotbugs
+
 jobs:
   # gradlew spotlessCheck assemble testClasses
   assemble_testClasses:
@@ -108,22 +117,14 @@ jobs:
       - store_test_results:
           path: plugin-gradle/build/test-results/NpmTest
       - run:
-          name: gradlew check
-          command: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew check --build-cache
+          name: gradlew test
+          command: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew test --build-cache
       - store_test_results:
           path: testlib/build/test-results/test
       - store_test_results:
           path: lib-extra/build/test-results/test
       - store_test_results:
           path: plugin-gradle/build/test-results/test
-      - store_artifacts:
-          path: lib/build/spotbugs
-      - store_artifacts:
-          path: lib-extra/build/spotbugs
-      - store_artifacts:
-          path: testlib/build/spotbugs
-      - store_artifacts:
-          path: plugin-gradle/build/spotbugs
   test_windows:
     executor:
       name: win/default

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ artifactIdGradle=spotless-plugin-gradle
 
 # Build requirements
 VER_JAVA=1.8
-VER_SPOTBUGS=4.0.2
+VER_SPOTBUGS=4.5.0
 
 # Dependencies provided by Spotless plugin
 VER_SLF4J=[1.6,2.0[

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -19,7 +19,8 @@ spotbugs {
 	ignoreFailures = false 	// bug free or it doesn't ship!
 	reportsDir = file('build/spotbugs')
 	reportLevel = 'medium'	// low|medium|high (low = sensitive to even minor mistakes)
-	omitVisitors = []		// bugs that we want to ignore
+	omitVisitors = [
+		'FindReturnRef'] // https://spotbugs.readthedocs.io/en/latest/detectors.html#findreturnref
 }
 tasks.named('spotbugsTest') {
 	enabled = false

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -26,7 +26,7 @@ tasks.named('spotbugsTest') {
 }
 tasks.named('spotbugsMain') {
 	// only run on Java 8 (no benefit to running twice)
-	enabled = org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8
+	enabled = org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_11
 	reports {
 		html.enabled = true
 	}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -169,7 +169,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 
 	protected abstract @Nullable Project getParent(Project project);
 
-	private static @Nullable Repository traverseParentsUntil(File startWith, File file) throws IOException {
+	private static @Nullable Repository traverseParentsUntil(File startWith, @Nullable File file) throws IOException {
 		while (startWith != null && !Objects.equals(startWith, file)) {
 			if (isGitRoot(startWith)) {
 				return createRepo(startWith);

--- a/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public final class FormatterProperties {
 		try {
 			Properties newSettings = FileParser.parse(settingsFile);
 			properties.putAll(newSettings);
-		} catch (IOException | IllegalArgumentException | NullPointerException exception) {
+		} catch (IOException | IllegalArgumentException exception) {
 			String message = String.format("Failed to add properties from '%s' to formatter settings.", settingsFile);
 			String detailedMessage = exception.getMessage();
 			if (null != detailedMessage) {

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 /**
  * Models the result of applying a {@link Formatter} on a given {@link File}
  * while characterizing various failure modes (slow convergence, cycles, and divergence).
@@ -240,9 +242,10 @@ public final class PaddedCell {
 	 *   then you can call {@link #writeCanonicalTo(OutputStream)} to get the canonical form of the given file.
 	 */
 	public static class DirtyState {
+		@Nullable
 		private final byte[] canonicalBytes;
 
-		private DirtyState(byte[] canonicalBytes) {
+		private DirtyState(@Nullable byte[] canonicalBytes) {
 			this.canonicalBytes = canonicalBytes;
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -61,7 +61,7 @@ public final class LicenseHeaderStep {
 	final String yearSeparator;
 	final Supplier<YearMode> yearMode;
 
-	private LicenseHeaderStep(String name, String contentPattern, ThrowingEx.Supplier<String> headerLazy, String delimiter, String yearSeparator, Supplier<YearMode> yearMode) {
+	private LicenseHeaderStep(@Nullable String name, @Nullable String contentPattern, ThrowingEx.Supplier<String> headerLazy, String delimiter, String yearSeparator, Supplier<YearMode> yearMode) {
 		this.name = sanitizeName(name);
 		this.contentPattern = sanitizeContentPattern(contentPattern);
 		this.headerLazy = Objects.requireNonNull(headerLazy);
@@ -141,7 +141,7 @@ public final class LicenseHeaderStep {
 		return formatterStep.filterByContentPattern(contentPattern);
 	}
 
-	private String sanitizeName(String name) {
+	private String sanitizeName(@Nullable String name) {
 		if (name == null) {
 			return DEFAULT_NAME_PREFIX;
 		}
@@ -156,7 +156,7 @@ public final class LicenseHeaderStep {
 	}
 
 	@Nullable
-	private String sanitizeContentPattern(String contentPattern) {
+	private String sanitizeContentPattern(@Nullable String contentPattern) {
 		if (contentPattern == null) {
 			return contentPattern;
 		}

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -35,6 +35,8 @@ import java.util.stream.Stream;
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public final class ImportOrderStep {
 	private static final boolean WILDCARDS_LAST_DEFAULT = false;
 
@@ -77,6 +79,7 @@ public final class ImportOrderStep {
 				State::toFormatter);
 	}
 
+	@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // workaround https://github.com/spotbugs/spotbugs/issues/756
 	private static List<String> getImportOrder(File importsFile) {
 		try (Stream<String> lines = Files.lines(importsFile.toPath())) {
 			return lines.filter(line -> !line.startsWith("#"))

--- a/lib/src/main/java/com/diffplug/spotless/npm/SimpleRestClient.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/SimpleRestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 class SimpleRestClient {
 	private final String baseUrl;
@@ -49,7 +50,7 @@ class SimpleRestClient {
 		return postJson(endpoint, (String) null);
 	}
 
-	String postJson(String endpoint, String rawJson) throws SimpleRestException {
+	String postJson(String endpoint, @Nullable String rawJson) throws SimpleRestException {
 		try {
 			URL url = new URL(this.baseUrl + endpoint);
 			HttpURLConnection con = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
- Move the spotbugs check out of `test_npm_8` and into `test_nomaven_11` because `test_npm_8` is failing repeatedly on CI due to resource exhaustion.
- Our old version of Spotbugs had some Java 11 bugs, update to latest Spotbugs 4.5.0
- Fix the warnings that the new Spotbugs finds