### PR TITLE
Fix encoding error messages when generated on Java 8.  @nedtwigg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Added support for enabling ktlint experimental ruleset. ([#1145](https://github.com/diffplug/spotless/pull/1168))
 ### Fixed
-* Fixed support for Python Black's new version reporting, and bumped default version to latest (`19.10b0` -> `22.3.0`) ([#1170](https://github.com/diffplug/spotless/issues/1170))
+* Fixed support for Python Black's new version reporting, and bumped default version to latest (`19.10b0` -> `22.3.0`). ([#1170](https://github.com/diffplug/spotless/issues/1170))
+* Error messages for unexpected file encoding now works on Java 8. (fixes [#1081](https://github.com/diffplug/spotless/issues/1081))
 
 ## [2.24.2] - 2022-04-06
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
+++ b/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -115,8 +116,8 @@ class EncodingErrorMsg {
 	}
 
 	private void appendExample(Charset charset, boolean must) {
-		byteBuf.clear();
-		charBuf.clear();
+		java8fix(byteBuf).clear();
+		java8fix(charBuf).clear();
 
 		CharsetDecoder decoder = charset.newDecoder();
 		if (!must) {
@@ -134,7 +135,7 @@ class EncodingErrorMsg {
 					.onUnmappableCharacter(CodingErrorAction.REPLACE)
 					.decode(byteBuf, charBuf, true);
 		}
-		charBuf.flip();
+		java8fix(charBuf).flip();
 
 		int start = Math.max(unrepresentable - CONTEXT, 0);
 		int end = Math.min(charBuf.limit(), unrepresentable + CONTEXT + 1);
@@ -145,5 +146,10 @@ class EncodingErrorMsg {
 				.replace('\t', '⇥'));
 		message.append(" <- ");
 		message.append(charset.name());
+	}
+
+	/** Fixes https://jira.mongodb.org/browse/JAVA-2559, as reported in https://github.com/diffplug/spotless/issues/1081 */
+	private static Buffer java8fix(Buffer b) {
+		return b;
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 * Fixed support for Python Black's new version reporting, and bumped default version to latest (`19.10b0` -> `22.3.0`). ([#1170](https://github.com/diffplug/spotless/issues/1170))
 * All tasks (including helper tasks) are now part of the `verification` group. (fixes [#1050](https://github.com/diffplug/spotless/issues/1050))
+* Error messages for unexpected file encoding now works on Java 8. (fixes [#1081](https://github.com/diffplug/spotless/issues/1081))
 ### Changed
 - Spotless now applies the `base` plugin to make sure that Spotless always has a `check` task to hook into. ([#1179](https://github.com/diffplug/spotless/pull/1179), fixes [#1164](https://github.com/diffplug/spotless/pull/1164), reverts [#1014](https://github.com/diffplug/spotless/pull/1014))
   - Spotless used to work this way, we stopped applying base starting with version [`6.0.3` (released Dec 2021)](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#603---2021-12-06) in order to play nicely with a now-outdated Android template, but not applying `base` causes more problems than it fixes (see [#1164](https://github.com/diffplug/spotless/pull/1164) for a good example).

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,7 +4,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* Fixed support for Python Black's new version reporting, and bumped default version to latest (`19.10b0` -> `22.3.0`) ([#1170](https://github.com/diffplug/spotless/issues/1170))
+* Fixed support for Python Black's new version reporting, and bumped default version to latest (`19.10b0` -> `22.3.0`). ([#1170](https://github.com/diffplug/spotless/issues/1170))
+* Error messages for unexpected file encoding now works on Java 8. (fixes [#1081](https://github.com/diffplug/spotless/issues/1081))
 
 ## [2.22.1] - 2022-04-06
 ### Fixed


### PR DESCRIPTION
We had a subtle dependency on Java 9+ API as pointed out in #1081, now fixed.