### PR TITLE
#1132 - Add magic value to disable ratchetFrom

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Magic value 'NONE' for disabling ratchet functionality ([#1134](https://github.com/diffplug/spotless/issues/1134))
+
 ### Changed
 * Use SLF4J for logging ([#1116](https://github.com/diffplug/spotless/issues/1116))
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -999,6 +999,14 @@ However, we strongly recommend that you use a non-local branch, such as a tag or
 
 This is especially helpful for injecting accurate copyright dates using the [license step](#license-header).
 
+You can explicitly disable ratchet functionality by providing the value 'NONE':
+```xml
+<configuration>
+  <ratchetFrom>NONE</ratchetFrom>
+</configuration>
+```
+This is useful for disabling the ratchet functionality in child projects where the parent defines a ratchetFrom value.
+
 ## `spotless:off` and `spotless:on`
 
 Sometimes there is a chunk of code  which you have carefully handcrafted, and you would like to exclude just this one little part from getting clobbered by the autoformat. Some formatters have a way to do this, many don't, but who cares. If you setup your spotless like this:

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -15,8 +15,6 @@
  */
 package com.diffplug.spotless.maven;
 
-import static java.util.stream.Collectors.toList;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -71,10 +69,16 @@ import com.diffplug.spotless.maven.scala.Scala;
 import com.diffplug.spotless.maven.sql.Sql;
 import com.diffplug.spotless.maven.typescript.Typescript;
 
+import static java.util.stream.Collectors.toList;
+
 public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	private static final String DEFAULT_INDEX_FILE_NAME = "spotless-index";
 	private static final String DEFAULT_ENCODING = "UTF-8";
 	private static final String DEFAULT_LINE_ENDINGS = "GIT_ATTRIBUTES";
+
+	/** Value to allow unsetting the ratchet inherited from parent pom configuration. */
+	static final String RATCHETFROM_NONE = "NONE";
+
 	static final String GOAL_CHECK = "check";
 	static final String GOAL_APPLY = "apply";
 
@@ -302,7 +306,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		Provisioner provisioner = MavenProvisioner.create(resolver);
 		List<FormatterStepFactory> formatterStepFactories = getFormatterStepFactories();
 		FileLocator fileLocator = getFileLocator();
-		return new FormatterConfig(baseDir, encoding, lineEndings, Optional.ofNullable(ratchetFrom), provisioner, fileLocator, formatterStepFactories, Optional.ofNullable(setLicenseHeaderYearsFromGitHistory));
+		final Optional<String> optionalRatchetFrom = Optional.ofNullable(this.ratchetFrom)
+			.filter(ratchet -> !RATCHETFROM_NONE.equals(ratchet));
+		return new FormatterConfig(baseDir, encoding, lineEndings, optionalRatchetFrom, provisioner, fileLocator, formatterStepFactories, Optional.ofNullable(setLicenseHeaderYearsFromGitHistory));
 	}
 
 	private FileLocator getFileLocator() {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.maven;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -68,8 +70,6 @@ import com.diffplug.spotless.maven.python.Python;
 import com.diffplug.spotless.maven.scala.Scala;
 import com.diffplug.spotless.maven.sql.Sql;
 import com.diffplug.spotless.maven.typescript.Typescript;
-
-import static java.util.stream.Collectors.toList;
 
 public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	private static final String DEFAULT_INDEX_FILE_NAME = "spotless-index";
@@ -307,7 +307,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		List<FormatterStepFactory> formatterStepFactories = getFormatterStepFactories();
 		FileLocator fileLocator = getFileLocator();
 		final Optional<String> optionalRatchetFrom = Optional.ofNullable(this.ratchetFrom)
-			.filter(ratchet -> !RATCHETFROM_NONE.equals(ratchet));
+				.filter(ratchet -> !RATCHETFROM_NONE.equals(ratchet));
 		return new FormatterConfig(baseDir, encoding, lineEndings, optionalRatchetFrom, provisioner, fileLocator, formatterStepFactories, Optional.ofNullable(setLicenseHeaderYearsFromGitHistory));
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -15,8 +15,6 @@
  */
 package com.diffplug.spotless.maven;
 
-import static java.util.Collections.emptySet;
-
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -35,7 +33,20 @@ import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.generic.PipeStepPair;
-import com.diffplug.spotless.maven.generic.*;
+import com.diffplug.spotless.maven.generic.EclipseWtp;
+import com.diffplug.spotless.maven.generic.EndWithNewline;
+import com.diffplug.spotless.maven.generic.Indent;
+import com.diffplug.spotless.maven.generic.Jsr223;
+import com.diffplug.spotless.maven.generic.LicenseHeader;
+import com.diffplug.spotless.maven.generic.NativeCmd;
+import com.diffplug.spotless.maven.generic.Prettier;
+import com.diffplug.spotless.maven.generic.Replace;
+import com.diffplug.spotless.maven.generic.ReplaceRegex;
+import com.diffplug.spotless.maven.generic.ToggleOffOn;
+import com.diffplug.spotless.maven.generic.TrimTrailingWhitespace;
+
+import static com.diffplug.spotless.maven.AbstractSpotlessMojo.RATCHETFROM_NONE;
+import static java.util.Collections.emptySet;
 
 public abstract class FormatterFactory {
 	@Parameter
@@ -159,6 +170,8 @@ public abstract class FormatterFactory {
 	Optional<String> ratchetFrom(FormatterConfig config) {
 		if (RATCHETFROM_NOT_SET_AT_FORMAT_LEVEL.equals(ratchetFrom)) {
 			return config.getRatchetFrom();
+		} else if (RATCHETFROM_NONE.equals(ratchetFrom)) {
+			return Optional.empty();
 		} else {
 			return Optional.ofNullable(ratchetFrom);
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 package com.diffplug.spotless.maven;
+
+import static com.diffplug.spotless.maven.AbstractSpotlessMojo.RATCHETFROM_NONE;
+import static java.util.Collections.emptySet;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -44,9 +47,6 @@ import com.diffplug.spotless.maven.generic.Replace;
 import com.diffplug.spotless.maven.generic.ReplaceRegex;
 import com.diffplug.spotless.maven.generic.ToggleOffOn;
 import com.diffplug.spotless.maven.generic.TrimTrailingWhitespace;
-
-import static com.diffplug.spotless.maven.AbstractSpotlessMojo.RATCHETFROM_NONE;
-import static java.util.Collections.emptySet;
 
 public abstract class FormatterFactory {
 	@Parameter


### PR DESCRIPTION
When overriding the maven plugin configuration from a parent pom in a child pom, there is no way to disable ratchetFrom if it's set to a particular value in the parent.

This PR introduces a magic value 'NONE' that allows to do this.
