### PR TITLE
No need for clean to trigger configuration of the spotless tasks if 'base' was already applied

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* There is no need for the `clean` task to trigger configuration of the Spotless tasks ([#1068](https://github.com/diffplug/spotless/pull/1068))
+* If the `base` plugin has already been applied, then there is no need for configuration of the `clean` task to trigger configuration of the Spotless tasks ([#1068](https://github.com/diffplug/spotless/pull/1068)).
 ### Changed
 * Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a breaking change for DiKTat users on the default version, because some rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* There is no need for the `clean` task to trigger configuration of the Spotless tasks ([revert 5ee9046](https://github.com/diffplug/spotless/commit/5ee904677320f5a6ca6abb3db7196927419011b4#commitcomment-62989038))
+* There is no need for the `clean` task to trigger configuration of the Spotless tasks ([#1068](https://github.com/diffplug/spotless/pull/1068))
 ### Changed
 * Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a breaking change for DiKTat users on the default version, because some rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* There is no need for the `clean` task to trigger configuration of the Spotless tasks ([revert 5ee9046](https://github.com/diffplug/spotless/commit/5ee904677320f5a6ca6abb3db7196927419011b4#commitcomment-62989038))
 ### Changed
 * Bumped default DiKTat from `0.4.0` to `1.0.1`. This is a breaking change for DiKTat users on the default version, because some rules were renamed/changed. Check [DiKTat changelog](https://github.com/analysis-dev/diktat/releases) for details.
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,13 @@ public class SpotlessPlugin implements Plugin<Project> {
 
 	/** clean removes the SpotlessCache, so we have to run after clean. */
 	static void taskMustRunAfterClean(Project project, TaskProvider<?> task) {
-		configureCleanTask(project, clean -> task.get().mustRunAfter(clean));
+		if (project.getPlugins().hasPlugin(BasePlugin.class)) {
+			// if we know that the clean task is around, then we can configure lazily
+			task.configure(t -> t.mustRunAfter(BasePlugin.CLEAN_TASK_NAME));
+		} else {
+			// otherwise, we trigger configuration when the clean task gets configured
+			configureCleanTask(project, clean -> task.get().mustRunAfter(clean));
+		}
 	}
 
 	static String capitalize(String input) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -63,7 +63,7 @@ public class SpotlessPlugin implements Plugin<Project> {
 
 	/** clean removes the SpotlessCache, so we have to run after clean. */
 	static void taskMustRunAfterClean(Project project, TaskProvider<?> task) {
-		configureCleanTask(project, clean -> task.get().mustRunAfter(clean));
+		configureCleanTask(project, clean -> task.configure(spotless -> spotless.mustRunAfter(clean)));
 	}
 
 	static String capitalize(String input) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class SpotlessPlugin implements Plugin<Project> {
 
 	/** clean removes the SpotlessCache, so we have to run after clean. */
 	static void taskMustRunAfterClean(Project project, TaskProvider<?> task) {
-		configureCleanTask(project, clean -> task.configure(spotless -> spotless.mustRunAfter(clean)));
+		configureCleanTask(project, clean -> task.get().mustRunAfter(clean));
 	}
 
 	static String capitalize(String input) {


### PR DESCRIPTION
As noted by @nhoughto [here](https://github.com/diffplug/spotless/commit/5ee904677320f5a6ca6abb3db7196927419011b4#commitcomment-62989038).