### PR TITLE
Ktfmt custom options fix for Gradle Kotlin scripts (kts)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
 * Fixed access modifiers for setters in KtfmtStep configuration
 
 ## [2.24.0] - 2022-03-28

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Fixed access modifiers for setters in KtfmtStep configuration
 
 ## [2.24.0] - 2022-03-28
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -97,6 +97,22 @@ public class KtfmtStep {
 			this.continuationIndent = continuationIndent;
 			this.removeUnusedImport = removeUnusedImport;
 		}
+
+		public void setMaxWidth(int maxWidth) {
+			this.maxWidth = maxWidth;
+		}
+
+		public void setBlockIndent(int blockIndent) {
+			this.blockIndent = blockIndent;
+		}
+
+		public void setContinuationIndent(int continuationIndent) {
+			this.continuationIndent = continuationIndent;
+		}
+
+		public void setRemoveUnusedImport(boolean removeUnusedImport) {
+			this.removeUnusedImport = removeUnusedImport;
+		}
 	}
 
 	/**

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
 * Fixed ktfmt options configuration in Gradle plugin for Gradle Kotlin scripts (kts).
 
 ## [6.4.0] - 2022-03-28

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Fixed ktfmt options configuration in Gradle plugin for Gradle Kotlin scripts (kts).
 
 ## [6.4.0] - 2022-03-28
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -141,9 +141,9 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 			return KtfmtStep.create(version, provisioner(), style, options);
 		}
 
-		class ConfigurableStyle {
+		public class ConfigurableStyle {
 
-			void configure(Consumer<KtfmtFormattingOptions> optionsConfiguration) {
+			public void configure(Consumer<KtfmtFormattingOptions> optionsConfiguration) {
 				KtfmtFormattingOptions ktfmtFormattingOptions = new KtfmtFormattingOptions();
 				optionsConfiguration.accept(ktfmtFormattingOptions);
 				options = ktfmtFormattingOptions;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -128,9 +128,9 @@ public class KotlinGradleExtension extends FormatExtension {
 			return KtfmtStep.create(version, provisioner(), style, options);
 		}
 
-		class ConfigurableStyle {
+		public class ConfigurableStyle {
 
-			void configure(Consumer<KtfmtFormattingOptions> optionsConfiguration) {
+			public void configure(Consumer<KtfmtFormattingOptions> optionsConfiguration) {
 				KtfmtFormattingOptions ktfmtFormattingOptions = new KtfmtFormattingOptions();
 				optionsConfiguration.accept(ktfmtFormattingOptions);
 				options = ktfmtFormattingOptions;

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -294,6 +294,28 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 
 	@Test
 	@EnabledForJreRange(min = JAVA_11) // ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
+	void testWithCustomMaxWidthDefaultStyleKtfmtGradleKts() throws IOException {
+		setFile("build.gradle.kts").toLines(
+				"plugins {",
+				"    id(\"org.jetbrains.kotlin.jvm\") version \"1.5.31\"",
+				"    id(\"com.diffplug.spotless\")",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktfmt().configure { options ->",
+				"            options.setMaxWidth(120)",
+				"		 }",
+				"    }",
+				"}");
+
+		setFile("src/main/kotlin/max-width.kt").toResource("kotlin/ktfmt/max-width.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/max-width.kt").sameAsResource("kotlin/ktfmt/max-width.clean");
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_11) // ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
 	void testWithCustomMaxWidthDropboxStyleKtfmt() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
@@ -305,6 +327,28 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 				"    kotlin {",
 				"        ktfmt().dropboxStyle().configure { options ->",
 				"            options.maxWidth = 120",
+				"		 }",
+				"    }",
+				"}");
+
+		setFile("src/main/kotlin/max-width.kt").toResource("kotlin/ktfmt/max-width.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/max-width.kt").sameAsResource("kotlin/ktfmt/max-width-dropbox.clean");
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_11) // ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
+	void testWithCustomMaxWidthDropboxStyleKtfmtGradleKts() throws IOException {
+		setFile("build.gradle.kts").toLines(
+				"plugins {",
+				"    id(\"org.jetbrains.kotlin.jvm\") version \"1.5.31\"",
+				"    id(\"com.diffplug.spotless\")",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktfmt().dropboxStyle().configure { options ->",
+				"            options.setMaxWidth(120)",
 				"		 }",
 				"    }",
 				"}");


### PR DESCRIPTION
Sorry, didn't realize in previous PR (https://github.com/diffplug/spotless/pull/1155) that Groovy ignores access modifiers in Java code, that not applies to compilation of Kotlin scripts in Gradle (kts). Fixed that issue and added some tests for check this behaviour.
