### PR TITLE
Update `IndentStep` to allow leading space on multi-line comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Update IndentStep to allow leading space on multi-line comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
 
 ## [2.21.1] - 2022-01-06
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* Update IndentStep to allow leading space on multi-line comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
+* Update IndentStep to allow leading space on multiline comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
 
 ## [2.21.1] - 2022-01-06
 ### Changed

--- a/lib/src/main/java/com/diffplug/spotless/generic/IndentStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/IndentStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,9 @@ public final class IndentStep {
 					++contentStart;
 				}
 
+				// detect potential multi-line comments
+				boolean mightBeMultiLineComment = (contentStart < raw.length()) && (raw.charAt(contentStart) == '*');
+
 				// add the leading space in a canonical way
 				if (numSpaces > 0) {
 					switch (state.type) {
@@ -111,6 +114,9 @@ public final class IndentStep {
 					case TAB:
 						for (int i = 0; i < numSpaces / state.numSpacesPerTab; ++i) {
 							builder.append('\t');
+						}
+						if (mightBeMultiLineComment && (numSpaces % state.numSpacesPerTab == 1)) {
+							builder.append(' ');
 						}
 						break;
 					default:

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Update IndentStep to allow leading space on multi-line comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
 
 ## [6.1.1] - 2022-01-06
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* Update IndentStep to allow leading space on multi-line comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
+* Update IndentStep to allow leading space on multiline comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
 
 ## [6.1.1] - 2022-01-06
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* Update IndentStep to allow leading space on multi-line comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
+* Update IndentStep to allow leading space on multiline comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
 
 ## [2.19.0] - 2022-01-06
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Update IndentStep to allow leading space on multi-line comments ([#1072](https://github.com/diffplug/spotless/pull/1072)).
 
 ## [2.19.0] - 2022-01-06
 ### Added

--- a/testlib/src/main/resources/indent/IndentedWithSpace.test
+++ b/testlib/src/main/resources/indent/IndentedWithSpace.test
@@ -2,8 +2,13 @@ package com.github.youribonnaffe.gradle.format;
 
 import java.util.function.Function;
 
-
+/**
+ * Test class.
+ */
 public class Java8Test {
+    /**
+     * Test method.
+     */
     public void doStuff() throws Exception {
         Function<String, Integer> example = Integer::parseInt;
         example.andThen(val -> {
@@ -21,7 +26,11 @@ public class Java8Test {
                 throw new Exception();
         }
     }
-    
+
+    /** Test enum
+    * with weirdly formatted javadoc
+    * which IndentStep should not change
+    */
     public enum SimpleEnum {
         A, B, C;
     }

--- a/testlib/src/main/resources/indent/IndentedWithTab.test
+++ b/testlib/src/main/resources/indent/IndentedWithTab.test
@@ -2,8 +2,13 @@ package com.github.youribonnaffe.gradle.format;
 
 import java.util.function.Function;
 
-
+/**
+ * Test class.
+ */
 public class Java8Test {
+	/**
+	 * Test method.
+	 */
 	public void doStuff() throws Exception {
 		Function<String, Integer> example = Integer::parseInt;
 		example.andThen(val -> {
@@ -21,7 +26,11 @@ public class Java8Test {
 				throw new Exception();
 		}
 	}
-	
+
+	/** Test enum
+	* with weirdly formatted javadoc
+	* which IndentStep should not change
+	*/
 	public enum SimpleEnum {
 		A, B, C;
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
@@ -87,9 +87,9 @@ class IndentStepTest extends ResourceHarness {
 	@Test
 	void allowLeadingSpaceIfMultiLineComment() throws Exception {
 		StepHarness.forStep(IndentStep.Type.TAB.create(4))
-			.testUnaffected("* test")
-			.testUnaffected(" * test")
-			.testUnaffected("\t* test")
-			.test("    * test", "\t* test");
+				.testUnaffected("* test")
+				.testUnaffected(" * test")
+				.testUnaffected("\t* test")
+				.test("    * test", "\t* test");
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
+import com.diffplug.spotless.StepHarness;
 
 class IndentStepTest extends ResourceHarness {
 	@Test
@@ -81,5 +82,14 @@ class IndentStepTest extends ResourceHarness {
 				return type.create(numSpacesPerTab);
 			}
 		}.testEquals();
+	}
+
+	@Test
+	void allowLeadingSpaceIfMultiLineComment() throws Exception {
+		StepHarness.forStep(IndentStep.Type.TAB.create(4))
+			.testUnaffected("* test")
+			.testUnaffected(" * test")
+			.testUnaffected("\t* test")
+			.test("    * test", "\t* test");
 	}
 }


### PR DESCRIPTION
At present, `indentWithTabs` doesn't handle leading space on multi-line comments and reports errors on properly formatted code.

This commit updates `IndentStep` to add support for detecting multi-line comments and allowing a single leading space for such lines.

Closes #1070