### PR TITLE
[POC] Parallel formatting for Maven plugin

### DIFF
--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattingParallelizer.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattingParallelizer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import com.diffplug.spotless.Formatter;
+import com.diffplug.spotless.PaddedCell;
+import com.diffplug.spotless.PaddedCell.DirtyState;
+
+public class FormattingParallelizer {
+
+	public static final FormattingParallelizer INSTANCE = new FormattingParallelizer();
+
+	private FormattingParallelizer() {}
+
+	private final Executor readerExecutor = Executors.newFixedThreadPool(2, daemonThreadFactory());
+
+	private final Executor formatterExecutor = Executors.newFixedThreadPool(
+			Runtime.getRuntime().availableProcessors() * 2, daemonThreadFactory());
+
+	private final Executor writerExecutor = Executors.newFixedThreadPool(2, daemonThreadFactory());
+
+	CompletableFuture<Void> format(File file, Formatter formatter) {
+		return readFileContent(file)
+				.thenApplyAsync(raw -> calculateDirtyState(file, formatter, raw), formatterExecutor)
+				.thenAcceptAsync(dirtyState -> writeFormatted(dirtyState, file), writerExecutor);
+	}
+
+	private CompletableFuture<byte[]> readFileContent(File file) {
+		return supplyAsync(
+				() -> {
+					try {
+						return Files.readAllBytes(file.toPath());
+					} catch (IOException e) {
+						throw new UncheckedIOException(e);
+					}
+				},
+				readerExecutor);
+	}
+
+	private DirtyState calculateDirtyState(File file, Formatter formatter, byte[] rawBytes) {
+		try {
+			return PaddedCell.calculateDirtyState(formatter, file, rawBytes);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private void writeFormatted(DirtyState dirtyState, File file) {
+		if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
+			try {
+				dirtyState.writeCanonicalTo(file);
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+	}
+
+	private static ThreadFactory daemonThreadFactory() {
+		return runnable -> {
+			Thread thread = new Thread(runnable);
+			thread.setDaemon(true);
+			return thread;
+		};
+	}
+}


### PR DESCRIPTION
POC to gather feedback about parallelizing execution of `Formatter`s in the Maven (and perhaps Gradle) plugin.

I tested this change on https://github.com/neo4j/neo4j codebase with the following simple configuration:

```xml
<plugin>
  <groupId>com.diffplug.spotless</groupId>
  <artifactId>spotless-maven-plugin</artifactId>
  <version>2.20.2-SNAPSHOT</version>
  <configuration>
    <java>
      <googleJavaFormat/>
    </java>
  </configuration>
</plugin>
```

On my Mac with an SSD drive, command `mvn spotless:apply` takes:
 * ~54 seconds without parallelization
 * ~23 seconds with parallelization

The speedup looks promising, but it will likely vary significantly depending on the configured formatters and hard drive.

Implementation notes:
 * One small thread pool for reading files to limit loading the disk with random reads
 * One small thread pool for writing formatted files to limit loading the disk with random writes
 * One large thread pool for executing formatters because formatters are probably CPU/memory-bound
 * Daemon threads for all thread pools because Maven plugins do not seem to have lifecycle hooks or #close() method where to shutdown the executors
 * Only the main thread accesses `UpToDateChecker` because it is not thread-safe (for now)
 * `FormattingParallelizer` is a singleton to make sure the plugin does not create too many thread pools. E.g. avoid creating 3 pools for each Maven module
 * Thread pool sizes are hardcoded. They should be configurable

Perhaps the logic to read-format-write can be shared between Maven and Gradle plugins. Then, both would benefit from such parallelization.

What do you think about parallelizing formatters? Are formatter instances typically thread-safe?

Any input is much appreciated :)