### PR TITLE
Fix build failures caused by the New Year

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a breaking change for DiKTat users on the default version, because some rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 
 ## [2.21.0] - 2021-12-23
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class DiktatStep {
 	// prevent direct instantiation
 	private DiktatStep() {}
 
-	private static final String DEFAULT_VERSION = "0.4.0";
+	private static final String DEFAULT_VERSION = "1.0.1";
 	static final String NAME = "diktat";
 	static final String PACKAGE_DIKTAT = "org.cqfn.diktat";
 	static final String PACKAGE_KTLINT = "com.pinterest.ktlint";

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changed
+* **BREAKING** Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a major version upgrade. Some DiKTat rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 
 ## [6.1.0] - 2021-12-23
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changed
-* **BREAKING** Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a major version upgrade. Some DiKTat rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
+* Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a breaking change for DiKTat users on the default version, because some rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 
 ## [6.1.0] - 2021-12-23
 ### Added

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,8 +90,7 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 				"}");
 		setFile("configuration.gradle.kts").toResource("kotlin/diktat/basic.dirty");
 		BuildResult result = gradleRunner().withArguments("spotlessApply").buildAndFail();
-		assertThat(result.getOutput()).contains("[HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE] files that contain multiple "
-				+ "or no classes should contain description of what is inside of this file: there are 0 declared classes and/or objects");
+		assertThat(result.getOutput()).contains("[AVOID_NESTED_FUNCTIONS] try to avoid using nested functions");
 	}
 
 	@Test

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -11,6 +11,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
     * `src/main/java/**/*.java`
     * `src/test/java/**/*.java`
   * This release removes the `.java` includes.
+### Changed
+* **BREAKING** Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a major version upgrade. Some DiKTat rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 
 ## [2.18.0] - 2021-12-23
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -12,7 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
     * `src/test/java/**/*.java`
   * This release removes the `.java` includes.
 ### Changed
-* **BREAKING** Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a major version upgrade. Some DiKTat rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
+* Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a breaking change for DiKTat users on the default version, because some rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 
 ## [2.18.0] - 2021-12-23
 ### Added

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,10 @@ class DiktatTest extends MavenIntegrationHarness {
 	@Test
 	void testDiktatWithVersion() throws Exception {
 
-		writePomWithKotlinSteps("<diktat><version>0.4.0</version></diktat>");
+		writePomWithKotlinSteps(
+				"<diktat>",
+				"  <version>1.0.1</version>",
+				"</diktat>");
 
 		String path = "src/main/kotlin/Main.kt";
 		setFile(path).toResource("kotlin/diktat/main.dirty");
@@ -51,7 +54,11 @@ class DiktatTest extends MavenIntegrationHarness {
 
 		String configPath = "src/main/kotlin/diktat-analysis.yml";
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
-		writePomWithKotlinSteps("<diktat><version>0.4.0</version><configFile>" + conf.getAbsolutePath() + "</configFile></diktat>");
+		writePomWithKotlinSteps(
+				"<diktat>",
+				"  <version>1.0.1</version>",
+				"  <configFile>" + conf.getAbsolutePath() + "</configFile>",
+				"</diktat>");
 
 		String path = "src/main/kotlin/Main.kt";
 		setFile(path).toResource("kotlin/diktat/main.dirty");

--- a/testlib/src/main/resources/kotlin/diktat/diktat-analysis.yml
+++ b/testlib/src/main/resources/kotlin/diktat/diktat-analysis.yml
@@ -75,13 +75,6 @@
   enabled: 'true'
 - name: HEADER_WRONG_FORMAT
   enabled: true
-- name: HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE
-  enabled: true
-- name: HEADER_MISSING_OR_WRONG_COPYRIGHT
-  enabled: true
-  configuration:
-    isCopyrightMandatory: false
-    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2021'
 - name: HEADER_NOT_BEFORE_PACKAGE
   enabled: true
 - name: FILE_IS_TOO_LONG
@@ -182,7 +175,7 @@
 - name: WRONG_NEWLINES_AROUND_KDOC
   enabled: true
 # Inspection that checks if there is no blank lines before first comment
-- name: FIRST_COMMENT_NO_SPACES
+- name: FIRST_COMMENT_NO_BLANK_LINE
   enabled: true
 # Inspection that checks if there are blank lines between code and comment and between code start token and comment's text
 - name: COMMENT_WHITE_SPACE

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@ package com.diffplug.spotless.generic;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.ZoneOffset;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -227,10 +229,11 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_update_year_for_license_with_address() throws Throwable {
+		int currentYear = LocalDate.now(ZoneOffset.UTC).getYear();
 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), package_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
 		StepHarness.forStep(step).test(
 				hasHeader(licenceWithAddress().replace("$YEAR", "2015")),
-				hasHeader(licenceWithAddress().replace("$YEAR", "2015-2021")));
+				hasHeader(licenceWithAddress().replace("$YEAR", "2015-" + currentYear)));
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ class DiktatStepTest extends ResourceHarness {
 					assertion.isInstanceOf(AssertionError.class);
 					assertion.hasMessage("There are 2 unfixed errors:" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
+							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: " +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable");
+							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared:  vs Unsolvable");
 				});
 	}
 
@@ -51,15 +51,15 @@ class DiktatStepTest extends ResourceHarness {
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		FileSignature config = signAsList(conf);
 
-		FormatterStep step = DiktatStep.create("0.3.0", TestProvisioner.mavenCentral(), Collections.emptyMap(), config);
+		FormatterStep step = DiktatStep.create("1.0.1", TestProvisioner.mavenCentral(), Collections.emptyMap(), config);
 		StepHarness.forStep(step)
 				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
 					assertion.hasMessage("There are 2 unfixed errors:" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
+							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: " +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable");
+							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared:  vs Unsolvable");
 				});
 	}
 


### PR DESCRIPTION
#### Bump the default DiKTat version

Use the latest major release - 1.0.1. The previous default version 0.4.0 started causing build failures because of the copyright rule. DiKTat tests started failing after the New Year. It is not entirely clear why the tests started failing, but the error behavior changes when adding a dummy copyright header to Kotlin source files. Example header:

```
/*
    Copyright (c) My Company, Ltd. 2000-2022. All rights reserved.
*/
```

Release notes for DiKTat 1.0.1 mention a PR that fixes the copyrights rule: https://github.com/analysis-dev/diktat/releases/tag/v1.0.1

### Fix DiKTat tests after a version bump

`FIRST_COMMENT_NO_SPACES` rule renamed to `FIRST_COMMENT_NO_BLANK_LINE` in https://github.com/analysis-dev/diktat/pull/759.

Update explicit version to 1.0.1.

Remove copyright header rules because we do not want DiKTat tests to fail every New Year.

### Fix licence header test 

Compute the current year instead of using a fixed year 2021. This test started failing after the New Year.

#### Fix a few more DiKTat test failures

Use the newest DiKTat version. Change expected messages. They do not look right - probably a bug in DiKTat.