### PR TITLE
Apply `base` eagerly to plugin-gradle

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,10 +4,14 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Added a runToFixMessage property to customize the run-to-fix message in spotlessCheck task ([#1175](https://github.com/diffplug/spotless/issues/1175)).
+* Added a `runToFixMessage` property to customize the run-to-fix message in `spotlessCheck` task ([#1175](https://github.com/diffplug/spotless/issues/1175)).
 * Added support for enabling ktlint experimental ruleset. ([#1145](https://github.com/diffplug/spotless/pull/1168))
 ### Fixed
 * Fixed support for Python Black's new version reporting, and bumped default version to latest (`19.10b0` -> `22.3.0`) ([#1170](https://github.com/diffplug/spotless/issues/1170))
+### Changed
+- Spotless now applies the `base` plugin to make sure that Spotless always has a `check` task to hook into ([#1179](https://github.com/diffplug/spotless/pull/1179), fixes [#1164](https://github.com/diffplug/spotless/pull/1164), reverts [#1014](https://github.com/diffplug/spotless/pull/1014))
+  - Spotless used to work this way, we stopped applying base starting with version [`6.0.3` (released Dec 2021)](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#603---2021-12-06) in order to play nicely with a now-outdated Android template, but not applying `base` causes more problems than it fixes (see [#1164](https://github.com/diffplug/spotless/pull/1164) for a good example).
+  - If you have anything like `tasks.register<Delete>("clean"` or `tasks.register("clean", Delete)`, just change the `register` to `named` so that you are configuring the existing `clean` created by `base`, rather than creating a new task.
 
 ## [6.4.2] - 2022-04-06
 ### Fixed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.BasePlugin;
 
 import com.diffplug.common.base.Preconditions;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
@@ -788,7 +789,7 @@ public class FormatExtension {
 		spotlessTask.init(spotless.getRegisterDependenciesTask().getTaskService());
 		setupTask(spotlessTask);
 		// clean removes the SpotlessCache, so we have to run after clean
-		SpotlessPlugin.configureCleanTask(spotless.project, spotlessTask::mustRunAfter);
+		spotlessTask.mustRunAfter(BasePlugin.CLEAN_TASK_NAME);
 		// create the apply task
 		SpotlessApply applyTask = spotless.project.getTasks().create(taskName, SpotlessApply.class);
 		applyTask.init(spotlessTask);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.UnknownTaskException;
+import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -41,12 +41,7 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 
 		project.afterEvaluate(unused -> {
 			if (enforceCheck) {
-				try {
-					project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME)
-							.configure(task -> task.dependsOn(rootCheckTask));
-				} catch (UnknownTaskException e) {
-					// no action needed, it's okay if there's no `check` task
-				}
+				project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(task -> task.dependsOn(rootCheckTask));
 			}
 		});
 	}
@@ -61,8 +56,9 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		TaskProvider<SpotlessTaskImpl> spotlessTask = tasks.register(taskName, SpotlessTaskImpl.class, task -> {
 			task.init(getRegisterDependenciesTask().getTaskService());
 			task.setEnabled(!isIdeHook);
+			// clean removes the SpotlessCache, so we have to run after clean
+			task.mustRunAfter(BasePlugin.CLEAN_TASK_NAME);
 		});
-		SpotlessPlugin.taskMustRunAfterClean(project, spotlessTask);
 		project.afterEvaluate(unused -> {
 			spotlessTask.configure(task -> {
 				// now that the task is being configured, we execute our actions
@@ -103,8 +99,8 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		// create the diagnose task
 		TaskProvider<SpotlessDiagnoseTask> diagnoseTask = tasks.register(taskName + DIAGNOSE, SpotlessDiagnoseTask.class, task -> {
 			task.source = spotlessTask.get();
+			task.mustRunAfter(BasePlugin.CLEAN_TASK_NAME);
 		});
-		SpotlessPlugin.taskMustRunAfterClean(project, diagnoseTask);
 		rootDiagnoseTask.configure(task -> task.dependsOn(diagnoseTask));
 	}
 }


### PR DESCRIPTION
Spotless now applies the `base` plugin to make sure that Spotless always has a `check` task to hook into.

- Spotless used to work this way, we stopped applying base starting with version [`6.0.3` (released Dec 2021)](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#603---2021-12-06) in order to play nicely with a now-outdated Android template.
- Fixes the good user story in #1164
- Reverts #1014