### PR TITLE
New API: SpotlessExtension.applyFile(File)

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Add new API `SpotlessExtension.applyFile(File)`, which Gradle build code can use to run Spotless on a single file using the project's Spotless configuration. ([#1035](https://github.com/diffplug/spotless/pull/1035))
 
 ## [6.0.4] - 2021-12-07
 ### Fixed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FileApplier.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FileApplier.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import com.diffplug.common.base.Errors;
+import com.diffplug.spotless.Formatter;
+import com.diffplug.spotless.PaddedCell;
+
+/**
+ * Runs the equivalent of {@code spotlessApply} on a single file.
+ *
+ * This is used to implement both the {@link IdeHook} and also the {@link SpotlessExtension#applyFile(File)} API.
+ */
+class FileApplier {
+	/** Attempt to run the given Spotless task on the given file. */
+	SpotlessApplyResult applyFile(SpotlessTaskImpl spotlessTask, File file) {
+		if (!file.isAbsolute())
+			throw new IllegalArgumentException("File must be an absolute path: " + file);
+		if (!spotlessTask.getTarget().contains(file))
+			return SpotlessApplyResult.OUT_OF_BOUNDS;
+		try (Formatter formatter = spotlessTask.buildFormatter()) {
+			if (spotlessTask.getRatchet() != null) {
+				if (spotlessTask.getRatchet().isClean(spotlessTask.getProjectDir().get().getAsFile(), spotlessTask.getRootTreeSha(), file)) {
+					onResult(SpotlessApplyResult.CLEAN);
+					return SpotlessApplyResult.CLEAN;
+				}
+			}
+			byte[] bytes = read(spotlessTask, file);
+			PaddedCell.DirtyState dirty = PaddedCell.calculateDirtyState(formatter, file, bytes);
+			if (dirty.isClean()) {
+				onResult(SpotlessApplyResult.CLEAN);
+				return SpotlessApplyResult.CLEAN;
+			} else if (dirty.didNotConverge()) {
+				onResult(SpotlessApplyResult.DID_NOT_CONVERGE);
+				return SpotlessApplyResult.DID_NOT_CONVERGE;
+			} else {
+				onResult(SpotlessApplyResult.DIRTY);
+				writeCanonical(spotlessTask, dirty, file);
+				return SpotlessApplyResult.DIRTY;
+			}
+		} catch (IOException e) {
+			onException(e);
+			throw Errors.asRuntime(e);
+		} finally {
+			onFinished();
+		}
+	}
+
+	/** Read contents of file. Provided so {@code IdeHook} can override this to read from standard input instead. */
+	protected byte[] read(SpotlessTaskImpl spotlessTask, File file) throws IOException {
+		return Files.readAllBytes(file.toPath());
+	}
+
+	/** Write contents of file. Provided so {@code IdeHook} can override this to write to standard output instead. */
+	protected void writeCanonical(SpotlessTaskImpl spotlessTask, PaddedCell.DirtyState dirty, File file) throws IOException {
+		dirty.writeCanonicalTo(file);
+	}
+
+	/** {@code IdeHook} overrides this to display status messages the IDE is expecting. */
+	protected void onResult(SpotlessApplyResult result) {}
+
+	/** {@code IdeHook} overrides this to ensure IDE is sent exception back trace. */
+	protected void onException(Exception e) {}
+
+	/** {@code IdeHook} overrides this to ensure standard input/output are closed at end of processing. */
+	protected void onFinished() {}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApplyResult.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApplyResult.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.File;
+
+/**
+ * Result codes for {@link SpotlessExtension#applyFile(File)} API.
+ */
+public enum SpotlessApplyResult {
+	/** Spotless was not configured to process this file. */
+	OUT_OF_BOUNDS,
+	/** File was clean (had correct formatting from the start). */
+	CLEAN,
+	/** Formatting of file failed to converge. */
+	DID_NOT_CONVERGE,
+	/** File was dirty (has been overwritten with formatted version) */
+	DIRTY
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -17,6 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -231,4 +232,7 @@ public abstract class SpotlessExtension {
 	}
 
 	protected abstract void createFormatTasks(String name, FormatExtension formatExtension);
+
+	/** Equivalent to running {@code spotlessApply} on the given file. */
+	public abstract SpotlessApplyResult applyFile(File file);
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.gradle.spotless;
 
+import java.io.File;
+
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.UnknownTaskException;
@@ -133,5 +135,16 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		});
 		SpotlessPlugin.taskMustRunAfterClean(project, diagnoseTask);
 		rootDiagnoseTask.configure(task -> task.dependsOn(diagnoseTask));
+	}
+
+	@Override
+	public SpotlessApplyResult applyFile(File file) {
+		TaskContainer tasks = project.getTasks();
+		for (SpotlessTaskImpl task : tasks.withType(SpotlessTaskImpl.class)) {
+			SpotlessApplyResult result = new FileApplier().applyFile(task, file);
+			if (result != SpotlessApplyResult.OUT_OF_BOUNDS)
+				return result;
+		}
+		return SpotlessApplyResult.OUT_OF_BOUNDS;
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ApplyFileTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ApplyFileTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016-2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+
+import org.assertj.core.api.Assertions;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.common.base.StringPrinter;
+import com.diffplug.common.io.Files;
+
+class ApplyFileTest extends GradleIntegrationHarness {
+	private String output, error;
+	private File dirty, clean, diverge, outOfBounds;
+
+	@BeforeEach
+	void before() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"  id 'com.diffplug.spotless'",
+				"}",
+				"spotless {",
+				"  format 'misc', {",
+				"    target 'DIRTY.md', 'CLEAN.md'",
+				"    custom 'lowercase', { str -> str.toLowerCase(Locale.ROOT) }",
+				"  }",
+				"  format 'diverge', {",
+				"    target 'DIVERGE.md'",
+				"    custom 'diverge', { str -> str + ' ' }",
+				"  }",
+				"}",
+				"import com.diffplug.gradle.spotless.SpotlessApplyResult",
+				"task customTask {",
+				"  doLast {",
+				"    SpotlessApplyResult result = spotless.applyFile(new File(project.properties.customTaskFile))",
+				"    System.err << result",
+				"  }",
+				"}");
+		dirty = new File(rootFolder(), "DIRTY.md");
+		Files.write("ABC".getBytes(StandardCharsets.UTF_8), dirty);
+		clean = new File(rootFolder(), "CLEAN.md");
+		Files.write("abc".getBytes(StandardCharsets.UTF_8), clean);
+		diverge = new File(rootFolder(), "DIVERGE.md");
+		Files.write("ABC".getBytes(StandardCharsets.UTF_8), diverge);
+		outOfBounds = new File(rootFolder(), "OUT_OF_BOUNDS.md");
+		Files.write("ABC".getBytes(StandardCharsets.UTF_8), outOfBounds);
+	}
+
+	private void runWith(String... arguments) throws IOException {
+		runWith(GradleRunner::build, arguments);
+	}
+
+	private void runToFail(String... arguments) throws IOException {
+		runWith(GradleRunner::buildAndFail, arguments);
+	}
+
+	private void runWith(Consumer<GradleRunner> runner, String... arguments) throws IOException {
+		StringBuilder output = new StringBuilder();
+		StringBuilder error = new StringBuilder();
+		try (Writer outputWriter = new StringPrinter(output::append).toWriter();
+				Writer errorWriter = new StringPrinter(error::append).toWriter()) {
+			runner.accept(
+					gradleRunner()
+							.withArguments(arguments)
+							.forwardStdOutput(outputWriter)
+							.forwardStdError(errorWriter));
+		} finally {
+			this.output = output.toString();
+			this.error = error.toString();
+		}
+	}
+
+	@Test
+	void dirty() throws IOException {
+		runWith("customTask", "--quiet", "-PcustomTaskFile=" + dirty.getAbsolutePath());
+		Assertions.assertThat(output).isEmpty();
+		Assertions.assertThat(error).isEqualTo(SpotlessApplyResult.DIRTY.name());
+		Assertions.assertThat(Files.toString(dirty, StandardCharsets.UTF_8)).isEqualTo("abc");
+	}
+
+	@Test
+	void clean() throws IOException {
+		runWith("customTask", "--quiet", "-PcustomTaskFile=" + clean.getAbsolutePath());
+		Assertions.assertThat(output).isEmpty();
+		Assertions.assertThat(error).isEqualTo(SpotlessApplyResult.CLEAN.name());
+	}
+
+	@Test
+	void diverge() throws IOException {
+		runWith("customTask", "--quiet", "-PcustomTaskFile=" + diverge.getAbsolutePath());
+		Assertions.assertThat(output).isEmpty();
+		Assertions.assertThat(error).isEqualTo(SpotlessApplyResult.DID_NOT_CONVERGE.name());
+	}
+
+	@Test
+	void outOfBounds() throws IOException {
+		runWith("customTask", "--quiet", "-PcustomTaskFile=" + outOfBounds.getAbsolutePath());
+		Assertions.assertThat(output).isEmpty();
+		Assertions.assertThat(error).isEqualTo(SpotlessApplyResult.OUT_OF_BOUNDS.name());
+	}
+
+	@Test
+	void notAbsolute() throws IOException {
+		runToFail("customTask", "--quiet", "--stacktrace", "-PcustomTaskFile=build.gradle");
+		Assertions.assertThat(output).isEmpty();
+		Assertions.assertThat(error).contains("java.lang.IllegalArgumentException: File must be an absolute path: build.gradle");
+	}
+}


### PR DESCRIPTION
Adds a new API which Groovy code running inside a Gradle build can invoke to run spotlessApply on a single file using that build's Spotless configuration.

Addresses feature request #1033

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
