### PR TITLE
Add option to use ktlint experimental ruleset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for enabling ktlint experimental ruleset. ([#1145](https://github.com/diffplug/spotless/pull/1168))
 
 ## [2.24.2] - 2022-04-06
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,3 @@ spotless {
 		endWithNewline()
 	}
 }
-
-static Class<?> spotBugsTaskType() {
-	return com.github.spotbugs.snom.SpotBugsTask
-}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	String VER_KTLINT='0.43.2'
 	ktlintCompileOnly "com.pinterest:ktlint:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-core:$VER_KTLINT"
+	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-experimental:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-standard:$VER_KTLINT"
 
 	// used for markdown formatting

--- a/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
+++ b/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
@@ -16,7 +16,7 @@
 package com.diffplug.spotless.glue.ktlint;
 
 import java.io.File;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +24,7 @@ import com.pinterest.ktlint.core.KtLint;
 import com.pinterest.ktlint.core.KtLint.Params;
 import com.pinterest.ktlint.core.LintError;
 import com.pinterest.ktlint.core.RuleSet;
+import com.pinterest.ktlint.ruleset.experimental.ExperimentalRuleSetProvider;
 import com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider;
 
 import com.diffplug.spotless.FormatterFunc;
@@ -38,8 +39,13 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 	private final Function2<? super LintError, ? super Boolean, Unit> formatterCallback;
 	private final boolean isScript;
 
-	public KtlintFormatterFunc(boolean isScript, Map<String, String> userData) {
-		rulesets = Collections.singletonList(new StandardRuleSetProvider().get());
+	public KtlintFormatterFunc(boolean isScript, boolean useExperimental, Map<String, String> userData) {
+		rulesets = new ArrayList<>();
+		rulesets.add(new StandardRuleSetProvider().get());
+
+		if (useExperimental) {
+			rulesets.add(new ExperimentalRuleSetProvider().get());
+		}
 		this.userData = userData;
 		formatterCallback = new FormatterCallback();
 		this.isScript = isScript;

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Added support for enabling ktlint experimental ruleset. ([#1145](https://github.com/diffplug/spotless/pull/1168))
 
 ## [6.4.2] - 2022-04-06
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -340,8 +340,10 @@ spotless {
 ```kotlin
 spotless {
   kotlin {
-    // version and userData are both optional
-    ktlint('0.43.2').userData(mapOf('indent_size' to '2', 'continuation_indent_size' to '2'))
+    // version, setUseExperimental and userData are all optional
+    ktlint('0.43.2')
+      .setUseExperimental(true)
+      .userData(mapOf('indent_size' to '2', 'continuation_indent_size' to '2'))
 ```
 
 ### diktat

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinExtension.java
@@ -59,7 +59,7 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 	/** Adds the specified version of <a href="https://github.com/pinterest/ktlint">ktlint</a>. */
 	public KotlinFormatExtension ktlint(String version) {
 		Objects.requireNonNull(version);
-		return new KotlinFormatExtension(version, Collections.emptyMap());
+		return new KotlinFormatExtension(version, false, Collections.emptyMap());
 	}
 
 	public KotlinFormatExtension ktlint() {
@@ -69,23 +69,32 @@ public class KotlinExtension extends FormatExtension implements HasBuiltinDelimi
 	public class KotlinFormatExtension {
 
 		private final String version;
+		private boolean useExperimental;
 		private Map<String, String> userData;
 
-		KotlinFormatExtension(String version, Map<String, String> config) {
+		KotlinFormatExtension(String version, boolean useExperimental, Map<String, String> config) {
 			this.version = version;
+			this.useExperimental = useExperimental;
 			this.userData = config;
 			addStep(createStep());
 		}
 
-		public void userData(Map<String, String> userData) {
+		public KotlinFormatExtension setUseExperimental(boolean useExperimental) {
+			this.useExperimental = useExperimental;
+			replaceStep(createStep());
+			return this;
+		}
+
+		public KotlinFormatExtension userData(Map<String, String> userData) {
 			// Copy the map to a sorted map because up-to-date checking is based on binary-equals of the serialized
 			// representation.
 			this.userData = userData;
 			replaceStep(createStep());
+			return this;
 		}
 
 		private FormatterStep createStep() {
-			return KtLintStep.create(version, provisioner(), userData);
+			return KtLintStep.create(version, provisioner(), useExperimental, userData);
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -45,7 +45,7 @@ public class KotlinGradleExtension extends FormatExtension {
 	/** Adds the specified version of <a href="https://github.com/pinterest/ktlint">ktlint</a>. */
 	public KotlinFormatExtension ktlint(String version) {
 		Objects.requireNonNull(version, "version");
-		return new KotlinFormatExtension(version, Collections.emptyMap());
+		return new KotlinFormatExtension(version, false, Collections.emptyMap());
 	}
 
 	public KotlinFormatExtension ktlint() {
@@ -55,23 +55,32 @@ public class KotlinGradleExtension extends FormatExtension {
 	public class KotlinFormatExtension {
 
 		private final String version;
+		private boolean useExperimental;
 		private Map<String, String> userData;
 
-		KotlinFormatExtension(String version, Map<String, String> config) {
+		KotlinFormatExtension(String version, boolean useExperimental, Map<String, String> config) {
 			this.version = version;
+			this.useExperimental = useExperimental;
 			this.userData = config;
 			addStep(createStep());
 		}
 
-		public void userData(Map<String, String> userData) {
+		public KotlinFormatExtension setUseExperimental(boolean useExperimental) {
+			this.useExperimental = useExperimental;
+			replaceStep(createStep());
+			return this;
+		}
+
+		public KotlinFormatExtension userData(Map<String, String> userData) {
 			// Copy the map to a sorted map because up-to-date checking is based on binary-equals of the serialized
 			// representation.
 			this.userData = ImmutableSortedMap.copyOf(userData);
 			replaceStep(createStep());
+			return this;
 		}
 
 		private FormatterStep createStep() {
-			return KtLintStep.createForScript(version, provisioner(), userData);
+			return KtLintStep.createForScript(version, provisioner(), useExperimental, userData);
 		}
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -140,6 +140,42 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	}
 
 	@Test
+	void withExperimental() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktlint().setUseExperimental(true)",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.clean");
+	}
+
+	@Test
+	void withExperimental_0_32() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktlint('0.32.0').setUseExperimental(true)",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktlint/basic.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktlint/basic.clean");
+	}
+
+	@Test
 	void testWithHeader() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -175,6 +175,31 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktlint/basic.clean");
 	}
 
+	/**
+	 * Check that the sample used to verify the experimental ruleset is untouched by the default ruleset, to verify
+	 * that enabling the experimental ruleset is actually doing something.
+	 *
+	 * If this test fails, it's likely that the experimental rule being used as a test graduated into the standard
+	 * ruleset, and therefore a new experimental rule should be used to verify functionality.
+	 */
+	@Test
+	void experimentalSampleUnchangedWithDefaultRuleset() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktlint()",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.dirty");
+	}
+
 	@Test
 	void testWithHeader() throws IOException {
 		setFile("build.gradle").toLines(

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -164,6 +164,31 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktlint/basic.clean");
 	}
 
+	/**
+	 * Check that the sample used to verify the experimental ruleset is untouched by the default ruleset, to verify
+	 * that enabling the experimental ruleset is actually doing something.
+	 *
+	 * If this test fails, it's likely that the experimental rule being used as a test graduated into the standard
+	 * ruleset, and therefore a new experimental rule should be used to verify functionality.
+	 */
+	@Test
+	void experimentalSampleUnchangedWithDefaultRuleset() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktlint()",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.dirty");
+	}
+
 	@Test
 	@EnabledForJreRange(min = JAVA_11) // ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
 	void integration_ktfmt() throws IOException {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -129,6 +129,42 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 	}
 
 	@Test
+	void withExperimental() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktlint().setUseExperimental(true)",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.clean");
+	}
+
+	@Test
+	void withExperimental_0_32() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlin {",
+				"        ktlint('0.32.0').setUseExperimental(true)",
+				"    }",
+				"}");
+		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktlint/basic.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktlint/basic.clean");
+	}
+
+	@Test
 	@EnabledForJreRange(min = JAVA_11) // ktfmt's dependency, google-java-format 1.8 requires a minimum of JRE 11+.
 	void integration_ktfmt() throws IOException {
 		setFile("build.gradle").toLines(

--- a/testlib/src/main/resources/kotlin/ktlint/experimental.clean
+++ b/testlib/src/main/resources/kotlin/ktlint/experimental.clean
@@ -1,0 +1,7 @@
+fun main() {
+    if (false) {
+        println("false")
+    } else {
+        println("true")
+    }
+}

--- a/testlib/src/main/resources/kotlin/ktlint/experimental.dirty
+++ b/testlib/src/main/resources/kotlin/ktlint/experimental.dirty
@@ -1,0 +1,6 @@
+fun main() {
+    if (false)
+        println("false")
+    else
+        println("true")
+}


### PR DESCRIPTION
Adds an option in the Gradle plugin to enable using ktlint's experimental ruleset.

This partially addresses #409 , but only allows enabling the built-in experimental ktlint ruleset and doesn't allow configuring arbitrary rulesets.
