### PR TITLE
Add support for worktrees

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+# Add full support for git worktrees ([#1119](https://github.com/diffplug/spotless/pull/1119))
 
 ## [2.22.1] - 2022-02-01
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Bump default ktfmt `0.30` -> `0.31` ([#1118](https://github.com/diffplug/spotless/pull/1118)).
+### Fixed
+* Add full support for git worktrees ([#1119](https://github.com/diffplug/spotless/pull/1119)).
 
 ## [2.22.1] - 2022-02-01
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # To fix metaspace errors
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8
 name=spotless
 description=Spotless - keep your code spotless with Gradle
 org=diffplug

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,25 @@ package com.diffplug.spotless.extra;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.jgit.errors.ConfigInvalidException;
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.lib.ConfigConstants;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.util.IO;
+import org.eclipse.jgit.util.RawParseUtils;
+import org.eclipse.jgit.util.SystemReader;
+
+import com.diffplug.common.base.Errors;
 
 /**
  * Utility methods for Git workarounds.
  */
-public class GitWorkarounds {
+public final class GitWorkarounds {
 	private GitWorkarounds() {}
 
 	/**
@@ -40,46 +48,154 @@ public class GitWorkarounds {
 	 * @return the path to the .git directory.
 	 */
 	static @Nullable File getDotGitDir(File projectDir) {
-		return fileRepositoryBuilderForProject(projectDir).getGitDir();
+		return fileRepositoryResolverForProject(projectDir).getGitDir();
 	}
 
 	/**
-	 * Creates a {@link FileRepositoryBuilder} for the given project directory.
+	 * Creates a {@link RepositorySpecificResolver} for the given project directory.
 	 *
 	 * This applies a workaround for JGit not supporting worktrees properly.
 	 *
 	 * @param projectDir the project directory.
 	 * @return the builder.
 	 */
-	static FileRepositoryBuilder fileRepositoryBuilderForProject(File projectDir) {
-		FileRepositoryBuilder builder = new FileRepositoryBuilder();
-		builder.findGitDir(projectDir);
-		File gitDir = builder.getGitDir();
-		if (gitDir != null) {
-			builder.setGitDir(resolveRealGitDirIfWorktreeDir(gitDir));
+	static RepositorySpecificResolver fileRepositoryResolverForProject(File projectDir) {
+		RepositorySpecificResolver repositoryResolver = new RepositorySpecificResolver();
+		repositoryResolver.findGitDir(projectDir);
+		repositoryResolver.readEnvironment();
+		if (repositoryResolver.getGitDir() != null || repositoryResolver.getWorkTree() != null) {
+			Errors.rethrow().get(repositoryResolver::setup);
 		}
-		return builder;
+		return repositoryResolver;
 	}
 
 	/**
-	 * If the dir is a worktree directory (typically .git/worktrees/something) then
-	 * returns the actual .git directory.
+	 * Piggyback on the {@link FileRepositoryBuilder} mechanics for finding the git directory.
 	 *
-	 * @param dir the directory which may be a worktree directory or may be a .git directory.
-	 * @return the .git directory.
+	 * Here we take into account that git repositories can share a common directory. This directory
+	 * will contain ./config ./objects/, ./info/, and ./refs/.
 	 */
-	private static File resolveRealGitDirIfWorktreeDir(File dir) {
-		File pointerFile = new File(dir, "gitdir");
-		if (pointerFile.isFile()) {
-			try {
-				String content = new String(Files.readAllBytes(pointerFile.toPath()), StandardCharsets.UTF_8).trim();
-				return new File(content);
-			} catch (IOException e) {
-				System.err.println("failed to parse git meta: " + e.getMessage());
-				return dir;
+	static class RepositorySpecificResolver extends FileRepositoryBuilder {
+		/**
+		 * The common directory file is used to define $GIT_COMMON_DIR if environment variable is not set.
+		 * https://github.com/git/git/blob/b23dac905bde28da47543484320db16312c87551/Documentation/gitrepository-layout.txt#L259
+		 */
+		private static final String COMMON_DIR = "commondir";
+		private static final String GIT_COMMON_DIR_ENV_KEY = "GIT_COMMON_DIR";
+
+		/**
+		 * Using an extension it is possible to have per-worktree config.
+		 * https://github.com/git/git/blob/b23dac905bde28da47543484320db16312c87551/Documentation/git-worktree.txt#L366
+		 */
+		private static final String EXTENSIONS_WORKTREE_CONFIG = "worktreeConfig";
+		private static final String EXTENSIONS_WORKTREE_CONFIG_FILENAME = "config.worktree";
+
+		private File commonDirectory;
+
+		/** @return the repository specific configuration. */
+		Config getRepositoryConfig() {
+			return Errors.rethrow().get(this::getConfig);
+		}
+
+		/**
+		 * @return the repository's configuration.
+		 * @throws IOException on errors accessing the configuration file.
+		 * @throws IllegalArgumentException on malformed configuration.
+		 */
+		@Override
+		protected Config loadConfig() throws IOException {
+			if (getGitDir() != null) {
+				File path = resolveWithCommonDir(Constants.CONFIG);
+				FileBasedConfig cfg = new FileBasedConfig(path, safeFS());
+				try {
+					cfg.load();
+
+					// Check for per-worktree config, it should be parsed after the common config
+					if (cfg.getBoolean(ConfigConstants.CONFIG_EXTENSIONS_SECTION, EXTENSIONS_WORKTREE_CONFIG, false)) {
+						File worktreeSpecificConfig = safeFS().resolve(getGitDir(), EXTENSIONS_WORKTREE_CONFIG_FILENAME);
+						if (safeFS().exists(worktreeSpecificConfig) && safeFS().isFile(worktreeSpecificConfig)) {
+							// It is important to base this on the common config, as both the common config and the per-worktree config should be used
+							cfg = new FileBasedConfig(cfg, worktreeSpecificConfig, safeFS());
+							try {
+								cfg.load();
+							} catch (ConfigInvalidException err) {
+								throw new IllegalArgumentException("Failed to parse config " + worktreeSpecificConfig.getAbsolutePath(), err);
+							}
+						}
+					}
+				} catch (ConfigInvalidException err) {
+					throw new IllegalArgumentException("Failed to parse config " + path.getAbsolutePath(), err);
+				}
+				return cfg;
 			}
-		} else {
-			return dir;
+			return super.loadConfig();
+		}
+
+		@Override
+		protected void setupGitDir() throws IOException {
+			super.setupGitDir();
+
+			// Setup common directory
+			if (commonDirectory == null) {
+				File commonDirFile = safeFS().resolve(getGitDir(), COMMON_DIR);
+				if (safeFS().exists(commonDirFile) && safeFS().isFile(commonDirFile)) {
+					byte[] content = IO.readFully(commonDirFile);
+					if (content.length < 1) {
+						throw emptyFile(commonDirFile);
+					}
+
+					int lineEnd = RawParseUtils.nextLF(content, 0);
+					while (content[lineEnd - 1] == '\n' || (content[lineEnd - 1] == '\r' && SystemReader.getInstance().isWindows())) {
+						lineEnd--;
+					}
+					if (lineEnd <= 1) {
+						throw emptyFile(commonDirFile);
+					}
+
+					String commonPath = RawParseUtils.decode(content, 0, lineEnd);
+					File common = new File(commonPath);
+					if (common.isAbsolute()) {
+						commonDirectory = common;
+					} else {
+						commonDirectory = safeFS().resolve(getGitDir(), commonPath).getCanonicalFile();
+					}
+				}
+			}
+
+			// Setup object directory
+			if (getObjectDirectory() == null) {
+				setObjectDirectory(resolveWithCommonDir(Constants.OBJECTS));
+			}
+		}
+
+		private static IOException emptyFile(File commonDir) {
+			return new IOException("Empty 'commondir' file: " + commonDir.getAbsolutePath());
+		}
+
+		@Override
+		public FileRepositoryBuilder readEnvironment(SystemReader sr) {
+			super.readEnvironment(sr);
+
+			// Always overwrite, will trump over the common dir file
+			String val = sr.getenv(GIT_COMMON_DIR_ENV_KEY);
+			if (val != null) {
+				commonDirectory = new File(val);
+			}
+
+			return self();
+		}
+
+		/**
+		 * For repository with multiple linked worktrees some data might be shared in a "common" directory.
+		 *
+		 * @param target the file we want to resolve.
+		 * @return a file resolved from the {@link #getGitDir()}, or possibly in the path specified by $GIT_COMMON_DIR or {@code commondir} file.
+		 */
+		File resolveWithCommonDir(String target) {
+			if (commonDirectory != null) {
+				return safeFS().resolve(commonDirectory, target);
+			}
+			return safeFS().resolve(getGitDir(), target);
 		}
 	}
 }

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
@@ -32,6 +32,8 @@ import org.eclipse.jgit.util.SystemReader;
 
 import com.diffplug.common.base.Errors;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Utility methods for Git workarounds.
  */
@@ -172,6 +174,7 @@ public final class GitWorkarounds {
 			return new IOException("Empty 'commondir' file: " + commonDir.getAbsolutePath());
 		}
 
+		@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
 		@Override
 		public FileRepositoryBuilder readEnvironment(SystemReader sr) {
 			super.readEnvironment(sr);

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
@@ -32,12 +32,13 @@ import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.ResourceHarness;
 
 class GitAttributesTest extends ResourceHarness {
-	private List<File> testFiles() {
+	private List<File> testFiles(String prefix) {
 		try {
 			List<File> result = new ArrayList<>();
 			for (String path : TEST_PATHS) {
-				setFile(path).toContent("");
-				result.add(newFile(path));
+				String prefixedPath = prefix + path;
+				setFile(prefixedPath).toContent("");
+				result.add(newFile(prefixedPath));
 			}
 			return result;
 		} catch (IOException e) {
@@ -45,7 +46,11 @@ class GitAttributesTest extends ResourceHarness {
 		}
 	}
 
-	private static List<String> TEST_PATHS = Arrays.asList("someFile", "subfolder/someFile", "MANIFEST.MF", "subfolder/MANIFEST.MF");
+	private List<File> testFiles() {
+		return testFiles("");
+	}
+
+	private static final List<String> TEST_PATHS = Arrays.asList("someFile", "subfolder/someFile", "MANIFEST.MF", "subfolder/MANIFEST.MF");
 
 	@Test
 	void cacheTest() throws IOException {
@@ -100,5 +105,43 @@ class GitAttributesTest extends ResourceHarness {
 				"eol=lf"));
 		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), () -> testFiles());
 		Assertions.assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\r\n");
+	}
+
+	@Test
+	void policyTestWithExternalGitDir() throws IOException, GitAPIException {
+		File projectFolder = newFolder("project");
+		File gitDir = newFolder("project.git");
+		Git.init().setDirectory(projectFolder).setGitDir(gitDir).call();
+
+		setFile("project.git/info/attributes").toContent(StringPrinter.buildStringFromLines(
+				"* eol=lf",
+				"*.MF eol=crlf"));
+		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(projectFolder, () -> testFiles("project/"));
+		Assertions.assertThat(policy.getEndingFor(newFile("project/someFile"))).isEqualTo("\n");
+		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/someFile"))).isEqualTo("\n");
+		Assertions.assertThat(policy.getEndingFor(newFile("project/MANIFEST.MF"))).isEqualTo("\r\n");
+		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
+	}
+
+	@Test
+	void policyTestWithCommonDir() throws IOException, GitAPIException {
+		File projectFolder = newFolder("project");
+		File commonGitDir = newFolder("project.git");
+		Git.init().setDirectory(projectFolder).setGitDir(commonGitDir).call();
+		newFolder("project.git/worktrees/");
+
+		File projectGitDir = newFolder("project.git/worktrees/project/");
+		setFile("project.git/worktrees/project/gitdir").toContent(projectFolder.getAbsolutePath() + "/.git");
+		setFile("project.git/worktrees/project/commondir").toContent("../..");
+		setFile("project/.git").toContent("gitdir: " + projectGitDir.getAbsolutePath());
+
+		setFile("project.git/info/attributes").toContent(StringPrinter.buildStringFromLines(
+				"* eol=lf",
+				"*.MF eol=crlf"));
+		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(projectFolder, () -> testFiles("project/"));
+		Assertions.assertThat(policy.getEndingFor(newFile("project/someFile"))).isEqualTo("\n");
+		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/someFile"))).isEqualTo("\n");
+		Assertions.assertThat(policy.getEndingFor(newFile("project/MANIFEST.MF"))).isEqualTo("\r\n");
+		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
 	}
 }

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitWorkaroundsTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitWorkaroundsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.extra;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Constants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.ResourceHarness;
+import com.diffplug.spotless.extra.GitWorkarounds.RepositorySpecificResolver;
+
+class GitWorkaroundsTest extends ResourceHarness {
+	@Test
+	void inline() throws IOException, GitAPIException {
+		File projectFolder = newFolder("project");
+		Git.init().setDirectory(projectFolder).call();
+
+		RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(projectFolder);
+		Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(new File(projectFolder, ".git"));
+	}
+
+	@Test
+	void external() throws IOException, GitAPIException {
+		File projectFolder = newFolder("project");
+		File gitDir = newFolder("project.git");
+		Git.init().setDirectory(projectFolder).setGitDir(gitDir).call();
+
+		RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(projectFolder);
+		Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(gitDir);
+	}
+
+	@Nested
+	@DisplayName("Worktrees")
+	class Worktrees {
+		private File project1Tree;
+		private File project1GitDir;
+		private File project2Tree;
+		private File project2GitDir;
+		private File commonGitDir;
+
+		@BeforeEach
+		void setUp() throws IOException, GitAPIException {
+			project1Tree = newFolder("project-w1");
+			project2Tree = newFolder("project-w2");
+			commonGitDir = newFolder("project.git");
+			Git.init().setDirectory(project1Tree).setGitDir(commonGitDir).call();
+
+			// Setup worktrees manually since JGit does not support it
+			newFolder("project.git/worktrees/");
+
+			project1GitDir = newFolder("project.git/worktrees/project-w1/");
+			setFile("project.git/worktrees/project-w1/gitdir").toContent(project1Tree.getAbsolutePath() + "/.git");
+			setFile("project.git/worktrees/project-w1/commondir").toContent("../.."); // Relative path
+			setFile("project-w1/.git").toContent("gitdir: " + project1GitDir.getAbsolutePath());
+
+			project2GitDir = newFolder("project.git/worktrees/project-w2/");
+			setFile("project.git/worktrees/project-w2/gitdir").toContent(project2Tree.getAbsolutePath() + "/.git");
+			setFile("project.git/worktrees/project-w2/commondir").toContent(commonGitDir.getAbsolutePath()); // Absolute path
+			setFile("project-w2/.git").toContent("gitdir: " + project2GitDir.getAbsolutePath());
+		}
+
+		@Test
+		void resolveGitDir() {
+			// Test worktree 1
+			{
+				RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(project1Tree);
+				Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(project1GitDir);
+				Assertions.assertThat(repositorySpecificResolver.resolveWithCommonDir(Constants.CONFIG)).isEqualTo(new File(commonGitDir, Constants.CONFIG));
+			}
+
+			// Test worktree 2
+			{
+				RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(project2Tree);
+				Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(project2GitDir);
+				Assertions.assertThat(repositorySpecificResolver.resolveWithCommonDir(Constants.CONFIG)).isEqualTo(new File(commonGitDir, Constants.CONFIG));
+			}
+		}
+
+		@Test
+		void perWorktreeConfig() throws IOException {
+			setFile("project.git/config").toLines("[core]", "mySetting = true");
+
+			Assertions.assertThat(getMySetting(project1Tree)).isTrue();
+			Assertions.assertThat(getMySetting(project2Tree)).isTrue();
+
+			// Override setting for project 1, but don't enable extension yet
+			setFile("project.git/worktrees/project-w1/config.worktree").toLines("[core]", "mySetting = false");
+
+			Assertions.assertThat(getMySetting(project1Tree)).isTrue();
+			Assertions.assertThat(getMySetting(project2Tree)).isTrue();
+
+			// Enable extension
+			setFile("project.git/config").toLines("[core]", "mySetting = true", "[extensions]", "worktreeConfig = true");
+
+			Assertions.assertThat(getMySetting(project1Tree)).isFalse(); // Should now be overridden by config.worktree
+			Assertions.assertThat(getMySetting(project2Tree)).isTrue();
+		}
+
+		private boolean getMySetting(File projectDir) {
+			return GitWorkarounds.fileRepositoryResolverForProject(projectDir).getRepositoryConfig().getBoolean("core", "mySetting", false);
+		}
+	}
+}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Bump default ktfmt `0.30` -> `0.31` ([#1118](https://github.com/diffplug/spotless/pull/1118)).
+### Fixed
+* Add full support for git worktrees ([#1119](https://github.com/diffplug/spotless/pull/1119)).
 
 ## [6.2.1] - 2022-02-01
 ### Changed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+# Add full support for git worktrees ([#1119](https://github.com/diffplug/spotless/pull/1119))
 
 ## [6.2.1] - 2022-02-01
 ### Changed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changed
 * Bump default ktfmt `0.30` -> `0.31` ([#1118](https://github.com/diffplug/spotless/pull/1118)).
+### Fixed
+* Add full support for git worktrees ([#1119](https://github.com/diffplug/spotless/pull/1119)).
 
 ## [2.20.1] - 2022-02-01
 * Bump default versions of formatters ([#1095](https://github.com/diffplug/spotless/pull/1095)).

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+# Add full support for git worktrees ([#1119](https://github.com/diffplug/spotless/pull/1119))
 
 ## [2.20.1] - 2022-02-01
 * Bump default versions of formatters ([#1095](https://github.com/diffplug/spotless/pull/1095)).


### PR DESCRIPTION
Git supports using the same local repository for multiple checked-out worktrees. JGit does not fully support this, so we have to do some workarounds for it to work.

The previous workaround provided by #965 did not take `commondir` into consideration, which is the location of a few files.

More details are available at: https://git-scm.com/docs/git-worktree#_details