### PR TITLE
Compatibility considerations for the IDE hook.

### DIFF
--- a/plugin-gradle/IDE_HOOK.md
+++ b/plugin-gradle/IDE_HOOK.md
@@ -22,3 +22,23 @@ In all of these cases, Spotless will send useful status information on `stderr`:
 - if `stderr` is anything else, then it is the stacktrace of whatever went wrong
 
 See the VS Code extension above for a working example, or [the PR](https://github.com/diffplug/spotless/pull/568) where this feature was added for more context.
+
+## Compatibility considerations and future plans
+
+### Configuration cache
+
+- Gradle 6.6 introduced the [configuration-cache](https://docs.gradle.org/6.6/release-notes.html#performance-improvements)
+- The Spotless IDE hook does not work with the configuration-cache, but this might change in a future version of Spotless ([#1082](https://github.com/diffplug/spotless/issues/1082))
+- A user might have enabled configuration-cache with `org.gradle.unsafe.configuration-cache=true` in a `gradle.properties` file
+- In that case, the IDE plugin must pass `--no-configuration-cache` at the command line or the user will get an error.
+- You could pass that flag all the time, but the flag will generate "unrecognized flag" errors in Gradle < 6.6.
+
+### Configure on demand
+
+This is not yet supported, but in a future version of Spotless you might be able to improve speed dramatically by calling `:spotlessApply --configure-on-demand` rather than `spotlessApply` (note the leading colon). This is being tracked in [#1101](https://github.com/diffplug/spotless/issues/1101).
+
+### Lint as well as format
+
+Spotless is in the process of adding support for linters ([#1097](https://github.com/diffplug/spotless/pull/1097)). When this gets added, Spotless will be able to provide a list of things like `L5: NPE on blah blah blah` and `L8-14: leaking resource` etc.
+
+We will provide those lint errors over stderr like so `IS DIRTY\nLINTS` or `IS CLEAN\nLINTS`, and then provide the list of lints in a TBD format. The key thing is that if you are correctly using `startsWith("IS DIRTY")` then older versions of your plugin are future-compatible.


### PR DESCRIPTION
The Spotless IDE hook should *just* be `spotlessApply -PspotlessIdeHook=${ABSOLUTE_PATH_TO_FILE}`. We've had this API since `3.30.0`, and you shouldn't have to parse a Gradle or Spotless version to use it.

But we've got two backward incompatible problems:

1) Spotless IDE hook is not compatible with the configuration-cache, so you have to specify `--no-configuration-cache`. But, that flag is not compatible with Gradle < 6.6. So you're stuck in this position where you have to parse the Gradle version to know whether you need that flag or not.

2) We can speed Spotless up a lot by changing the API to `:spotlessApply -PspotlessIdeHook=BLAH`, but only after #1101 gets implemented. So you're stuck in this position where you have to parse the Spotless version to know whether you can add the leading colon or not.

We could fix both of those issues by changing the API to this:


`:spotlessIdeHook -PspotlessIdeHook=BLAH --configure-on-demand`

This fixes problem 1 because Gradle 7.4 adds a new [`Task.notCompatibleWithConfigurationCache()` method](https://docs.gradle.org/7.4-rc-1/userguide/configuration_cache.html#config_cache:task_opt_out). We can't use that method to fix problem 1 for `spotlessApply`, but we could use it to fix a new task called `spotlessIdeHook`.

It also fixes problem 2 because we can change the implementation of `:spotlessIdeHook` over time. At first it would trigger the evaluation of all subprojects (like `spotlessApply` does now), but later on it could take advantage of configure-on-demand to speed up execution dramatically.

So I have a question for each of you, @badsyntax and @ragurney, which is easier?

A) Parse Gradle and Spotless versions to determine which arguments to use.
B) Optimistically try `:spotlessIdeHook` method, if it fails fall back to `spotlessApply`, and then remember "optimistic attempt failed" for the rest of the plugin's runtime. No parsing needed, just detecting an error.

As an aside, Spotless is adding support for linters in the medium-term future, and those lints will be available in the IDE hook. We are able to add this information in a backward-compatible way, so it will be optional whether you choose to add support for that in future, no version-parsing or feature-detection required.