### PR TITLE
Large parallel builds could throw `ConcurrentModificationException`, now fixed

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 * Spotless no longer applies `BasePlugin` ([#1014](https://github.com/diffplug/spotless/pull/1014)).
   * This was done to ensure that any Spotless tasks would run after the `clean` task, but we found a way to do this without applying the `BasePlugin`. This resolves a conflict with the [Android Gradle template](https://issuetracker.google.com/issues/186924459) (fixes [#858](https://github.com/diffplug/spotless/issues/858)).
+* Large parallel builds could throw `ConcurrentModificationException` (masked by "Cannot add a configuration with name"), now fixed. ([#1015](https://github.com/diffplug/spotless/issues/1015))
 
 ## [6.0.2] - 2021-12-05
 ### Changed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -757,6 +757,16 @@ public class FormatExtension {
 		} else {
 			steps = this.steps;
 		}
+		// <IMPORTANT>
+		// By calling .hashCode, we are triggering all steps to evaluate their state,
+		// which triggers dependency resolution. It's important to do that here, because
+		// otherwise it won't happen until Gradle starts checking for task up-to-date-ness.
+		// For a large parallel build, the task up-to-dateness might get called on a different
+		// thread than the thread where task configuration happens, which will trigger a
+		// java.util.ConcurrentModificationException
+		// See https://github.com/diffplug/spotless/issues/1015 for details.
+		steps.hashCode();
+		// </IMPORTANT>
 		task.setSteps(steps);
 		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> totalTarget));
 		spotless.getRegisterDependenciesTask().hookSubprojectTask(task);


### PR DESCRIPTION
Fixes #1015.