### PR TITLE
Internal-only breaking changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ This document is intended for Spotless developers.
 
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
+## [TBD lint release]
+* **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use `PaddedCell.check()`.
+
 ## [Unreleased]
 ### Changes
 * Bump the dev version of Gradle from `7.5.1` to `7.6` ([#1409](https://github.com/diffplug/spotless/pull/1409))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use `PaddedCell.check()`.
 * **BREAKING** Removed `FormatterStep.Strict` because it was unnecessary and unused implementation detail.
 * **BREAKING** Moved `PaddedCell.DirtyState` to its own top-level class with new methods.
+* **BREAKING** Removed `rootDir` parameter from `Formatter`
 
 ## [Unreleased]
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [TBD lint release]
 * **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use `PaddedCell.check()`.
+* **BREAKING** Removed `FormatterStep.Strict` because it was unnecessary and unused implementation detail.
 
 ## [Unreleased]
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,11 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [TBD lint release]
-* **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use `PaddedCell.check()`.
-* **BREAKING** Removed `FormatterStep.Strict` because it was unnecessary and unused implementation detail.
-* **BREAKING** Moved `PaddedCell.DirtyState` to its own top-level class with new methods.
+* **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use new class `DirtyState.of`
+* **BREAKING** Removed `FormatterStep.Strict` because it was an unnecessary and unused implementation detail
 * **BREAKING** Removed `rootDir` and `exceptionPolicy` parameters from `Formatter`
+* **BREAKING** Renamed `PipeStepPair` to `FenceStep` and changed its approach to be lint-friendly
+* **BREAKING** Modified `StepHarness` and `StepHarnessWithFile` to stop asserting on exceptions (to prepare for Lint)
 
 ## [Unreleased]
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use `PaddedCell.check()`.
 * **BREAKING** Removed `FormatterStep.Strict` because it was unnecessary and unused implementation detail.
 * **BREAKING** Moved `PaddedCell.DirtyState` to its own top-level class with new methods.
-* **BREAKING** Removed `rootDir` parameter from `Formatter`
+* **BREAKING** Removed `rootDir` and `exceptionPolicy` parameters from `Formatter`
 
 ## [Unreleased]
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [TBD lint release]
 * **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use `PaddedCell.check()`.
 * **BREAKING** Removed `FormatterStep.Strict` because it was unnecessary and unused implementation detail.
+* **BREAKING** Moved `PaddedCell.DirtyState` to its own top-level class with new methods.
 
 ## [Unreleased]
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [TBD lint release]
+* **BREAKING** Removed all deprecated methods.
 * **BREAKING** Removed `isClean`, `applyTo`, and `applyToAndReturnResultIfDirty` from `Formatter` because users should instead use new class `DirtyState.of`
 * **BREAKING** Removed `FormatterStep.Strict` because it was an unnecessary and unused implementation detail
 * **BREAKING** Removed `rootDir` and `exceptionPolicy` parameters from `Formatter`

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,15 +56,17 @@ public final class DiffMessageFormatter {
 	}
 
 	private static class CleanProviderFormatter implements CleanProvider {
+		private final Path rootDir;
 		private final Formatter formatter;
 
-		CleanProviderFormatter(Formatter formatter) {
+		CleanProviderFormatter(Path rootDir, Formatter formatter) {
+			this.rootDir = Objects.requireNonNull(rootDir);
 			this.formatter = Objects.requireNonNull(formatter);
 		}
 
 		@Override
 		public Path getRootDir() {
-			return formatter.getRootDir();
+			return rootDir;
 		}
 
 		@Override
@@ -121,8 +123,8 @@ public final class DiffMessageFormatter {
 			return this;
 		}
 
-		public Builder formatter(Formatter formatter) {
-			this.formatter = new CleanProviderFormatter(formatter);
+		public Builder formatter(Path rootDir, Formatter formatter) {
+			this.formatter = new CleanProviderFormatter(rootDir, formatter);
 			return this;
 		}
 

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,24 +26,19 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.common.base.Errors;
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.ResourceHarness;
 
 class GitAttributesTest extends ResourceHarness {
 	private List<File> testFiles(String prefix) {
-		try {
-			List<File> result = new ArrayList<>();
-			for (String path : TEST_PATHS) {
-				String prefixedPath = prefix + path;
-				setFile(prefixedPath).toContent("");
-				result.add(newFile(prefixedPath));
-			}
-			return result;
-		} catch (IOException e) {
-			throw Errors.asRuntime(e);
+		List<File> result = new ArrayList<>();
+		for (String path : TEST_PATHS) {
+			String prefixedPath = prefix + path;
+			setFile(prefixedPath).toContent("");
+			result.add(newFile(prefixedPath));
 		}
+		return result;
 	}
 
 	private List<File> testFiles() {

--- a/lib/src/main/java/com/diffplug/spotless/DirtyState.java
+++ b/lib/src/main/java/com/diffplug/spotless/DirtyState.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022-2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import javax.annotation.Nullable;
+
+/**
+ * The clean/dirty state of a single file.  Intended use:
+ * - {@link #isClean()} means that the file is is clean, and there's nothing else to say
+ * - {@link #didNotConverge()} means that we were unable to determine a clean state
+ * - once you've tested the above conditions and you know that it's a dirty file with a converged state,
+ * then you can call {@link #writeCanonicalTo(OutputStream)} to get the canonical form of the given file.
+ */
+public class DirtyState {
+	@Nullable
+	private final byte[] canonicalBytes;
+
+	DirtyState(@Nullable byte[] canonicalBytes) {
+		this.canonicalBytes = canonicalBytes;
+	}
+
+	public boolean isClean() {
+		return this == isClean;
+	}
+
+	public boolean didNotConverge() {
+		return this == didNotConverge;
+	}
+
+	private byte[] canonicalBytes() {
+		if (canonicalBytes == null) {
+			throw new IllegalStateException("First make sure that {@code !isClean()} and {@code !didNotConverge()}");
+		}
+		return canonicalBytes;
+	}
+
+	public void writeCanonicalTo(File file) throws IOException {
+		Files.write(file.toPath(), canonicalBytes());
+	}
+
+	public void writeCanonicalTo(OutputStream out) throws IOException {
+		out.write(canonicalBytes());
+	}
+
+	/** Returns the DirtyState which corresponds to {@code isClean()}. */
+	public static DirtyState clean() {
+		return isClean;
+	}
+
+	static final DirtyState didNotConverge = new DirtyState(null);
+	static final DirtyState isClean = new DirtyState(null);
+
+	public static Calculation of(Formatter formatter, File file) throws IOException {
+		return of(formatter, file, Files.readAllBytes(file.toPath()));
+	}
+
+	public static Calculation of(Formatter formatter, File file, byte[] rawBytes) {
+		return new Calculation(formatter, file, rawBytes);
+	}
+
+	public static class Calculation {
+		private final Formatter formatter;
+		private final File file;
+		private final byte[] rawBytes;
+		private final String raw;
+
+		private Calculation(Formatter formatter, File file, byte[] rawBytes) {
+			this.formatter = formatter;
+			this.file = file;
+			this.rawBytes = rawBytes;
+			this.raw = new String(rawBytes, formatter.getEncoding());
+			// check that all characters were encodable
+			String encodingError = EncodingErrorMsg.msg(raw, rawBytes, formatter.getEncoding());
+			if (encodingError != null) {
+				throw new IllegalArgumentException(encodingError);
+			}
+		}
+
+		/**
+		 * Calculates whether the given file is dirty according to a PaddedCell invocation of the given formatter.
+		 * DirtyState includes the clean state of the file, as well as a warning if we were not able to apply the formatter
+		 * due to diverging idempotence.
+		 */
+		public DirtyState calculateDirtyState() {
+			String rawUnix = LineEnding.toUnix(raw);
+
+			// enforce the format
+			String formattedUnix = formatter.compute(rawUnix, file);
+			// convert the line endings if necessary
+			String formatted = formatter.computeLineEndings(formattedUnix, file);
+
+			// if F(input) == input, then the formatter is well-behaving and the input is clean
+			byte[] formattedBytes = formatted.getBytes(formatter.getEncoding());
+			if (Arrays.equals(rawBytes, formattedBytes)) {
+				return isClean;
+			}
+
+			// F(input) != input, so we'll do a padded check
+			String doubleFormattedUnix = formatter.compute(formattedUnix, file);
+			if (doubleFormattedUnix.equals(formattedUnix)) {
+				// most dirty files are idempotent-dirty, so this is a quick-short circuit for that common case
+				return new DirtyState(formattedBytes);
+			}
+
+			PaddedCell cell = PaddedCell.check(formatter, file, rawUnix);
+			if (!cell.isResolvable()) {
+				return didNotConverge;
+			}
+
+			// get the canonical bytes
+			String canonicalUnix = cell.canonical();
+			String canonical = formatter.computeLineEndings(canonicalUnix, file);
+			byte[] canonicalBytes = canonical.getBytes(formatter.getEncoding());
+			if (!Arrays.equals(rawBytes, canonicalBytes)) {
+				// and write them to disk if needed
+				return new DirtyState(canonicalBytes);
+			} else {
+				return isClean;
+			}
+		}
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,16 +24,11 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
-import javax.annotation.Nullable;
 
 /** Formatter which performs the full formatting. */
 public final class Formatter implements Serializable, AutoCloseable {
@@ -140,66 +135,6 @@ public final class Formatter implements Serializable, AutoCloseable {
 		public Formatter build() {
 			return new Formatter(lineEndingsPolicy, encoding, rootDir, steps,
 					exceptionPolicy == null ? FormatExceptionPolicy.failOnlyOnError() : exceptionPolicy);
-		}
-	}
-
-	/** Returns true iff the given file's formatting is up-to-date. */
-	public boolean isClean(File file) throws IOException {
-		Objects.requireNonNull(file);
-
-		String raw = new String(Files.readAllBytes(file.toPath()), encoding);
-		String unix = LineEnding.toUnix(raw);
-
-		// check the newlines (we can find these problems without even running the steps)
-		int totalNewLines = (int) unix.codePoints().filter(val -> val == '\n').count();
-		int windowsNewLines = raw.length() - unix.length();
-		if (lineEndingsPolicy.isUnix(file)) {
-			if (windowsNewLines != 0) {
-				return false;
-			}
-		} else {
-			if (windowsNewLines != totalNewLines) {
-				return false;
-			}
-		}
-
-		// check the other formats
-		String formatted = compute(unix, file);
-
-		// return true iff the formatted string equals the unix one
-		return formatted.equals(unix);
-	}
-
-	/** Applies formatting to the given file. */
-	public void applyTo(File file) throws IOException {
-		applyToAndReturnResultIfDirty(file);
-	}
-
-	/**
-	 * Applies formatting to the given file.
-	 *
-	 * Returns null if the file was already clean, or the
-	 * formatted result with unix newlines if it was not.
-	 */
-	public @Nullable String applyToAndReturnResultIfDirty(File file) throws IOException {
-		Objects.requireNonNull(file);
-
-		byte[] rawBytes = Files.readAllBytes(file.toPath());
-		String raw = new String(rawBytes, encoding);
-		String rawUnix = LineEnding.toUnix(raw);
-
-		// enforce the format
-		String formattedUnix = compute(rawUnix, file);
-		// enforce the line endings
-		String formatted = computeLineEndings(formattedUnix, file);
-
-		// write out the file iff it has changed
-		byte[] formattedBytes = formatted.getBytes(encoding);
-		if (!Arrays.equals(rawBytes, formattedBytes)) {
-			Files.write(file.toPath(), formattedBytes, StandardOpenOption.TRUNCATE_EXISTING);
-			return formattedUnix;
-		} else {
-			return null;
 		}
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,12 +69,6 @@ public interface FormatterFunc {
 					return function.apply(unix);
 				}
 			};
-		}
-
-		/** @deprecated synonym for {@link #ofDangerous(AutoCloseable, FormatterFunc)} */
-		@Deprecated
-		public static Closeable of(AutoCloseable closeable, FormatterFunc function) {
-			return ofDangerous(closeable, function);
 		}
 
 		@FunctionalInterface

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,28 +65,6 @@ public interface FormatterStep extends Serializable {
 	 */
 	public default FormatterStep filterByFile(SerializableFileFilter filter) {
 		return new FilterByFileFormatterStep(this, filter);
-	}
-
-	/**
-	 * Implements a FormatterStep in a strict way which guarantees correct and lazy implementation
-	 * of up-to-date checks.  This maximizes performance for cases where the FormatterStep is not
-	 * actually needed (e.g. don't load eclipse setting file unless this step is actually running)
-	 * while also ensuring that gradle can detect changes in a step's settings to determine that
-	 * it needs to rerun a format.
-	 */
-	abstract class Strict<State extends Serializable> extends LazyForwardingEquality<State> implements FormatterStep {
-		private static final long serialVersionUID = 1L;
-
-		/**
-		 * Implements the formatting function strictly in terms
-		 * of the input data and the result of {@link #calculateState()}.
-		 */
-		protected abstract String format(State state, String rawUnix, File file) throws Exception;
-
-		@Override
-		public final String format(String rawUnix, File file) throws Exception {
-			return format(state(), rawUnix, file);
-		}
 	}
 
 	/**

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.Random;
 
-import com.diffplug.spotless.FormatterStep.Strict;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -32,7 +30,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * from the API.
  */
 @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-abstract class FormatterStepImpl<State extends Serializable> extends Strict<State> {
+abstract class FormatterStepImpl<State extends Serializable> extends LazyForwardingEquality<State> implements FormatterStep {
 	private static final long serialVersionUID = 1L;
 
 	/** Transient because only the state matters. */
@@ -71,15 +69,19 @@ abstract class FormatterStepImpl<State extends Serializable> extends Strict<Stat
 			this.stateToFormatter = Objects.requireNonNull(stateToFormatter);
 		}
 
+		private FormatterFunc func() throws Exception {
+			if (formatter != null) {
+				return formatter;
+			}
+			formatter = stateToFormatter.apply(state());
+			return formatter;
+		}
+
 		@Override
-		protected String format(State state, String rawUnix, File file) throws Exception {
-			Objects.requireNonNull(state, "state");
+		public String format(String rawUnix, File file) throws Exception {
 			Objects.requireNonNull(rawUnix, "rawUnix");
 			Objects.requireNonNull(file, "file");
-			if (formatter == null) {
-				formatter = stateToFormatter.apply(state());
-			}
-			return formatter.apply(rawUnix, file);
+			return func().apply(rawUnix, file);
 		}
 
 		void cleanupFormatterFunc() {
@@ -104,15 +106,17 @@ abstract class FormatterStepImpl<State extends Serializable> extends Strict<Stat
 			this.formatterSupplier = Objects.requireNonNull(formatterSupplier, "formatterSupplier");
 		}
 
-		@Override
-		protected String format(Integer state, String rawUnix, File file) throws Exception {
-			if (formatter == null) {
-				formatter = formatterSupplier.get();
-				if (formatter instanceof FormatterFunc.Closeable) {
-					throw new AssertionError("NeverUpToDate does not support FormatterFunc.Closeable.  See https://github.com/diffplug/spotless/pull/284");
-				}
+		private FormatterFunc func() throws Exception {
+			if (formatter != null) {
+				return formatter;
 			}
-			return formatter.apply(rawUnix, file);
+			formatter = formatterSupplier.get();
+			return formatter;
+		}
+
+		@Override
+		public String format(String rawUnix, File file) throws Exception {
+			return func().apply(rawUnix, file);
 		}
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,18 +102,6 @@ public enum LineEnding {
     private static final Policy MAC_CLASSIC_POLICY = new ConstantLineEndingPolicy(MAC_CLASSIC.str());
 	private static final String _platformNative = System.getProperty("line.separator");
 	private static final Policy _platformNativePolicy = new ConstantLineEndingPolicy(_platformNative);
-	private static final boolean nativeIsWin = _platformNative.equals(WINDOWS.str());
-
-	/**
-	 * @deprecated Using the system-native line endings to detect the windows operating system has turned out
-	 * to be unreliable.  Use {@link FileSignature#machineIsWin()} instead.
-	 *
-	 * @see FileSignature#machineIsWin()
-	 */
-	@Deprecated
-	public static boolean nativeIsWin() {
-		return nativeIsWin;
-	}
 
 	/** Returns the standard line ending for this policy. */
 	public String str() {

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,13 @@ package com.diffplug.spotless;
 import static com.diffplug.spotless.LibPreconditions.requireElementsNonNull;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
-
-import javax.annotation.Nullable;
 
 /**
  * Models the result of applying a {@link Formatter} on a given {@link File}
@@ -176,108 +171,4 @@ public final class PaddedCell {
 		}
 		// @formatter:on
 	}
-
-	/**
-	 * Calculates whether the given file is dirty according to a PaddedCell invocation of the given formatter.
-	 * DirtyState includes the clean state of the file, as well as a warning if we were not able to apply the formatter
-	 * due to diverging idempotence.
-	 */
-	public static DirtyState calculateDirtyState(Formatter formatter, File file) throws IOException {
-		Objects.requireNonNull(formatter, "formatter");
-		Objects.requireNonNull(file, "file");
-
-		byte[] rawBytes = Files.readAllBytes(file.toPath());
-		return calculateDirtyState(formatter, file, rawBytes);
-	}
-
-	public static DirtyState calculateDirtyState(Formatter formatter, File file, byte[] rawBytes) throws IOException {
-		String raw = new String(rawBytes, formatter.getEncoding());
-		// check that all characters were encodable
-		String encodingError = EncodingErrorMsg.msg(raw, rawBytes, formatter.getEncoding());
-		if (encodingError != null) {
-			throw new IllegalArgumentException(encodingError);
-		}
-		String rawUnix = LineEnding.toUnix(raw);
-
-		// enforce the format
-		String formattedUnix = formatter.compute(rawUnix, file);
-		// convert the line endings if necessary
-		String formatted = formatter.computeLineEndings(formattedUnix, file);
-
-		// if F(input) == input, then the formatter is well-behaving and the input is clean
-		byte[] formattedBytes = formatted.getBytes(formatter.getEncoding());
-		if (Arrays.equals(rawBytes, formattedBytes)) {
-			return isClean;
-		}
-
-		// F(input) != input, so we'll do a padded check
-		String doubleFormattedUnix = formatter.compute(formattedUnix, file);
-		if (doubleFormattedUnix.equals(formattedUnix)) {
-			// most dirty files are idempotent-dirty, so this is a quick-short circuit for that common case
-			return new DirtyState(formattedBytes);
-		}
-
-		PaddedCell cell = PaddedCell.check(formatter, file, rawUnix);
-		if (!cell.isResolvable()) {
-			return didNotConverge;
-		}
-
-		// get the canonical bytes
-		String canonicalUnix = cell.canonical();
-		String canonical = formatter.computeLineEndings(canonicalUnix, file);
-		byte[] canonicalBytes = canonical.getBytes(formatter.getEncoding());
-		if (!Arrays.equals(rawBytes, canonicalBytes)) {
-			// and write them to disk if needed
-			return new DirtyState(canonicalBytes);
-		} else {
-			return isClean;
-		}
-	}
-
-	/**
-	 * The clean/dirty state of a single file.  Intended use:
-	 * - {@link #isClean()} means that the file is clean, and there's nothing else to say
-	 * - {@link #didNotConverge()} means that we were unable to determine a clean state
-	 * - once you've tested the above conditions and you know that it's a dirty file with a converged state,
-	 *   then you can call {@link #writeCanonicalTo(OutputStream)} to get the canonical form of the given file.
-	 */
-	public static class DirtyState {
-		@Nullable
-		private final byte[] canonicalBytes;
-
-		private DirtyState(@Nullable byte[] canonicalBytes) {
-			this.canonicalBytes = canonicalBytes;
-		}
-
-		public boolean isClean() {
-			return this == isClean;
-		}
-
-		public boolean didNotConverge() {
-			return this == didNotConverge;
-		}
-
-		private byte[] canonicalBytes() {
-			if (canonicalBytes == null) {
-				throw new IllegalStateException("First make sure that {@code !isClean()} and {@code !didNotConverge()}");
-			}
-			return canonicalBytes;
-		}
-
-		public void writeCanonicalTo(File file) throws IOException {
-			Files.write(file.toPath(), canonicalBytes());
-		}
-
-		public void writeCanonicalTo(OutputStream out) throws IOException {
-			out.write(canonicalBytes());
-		}
-	}
-
-	/** Returns the DirtyState which corresponds to {@code isClean()}. */
-	public static DirtyState isClean() {
-		return isClean;
-	}
-
-	private static final DirtyState didNotConverge = new DirtyState(null);
-	private static final DirtyState isClean = new DirtyState(null);
 }

--- a/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
@@ -29,10 +29,10 @@ import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
-public class PipeStepPair {
+public class FenceStep {
 	/** Declares the name of the step. */
-	public static PipeStepPair named(String name) {
-		return new PipeStepPair(name);
+	public static FenceStep named(String name) {
+		return new FenceStep(name);
 	}
 
 	public static String defaultToggleName() {
@@ -50,22 +50,22 @@ public class PipeStepPair {
 	String name;
 	Pattern regex;
 
-	private PipeStepPair(String name) {
+	private FenceStep(String name) {
 		this.name = Objects.requireNonNull(name);
 	}
 
 	/** Defines the opening and closing markers. */
-	public PipeStepPair openClose(String open, String close) {
+	public FenceStep openClose(String open, String close) {
 		return regex(Pattern.quote(open) + "([\\s\\S]*?)" + Pattern.quote(close));
 	}
 
 	/** Defines the pipe via regex. Must have *exactly one* capturing group. */
-	public PipeStepPair regex(String regex) {
+	public FenceStep regex(String regex) {
 		return regex(Pattern.compile(regex));
 	}
 
 	/** Defines the pipe via regex. Must have *exactly one* capturing group. */
-	public PipeStepPair regex(Pattern regex) {
+	public FenceStep regex(Pattern regex) {
 		this.regex = Objects.requireNonNull(regex);
 		return this;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
@@ -29,6 +29,8 @@ import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class FenceStep {
 	/** Declares the name of the step. */
 	public static FenceStep named(String name) {
@@ -94,6 +96,8 @@ public class FenceStep {
 	}
 
 	static class ApplyWithin extends Apply implements FormatterFunc.Closeable.ResourceFuncNeedsFile<Formatter> {
+		private static final long serialVersionUID = 17061466531957339L;
+
 		ApplyWithin(Pattern regex, List<FormatterStep> steps) {
 			super(regex, steps);
 		}
@@ -112,6 +116,8 @@ public class FenceStep {
 	}
 
 	static class PreserveWithin extends Apply implements FormatterFunc.Closeable.ResourceFuncNeedsFile<Formatter> {
+		private static final long serialVersionUID = -8676786492305178343L;
+
 		PreserveWithin(Pattern regex, List<FormatterStep> steps) {
 			super(regex, steps);
 		}
@@ -133,7 +139,9 @@ public class FenceStep {
 		}
 	}
 
+	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 	static class Apply implements Serializable {
+		private static final long serialVersionUID = -2301848328356559915L;
 		final Pattern regex;
 		final List<FormatterStep> steps;
 
@@ -189,8 +197,9 @@ public class FenceStep {
 				builder.append(unix, lastEnd, unix.length());
 				return builder.toString();
 			} else {
-				int startLine = 1 + (int) builder.toString().codePoints().filter(c -> c == '\n').count();
-				int endLine = 1 + (int) unix.codePoints().filter(c -> c == '\n').count();
+				// these will be needed to generate Lints later on
+				// int startLine = 1 + (int) builder.toString().codePoints().filter(c -> c == '\n').count();
+				// int endLine = 1 + (int) unix.codePoints().filter(c -> c == '\n').count();
 
 				// throw an error with either the full regex, or the nicer open/close pair
 				Matcher openClose = Pattern.compile("\\\\Q([\\s\\S]*?)\\\\E" + "\\Q([\\s\\S]*?)\\E" + "\\\\Q([\\s\\S]*?)\\\\E")

--- a/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -30,12 +29,10 @@ import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class PipeStepPair {
-	/** The two steps will be named {@code <name>In} and {@code <name>Out}. */
-	public static Builder named(String name) {
-		return new Builder(name);
+	/** Declares the name of the step. */
+	public static PipeStepPair named(String name) {
+		return new PipeStepPair(name);
 	}
 
 	public static String defaultToggleName() {
@@ -50,73 +47,123 @@ public class PipeStepPair {
 		return "spotless:on";
 	}
 
-	public static class Builder {
-		String name;
-		Pattern regex;
+	String name;
+	Pattern regex;
 
-		private Builder(String name) {
-			this.name = Objects.requireNonNull(name);
+	private PipeStepPair(String name) {
+		this.name = Objects.requireNonNull(name);
+	}
+
+	/** Defines the opening and closing markers. */
+	public PipeStepPair openClose(String open, String close) {
+		return regex(Pattern.quote(open) + "([\\s\\S]*?)" + Pattern.quote(close));
+	}
+
+	/** Defines the pipe via regex. Must have *exactly one* capturing group. */
+	public PipeStepPair regex(String regex) {
+		return regex(Pattern.compile(regex));
+	}
+
+	/** Defines the pipe via regex. Must have *exactly one* capturing group. */
+	public PipeStepPair regex(Pattern regex) {
+		this.regex = Objects.requireNonNull(regex);
+		return this;
+	}
+
+	private void assertRegexSet() {
+		Objects.requireNonNull(regex, "must call regex() or openClose()");
+	}
+
+	/** Returns a step which will apply the given steps but preserve the content selected by the regex / openClose pair. */
+	public FormatterStep preserveWithin(List<FormatterStep> steps) {
+		assertRegexSet();
+		return FormatterStep.createLazy(name,
+				() -> new PreserveWithin(regex, steps),
+				state -> FormatterFunc.Closeable.of(state.buildFormatter(), state));
+	}
+
+	/**
+	 * Returns a step which will apply the given steps only within the blocks selected by the regex / openClose pair.
+	 * Linting within the substeps is not supported.
+	 */
+	public FormatterStep applyWithin(List<FormatterStep> steps) {
+		assertRegexSet();
+		return FormatterStep.createLazy(name,
+				() -> new ApplyWithin(regex, steps),
+				state -> FormatterFunc.Closeable.of(state.buildFormatter(), state));
+	}
+
+	static class ApplyWithin extends Apply implements FormatterFunc.Closeable.ResourceFuncNeedsFile<Formatter> {
+		ApplyWithin(Pattern regex, List<FormatterStep> steps) {
+			super(regex, steps);
 		}
 
-		/** Defines the opening and closing markers. */
-		public Builder openClose(String open, String close) {
-			return regex(Pattern.quote(open) + "([\\s\\S]*?)" + Pattern.quote(close));
-		}
-
-		/** Defines the pipe via regex. Must have *exactly one* capturing group. */
-		public Builder regex(String regex) {
-			return regex(Pattern.compile(regex));
-		}
-
-		/** Defines the pipe via regex. Must have *exactly one* capturing group. */
-		public Builder regex(Pattern regex) {
-			this.regex = Objects.requireNonNull(regex);
-			return this;
-		}
-
-		/** Returns a pair of steps which captures in the first part, then returns in the second. */
-		public PipeStepPair buildPair() {
-			return new PipeStepPair(name, regex);
-		}
-
-		/** Returns a single step which will apply the given steps only within the blocks selected by the regex / openClose pair. */
-		public FormatterStep buildStepWhichAppliesSubSteps(Collection<? extends FormatterStep> steps) {
-			return FormatterStep.createLazy(name,
-					() -> new StateApplyToBlock(regex, steps),
-					state -> FormatterFunc.Closeable.of(state.buildFormatter(), state::format));
+		@Override
+		public String apply(Formatter formatter, String unix, File file) throws Exception {
+			List<String> groups = groupsZeroed();
+			Matcher matcher = regex.matcher(unix);
+			while (matcher.find()) {
+				// apply the formatter to each group
+				groups.add(formatter.compute(matcher.group(1), file));
+			}
+			// and then assemble the result right away
+			return assembleGroups(unix);
 		}
 	}
 
-	final FormatterStep in, out;
+	static class PreserveWithin extends Apply implements FormatterFunc.Closeable.ResourceFuncNeedsFile<Formatter> {
+		PreserveWithin(Pattern regex, List<FormatterStep> steps) {
+			super(regex, steps);
+		}
 
-	private PipeStepPair(String name, Pattern pattern) {
-		StateIn stateIn = new StateIn(pattern);
-		StateOut stateOut = new StateOut(stateIn);
-		in = FormatterStep.create(name + "In", stateIn, state -> state::format);
-		out = FormatterStep.create(name + "Out", stateOut, state -> state::format);
+		private void storeGroups(String unix) {
+			List<String> groups = groupsZeroed();
+			Matcher matcher = regex.matcher(unix);
+			while (matcher.find()) {
+				// store whatever is within the open/close tags
+				groups.add(matcher.group(1));
+			}
+		}
+
+		@Override
+		public String apply(Formatter formatter, String unix, File file) throws Exception {
+			storeGroups(unix);
+			String formatted = formatter.compute(unix, file);
+			return assembleGroups(formatted);
+		}
 	}
 
-	public FormatterStep in() {
-		return in;
-	}
-
-	public FormatterStep out() {
-		return out;
-	}
-
-	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	static class StateApplyToBlock extends StateIn implements Serializable {
-		private static final long serialVersionUID = -844178006407733370L;
-
+	static class Apply implements Serializable {
+		final Pattern regex;
 		final List<FormatterStep> steps;
-		final transient StringBuilder builder = new StringBuilder();
 
-		StateApplyToBlock(Pattern regex, Collection<? extends FormatterStep> steps) {
-			super(regex);
-			this.steps = new ArrayList<>(steps);
+		transient ArrayList<String> groups = new ArrayList<>();
+		transient StringBuilder builderInternal;
+
+		public Apply(Pattern regex, List<FormatterStep> steps) {
+			this.regex = regex;
+			this.steps = steps;
 		}
 
-		Formatter buildFormatter() {
+		protected ArrayList<String> groupsZeroed() {
+			if (groups == null) {
+				groups = new ArrayList<>();
+			} else {
+				groups.clear();
+			}
+			return groups;
+		}
+
+		private StringBuilder builderZeroed() {
+			if (builderInternal == null) {
+				builderInternal = new StringBuilder();
+			} else {
+				builderInternal.setLength(0);
+			}
+			return builderInternal;
+		}
+
+		protected Formatter buildFormatter() {
 			return Formatter.builder()
 					.encoding(StandardCharsets.UTF_8) // can be any UTF, doesn't matter
 					.lineEndingsPolicy(LineEnding.UNIX.createPolicy()) // just internal, won't conflict with user
@@ -124,85 +171,38 @@ public class PipeStepPair {
 					.build();
 		}
 
-		private String format(Formatter formatter, String unix, File file) throws Exception {
-			groups.clear();
-			Matcher matcher = regex.matcher(unix);
-			while (matcher.find()) {
-				// apply the formatter to each group
-				groups.add(formatter.compute(matcher.group(1), file));
+		protected String assembleGroups(String unix) {
+			if (groups.isEmpty()) {
+				return unix;
 			}
-			// and then assemble the result right away
-			return stateOutCompute(this, builder, unix);
-		}
-	}
-
-	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	static class StateIn implements Serializable {
-		private static final long serialVersionUID = -844178006407733370L;
-
-		final Pattern regex;
-
-		public StateIn(Pattern regex) {
-			this.regex = Objects.requireNonNull(regex);
-		}
-
-		final transient ArrayList<String> groups = new ArrayList<>();
-
-		private String format(String unix) throws Exception {
-			groups.clear();
+			StringBuilder builder = builderZeroed();
 			Matcher matcher = regex.matcher(unix);
+			int lastEnd = 0;
+			int groupIdx = 0;
 			while (matcher.find()) {
-				groups.add(matcher.group(1));
+				builder.append(unix, lastEnd, matcher.start(1));
+				builder.append(groups.get(groupIdx));
+				lastEnd = matcher.end(1);
+				++groupIdx;
 			}
-			return unix;
-		}
-	}
-
-	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	static class StateOut implements Serializable {
-		private static final long serialVersionUID = -1195263184715054229L;
-
-		final StateIn in;
-
-		StateOut(StateIn in) {
-			this.in = Objects.requireNonNull(in);
-		}
-
-		final transient StringBuilder builder = new StringBuilder();
-
-		private String format(String unix) {
-			return stateOutCompute(in, builder, unix);
-		}
-	}
-
-	private static String stateOutCompute(StateIn in, StringBuilder builder, String unix) {
-		if (in.groups.isEmpty()) {
-			return unix;
-		}
-		builder.setLength(0);
-		Matcher matcher = in.regex.matcher(unix);
-		int lastEnd = 0;
-		int groupIdx = 0;
-		while (matcher.find()) {
-			builder.append(unix, lastEnd, matcher.start(1));
-			builder.append(in.groups.get(groupIdx));
-			lastEnd = matcher.end(1);
-			++groupIdx;
-		}
-		if (groupIdx == in.groups.size()) {
-			builder.append(unix, lastEnd, unix.length());
-			return builder.toString();
-		} else {
-			// throw an error with either the full regex, or the nicer open/close pair
-			Matcher openClose = Pattern.compile("\\\\Q([\\s\\S]*?)\\\\E" + "\\Q([\\s\\S]*?)\\E" + "\\\\Q([\\s\\S]*?)\\\\E")
-					.matcher(in.regex.pattern());
-			String pattern;
-			if (openClose.matches()) {
-				pattern = openClose.group(1) + " " + openClose.group(2);
+			if (groupIdx == groups.size()) {
+				builder.append(unix, lastEnd, unix.length());
+				return builder.toString();
 			} else {
-				pattern = in.regex.pattern();
+				int startLine = 1 + (int) builder.toString().codePoints().filter(c -> c == '\n').count();
+				int endLine = 1 + (int) unix.codePoints().filter(c -> c == '\n').count();
+
+				// throw an error with either the full regex, or the nicer open/close pair
+				Matcher openClose = Pattern.compile("\\\\Q([\\s\\S]*?)\\\\E" + "\\Q([\\s\\S]*?)\\E" + "\\\\Q([\\s\\S]*?)\\\\E")
+						.matcher(regex.pattern());
+				String pattern;
+				if (openClose.matches()) {
+					pattern = openClose.group(1) + " " + openClose.group(2);
+				} else {
+					pattern = regex.pattern();
+				}
+				throw new Error("An intermediate step removed a match of " + pattern);
 			}
-			throw new Error("An intermediate step removed a match of " + pattern);
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/PipeStepPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.diffplug.spotless.generic;
 import java.io.File;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -81,10 +80,10 @@ public class PipeStepPair {
 		}
 
 		/** Returns a single step which will apply the given steps only within the blocks selected by the regex / openClose pair. */
-		public FormatterStep buildStepWhichAppliesSubSteps(Path rootPath, Collection<? extends FormatterStep> steps) {
+		public FormatterStep buildStepWhichAppliesSubSteps(Collection<? extends FormatterStep> steps) {
 			return FormatterStep.createLazy(name,
 					() -> new StateApplyToBlock(regex, steps),
-					state -> FormatterFunc.Closeable.of(state.buildFormatter(rootPath), state::format));
+					state -> FormatterFunc.Closeable.of(state.buildFormatter(), state::format));
 		}
 	}
 
@@ -117,12 +116,11 @@ public class PipeStepPair {
 			this.steps = new ArrayList<>(steps);
 		}
 
-		Formatter buildFormatter(Path rootDir) {
+		Formatter buildFormatter() {
 			return Formatter.builder()
 					.encoding(StandardCharsets.UTF_8) // can be any UTF, doesn't matter
 					.lineEndingsPolicy(LineEnding.UNIX.createPolicy()) // just internal, won't conflict with user
 					.steps(steps)
-					.rootDir(rootDir)
 					.build();
 		}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -710,13 +711,13 @@ public class FormatExtension {
 		withinBlocksHelper(PipeStepPair.named(name).regex(regex), clazz, configure);
 	}
 
-	private <T extends FormatExtension> void withinBlocksHelper(PipeStepPair.Builder builder, Class<T> clazz, Action<T> configure) {
+	private <T extends FormatExtension> void withinBlocksHelper(PipeStepPair builder, Class<T> clazz, Action<T> configure) {
 		// create the sub-extension
 		T formatExtension = spotless.instantiateFormatExtension(clazz);
 		// configure it
 		configure.execute(formatExtension);
 		// create a step which applies all of those steps as sub-steps
-		addStep(builder.buildStepWhichAppliesSubSteps(formatExtension.steps));
+		addStep(builder.applyWithin(formatExtension.steps));
 	}
 
 	/**
@@ -724,12 +725,12 @@ public class FormatExtension {
 	 * inside that captured group.
 	 */
 	public void toggleOffOnRegex(String regex) {
-		this.togglePair = PipeStepPair.named(PipeStepPair.defaultToggleName()).regex(regex).buildPair();
+		this.togglePair = PipeStepPair.named(PipeStepPair.defaultToggleName()).regex(regex);
 	}
 
 	/** Disables formatting between the given tags. */
 	public void toggleOffOn(String off, String on) {
-		this.togglePair = PipeStepPair.named(PipeStepPair.defaultToggleName()).openClose(off, on).buildPair();
+		this.togglePair = PipeStepPair.named(PipeStepPair.defaultToggleName()).openClose(off, on);
 	}
 
 	/** Disables formatting between {@code spotless:off} and {@code spotless:on}. */
@@ -752,10 +753,7 @@ public class FormatExtension {
 		task.setTarget(totalTarget);
 		List<FormatterStep> steps;
 		if (togglePair != null) {
-			steps = new ArrayList<>(this.steps.size() + 2);
-			steps.add(togglePair.in());
-			steps.addAll(this.steps);
-			steps.add(togglePair.out());
+			steps = Collections.singletonList(togglePair.preserveWithin(this.steps));
 		} else {
 			steps = this.steps;
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -52,11 +52,11 @@ import com.diffplug.spotless.cpp.ClangFormatStep;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
 import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 import com.diffplug.spotless.generic.EndWithNewlineStep;
+import com.diffplug.spotless.generic.FenceStep;
 import com.diffplug.spotless.generic.IndentStep;
 import com.diffplug.spotless.generic.LicenseHeaderStep;
 import com.diffplug.spotless.generic.LicenseHeaderStep.YearMode;
 import com.diffplug.spotless.generic.NativeCmdStep;
-import com.diffplug.spotless.generic.PipeStepPair;
 import com.diffplug.spotless.generic.ReplaceRegexStep;
 import com.diffplug.spotless.generic.ReplaceStep;
 import com.diffplug.spotless.generic.TrimTrailingWhitespaceStep;
@@ -698,7 +698,7 @@ public class FormatExtension {
 	 * </pre>
 	 */
 	public <T extends FormatExtension> void withinBlocks(String name, String open, String close, Class<T> clazz, Action<T> configure) {
-		withinBlocksHelper(PipeStepPair.named(name).openClose(open, close), clazz, configure);
+		withinBlocksHelper(FenceStep.named(name).openClose(open, close), clazz, configure);
 	}
 
 	/** Same as {@link #withinBlocks(String, String, String, Action)}, except instead of an open/close pair, you specify a regex with exactly one capturing group. */
@@ -708,10 +708,10 @@ public class FormatExtension {
 
 	/** Same as {@link #withinBlocksRegex(String, String, Action)}, except you can specify any language-specific subclass of {@link FormatExtension} to get language-specific steps. */
 	public <T extends FormatExtension> void withinBlocksRegex(String name, String regex, Class<T> clazz, Action<T> configure) {
-		withinBlocksHelper(PipeStepPair.named(name).regex(regex), clazz, configure);
+		withinBlocksHelper(FenceStep.named(name).regex(regex), clazz, configure);
 	}
 
-	private <T extends FormatExtension> void withinBlocksHelper(PipeStepPair builder, Class<T> clazz, Action<T> configure) {
+	private <T extends FormatExtension> void withinBlocksHelper(FenceStep builder, Class<T> clazz, Action<T> configure) {
 		// create the sub-extension
 		T formatExtension = spotless.instantiateFormatExtension(clazz);
 		// configure it
@@ -725,17 +725,17 @@ public class FormatExtension {
 	 * inside that captured group.
 	 */
 	public void toggleOffOnRegex(String regex) {
-		this.togglePair = PipeStepPair.named(PipeStepPair.defaultToggleName()).regex(regex);
+		this.togglePair = FenceStep.named(FenceStep.defaultToggleName()).regex(regex);
 	}
 
 	/** Disables formatting between the given tags. */
 	public void toggleOffOn(String off, String on) {
-		this.togglePair = PipeStepPair.named(PipeStepPair.defaultToggleName()).openClose(off, on);
+		this.togglePair = FenceStep.named(FenceStep.defaultToggleName()).openClose(off, on);
 	}
 
 	/** Disables formatting between {@code spotless:off} and {@code spotless:on}. */
 	public void toggleOffOn() {
-		toggleOffOn(PipeStepPair.defaultToggleOff(), PipeStepPair.defaultToggleOn());
+		toggleOffOn(FenceStep.defaultToggleOff(), FenceStep.defaultToggleOn());
 	}
 
 	/** Undoes all previous calls to {@link #toggleOffOn()} and {@link #toggleOffOn(String, String)}. */
@@ -743,7 +743,7 @@ public class FormatExtension {
 		this.togglePair = null;
 	}
 
-	private @Nullable PipeStepPair togglePair;
+	private @Nullable FenceStep togglePair;
 
 	/** Sets up a format task according to the values in this extension. */
 	protected void setupTask(SpotlessTask task) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -716,8 +716,7 @@ public class FormatExtension {
 		// configure it
 		configure.execute(formatExtension);
 		// create a step which applies all of those steps as sub-steps
-		FormatterStep step = builder.buildStepWhichAppliesSubSteps(spotless.project.getRootDir().toPath(), formatExtension.steps);
-		addStep(step);
+		addStep(builder.buildStepWhichAppliesSubSteps(formatExtension.steps));
 	}
 
 	/**

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -725,12 +725,12 @@ public class FormatExtension {
 	 * inside that captured group.
 	 */
 	public void toggleOffOnRegex(String regex) {
-		this.togglePair = FenceStep.named(FenceStep.defaultToggleName()).regex(regex);
+		this.toggleFence = FenceStep.named(FenceStep.defaultToggleName()).regex(regex);
 	}
 
 	/** Disables formatting between the given tags. */
 	public void toggleOffOn(String off, String on) {
-		this.togglePair = FenceStep.named(FenceStep.defaultToggleName()).openClose(off, on);
+		this.toggleFence = FenceStep.named(FenceStep.defaultToggleName()).openClose(off, on);
 	}
 
 	/** Disables formatting between {@code spotless:off} and {@code spotless:on}. */
@@ -740,10 +740,10 @@ public class FormatExtension {
 
 	/** Undoes all previous calls to {@link #toggleOffOn()} and {@link #toggleOffOn(String, String)}. */
 	public void toggleOffOnDisable() {
-		this.togglePair = null;
+		this.toggleFence = null;
 	}
 
-	private @Nullable FenceStep togglePair;
+	private @Nullable FenceStep toggleFence;
 
 	/** Sets up a format task according to the values in this extension. */
 	protected void setupTask(SpotlessTask task) {
@@ -752,8 +752,8 @@ public class FormatExtension {
 		FileCollection totalTarget = targetExclude == null ? target : target.minus(targetExclude);
 		task.setTarget(totalTarget);
 		List<FormatterStep> steps;
-		if (togglePair != null) {
-			steps = Collections.singletonList(togglePair.preserveWithin(this.steps));
+		if (toggleFence != null) {
+			steps = Collections.singletonList(toggleFence.preserveWithin(this.steps));
 		} else {
 			steps = this.steps;
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@ package com.diffplug.gradle.spotless;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 import com.diffplug.common.base.Errors;
 import com.diffplug.common.io.ByteStreams;
+import com.diffplug.spotless.DirtyState;
 import com.diffplug.spotless.Formatter;
-import com.diffplug.spotless.PaddedCell;
 
 class IdeHook {
 	final static String PROPERTY = "spotlessIdeHook";
@@ -49,13 +48,14 @@ class IdeHook {
 						return;
 					}
 				}
+				DirtyState.Calculation init;
 				byte[] bytes;
 				if (spotlessTask.getProject().hasProperty(USE_STD_IN)) {
-					bytes = ByteStreams.toByteArray(System.in);
+					init = DirtyState.of(formatter, file, ByteStreams.toByteArray(System.in));
 				} else {
-					bytes = Files.readAllBytes(file.toPath());
+					init = DirtyState.of(formatter, file);
 				}
-				PaddedCell.DirtyState dirty = PaddedCell.calculateDirtyState(formatter, file, bytes);
+				DirtyState dirty = init.calculateDirtyState();
 				if (dirty.isClean()) {
 					dumpIsClean();
 				} else if (dirty.didNotConverge()) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,7 +186,6 @@ public abstract class SpotlessTask extends DefaultTask {
 		return Formatter.builder()
 				.lineEndingsPolicy(lineEndingsPolicy.get())
 				.encoding(Charset.forName(encoding))
-				.rootDir(getProjectDir().get().getAsFile().toPath())
 				.steps(steps.get())
 				.exceptionPolicy(exceptionPolicy)
 				.build();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -187,7 +187,6 @@ public abstract class SpotlessTask extends DefaultTask {
 				.lineEndingsPolicy(lineEndingsPolicy.get())
 				.encoding(Charset.forName(encoding))
 				.steps(steps.get())
-				.exceptionPolicy(exceptionPolicy)
 				.build();
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ import org.gradle.work.FileChange;
 import org.gradle.work.InputChanges;
 
 import com.diffplug.common.base.StringPrinter;
+import com.diffplug.spotless.DirtyState;
 import com.diffplug.spotless.Formatter;
-import com.diffplug.spotless.PaddedCell;
 import com.diffplug.spotless.extra.GitRatchet;
 
 @CacheableTask
@@ -95,11 +95,11 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 	private void processInputFile(@Nullable GitRatchet ratchet, Formatter formatter, File input) throws IOException {
 		File output = getOutputFile(input);
 		getLogger().debug("Applying format to " + input + " and writing to " + output);
-		PaddedCell.DirtyState dirtyState;
+		DirtyState dirtyState;
 		if (ratchet != null && ratchet.isClean(getProjectDir().get().getAsFile(), getRootTreeSha(), input)) {
-			dirtyState = PaddedCell.isClean();
+			dirtyState = DirtyState.clean();
 		} else {
-			dirtyState = PaddedCell.calculateDirtyState(formatter, input);
+			dirtyState = DirtyState.of(formatter, input).calculateDirtyState();
 		}
 		if (dirtyState.isClean()) {
 			// Remove previous output if it exists

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ErrorShouldRethrowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.CharMatcher;
@@ -30,6 +31,7 @@ import com.diffplug.common.base.Splitter;
 import com.diffplug.spotless.LineEnding;
 
 /** Tests the desired behavior from https://github.com/diffplug/spotless/issues/46. */
+@Disabled("Because Formatter doesn't respect FormatExceptionPolicy anymore")
 class ErrorShouldRethrowTest extends GradleIntegrationHarness {
 	private void writeBuild(String... toInsert) throws IOException {
 		List<String> lines = new ArrayList<>();

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	private List<RemoteRepository> repositories;
 
 	@Parameter(defaultValue = "${project.basedir}", required = true, readonly = true)
-	private File baseDir;
+	protected File baseDir;
 
 	@Parameter(defaultValue = "${project.build.directory}", required = true, readonly = true)
 	private File buildDir;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,6 @@ public abstract class FormatterFactory {
 				.lineEndingsPolicy(formatterLineEndingPolicy)
 				.exceptionPolicy(new FormatExceptionPolicyStrict())
 				.steps(formatterSteps)
-				.rootDir(config.getFileLocator().getBaseDir().toPath())
 				.build();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptySet;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -34,7 +35,6 @@ import com.diffplug.common.collect.Sets;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
-import com.diffplug.spotless.generic.PipeStepPair;
 import com.diffplug.spotless.maven.generic.EclipseWtp;
 import com.diffplug.spotless.maven.generic.EndWithNewline;
 import com.diffplug.spotless.maven.generic.Indent;
@@ -95,11 +95,9 @@ public abstract class FormatterFactory {
 				.map(factory -> factory.newFormatterStep(stepConfig))
 				.collect(Collectors.toCollection(() -> new ArrayList<FormatterStep>()));
 		if (toggle != null) {
-			PipeStepPair pair = toggle.createPair();
-			formatterSteps.add(0, pair.in());
-			formatterSteps.add(pair.out());
+			List<FormatterStep> formatterStepsBeforeToggle = formatterSteps;
+			formatterSteps = Collections.singletonList(toggle.createPair().preserveWithin(formatterStepsBeforeToggle));
 		}
-
 		return Formatter.builder()
 				.encoding(formatterEncoding)
 				.lineEndingsPolicy(formatterLineEndingPolicy)

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import com.diffplug.common.collect.Sets;
-import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
@@ -104,7 +103,6 @@ public abstract class FormatterFactory {
 		return Formatter.builder()
 				.encoding(formatterEncoding)
 				.lineEndingsPolicy(formatterLineEndingPolicy)
-				.exceptionPolicy(new FormatExceptionPolicyStrict())
 				.steps(formatterSteps)
 				.build();
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -96,7 +96,7 @@ public abstract class FormatterFactory {
 				.collect(Collectors.toCollection(() -> new ArrayList<FormatterStep>()));
 		if (toggle != null) {
 			List<FormatterStep> formatterStepsBeforeToggle = formatterSteps;
-			formatterSteps = Collections.singletonList(toggle.createPair().preserveWithin(formatterStepsBeforeToggle));
+			formatterSteps = Collections.singletonList(toggle.createFence().preserveWithin(formatterStepsBeforeToggle));
 		}
 		return Formatter.builder()
 				.encoding(formatterEncoding)

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import java.io.IOException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
+import com.diffplug.spotless.DirtyState;
 import com.diffplug.spotless.Formatter;
-import com.diffplug.spotless.PaddedCell;
 import com.diffplug.spotless.maven.incremental.UpToDateChecker;
 
 /**
@@ -42,7 +42,7 @@ public class SpotlessApplyMojo extends AbstractSpotlessMojo {
 			}
 
 			try {
-				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
+				DirtyState dirtyState = DirtyState.of(formatter, file).calculateDirtyState();
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					dirtyState.writeCanonicalTo(file);
 					buildContext.refresh(file);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -62,7 +62,7 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 		if (!problemFiles.isEmpty()) {
 			throw new MojoExecutionException(DiffMessageFormatter.builder()
 					.runToFix("Run 'mvn spotless:apply' to fix these violations.")
-					.formatter(formatter)
+					.formatter(baseDir.toPath(), formatter)
 					.problemFiles(problemFiles)
 					.getMessage());
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
+import com.diffplug.spotless.DirtyState;
 import com.diffplug.spotless.Formatter;
-import com.diffplug.spotless.PaddedCell;
 import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 import com.diffplug.spotless.maven.incremental.UpToDateChecker;
 
@@ -48,7 +48,7 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 			}
 
 			try {
-				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
+				DirtyState dirtyState = DirtyState.of(formatter, file).calculateDirtyState();
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					problemFiles.add(file);
 				} else {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ToggleOffOn.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ToggleOffOn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,9 @@ public class ToggleOffOn {
 
 	public PipeStepPair createPair() {
 		if (regex != null) {
-			return PipeStepPair.named(PipeStepPair.defaultToggleName()).regex(regex).buildPair();
+			return PipeStepPair.named(PipeStepPair.defaultToggleName()).regex(regex);
 		} else {
-			return PipeStepPair.named(PipeStepPair.defaultToggleName()).openClose(off, on).buildPair();
+			return PipeStepPair.named(PipeStepPair.defaultToggleName()).openClose(off, on);
 		}
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ToggleOffOn.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ToggleOffOn.java
@@ -17,23 +17,23 @@ package com.diffplug.spotless.maven.generic;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
-import com.diffplug.spotless.generic.PipeStepPair;
+import com.diffplug.spotless.generic.FenceStep;
 
 public class ToggleOffOn {
 	@Parameter
-	public String off = PipeStepPair.defaultToggleOff();
+	public String off = FenceStep.defaultToggleOff();
 
 	@Parameter
-	public String on = PipeStepPair.defaultToggleOn();
+	public String on = FenceStep.defaultToggleOn();
 
 	@Parameter
 	public String regex;
 
-	public PipeStepPair createPair() {
+	public FenceStep createPair() {
 		if (regex != null) {
-			return PipeStepPair.named(PipeStepPair.defaultToggleName()).regex(regex);
+			return FenceStep.named(FenceStep.defaultToggleName()).regex(regex);
 		} else {
-			return PipeStepPair.named(PipeStepPair.defaultToggleName()).openClose(off, on);
+			return FenceStep.named(FenceStep.defaultToggleName()).openClose(off, on);
 		}
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ToggleOffOn.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ToggleOffOn.java
@@ -29,7 +29,7 @@ public class ToggleOffOn {
 	@Parameter
 	public String regex;
 
-	public FenceStep createPair() {
+	public FenceStep createFence() {
 		if (regex != null) {
 			return FenceStep.named(FenceStep.defaultToggleName()).regex(regex);
 		} else {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/NoopCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
@@ -37,7 +36,6 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
@@ -116,11 +114,9 @@ class NoopCheckerTest extends ResourceHarness {
 
 	private static Formatter dummyFormatter() {
 		return Formatter.builder()
-				.rootDir(Paths.get(""))
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
 				.encoding(UTF_8)
 				.steps(singletonList(mock(FormatterStep.class, withSettings().serializable())))
-				.exceptionPolicy(new FormatExceptionPolicyStrict())
 				.build();
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -32,7 +31,6 @@ import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.spotless.FormatExceptionPolicyStrict;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
@@ -246,11 +244,9 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 
 	private static Formatter formatter(LineEnding lineEnding, FormatterStep... steps) {
 		return Formatter.builder()
-				.rootDir(Paths.get(""))
 				.lineEndingsPolicy(lineEnding.createPolicy())
 				.encoding(UTF_8)
 				.steps(Arrays.asList(steps))
-				.exceptionPolicy(new FormatExceptionPolicyStrict())
 				.build();
 	}
 }

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class ResourceHarness {
 	}
 
 	/** Returns a new child of the root folder. */
-	protected File newFile(String subpath) throws IOException {
+	protected File newFile(String subpath) {
 		return new File(rootFolder(), subpath);
 	}
 
@@ -85,12 +85,12 @@ public class ResourceHarness {
 	}
 
 	/** Returns the contents of the given file from the src/test/resources directory. */
-	protected static String getTestResource(String filename) throws IOException {
+	protected static String getTestResource(String filename) {
 		URL url = ResourceHarness.class.getResource("/" + filename);
 		if (url == null) {
 			throw new IllegalArgumentException("No such resource " + filename);
 		}
-		return Resources.toString(url, StandardCharsets.UTF_8);
+		return ThrowingEx.get(() -> LineEnding.toUnix(Resources.toString(url, StandardCharsets.UTF_8)));
 	}
 
 	/** Returns Files (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
@@ -176,7 +176,7 @@ public class ResourceHarness {
 		}
 	}
 
-	protected WriteAsserter setFile(String path) throws IOException {
+	protected WriteAsserter setFile(String path) {
 		return new WriteAsserter(newFile(path));
 	}
 
@@ -188,21 +188,25 @@ public class ResourceHarness {
 			this.file = file;
 		}
 
-		public File toLines(String... lines) throws IOException {
+		public File toLines(String... lines) {
 			return toContent(String.join("\n", Arrays.asList(lines)));
 		}
 
-		public File toContent(String content) throws IOException {
+		public File toContent(String content) {
 			return toContent(content, StandardCharsets.UTF_8);
 		}
 
-		public File toContent(String content, Charset charset) throws IOException {
-			Files.write(file.toPath(), content.getBytes(charset));
+		public File toContent(String content, Charset charset) {
+			ThrowingEx.run(() -> {
+				Files.write(file.toPath(), content.getBytes(charset));
+			});
 			return file;
 		}
 
-		public File toResource(String path) throws IOException {
-			Files.write(file.toPath(), getTestResource(path).getBytes(StandardCharsets.UTF_8));
+		public File toResource(String path) {
+			ThrowingEx.run(() -> {
+				Files.write(file.toPath(), getTestResource(path).getBytes(StandardCharsets.UTF_8));
+			});
 			return file;
 		}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -21,31 +21,21 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.function.Consumer;
 
-import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 
 /** An api for testing a {@code FormatterStep} that doesn't depend on the File path. DO NOT ADD FILE SUPPORT TO THIS, use {@link StepHarnessWithFile} if you need that. */
 public class StepHarness implements AutoCloseable {
-	private final FormatterFunc formatter;
+	private final Formatter formatter;
 
-	private StepHarness(FormatterFunc formatter) {
+	private StepHarness(Formatter formatter) {
 		this.formatter = Objects.requireNonNull(formatter);
 	}
 
 	/** Creates a harness for testing steps which don't depend on the file. */
 	public static StepHarness forStep(FormatterStep step) {
-		// We don't care if an individual FormatterStep is misbehaving on line-endings, because
-		// Formatter fixes that.  No reason to care in tests either.  It's likely to pop up when
-		// running tests on Windows from time-to-time
-		return new StepHarness(FormatterFunc.Closeable.ofDangerous(
-				() -> {
-					if (step instanceof FormatterStepImpl.Standard) {
-						((FormatterStepImpl.Standard<?>) step).cleanupFormatterFunc();
-					}
-				},
-				input -> LineEnding.toUnix(step.format(input, new File("")))));
+		return forSteps(step);
 	}
 
 	/** Creates a harness for testing steps which don't depend on the file. */
@@ -59,55 +49,62 @@ public class StepHarness implements AutoCloseable {
 
 	/** Creates a harness for testing a formatter whose steps don't depend on the file. */
 	public static StepHarness forFormatter(Formatter formatter) {
-		return new StepHarness(FormatterFunc.Closeable.ofDangerous(
-				formatter::close,
-				input -> formatter.compute(input, new File(""))));
+		return new StepHarness(formatter);
 	}
 
 	/** Asserts that the given element is transformed as expected, and that the result is idempotent. */
-	public StepHarness test(String before, String after) throws Exception {
-		String actual = formatter.apply(before);
+	public StepHarness test(String before, String after) {
+		String actual = formatter.compute(LineEnding.toUnix(before), new File(""));
 		assertEquals(after, actual, "Step application failed");
 		return testUnaffected(after);
 	}
 
 	/** Asserts that the given element is idempotent w.r.t the step under test. */
-	public StepHarness testUnaffected(String idempotentElement) throws Exception {
-		String actual = formatter.apply(idempotentElement);
+	public StepHarness testUnaffected(String idempotentElement) {
+		String actual = formatter.compute(LineEnding.toUnix(idempotentElement), new File(""));
 		assertEquals(idempotentElement, actual, "Step is not idempotent");
 		return this;
 	}
 
 	/** Asserts that the given elements in  the resources directory are transformed as expected. */
-	public StepHarness testResource(String resourceBefore, String resourceAfter) throws Exception {
+	public StepHarness testResource(String resourceBefore, String resourceAfter) {
 		String before = ResourceHarness.getTestResource(resourceBefore);
 		String after = ResourceHarness.getTestResource(resourceAfter);
 		return test(before, after);
 	}
 
 	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarness testResourceUnaffected(String resourceIdempotent) throws Exception {
+	public StepHarness testResourceUnaffected(String resourceIdempotent) {
 		String idempotentElement = ResourceHarness.getTestResource(resourceIdempotent);
 		return testUnaffected(idempotentElement);
 	}
 
-	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarness testResourceException(String resourceBefore, Consumer<AbstractThrowableAssert<?, ? extends Throwable>> exceptionAssertion) throws Exception {
-		return testException(ResourceHarness.getTestResource(resourceBefore), exceptionAssertion);
+	public AbstractStringAssert<?> testResourceExceptionMsg(String resourceBefore) {
+		return testExceptionMsg(ResourceHarness.getTestResource(resourceBefore));
 	}
 
-	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarness testException(String before, Consumer<AbstractThrowableAssert<?, ? extends Throwable>> exceptionAssertion) throws Exception {
-		Throwable t = assertThrows(Throwable.class, () -> formatter.apply(before));
-		AbstractThrowableAssert<?, ? extends Throwable> abstractAssert = Assertions.assertThat(t);
-		exceptionAssertion.accept(abstractAssert);
-		return this;
+	public AbstractStringAssert<?> testExceptionMsg(String before) {
+		try {
+			formatter.compute(LineEnding.toUnix(before), FormatterStepImpl.SENTINEL);
+			throw new SecurityException("Expected exception");
+		} catch (Throwable e) {
+			if (e instanceof SecurityException) {
+				throw new AssertionError(e.getMessage());
+			} else {
+				Throwable rootCause = e;
+				while (rootCause.getCause() != null) {
+					if (rootCause instanceof IllegalStateException) {
+						break;
+					}
+					rootCause = rootCause.getCause();
+				}
+				return Assertions.assertThat(rootCause.getMessage());
+			}
+		}
 	}
 
 	@Override
 	public void close() {
-		if (formatter instanceof FormatterFunc.Closeable) {
-			((FormatterFunc.Closeable) formatter).close();
-		}
+		formatter.close();
 	}
 }

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -55,7 +54,6 @@ public class StepHarness implements AutoCloseable {
 				.steps(Arrays.asList(steps))
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
 				.encoding(StandardCharsets.UTF_8)
-				.rootDir(Paths.get(""))
 				.build());
 	}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,78 +18,99 @@ package com.diffplug.spotless;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Objects;
+
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.Assertions;
 
 /** An api for testing a {@code FormatterStep} that depends on the File path. */
 public class StepHarnessWithFile implements AutoCloseable {
-	private final FormatterFunc formatter;
+	private final Formatter formatter;
+	private ResourceHarness harness;
 
-	private StepHarnessWithFile(FormatterFunc formatter) {
+	private StepHarnessWithFile(ResourceHarness harness, Formatter formatter) {
+		this.harness = Objects.requireNonNull(harness);
 		this.formatter = Objects.requireNonNull(formatter);
+
 	}
 
 	/** Creates a harness for testing steps which do depend on the file. */
-	public static StepHarnessWithFile forStep(FormatterStep step) {
-		// We don't care if an individual FormatterStep is misbehaving on line-endings, because
-		// Formatter fixes that.  No reason to care in tests either.  It's likely to pop up when
-		// running tests on Windows from time-to-time
-		return new StepHarnessWithFile(FormatterFunc.Closeable.ofDangerous(
-				() -> {
-					if (step instanceof FormatterStepImpl.Standard) {
-						((FormatterStepImpl.Standard<?>) step).cleanupFormatterFunc();
-					}
-				},
-				new FormatterFunc() {
-					@Override
-					public String apply(String unix) throws Exception {
-						return apply(unix, new File(""));
-					}
-
-					@Override
-					public String apply(String unix, File file) throws Exception {
-						return LineEnding.toUnix(step.format(unix, file));
-					}
-				}));
+	public static StepHarnessWithFile forStep(ResourceHarness harness, FormatterStep step) {
+		return new StepHarnessWithFile(harness, Formatter.builder()
+				.encoding(StandardCharsets.UTF_8)
+				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
+				.steps(Arrays.asList(step))
+				.build());
 	}
 
 	/** Creates a harness for testing a formatter whose steps do depend on the file. */
-	public static StepHarnessWithFile forFormatter(Formatter formatter) {
-		return new StepHarnessWithFile(FormatterFunc.Closeable.ofDangerous(
-				formatter::close,
-				input -> formatter.compute(input, new File(""))));
+	public static StepHarnessWithFile forFormatter(ResourceHarness harness, Formatter formatter) {
+		return new StepHarnessWithFile(harness, formatter);
 	}
 
 	/** Asserts that the given element is transformed as expected, and that the result is idempotent. */
-	public StepHarnessWithFile test(File file, String before, String after) throws Exception {
-		String actual = formatter.apply(before, file);
+	public StepHarnessWithFile test(File file, String before, String after) {
+		String actual = formatter.compute(LineEnding.toUnix(before), file);
 		assertEquals(after, actual, "Step application failed");
 		return testUnaffected(file, after);
 	}
 
 	/** Asserts that the given element is idempotent w.r.t the step under test. */
-	public StepHarnessWithFile testUnaffected(File file, String idempotentElement) throws Exception {
-		String actual = formatter.apply(idempotentElement, file);
+	public StepHarnessWithFile testUnaffected(File file, String idempotentElement) {
+		String actual = formatter.compute(LineEnding.toUnix(idempotentElement), file);
 		assertEquals(idempotentElement, actual, "Step is not idempotent");
 		return this;
 	}
 
 	/** Asserts that the given elements in  the resources directory are transformed as expected. */
-	public StepHarnessWithFile testResource(File file, String resourceBefore, String resourceAfter) throws Exception {
-		String before = ResourceHarness.getTestResource(resourceBefore);
-		String after = ResourceHarness.getTestResource(resourceAfter);
-		return test(file, before, after);
+	public StepHarnessWithFile testResource(String resourceBefore, String resourceAfter) {
+		return testResource(resourceBefore, resourceBefore, resourceAfter);
+	}
+
+	public StepHarnessWithFile testResource(String filename, String resourceBefore, String resourceAfter) {
+		String contentBefore = ResourceHarness.getTestResource(resourceBefore);
+		File file = harness.setFile(filename).toContent(contentBefore);
+		return test(file, contentBefore, ResourceHarness.getTestResource(resourceAfter));
 	}
 
 	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarnessWithFile testResourceUnaffected(File file, String resourceIdempotent) throws Exception {
-		String idempotentElement = ResourceHarness.getTestResource(resourceIdempotent);
-		return testUnaffected(file, idempotentElement);
+	public StepHarnessWithFile testResourceUnaffected(String resourceIdempotent) {
+		String contentBefore = ResourceHarness.getTestResource(resourceIdempotent);
+		File file = harness.setFile(resourceIdempotent).toContent(contentBefore);
+		return testUnaffected(file, contentBefore);
+	}
+
+	public AbstractStringAssert<?> testResourceExceptionMsg(String resourceBefore) {
+		return testResourceExceptionMsg(resourceBefore, resourceBefore);
+	}
+
+	public AbstractStringAssert<?> testResourceExceptionMsg(String filename, String resourceBefore) {
+		String contentBefore = ResourceHarness.getTestResource(resourceBefore);
+		File file = harness.setFile(filename).toContent(contentBefore);
+		return testExceptionMsg(file, contentBefore);
+	}
+
+	public AbstractStringAssert<?> testExceptionMsg(File file, String before) {
+		try {
+			formatter.compute(LineEnding.toUnix(before), file);
+			throw new SecurityException("Expected exception");
+		} catch (Throwable e) {
+			if (e instanceof SecurityException) {
+				throw new AssertionError(e.getMessage());
+			} else {
+				Throwable rootCause = e;
+				while (rootCause.getCause() != null) {
+					rootCause = rootCause.getCause();
+				}
+				return Assertions.assertThat(rootCause.getMessage());
+			}
+		}
 	}
 
 	@Override
 	public void close() {
-		if (formatter instanceof FormatterFunc.Closeable) {
-			((FormatterFunc.Closeable) formatter).close();
-		}
+		formatter.close();
 	}
 }

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -33,7 +33,6 @@ public class StepHarnessWithFile implements AutoCloseable {
 	private StepHarnessWithFile(ResourceHarness harness, Formatter formatter) {
 		this.harness = Objects.requireNonNull(harness);
 		this.formatter = Objects.requireNonNull(formatter);
-
 	}
 
 	/** Creates a harness for testing steps which do depend on the file. */

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,12 @@ package com.diffplug.spotless;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.common.base.StandardSystemProperty;
 import com.diffplug.spotless.generic.EndWithNewlineStep;
 
 class FormatterTest {
@@ -42,9 +39,7 @@ class FormatterTest {
 		new SerializableEqualityTester() {
 			private LineEnding.Policy lineEndingsPolicy = LineEnding.UNIX.createPolicy();
 			private Charset encoding = StandardCharsets.UTF_8;
-			private Path rootDir = Paths.get(StandardSystemProperty.USER_DIR.value());
 			private List<FormatterStep> steps = new ArrayList<>();
-			private FormatExceptionPolicy exceptionPolicy = FormatExceptionPolicy.failOnlyOnError();
 
 			@Override
 			protected void setupTest(API api) throws Exception {
@@ -56,25 +51,8 @@ class FormatterTest {
 				encoding = StandardCharsets.UTF_16;
 				api.areDifferentThan();
 
-				rootDir = rootDir.getParent();
-				api.areDifferentThan();
-
 				steps.add(EndWithNewlineStep.create());
 				api.areDifferentThan();
-
-				{
-					FormatExceptionPolicyStrict standard = new FormatExceptionPolicyStrict();
-					standard.excludePath("path");
-					exceptionPolicy = standard;
-					api.areDifferentThan();
-				}
-
-				{
-					FormatExceptionPolicyStrict standard = new FormatExceptionPolicyStrict();
-					standard.excludeStep("step");
-					exceptionPolicy = standard;
-					api.areDifferentThan();
-				}
 			}
 
 			@Override
@@ -82,9 +60,7 @@ class FormatterTest {
 				return Formatter.builder()
 						.lineEndingsPolicy(lineEndingsPolicy)
 						.encoding(encoding)
-						.rootDir(rootDir)
 						.steps(steps)
-						.exceptionPolicy(exceptionPolicy)
 						.build();
 			}
 		}.testEquals();

--- a/testlib/src/test/java/com/diffplug/spotless/PaddedCellTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/PaddedCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,6 @@ class PaddedCellTest {
 		try (Formatter formatter = Formatter.builder()
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
 				.encoding(StandardCharsets.UTF_8)
-				.rootDir(rootFolder.toPath())
 				.steps(formatterSteps).build()) {
 
 			File file = new File(rootFolder, "input");

--- a/testlib/src/test/java/com/diffplug/spotless/cpp/ClangFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/cpp/ClangFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,26 @@
  */
 package com.diffplug.spotless.cpp;
 
-import java.io.File;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.tag.ClangTest;
 
 @ClangTest
-class ClangFormatStepTest {
+class ClangFormatStepTest extends ResourceHarness {
 	@Test
 	void test() throws Exception {
-		try (StepHarnessWithFile harness = StepHarnessWithFile.forStep(ClangFormatStep.withVersion(ClangFormatStep.defaultVersion()).create())) {
+		try (StepHarnessWithFile harness = StepHarnessWithFile.forStep(this, ClangFormatStep.withVersion(ClangFormatStep.defaultVersion()).create())) {
 			// can't be named java or it gets compiled into .class file
-			harness.testResource(new File("example.java"), "clang/example.java.dirty", "clang/example.java.clean");
+			harness.testResource("example.java", "clang/example.java.dirty", "clang/example.java.clean");
 			// test every other language clang supports
 			for (String ext : Arrays.asList("c", "cs", "js", "m", "proto")) {
 				String filename = "example." + ext;
 				String root = "clang/" + filename;
-				harness.testResource(new File(filename), root, root + ".clean");
+				harness.testResource(filename, root, root + ".clean");
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
@@ -26,10 +26,10 @@ import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.StepHarnessWithFile;
 
-class PipeStepPairTest extends ResourceHarness {
+class FenceStepTest extends ResourceHarness {
 	@Test
 	void single() {
-		FormatterStep pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on")
+		FormatterStep pair = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
 				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
 		StepHarness harness = StepHarness.forSteps(pair);
 		harness.test(
@@ -49,7 +49,7 @@ class PipeStepPairTest extends ResourceHarness {
 
 	@Test
 	void multiple() {
-		FormatterStep pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on")
+		FormatterStep pair = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
 				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
 		StepHarness harness = StepHarness.forSteps(pair);
 		harness.test(
@@ -83,7 +83,7 @@ class PipeStepPairTest extends ResourceHarness {
 
 	@Test
 	void broken() {
-		FormatterStep pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on")
+		FormatterStep pair = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
 				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("uppercase", str -> str.toUpperCase(Locale.ROOT))));
 		StepHarnessWithFile harness = StepHarnessWithFile.forStep(this, pair);
 		// this fails because uppercase turns spotless:off into SPOTLESS:OFF, etc
@@ -96,7 +96,7 @@ class PipeStepPairTest extends ResourceHarness {
 
 	@Test
 	void andApply() {
-		FormatterStep pair = PipeStepPair.named("lowercaseSometimes").openClose("<lower>", "</lower>")
+		FormatterStep pair = FenceStep.named("lowercaseSometimes").openClose("<lower>", "</lower>")
 				.applyWithin(Arrays.asList(
 						FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
 		StepHarness.forSteps(pair).test(

--- a/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
@@ -29,9 +29,9 @@ import com.diffplug.spotless.StepHarnessWithFile;
 class FenceStepTest extends ResourceHarness {
 	@Test
 	void single() {
-		FormatterStep pair = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
+		FormatterStep fence = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
 				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
-		StepHarness harness = StepHarness.forSteps(pair);
+		StepHarness harness = StepHarness.forSteps(fence);
 		harness.test(
 				StringPrinter.buildStringFromLines(
 						"A B C",
@@ -49,9 +49,9 @@ class FenceStepTest extends ResourceHarness {
 
 	@Test
 	void multiple() {
-		FormatterStep pair = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
+		FormatterStep fence = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
 				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
-		StepHarness harness = StepHarness.forSteps(pair);
+		StepHarness harness = StepHarness.forSteps(fence);
 		harness.test(
 				StringPrinter.buildStringFromLines(
 						"A B C",
@@ -83,9 +83,9 @@ class FenceStepTest extends ResourceHarness {
 
 	@Test
 	void broken() {
-		FormatterStep pair = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
+		FormatterStep fence = FenceStep.named("underTest").openClose("spotless:off", "spotless:on")
 				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("uppercase", str -> str.toUpperCase(Locale.ROOT))));
-		StepHarnessWithFile harness = StepHarnessWithFile.forStep(this, pair);
+		StepHarnessWithFile harness = StepHarnessWithFile.forStep(this, fence);
 		// this fails because uppercase turns spotless:off into SPOTLESS:OFF, etc
 		harness.testExceptionMsg(newFile("test"), StringPrinter.buildStringFromLines("A B C",
 				"spotless:off",
@@ -96,10 +96,10 @@ class FenceStepTest extends ResourceHarness {
 
 	@Test
 	void andApply() {
-		FormatterStep pair = FenceStep.named("lowercaseSometimes").openClose("<lower>", "</lower>")
+		FormatterStep fence = FenceStep.named("lowercaseSometimes").openClose("<lower>", "</lower>")
 				.applyWithin(Arrays.asList(
 						FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
-		StepHarness.forSteps(pair).test(
+		StepHarness.forSteps(fence).test(
 				StringPrinter.buildStringFromLines(
 						"A B C",
 						"<lower>",

--- a/testlib/src/test/java/com/diffplug/spotless/generic/PipeStepPairTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/PipeStepPairTest.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.spotless.generic;
 
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -23,13 +22,15 @@ import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.StepHarnessWithFile;
 
-class PipeStepPairTest {
+class PipeStepPairTest extends ResourceHarness {
 	@Test
 	void single() {
 		FormatterStep pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on")
-				.preserveWithin(Paths.get(""), Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
+				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
 		StepHarness harness = StepHarness.forSteps(pair);
 		harness.test(
 				StringPrinter.buildStringFromLines(
@@ -49,7 +50,7 @@ class PipeStepPairTest {
 	@Test
 	void multiple() {
 		FormatterStep pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on")
-				.preserveWithin(Paths.get(""), Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
+				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
 		StepHarness harness = StepHarness.forSteps(pair);
 		harness.test(
 				StringPrinter.buildStringFromLines(
@@ -83,11 +84,10 @@ class PipeStepPairTest {
 	@Test
 	void broken() {
 		FormatterStep pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on")
-				.preserveWithin(Paths.get(""), Arrays.asList(FormatterStep.createNeverUpToDate("uppercase", str -> str.toUpperCase(Locale.ROOT))));
-		StepHarness harness = StepHarness.forSteps(pair);
+				.preserveWithin(Arrays.asList(FormatterStep.createNeverUpToDate("uppercase", str -> str.toUpperCase(Locale.ROOT))));
+		StepHarnessWithFile harness = StepHarnessWithFile.forStep(this, pair);
 		// this fails because uppercase turns spotless:off into SPOTLESS:OFF, etc
-		harness.testExceptionMsg(StringPrinter.buildStringFromLines(
-				"A B C",
+		harness.testExceptionMsg(newFile("test"), StringPrinter.buildStringFromLines("A B C",
 				"spotless:off",
 				"D E F",
 				"spotless:on",
@@ -97,7 +97,7 @@ class PipeStepPairTest {
 	@Test
 	void andApply() {
 		FormatterStep pair = PipeStepPair.named("lowercaseSometimes").openClose("<lower>", "</lower>")
-				.applyWithin(Paths.get(""), Arrays.asList(
+				.applyWithin(Arrays.asList(
 						FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT))));
 		StepHarness.forSteps(pair).test(
 				StringPrinter.buildStringFromLines(

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,48 +19,115 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.spotless.*;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.SerializableEqualityTester;
+import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.TestProvisioner;
 
-class JsonSimpleStepTest extends JsonFormatterStepCommonTests {
+class JsonSimpleStepTest {
+
+	private static final int INDENT = 4;
+
+	private final FormatterStep step = JsonSimpleStep.create(INDENT, TestProvisioner.mavenCentral());
+	private final StepHarness stepHarness = StepHarness.forStep(step);
 
 	@Test
-	void handlesSingletonObject() throws Exception {
-		doWithResource("singletonObject");
+	void cannotProvidedNullProvisioner() {
+		assertThatThrownBy(() -> JsonSimpleStep.create(INDENT, null)).isInstanceOf(NullPointerException.class).hasMessage("provisioner cannot be null");
 	}
 
 	@Test
-	void handlesSingletonObjectWithArray() throws Exception {
-		doWithResource("singletonObjectWithArray");
+	void handlesSingletonObject() {
+		doWithResource(stepHarness, "singletonObject");
 	}
 
 	@Test
-	void handlesComplexNestedObject() throws Exception {
-		doWithResource("cucumberJsonSample");
+	void handlesSingletonObjectWithArray() {
+		doWithResource(stepHarness, "singletonObjectWithArray");
 	}
 
 	@Test
-	void handlesObjectWithNull() throws Exception {
-		doWithResource("objectWithNull");
+	void handlesNestedObject() {
+		doWithResource(stepHarness, "nestedObject");
+	}
+
+	@Test
+	void handlesSingletonArray() {
+		doWithResource(stepHarness, "singletonArray");
+	}
+
+	@Test
+	void handlesEmptyFile() {
+		doWithResource(stepHarness, "empty");
+	}
+
+	@Test
+	void handlesComplexNestedObject() {
+		doWithResource(stepHarness, "cucumberJsonSample");
+	}
+
+	@Test
+	void handlesObjectWithNull() {
+		doWithResource(stepHarness, "objectWithNull");
 	}
 
 	@Test
 	void handlesInvalidJson() {
-		assertThatThrownBy(() -> doWithResource("invalidJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to format JSON")
-				.hasRootCauseMessage("Expected a ',' or '}' at 9 [character 0 line 3]");
+		stepHarness.testResourceExceptionMsg("json/invalidJsonBefore.json")
+				.contains("Expected a ',' or '}' at 9 [character 0 line 3]");
 	}
 
 	@Test
 	void handlesNotJson() {
-		assertThatThrownBy(() -> doWithResource("notJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to determine JSON type, expected a '{' or '[' but found '#'")
-				.hasNoCause();
+		stepHarness.testResourceExceptionMsg("json/notJsonBefore.json")
+				.contains("Unable to determine JSON type, expected a '{' or '[' but found '#'");
 	}
 
-	@Override
-	protected FormatterStep createFormatterStep(int indent, Provisioner provisioner) {
-		return JsonSimpleStep.create(indent, provisioner);
+	@Test
+	void canSetCustomIndentationLevel() {
+		FormatterStep step = JsonSimpleStep.create(6, TestProvisioner.mavenCentral());
+		StepHarness stepHarness = StepHarness.forStep(step);
+
+		String before = "json/singletonArrayBefore.json";
+		String after = "json/singletonArrayAfter6Spaces.json";
+		stepHarness.testResource(before, after);
+	}
+
+	@Test
+	void canSetIndentationLevelTo0() {
+		FormatterStep step = JsonSimpleStep.create(0, TestProvisioner.mavenCentral());
+		StepHarness stepHarness = StepHarness.forStep(step);
+
+		String before = "json/singletonArrayBefore.json";
+		String after = "json/singletonArrayAfter0Spaces.json";
+		stepHarness.testResource(before, after);
+	}
+
+	@Test
+	void equality() {
+		new SerializableEqualityTester() {
+			int spaces = 0;
+
+			@Override
+			protected void setupTest(API api) {
+				// no changes, are the same
+				api.areDifferentThan();
+
+				// with different spacing
+				spaces = 1;
+				api.areDifferentThan();
+			}
+
+			@Override
+			protected FormatterStep create() {
+				return JsonSimpleStep.create(spaces, TestProvisioner.mavenCentral());
+			}
+		}.testEquals();
+	}
+
+	private static void doWithResource(StepHarness stepHarness, String name) {
+		String before = String.format("json/%sBefore.json", name);
+		String after = String.format("json/%sAfter.json", name);
+		stepHarness.testResource(before, after);
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.spotless.json.gson;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,25 +39,18 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 
 	@Test
 	void handlesInvalidJson() {
-		assertThatThrownBy(() -> doWithResource("invalidJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to format JSON")
-				.hasRootCauseMessage("End of input at line 3 column 1 path $.a");
+		getStepHarness().testResourceExceptionMsg("json/invalidJsonBefore.json").isEqualTo("End of input at line 3 column 1 path $.a");
 	}
 
 	@Test
 	void handlesNotJson() {
-		assertThatThrownBy(() -> doWithResource("notJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to format JSON")
-				.hasNoCause();
+		getStepHarness().testResourceExceptionMsg("json/notJsonBefore.json").isEqualTo("Unable to format JSON");
 	}
 
 	@Test
 	void handlesSortingWhenSortByKeyEnabled() throws Exception {
 		FormatterStep step = GsonStep.create(INDENT, true, false, DEFAULT_VERSION, TestProvisioner.mavenCentral());
-		StepHarness stepHarness = StepHarness.forStep(step);
-		stepHarness.testResource("json/sortByKeysBefore.json", "json/sortByKeysAfter.json");
+		StepHarness.forStep(step).testResource("json/sortByKeysBefore.json", "json/sortByKeysAfter.json");
 	}
 
 	@Test
@@ -86,10 +77,8 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 	@Test
 	void handlesVersionIncompatibility() {
 		FormatterStep step = GsonStep.create(INDENT, false, false, "1.7", TestProvisioner.mavenCentral());
-		StepHarness stepHarness = StepHarness.forStep(step);
-		assertThatThrownBy(() -> stepHarness.testResource("json/cucumberJsonSampleGsonBefore.json", "json/cucumberJsonSampleGsonAfter.json"))
-				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("There was a problem interacting with Gson; maybe you set an incompatible version?");
+		StepHarness.forStep(step).testResourceExceptionMsg("json/cucumberJsonSampleGsonBefore.json")
+				.isEqualTo("There was a problem interacting with Gson; maybe you set an incompatible version?");
 	}
 
 	@Override

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,27 +25,19 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 
 class DiktatStepTest extends ResourceHarness {
 
 	@Test
-	void behavior() throws Exception {
+	void behavior() {
 		FormatterStep step = DiktatStep.create(TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
-				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 4 unfixed errors:" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
-							System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
-				});
+		StepHarnessWithFile.forStep(this, step).testResourceExceptionMsg("kotlin/diktat/Unsolvable.kt").isEqualTo("There are 2 unfixed errors:" +
+				System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
+				System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
 	}
 
 	@Test
@@ -55,19 +47,11 @@ class DiktatStepTest extends ResourceHarness {
 		FileSignature config = signAsList(conf);
 
 		FormatterStep step = DiktatStep.create("1.2.1", TestProvisioner.mavenCentral(), config);
-		StepHarness.forStep(step)
-				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 4 unfixed errors:" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
-							System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
-				});
+		StepHarnessWithFile.forStep(this, step).testResourceExceptionMsg("kotlin/diktat/Unsolvable.kt").isEqualTo("There are 2 unfixed errors:" +
+				System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
+				System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -22,33 +22,30 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 
 class KtLintStepTest extends ResourceHarness {
 	@Test
 	void behavior() throws Exception {
 		FormatterStep step = KtLintStep.create(TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo(
+						"Error on line: 1, column: 1\n" +
+								"rule: no-wildcard-imports\n" +
+								"Wildcard import");
 	}
 
 	@Test
 	void worksShyiko() throws Exception {
 		FormatterStep step = KtLintStep.create("0.31.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo(
+						"Error on line: 1, column: 1\n" +
+								"rule: no-wildcard-imports\n" +
+								"Wildcard import");
 	}
 
 	// Regression test to ensure it works on the version it switched to Pinterest (version 0.32.0)
@@ -57,14 +54,11 @@ class KtLintStepTest extends ResourceHarness {
 	@Test
 	void worksPinterestAndPre034() throws Exception {
 		FormatterStep step = KtLintStep.create("0.32.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	// Regression test to handle alpha and 1.x version numbers
@@ -108,53 +102,41 @@ class KtLintStepTest extends ResourceHarness {
 	@Test
 	void works0_46_0() throws Exception {
 		FormatterStep step = KtLintStep.create("0.46.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test
 	void works0_47_0() throws Exception {
 		FormatterStep step = KtLintStep.create("0.47.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test
 	void works0_47_1() throws Exception {
 		FormatterStep step = KtLintStep.create("0.47.1", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test
 	void works0_48_0() throws Exception {
 		FormatterStep step = KtLintStep.create("0.48.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
@@ -111,8 +111,8 @@ class PrettierFormatterStepTest extends ResourceHarness {
 					npmPathResolver(),
 					new PrettierConfig(null, ImmutableMap.of("parser", "postcss")));
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
-				stepHarness.testResourceExceptionMsg("npm/prettier/filetypes/scss/scss.dirty").startsWith(
-						"com.diffplug.spotless.npm.SimpleRestClient$SimpleRestResponseException: Unexpected response status code at /prettier/format [HTTP 501] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")");
+				stepHarness.testResourceExceptionMsg("npm/prettier/filetypes/scss/scss.dirty").isEqualTo(
+						"Unexpected response status code at /prettier/format [HTTP 501] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")");
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,13 +25,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.diffplug.common.collect.ImmutableMap;
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.tag.NpmTest;
 
 @NpmTest
-class PrettierFormatterStepTest {
+class PrettierFormatterStepTest extends ResourceHarness {
 
 	@NpmTest
 	@Nested
@@ -96,8 +97,8 @@ class PrettierFormatterStepTest {
 					npmPathResolver(),
 					new PrettierConfig(null, Collections.emptyMap()));
 
-			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(formatterStep)) {
-				stepHarness.testResource(new File("test.json"), dirtyFile, cleanFile);
+			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
+				stepHarness.testResource("test.json", dirtyFile, cleanFile);
 			}
 		}
 
@@ -109,11 +110,9 @@ class PrettierFormatterStepTest {
 					buildDir(),
 					npmPathResolver(),
 					new PrettierConfig(null, ImmutableMap.of("parser", "postcss")));
-			try (StepHarness stepHarness = StepHarness.forStep(formatterStep)) {
-				stepHarness.testResourceException("npm/prettier/filetypes/scss/scss.dirty", exception -> {
-					exception.hasMessageContaining("HTTP 501");
-					exception.hasMessageContaining("Couldn't resolve parser \"postcss\"");
-				});
+			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
+				stepHarness.testResourceExceptionMsg("npm/prettier/filetypes/scss/scss.dirty").startsWith(
+						"com.diffplug.spotless.npm.SimpleRestClient$SimpleRestResponseException: Unexpected response status code at /prettier/format [HTTP 501] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")");
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,8 @@
  */
 package com.diffplug.spotless.scala;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +57,7 @@ class ScalaFmtStepTest extends ResourceHarness {
 	@Test
 	void equality() throws Exception {
 		new SerializableEqualityTester() {
-			String version = "3.5.9";
+			String version = "3.6.1";
 			File configFile = null;
 
 			@Override
@@ -69,7 +65,7 @@ class ScalaFmtStepTest extends ResourceHarness {
 				// same version == same
 				api.areDifferentThan();
 				// change the version, and it's different
-				version = "3.5.8";
+				version = "3.0.0";
 				api.areDifferentThan();
 				// add a config file, and its different
 				configFile = createTestFile("scala/scalafmt/scalafmt.conf");
@@ -90,9 +86,7 @@ class ScalaFmtStepTest extends ResourceHarness {
 	void invalidConfiguration() throws Exception {
 		File invalidConfFile = createTestFile("scala/scalafmt/scalafmt.invalid.conf");
 		Provisioner provisioner = TestProvisioner.mavenCentral();
-
-		InvocationTargetException exception = assertThrows(InvocationTargetException.class,
-				() -> StepHarness.forStep(ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile)).test("", ""));
-		assertThat(exception.getCause().getMessage()).contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
+		StepHarness.forStep(ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile))
+				.testExceptionMsg("").contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
 	}
 }


### PR DESCRIPTION
We've accumulated a little bit of cruft in our internal APIs. Refactoring to support linters is easier if we clean this out first.