### PR TITLE
Add support for predeclared dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,14 @@ jobs:
       - *restore_cache_wrapper
       - *restore_cache_deps
       - run:
-          name: gradlew npmTest
-          command: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew npmTest --build-cache
+          name: gradlew testNpm
+          command: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew testNpm --build-cache
       - store_test_results:
-          path: testlib/build/test-results/NpmTest
+          path: testlib/build/test-results/testNpm
       - store_test_results:
-          path: plugin-maven/build/test-results/NpmTest
+          path: plugin-maven/build/test-results/testNpm
       - store_test_results:
-          path: plugin-gradle/build/test-results/NpmTest
+          path: plugin-gradle/build/test-results/testNpm
       - run:
           name: gradlew test
           command: export SPOTLESS_EXCLUDE_MAVEN=true && ./gradlew test --build-cache
@@ -141,12 +141,12 @@ jobs:
       - store_test_results:
           path: plugin-gradle/build/test-results/test
       - run:
-          name: gradlew npmTest
-          command: gradlew npmTest --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
+          name: gradlew testNpm
+          command: gradlew testNpm --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
       - store_test_results:
-          path: testlib/build/test-results/NpmTest
+          path: testlib/build/test-results/testNpm
       - store_test_results:
-          path: plugin-gradle/build/test-results/NpmTest
+          path: plugin-gradle/build/test-results/testNpm
   changelog_print:
     << : *env_gradle
     steps:

--- a/gradle/special-tests.gradle
+++ b/gradle/special-tests.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'org.gradle.test-retry'
-
+apply plugin: 'com.adarshr.test-logger'
 def special = [
 	'Npm',
 	'Black',
@@ -21,7 +21,7 @@ tasks.named('test') {
 }
 
 special.forEach { tag ->
-	tasks.register("${tag}Test", Test) {
+	tasks.register("test${tag}", Test) {
 		useJUnitPlatform { includeTags tag }
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,23 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* You can now predeclare formatter dependencies in the root project.
+  * specify one of:
+  * `spotless { predeclareDeps() }` to resolve all deps from the root project, which will show up in dependency reports.
+  * `spotless { predeclareDepsFromBuildscript() }` to resolve all deps from `buildscript { repositories {`, which will not show up in dependency reports ([see #1027](https://github.com/diffplug/spotless/issues/1027)).
+  * and then below that you have a block where you simply declare each formatter which you are using, e.g.
+  * ```
+    spotless {
+      ...
+      predeclareDepsFromBuildscript()
+    }
+    spotlessPredeclare {
+      java { eclipse() }
+      kotlin { ktfmt('0.28') }
+    }
+    ```
+  * By default, Spotless resolves all dependencies per-project, and the predeclaration above is unnecessary in the vast majority of cases.
 ### Fixed
 * `ratchetFrom` is now faster and uses less memory ([#1038](https://github.com/diffplug/spotless/pull/1038)).
 
@@ -40,7 +57,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   * To make this daemon-restriction obsolete, please see and upvote [#987](https://github.com/diffplug/spotless/issues/987).
 ### Changed
 * **BREAKING** Previously, many projects required `buildscript { repositories { mavenCentral() }}` at the top of their root project, because Spotless resolved its dependencies using the buildscript repositories. Spotless now resolves its dependencies from the normal project repositories of each project with a `spotless {...}` block. This means that you can remove the `buildscript {}` block, but you still need a `repositories { mavenCentral() }` (or similar) in each project which is using Spotless. ([#980](https://github.com/diffplug/spotless/pull/980), [#983](https://github.com/diffplug/spotless/pull/983))
-  * If you prefer the old behavior, we are open to adding that back as a new feature, see [#984 predeclared dependencies](https://github.com/diffplug/spotless/issues/984).
+  * If you prefer the old behavior, it is available via [`predeclareDepsFromBuildscript()` starting in `6.1.0`](../README.md#dependency-resolution-modes).
 * **BREAKING** `createIndepentApplyTask(String taskName)` now requires that `taskName` does not end with `Apply`
 * Bump minimum required Gradle from `6.1` to `6.1.1`.
 * Bump default formatter versions ([#989](https://github.com/diffplug/spotless/pull/989))

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -86,6 +86,7 @@ Spotless supports all of Gradle's built-in performance features (incremental bui
   - [Multiple (or custom) language-specific blocks](#multiple-or-custom-language-specific-blocks)
   - [Inception (languages within languages within...)](#inception-languages-within-languages-within)
   - [Disabling warnings and error messages](#disabling-warnings-and-error-messages)
+  - [Dependency resolution modes](#dependency-resolution-modes)
   - [How do I preview what `spotlessApply` will do?](#how-do-i-preview-what-spotlessapply-will-do)
   - [Example configurations (from real-world projects)](#example-configurations-from-real-world-projects)
 
@@ -909,6 +910,26 @@ spotless {
     ignoreErrorForStep('my-glitchy-step')   // ignore errors on all files thrown by a specific step
     ignoreErrorForPath('path/to/file.java') // ignore errors by all steps on this specific file
 ```
+
+<a name="dependency-resolution-modes"></a>
+## Dependency resolution modes
+
+By default, Spotless resolves dependencies on a per-project basis. For very large parallel builds, this can sometimes cause problems. As an alternative, Spotless can be configured to resolve all dependencies in the root project like so:
+
+```gradle
+spotless {
+  ...
+  predeclareDeps()
+}
+spotlessPredeclare {
+  java { eclipse() }
+  kotlin { ktfmt('0.28') }
+}
+```
+
+Alternatively, you can also use `predeclareDepsFromBuildscript()` to resolve the dependencies from the buildscript repositories rather than the project repositories.
+
+If you use this feature, you will get an error if you use a formatter in a subproject which is not declared in the `spotlessPredeclare` block.
 
 <a name="preview"></a>
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -73,7 +73,7 @@ public class FormatExtension {
 	}
 
 	protected final Provisioner provisioner() {
-		return spotless.getRegisterDependenciesTask().getTaskService().get().provisionerFor(spotless.project);
+		return spotless.getRegisterDependenciesTask().getTaskService().get().provisionerFor(spotless);
 	}
 
 	private String formatName() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -757,16 +757,6 @@ public class FormatExtension {
 		} else {
 			steps = this.steps;
 		}
-		// <IMPORTANT>
-		// By calling .hashCode, we are triggering all steps to evaluate their state,
-		// which triggers dependency resolution. It's important to do that here, because
-		// otherwise it won't happen until Gradle starts checking for task up-to-date-ness.
-		// For a large parallel build, the task up-to-dateness might get called on a different
-		// thread than the thread where task configuration happens, which will trigger a
-		// java.util.ConcurrentModificationException
-		// See https://github.com/diffplug/spotless/issues/1015 for details.
-		steps.hashCode();
-		// </IMPORTANT>
 		task.setSteps(steps);
 		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> totalTarget));
 		spotless.getRegisterDependenciesTask().hookSubprojectTask(task);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -94,7 +94,7 @@ class GradleProvisioner {
 			if (result != null) {
 				return result;
 			}
-			throw new GradleException("Add a step with " + req + " into the `spotlessPredeclare` block in the root project.");
+			throw new GradleException("Add a step with " + req.mavenCoords + " into the `spotlessPredeclare` block in the root project.");
 		};
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -94,7 +94,7 @@ class GradleProvisioner {
 			if (result != null) {
 				return result;
 			}
-			throw new GradleException("Add a step with " + req + " into the root project.");
+			throw new GradleException("Add a step with " + req + " into the `spotlessPredeclare` block in the root project.");
 		};
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -50,11 +50,10 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 	static final String TASK_NAME = "spotlessInternalRegisterDependencies";
 
 	void hookSubprojectTask(SpotlessTask task) {
-		// TODO: in the future, we might use this hook to implement #984
-		// spotlessSetup {
-		//    java { googleJavaFormat('1.2') }
-		//    ...etc
-		// }
+		// this ensures that if a user is using predeclared dependencies,
+		// those predeclared deps will be resolved before they are needed
+		// by the child tasks
+		//
 		// it's also needed to make sure that jvmLocalCache gets set
 		// in the SpotlessTaskService before any spotless tasks run
 		task.dependsOn(this);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -15,16 +15,26 @@
  */
 package com.diffplug.gradle.spotless;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.BuildServiceRegistry;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.build.event.BuildEventsListenerRegistry;
 
 import com.diffplug.common.base.Preconditions;
+import com.diffplug.common.io.Files;
+import com.diffplug.spotless.FormatterStep;
 
 /**
  * NOT AN END-USER TASK, DO NOT USE FOR ANYTHING!
@@ -56,11 +66,27 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 		BuildServiceRegistry buildServices = getProject().getGradle().getSharedServices();
 		getTaskService().set(buildServices.registerIfAbsent("SpotlessTaskService" + compositeBuildSuffix, SpotlessTaskService.class, spec -> {}));
 		getBuildEventsListenerRegistry().onTaskCompletion(getTaskService());
+		unitOutput = new File(getProject().getBuildDir(), "tmp/spotless-register-dependencies");
+	}
+
+	List<FormatterStep> steps = new ArrayList<>();
+
+	@Input
+	public List<FormatterStep> getSteps() {
+		return steps;
+	}
+
+	File unitOutput;
+
+	@OutputFile
+	public File getUnitOutput() {
+		return unitOutput;
 	}
 
 	@TaskAction
-	public void trivialFunction() {
-		// nothing to do :)
+	public void trivialFunction() throws IOException {
+		Files.createParentDirs(unitOutput);
+		Files.write(Integer.toString(1), unitOutput, StandardCharsets.UTF_8);
 	}
 
 	@Internal

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -27,11 +27,14 @@ import javax.annotation.Nullable;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
 
 import com.diffplug.spotless.LineEnding;
 
 public abstract class SpotlessExtension {
 	final Project project;
+	private final RegisterDependenciesTask registerDependenciesTask;
 
 	protected static final String TASK_GROUP = "Verification";
 	protected static final String CHECK_DESCRIPTION = "Checks that sourcecode satisfies formatting steps.";
@@ -44,9 +47,12 @@ public abstract class SpotlessExtension {
 
 	protected SpotlessExtension(Project project) {
 		this.project = requireNonNull(project);
+		this.registerDependenciesTask = findRegisterDepsTask().get();
 	}
 
-	abstract RegisterDependenciesTask getRegisterDependenciesTask();
+	RegisterDependenciesTask getRegisterDependenciesTask() {
+		return registerDependenciesTask;
+	}
 
 	/** Line endings (if any). */
 	LineEnding lineEndings = LineEnding.GIT_ATTRIBUTES;
@@ -231,4 +237,25 @@ public abstract class SpotlessExtension {
 	}
 
 	protected abstract void createFormatTasks(String name, FormatExtension formatExtension);
+
+	TaskProvider<RegisterDependenciesTask> findRegisterDepsTask() {
+		try {
+			return findRegisterDepsTask(RegisterDependenciesTask.TASK_NAME);
+		} catch (Exception e) {
+			// in a composite build there can be multiple Spotless plugins on the classpath, and they will each try to register
+			// a task on the root project with the same name. That will generate casting errors, which we can catch and try again
+			// with an identity-specific identifier.
+			// https://github.com/diffplug/spotless/pull/1001 for details
+			return findRegisterDepsTask(RegisterDependenciesTask.TASK_NAME + System.identityHashCode(RegisterDependenciesTask.class));
+		}
+	}
+
+	private TaskProvider<RegisterDependenciesTask> findRegisterDepsTask(String taskName) {
+		TaskContainer rootProjectTasks = project.getRootProject().getTasks();
+		if (!rootProjectTasks.getNames().contains(taskName)) {
+			return rootProjectTasks.register(taskName, RegisterDependenciesTask.class, RegisterDependenciesTask::setup);
+		} else {
+			return rootProjectTasks.named(taskName, RegisterDependenciesTask.class);
+		}
+	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -275,6 +275,6 @@ public abstract class SpotlessExtension {
 	}
 
 	protected void predeclare(GradleProvisioner.Policy policy) {
-		project.getExtensions().create(SpotlessExtension.class, EXTENSION_PREDECLARE, SpotlessExtensionRoot.class, project, policy);
+		project.getExtensions().create(SpotlessExtension.class, EXTENSION_PREDECLARE, SpotlessExtensionPredeclare.class, project, policy);
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -41,6 +41,7 @@ public abstract class SpotlessExtension {
 	protected static final String APPLY_DESCRIPTION = "Applies code formatting steps to sourcecode in-place.";
 
 	static final String EXTENSION = "spotless";
+	static final String EXTENSION_PREDECLARE = "spotlessPredeclare";
 	static final String CHECK = "Check";
 	static final String APPLY = "Apply";
 	static final String DIAGNOSE = "Diagnose";
@@ -257,5 +258,23 @@ public abstract class SpotlessExtension {
 		} else {
 			return rootProjectTasks.named(taskName, RegisterDependenciesTask.class);
 		}
+	}
+
+	public void predeclareDepsFromBuildscript() {
+		if (project.getRootProject() != project) {
+			throw new GradleException("predeclareDepsFromBuildscript can only be called from the root project");
+		}
+		predeclare(GradleProvisioner.Policy.ROOT_BUILDSCRIPT);
+	}
+
+	public void predeclareDeps() {
+		if (project.getRootProject() != project) {
+			throw new GradleException("predeclareDeps can only be called from the root project");
+		}
+		predeclare(GradleProvisioner.Policy.ROOT_PROJECT);
+	}
+
+	protected void predeclare(GradleProvisioner.Policy policy) {
+		project.getExtensions().create(SpotlessExtension.class, EXTENSION_PREDECLARE, SpotlessExtensionRoot.class, project, policy);
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
@@ -21,12 +21,12 @@ import java.util.TreeMap;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 
-public class SpotlessExtensionRoot extends SpotlessExtension {
+public class SpotlessExtensionPredeclare extends SpotlessExtension {
 	private final SortedMap<String, FormatExtension> toSetup = new TreeMap<>();
 
-	public SpotlessExtensionRoot(Project project, GradleProvisioner.Policy policy) {
+	public SpotlessExtensionPredeclare(Project project, GradleProvisioner.Policy policy) {
 		super(project);
-		getRegisterDependenciesTask().getTaskService().get().rootProvisioner = policy.dedupingProvisioner(project);
+		getRegisterDependenciesTask().getTaskService().get().predeclaredProvisioner = policy.dedupingProvisioner(project);
 		project.afterEvaluate(unused -> {
 			toSetup.forEach((name, formatExtension) -> {
 				for (Action<FormatExtension> lazyAction : formatExtension.lazyActions) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionRoot.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionRoot.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+
+public class SpotlessExtensionRoot extends SpotlessExtension {
+	private final SortedMap<String, FormatExtension> toSetup = new TreeMap<>();
+
+	public SpotlessExtensionRoot(Project project, GradleProvisioner.Policy policy) {
+		super(project);
+		getRegisterDependenciesTask().getTaskService().get().rootProvisioner = policy.dedupingProvisioner(project);
+		project.afterEvaluate(unused -> {
+			toSetup.forEach((name, formatExtension) -> {
+				for (Action<FormatExtension> lazyAction : formatExtension.lazyActions) {
+					lazyAction.execute(formatExtension);
+				}
+				getRegisterDependenciesTask().steps.addAll(formatExtension.steps);
+			});
+		});
+	}
+
+	@Override
+	protected void createFormatTasks(String name, FormatExtension formatExtension) {
+		toSetup.put(name, formatExtension);
+	}
+
+	@Override
+	protected void predeclare(GradleProvisioner.Policy policy) {
+		throw new UnsupportedOperationException("predeclare can't be called from within `" + EXTENSION_PREDECLARE + "`");
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -49,14 +49,14 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
 
 	@Nullable
-	GradleProvisioner.DedupingProvisioner rootProvisioner;
+	GradleProvisioner.DedupingProvisioner predeclaredProvisioner;
 
 	Provisioner provisionerFor(SpotlessExtension spotless) {
-		if (spotless instanceof SpotlessExtensionRoot) {
-			return rootProvisioner;
+		if (spotless instanceof SpotlessExtensionPredeclare) {
+			return predeclaredProvisioner;
 		} else {
-			if (rootProvisioner != null) {
-				return rootProvisioner.cachedOnly;
+			if (predeclaredProvisioner != null) {
+				return predeclaredProvisioner.cachedOnly;
 			} else {
 				return provisioner.computeIfAbsent(spotless.project.getPath(), unused -> new GradleProvisioner.DedupingProvisioner(GradleProvisioner.forProject(spotless.project)));
 			}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -20,10 +20,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -48,10 +48,19 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
 
-	Provisioner provisionerFor(Project project) {
-		return provisioner.computeIfAbsent(project.getPath(), unused -> {
-			return new GradleProvisioner.DedupingProvisioner(GradleProvisioner.forProject(project));
-		});
+	@Nullable
+	GradleProvisioner.DedupingProvisioner rootProvisioner;
+
+	Provisioner provisionerFor(SpotlessExtension spotless) {
+		if (spotless instanceof SpotlessExtensionRoot) {
+			return rootProvisioner;
+		} else {
+			if (rootProvisioner != null) {
+				return rootProvisioner.cachedOnly;
+			} else {
+				return provisioner.computeIfAbsent(spotless.project.getPath(), unused -> new GradleProvisioner.DedupingProvisioner(GradleProvisioner.forProject(spotless.project)));
+			}
+		}
 	}
 
 	void registerSourceAlreadyRan(SpotlessTask task) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -50,7 +50,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 
 	Provisioner provisionerFor(Project project) {
 		return provisioner.computeIfAbsent(project.getPath(), unused -> {
-			return GradleProvisioner.newDedupingProvisioner(project);
+			return new GradleProvisioner.DedupingProvisioner(GradleProvisioner.forProject(project));
 		});
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
@@ -88,7 +88,7 @@ class MultiProjectTest extends GradleIntegrationHarness {
 				"spotless { predeclareDeps() }");
 		createNSubprojects();
 		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
-				.contains("Add a step with com.google.googlejavaformat:google-java-format:1.2 with transitives into the root project.");
+				.contains("Add a step with com.google.googlejavaformat:google-java-format:1.2 into the `spotlessPredeclare` block in the root project.");
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2016-2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.common.base.StringPrinter;
+
+class MultiProjectTest extends GradleIntegrationHarness {
+	private static int N = 100;
+
+	private void createNSubprojects() throws IOException {
+		for (int i = 0; i < N; ++i) {
+			createSubproject(Integer.toString(i));
+		}
+		String settings = StringPrinter.buildString(printer -> {
+			for (int i = 0; i < N; ++i) {
+				printer.println("include '" + i + "'");
+			}
+		});
+		setFile("settings.gradle").toContent(settings);
+	}
+
+	void createSubproject(String name) throws IOException {
+		setFile(name + "/build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"    java {",
+				"        target file('test.java')",
+				"        googleJavaFormat('1.2')",
+				"    }",
+				"}");
+		setFile(name + "/test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+	}
+
+	@Test
+	public void noRootSpotless() throws IOException {
+		createNSubprojects();
+		setFile("build.gradle").toLines();
+		applyIsUpToDate(false);
+	}
+
+	@Test
+	public void hasRootSpotless() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"    java {",
+				"        target file('test.java')",
+				"        googleJavaFormat('1.2')",
+				"    }",
+				"}");
+		setFile("test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		createNSubprojects();
+		applyIsUpToDate(false);
+	}
+
+	@Test
+	public void predeclaredFails() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"spotless { predeclareDeps() }");
+		createNSubprojects();
+		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
+				.contains("Add a step with com.google.googlejavaformat:google-java-format:1.2 with transitives into the root project.");
+	}
+
+	@Test
+	public void predeclaredSucceeds() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless { predeclareDeps() }",
+				"spotlessPredeclare {",
+				" java { googleJavaFormat('1.2') }",
+				"}");
+		createNSubprojects();
+		gradleRunner().withArguments("spotlessApply").build();
+	}
+
+	@Test
+	public void predeclaredFromBuildscriptSucceeds() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless { predeclareDepsFromBuildscript() }",
+				"spotlessPredeclare {",
+				" java { googleJavaFormat('1.2') }",
+				"}");
+		createNSubprojects();
+		gradleRunner().withArguments("spotlessApply").build();
+	}
+
+	@Test
+	public void predeclaredOrdering() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotlessPredeclare {",
+				" java { googleJavaFormat('1.2') }",
+				"}",
+				"spotless { predeclareDepsFromBuildscript() }");
+		createNSubprojects();
+		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
+				.contains("Could not find method spotlessPredeclare() for arguments");
+	}
+
+	@Test
+	public void predeclaredUndeclared() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotlessPredeclare {",
+				" java { googleJavaFormat('1.2') }",
+				"}");
+		createNSubprojects();
+		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
+				.contains("Could not find method spotlessPredeclare() for arguments");
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
@@ -88,7 +88,7 @@ class MultiProjectTest extends GradleIntegrationHarness {
 				"spotless { predeclareDeps() }");
 		createNSubprojects();
 		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
-				.contains("Add a step with com.google.googlejavaformat:google-java-format:1.2 into the `spotlessPredeclare` block in the root project.");
+				.contains("Add a step with [com.google.googlejavaformat:google-java-format:1.2] into the `spotlessPredeclare` block in the root project.");
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
@@ -88,8 +88,8 @@ class UpToDateTest extends GradleIntegrationHarness {
 		// the format task is UP-TO-DATE (same inputs), but the apply tasks will run again
 		pauseForFilesystem();
 		BuildResult buildResult = gradleRunner().withArguments("spotlessApply").build();
-		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.UP_TO_DATE)).containsExactly(":spotlessMisc");
-		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.SUCCESS)).containsExactly(":spotlessInternalRegisterDependencies", ":spotlessMiscApply", ":spotlessApply");
+		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.UP_TO_DATE)).containsExactly(":spotlessInternalRegisterDependencies", ":spotlessMisc");
+		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.SUCCESS)).containsExactly(":spotlessMiscApply", ":spotlessApply");
 		assertFile("README.md").hasContent("abc");
 
 		// and it'll take two more runs to get to fully UP-TO-DATE

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,8 @@ pluginManagement {
 		id 'com.diffplug.p2.asmaven'               version '3.27.0' // DO NOT UPDATE, see https://github.com/diffplug/spotless/pull/874
 		// https://github.com/gradle/test-retry-gradle-plugin/releases
 		id 'org.gradle.test-retry'                 version '1.3.1'
+		// https://github.com/radarsh/gradle-test-logger-plugin/blob/develop/CHANGELOG.md
+		id 'com.adarshr.test-logger'               version '3.1.0'
 	}
 }
 plugins {
@@ -23,6 +25,7 @@ plugins {
 	id 'com.diffplug.spotless-changelog'       apply false
 	id 'com.diffplug.p2.asmaven'               apply false
 	id 'org.gradle.test-retry'                 apply false
+	id 'com.adarshr.test-logger'               apply false
 }
 if (System.env['CI'] != null) {
 	// use the remote buildcache on all CI builds


### PR DESCRIPTION
Starting in 6.0, dependencies are now resolved from project repositories rather than buildscript repositories. That fixed some things, but broke other things. In this PR, we add the ability to fix everything by predeclaring your formatters in the root project.

```gradle
spotless {
  ...
  predeclareDeps()
}
spotlessPredeclare {
  java { eclipse() }
  kotlin { ktfmt('0.28') }
}
```

Alternatively, you can also use `predeclareDepsFromBuildscript()` to resolve the dependencies from the buildscript repositories rather than the project repositories.

If you use this feature, you will get an error if you use a formatter in a subproject which is not declared in the `spotlessPredeclare` block.

Fixes #1026, #1027, #1028, #1032, #1034, and #1042, by implementing #984