### PR TITLE
Use unique type for predeclare extension declaration.

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changed
+* Register `spotlessPredeclare` extension with type `SpotlessPredeclareExtension` instead of the same `SpotlessExtension` as `spotless` ([#1084](https://github.com/diffplug/spotless/pull/1084)).
+
 
 ## [6.1.2] - 2022-01-07
 ### Fixed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -275,6 +275,6 @@ public abstract class SpotlessExtension {
 	}
 
 	protected void predeclare(GradleProvisioner.Policy policy) {
-		project.getExtensions().create(SpotlessExtension.class, EXTENSION_PREDECLARE, SpotlessExtensionPredeclare.class, project, policy);
+		project.getExtensions().create(SpotlessExtensionPredeclare.class, EXTENSION_PREDECLARE, SpotlessExtensionPredeclare.class, project, policy);
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
It seems because the extension is added lazily when calling `predeclareDeps`, Gradle does not generate Kotlin accessors to be able to just call `spotlessPredeclare { }` (or maybe just something I couldn't figure out well). This isn't ideal but not a big deal if we could use the other standard gradle pattern `configure`, but currently we cannot because there are two extensions with the same type.

```kotlin
configure<SpotlessPredeclareExtension> {  // Nor does SpotlessExtension work since two with that type
}
```

I guess there is a Gradle idiom of making sure to use unique types for extension declarations so this PR is probably needed.

Separately, I wonder if instead of having `predeclareDeps` in spotless should be replaced by always registering the `spotlessPredeclare` extension and adding a `policy` method or similar in it, so it is activated when calling that `policy` method instead of `predelcareDeps` on the `spotless` extension.

- [x] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.