### PR TITLE
Improve a precondition in PluginFingerprint

### DIFF
--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,6 +106,10 @@ class NoopCheckerTest extends ResourceHarness {
 		project.setFile(pomFile);
 		Build build = new Build();
 		build.setDirectory(targetDir.getName());
+		Plugin spotlessPlugin = new Plugin();
+		spotlessPlugin.setGroupId("com.diffplug.spotless");
+		spotlessPlugin.setArtifactId("spotless-maven-plugin");
+		build.addPlugin(spotlessPlugin);
 		project.setBuild(build);
 		return project;
 	}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
@@ -18,6 +18,7 @@ package com.diffplug.spotless.maven.incremental;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Paths;
@@ -212,6 +213,15 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		PluginFingerprint fingerprint = PluginFingerprint.empty();
 
 		assertThat(fingerprint.value()).isEmpty();
+	}
+
+	@Test
+	void failsWhenProjectDoesNotContainSpotlessPlugin() {
+		MavenProject projectWithoutSpotless = new MavenProject();
+
+		assertThatThrownBy(() -> PluginFingerprint.from(projectWithoutSpotless, FORMATTERS))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Spotless plugin absent from the project");
 	}
 
 	private static MavenProject mavenProject(String xml) throws Exception {


### PR DESCRIPTION
Make sure Spotless plugin has a corresponding `Plugin` object in the Maven model. This allows removing a few null checks for `Plugin` serialization.