### PR TITLE
Method encoding should accept java.nio.charset.Charset type

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Accept `java.nio.charset.Charset` type when setting the character encoding via `encoding` ([#1128](https://github.com/diffplug/spotless/issues/1128))
 
 ## [6.3.0] - 2022-02-15
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -74,14 +74,19 @@ public abstract class SpotlessExtension {
 	}
 
 	/** Sets encoding to use (defaults to UTF_8). */
+	public void setEncoding(Charset charset) {
+		encoding = requireNonNull(charset);
+	}
+
+	/** Sets encoding to use (defaults to UTF_8). */
 	public void setEncoding(String name) {
 		requireNonNull(name);
 		setEncoding(Charset.forName(name));
 	}
 
 	/** Sets encoding to use (defaults to UTF_8). */
-	public void setEncoding(Charset charset) {
-		encoding = requireNonNull(charset);
+	public void encoding(Charset charset) {
+		setEncoding(charset);
 	}
 
 	/** Sets encoding to use (defaults to UTF_8). */


### PR DESCRIPTION
This is a small change in order to accept a proper constant when using `encoding`. For instance, instead of doing this:

```groovy
spotless {
  encoding(StandardCharsets.UTF_8 as String)
  ...
}
```

...we could do this instead:

```groovy
spotless {
  encoding(StandardCharsets.UTF_8)
  ...
}
```

---

Closes #1128 