### PR TITLE
Add support for git's `core.autocrlf`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default versions of formatters ([#1095](https://github.com/diffplug/spotless/pull/1095)).
   * google-java-format `1.12.0` -> `1.13.0`
   * ktfmt `0.29` -> `0.30`
+* Added support for git property `core.autocrlf` ([#540](https://github.com/diffplug/spotless/issues/540))
 
 ## [2.22.0] - 2022-01-13
 ### Added

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -287,11 +287,13 @@ public final class GitAttributesLineEndings {
 				//                and does no conversion during checkout
 				// mostly used on Unix, so LF is the default encoding
 				return LineEnding.UNIX;
+			} else if (autoCRLF == AutoCRLF.FALSE) {
+				// handle core.eol
+				EOL eol = config.getEnum(ConfigConstants.CONFIG_CORE_SECTION, null, ConfigConstants.CONFIG_KEY_EOL, EOL.NATIVE);
+				return fromEol(eol);
+			} else {
+				throw new IllegalStateException("Unexpected value for autoCRLF " + autoCRLF);
 			}
-
-			// handle core.eol
-			EOL eol = config.getEnum(ConfigConstants.CONFIG_CORE_SECTION, null, ConfigConstants.CONFIG_KEY_EOL, EOL.NATIVE);
-			return fromEol(eol);
 		}
 
 		/** Creates a LineEnding from an EOL. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.Errors;
@@ -86,5 +88,18 @@ class GitAttributesTest extends ResourceHarness {
 		Assertions.assertThat(policy.getEndingFor(newFile("subfolder/someFile"))).isEqualTo("\n");
 		Assertions.assertThat(policy.getEndingFor(newFile("MANIFEST.MF"))).isEqualTo("\r\n");
 		Assertions.assertThat(policy.getEndingFor(newFile("subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
+	}
+
+	@Test
+	void policyDefaultLineEndingTest() throws GitAPIException, IOException {
+		Git git = Git.init().setDirectory(rootFolder()).call();
+		git.close();
+		setFile(".git/config").toContent(StringPrinter.buildStringFromLines(
+			"[core]",
+			"autocrlf=true",
+			"eol=lf"
+		));
+		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), () -> testFiles());
+		Assertions.assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\r\n");
 	}
 }

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,10 +95,9 @@ class GitAttributesTest extends ResourceHarness {
 		Git git = Git.init().setDirectory(rootFolder()).call();
 		git.close();
 		setFile(".git/config").toContent(StringPrinter.buildStringFromLines(
-			"[core]",
-			"autocrlf=true",
-			"eol=lf"
-		));
+				"[core]",
+				"autocrlf=true",
+				"eol=lf"));
 		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), () -> testFiles());
 		Assertions.assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\r\n");
 	}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default versions of formatters ([#1095](https://github.com/diffplug/spotless/pull/1095)).
   * google-java-format `1.12.0` -> `1.13.0`
   * ktfmt `0.29` -> `0.30`
+* Added support for git property `core.autocrlf` ([#540](https://github.com/diffplug/spotless/issues/540))
 
 ## [6.2.0] - 2022-01-13
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default versions of formatters ([#1095](https://github.com/diffplug/spotless/pull/1095)).
   * google-java-format `1.12.0` -> `1.13.0`
   * ktfmt `0.29` -> `0.30`
+* Added support for git property `core.autocrlf` ([#540](https://github.com/diffplug/spotless/issues/540))
 
 ## [2.20.0] - 2022-01-13
 ### Added


### PR DESCRIPTION
Among others, Spotless uses .gitattributes to determine the line ending of files. In the absence of this file, Spotless falls back to `core.eol` from git config.

Before this commit, Spotless ignored the `core.autocrlf` property. Git behaves in such a way that it ignores `core.eol` if `core.autocrlf` is set to `true` or `input`. This commit aligns the behavior of Spotless to favor `core.autocrlf` over `core.eol`.

If merged, this fixes #540.