### PR TITLE
.editorconfig for ktlint.

### DIFF
--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -68,6 +68,7 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 
 		private final String version;
 		private Map<String, String> userData;
+		private String editorConfig;
 
 		KotlinFormatExtension(String version, Map<String, String> config) {
 			this.version = version;
@@ -82,8 +83,13 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 			replaceStep(createStep());
 		}
 
+		public void editorConfig(String editorConfig) {
+			this.editorConfig = editorConfig;
+			replaceStep(createStep());
+		}
+
 		private FormatterStep createStep() {
-			return KtLintStep.create(version, provisioner(), userData);
+			return KtLintStep.create(version, provisioner(), userData, editorConfig);
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -54,6 +54,7 @@ public class KotlinGradleExtension extends FormatExtension {
 
 		private final String version;
 		private Map<String, String> userData;
+		private String editorConfig;
 
 		KotlinFormatExtension(String version, Map<String, String> config) {
 			this.version = version;
@@ -68,8 +69,13 @@ public class KotlinGradleExtension extends FormatExtension {
 			replaceStep(createStep());
 		}
 
+		public void editorConfig(String editorConfig) {
+			this.editorConfig = editorConfig;
+			replaceStep(createStep());
+		}
+
 		private FormatterStep createStep() {
-			return KtLintStep.createForScript(version, provisioner(), userData);
+			return KtLintStep.createForScript(version, provisioner(), userData, editorConfig);
 		}
 	}
 


### PR DESCRIPTION
- set .editorconfig fullpath: then use it.
ktlint().userData([editorconfig: project.file(".editorconfig").absolutePath])

- set "?": recursively search the closest .editorconfig
ktlint().userData([editorconfig: "?"])
