### PR TITLE
Removed system line separator change from eclipse-base config

### DIFF
--- a/_ext/eclipse-base/CHANGES.md
+++ b/_ext/eclipse-base/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.2.1`).
 
 ## [Unreleased]
+### Changed
+* **BREAKING** `changeSystemLineSeparator` is no longer part of default configuration (see [#1049](https://github.com/diffplug/spotless/issues/1049)).
 
 ## [3.5.2] - 2021-10-23
 ### Fixed

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseServiceConfig.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/SpotlessEclipseServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,6 @@ public interface SpotlessEclipseServiceConfig {
 	 * system property.
 	 * Change the system default to the UNIX line separator as required
 	 * by Spotless.
-	 * @throws ServiceException in case service has already been configured
 	 */
 	default public void changeSystemLineSeparator() throws ServiceException {
 		System.setProperty("line.separator", LINE_DELIMITER);
@@ -149,6 +148,5 @@ public interface SpotlessEclipseServiceConfig {
 		disableDebugging();
 		ignoreUnsupportedPreferences();
 		useTemporaryLocations();
-		changeSystemLineSeparator();
 	}
 }

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/ResourceAccessor.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/osgi/ResourceAccessor.java
@@ -85,12 +85,13 @@ class ResourceAccessor {
 		}
 	}
 
+	@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "Null-checking costs higher than benefit.")
 	private static URI getBundleUri(Class<?> clazz) throws BundleException {
 		try {
 			URL objUrl = clazz.getProtectionDomain().getCodeSource().getLocation();
 			return objUrl.toURI();
 		} catch (NullPointerException e) {
-			//No bunlde should be used for RT classes lookup. See also org.eclipse.core.runtime.PerformanceStats.
+			//No bundle should be used for RT classes lookup. See also org.eclipse.core.runtime.PerformanceStats.
 			throw new BundleException(String.format("No code source can be located for class '%s'. Class is probably not within a bundle, but part of the RT.", clazz.getName()), BundleException.READ_ERROR, e);
 		} catch (SecurityException e) {
 			throw new BundleException(String.format("Access to class '%s' is denied.", clazz.getName()), BundleException.READ_ERROR, e);

--- a/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/TemporaryLocation.java
+++ b/_ext/eclipse-base/src/main/java/com/diffplug/spotless/extra/eclipse/base/service/TemporaryLocation.java
@@ -128,6 +128,7 @@ public class TemporaryLocation implements Location, AutoCloseable {
 	}
 
 	@Override
+	@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification = "At shutdown everything is just done on best-efforts basis")
 	public void close() throws Exception {
 		try {
 			Path path = Path.of(location.toURI());


### PR DESCRIPTION
- changeSystemLineSeparator no longer part of default configuration
- Added annotations due to spotbugs version bump

As agreed for #1049, the line separator config will no longer be part of the default configuration.
First tests shows that the System line separator is currently only used by WTP.
Tests for the different formatters will be provided in dedicated PR.