### PR TITLE
Fix fingerprint with deps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = 2
 # Doc: https://youtrack.jetbrains.com/issue/IDEA-170643#focus=streamItem-27-3708697.0-0
 ij_java_imports_layout = java.**,|,javax.**,|,org.**,|,com.**,|,com.diffplug.**,|,*
 ij_java_use_single_class_imports = true
+
+[*.xml.mustache]
+indent_style = space

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Enabling the upToDateChecking with the plugin configured inside pluginManagement, with an additional dependency and running under Maven 3.6.3 leads to a java.io.NotSerializableException. ([#1074](https://github.com/diffplug/spotless/pull/1074)).
 
 ## [2.19.1] - 2022-01-07
 ### Fixed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/PluginFingerprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@ package com.diffplug.spotless.maven.incremental;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.Objects;
 
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 
@@ -77,6 +80,13 @@ class PluginFingerprint {
 	}
 
 	private static byte[] digest(Plugin plugin, Iterable<Formatter> formatters) {
+		// dependencies can be an unserializable org.apache.maven.model.merge.ModelMerger$MergingList
+		// replace it with a serializable ArrayList
+		List<Dependency> dependencies = null;
+		if (plugin != null) {
+			dependencies = plugin.getDependencies();
+			plugin.setDependencies(new ArrayList<>(dependencies));
+		}
 		try (ObjectDigestOutputStream out = ObjectDigestOutputStream.create()) {
 			out.writeObject(plugin);
 			for (Formatter formatter : formatters) {
@@ -86,6 +96,11 @@ class PluginFingerprint {
 			return out.digest();
 		} catch (IOException e) {
 			throw new UncheckedIOException("Unable to serialize plugin " + plugin, e);
+		} finally {
+			// reset the original list
+			if (plugin != null) {
+				plugin.setDependencies(dependencies);
+			}
 		}
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,8 @@ class SpotlessCheckMojoTest extends MavenIntegrationHarness {
 						"  <licenseHeader>",
 						"    <file>${basedir}/license.txt</file>",
 						"  </licenseHeader>",
-						"</java>"});
+						"</java>"},
+				null);
 
 		testSpotlessCheck(UNFORMATTED_FILE, "verify", true);
 	}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,25 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 			"</googleJavaFormat>"
 	};
 
+	private static final String[] DEPENDENCIES_1 = {
+			"<dependencies>",
+			"  <dependency>",
+			"    <groupId>unknown</groupId>",
+			"    <artifactId>unknown</artifactId>",
+			"    <version>1.0</version>",
+			"  </dependency>",
+			"</dependencies>"
+	};
+	private static final String[] DEPENDENCIES_2 = {
+			"<dependencies>",
+			"  <dependency>",
+			"    <groupId>unknown</groupId>",
+			"    <artifactId>unknown</artifactId>",
+			"    <version>2.0</version>",
+			"  </dependency>",
+			"</dependencies>"
+	};
+
 	private static final List<Formatter> FORMATTERS = singletonList(formatter(formatterStep("default")));
 
 	@Test
@@ -78,6 +97,34 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
 
 		assertThat(fingerprint1).isEqualTo(fingerprint2);
+	}
+
+	@Test
+	void sameFingerprintWithDependencies() throws Exception {
+		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_1);
+		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_1);
+
+		MavenProject project1 = mavenProject(xml1);
+		MavenProject project2 = mavenProject(xml2);
+
+		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
+		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
+
+		assertThat(fingerprint1).isEqualTo(fingerprint2);
+	}
+
+	@Test
+	void differentFingerprintForDifferentDependencies() throws Exception {
+		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_1);
+		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_2);
+
+		MavenProject project1 = mavenProject(xml1);
+		MavenProject project2 = mavenProject(xml2);
+
+		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
+		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
+
+		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
@@ -57,6 +57,51 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 	}
 
 	@Test
+	void enableUpToDateCheckingWithPluginDependencies() throws Exception {
+		writePomWithPluginManagementAndDependency();
+
+		List<File> files = writeUnformattedFiles(1);
+		String output = runSpotlessApply();
+
+		assertThat(output).contains("Up-to-date checking enabled");
+		assertFormatted(files);
+	}
+
+	@Test
+	void enableUpToDateCheckingWithPluginDependenciesMaven3_6_3() throws Exception {
+		writePomWithPluginManagementAndDependency();
+
+		setFile(".mvn/wrapper/maven-wrapper.properties").toContent("distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip\n");
+
+		List<File> files = writeUnformattedFiles(1);
+		String output = runSpotlessApply();
+
+		assertThat(output).contains("Up-to-date checking enabled");
+		assertFormatted(files);
+	}
+
+	private void writePomWithPluginManagementAndDependency() throws IOException {
+		setFile("pom.xml").toContent(createPomXmlContent("/pom-test-management.xml.mustache",
+				null,
+				null,
+				new String[]{
+						"<java>",
+						"  <googleJavaFormat/>",
+						"</java>",
+						"<upToDateChecking>",
+						"  <enabled>true</enabled>",
+						"</upToDateChecking>"},
+				new String[]{
+						"<dependencies>",
+						"  <dependency>",
+						"    <groupId>javax.inject</groupId>",
+						"    <artifactId>javax.inject</artifactId>",
+						"    <version>1</version>",
+						"  </dependency>",
+						"</dependencies>"}));
+	}
+
+	@Test
 	void disableUpToDateChecking() throws Exception {
 		writePomWithUpToDateCheckingEnabled(false);
 

--- a/plugin-maven/src/test/resources/pom-test-management.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-test-management.xml.mustache
@@ -20,18 +20,26 @@
     </properties>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>{{spotlessMavenPluginVersion}}</version>
+                    <configuration>
+                        {{{configuration}}}
+                    </configuration>
+                    {{{dependencies}}}
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>{{spotlessMavenPluginVersion}}</version>
-                <configuration>
-                    {{{configuration}}}
-                </configuration>
                 <executions>
                     {{{executions}}}
                 </executions>
-                {{{dependencies}}}
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Newer Maven versions (at least 3.6.3 is affected) use a `org.apache.maven.model.merge.ModelMerger$MergingList`, if a plugin is defined inside `pluginManagement` and additionally defines custom `dependencies`. This class is not serializable, which will fail the `PluginFingerprint`.

This change replaces the dependency list with an `ArrayList` before serialization and sets it back to the original list afterwards.

You can try the demonstrator test without the fix commit, to validate the error.

Fixes: #1073 