### PR TITLE
Convert diktat integration to use a compile-only sourceset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,9 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-* Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
+### Changes
+* Bump default `diktat` version to latest `1.0.1` -> `1.0.1`.
+  * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
 
 ## [2.25.1] - 2022-04-27
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
-* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`.
-  * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
-  * Use the full path to a file in `diktat` integration ([#1189](https://github.com/diffplug/spotless/issues/1189))
+* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`. ([#1190](https://github.com/diffplug/spotless/pull/1190))
+  * Converted `diktat` integration to use a compile-only source set. (fixes [#524](https://github.com/diffplug/spotless/issues/524))
+  * Use the full path to a file in `diktat` integration. (fixes [#1189](https://github.com/diffplug/spotless/issues/1189))
 
 ## [2.25.1] - 2022-04-27
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
-* Bump default `diktat` version to latest `1.0.1` -> `1.0.1`.
+* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`.
   * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
+  * Use the full path to a file in `diktat` integration ([#1189](https://github.com/diffplug/spotless/issues/1189))
 
 ## [2.25.1] - 2022-04-27
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
 
 ## [2.25.1] - 2022-04-27
 ### Changes

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -11,7 +11,8 @@ def NEEDS_GLUE = [
 	'palantirJavaFormat',
 	'ktfmt',
 	'ktlint',
-	'flexmark'
+	'flexmark',
+	'diktat'
 ]
 for (glue in NEEDS_GLUE) {
 	sourceSets.register(glue) {
@@ -49,6 +50,9 @@ dependencies {
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-core:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-experimental:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-standard:$VER_KTLINT"
+
+	String VER_DIKTAT = "1.1.0"
+	diktatCompileOnly "org.cqfn.diktat:diktat-rules:$VER_DIKTAT"
 
 	// used for markdown formatting
 	flexmarkCompileOnly 'com.vladsch.flexmark:flexmark-all:0.62.2'

--- a/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
+++ b/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021-2022 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.glue.diktat;
+
+import java.io.File;
+import java.util.*;
+
+import org.cqfn.diktat.ruleset.rules.DiktatRuleSetProvider;
+
+import com.pinterest.ktlint.core.KtLint;
+import com.pinterest.ktlint.core.KtLint.Params;
+import com.pinterest.ktlint.core.LintError;
+import com.pinterest.ktlint.core.RuleSet;
+
+import com.diffplug.spotless.FormatterFunc;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function2;
+
+public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
+
+	private final List<RuleSet> rulesets;
+	private final Map<String, String> userData;
+	private final Function2<? super LintError, ? super Boolean, Unit> formatterCallback;
+	private final boolean isScript;
+
+	private final ArrayList<LintError> errors = new ArrayList<>();
+
+	public DiktatFormatterFunc(boolean isScript, Map<String, String> userData) {
+		rulesets = Collections.singletonList(new DiktatRuleSetProvider().get());
+		this.userData = userData;
+		this.formatterCallback = new FormatterCallback(errors);
+		this.isScript = isScript;
+	}
+
+	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
+		private final ArrayList<LintError> errors;
+
+		FormatterCallback(ArrayList<LintError> errors) {
+			this.errors = errors;
+		}
+
+		@Override
+		public Unit invoke(LintError lintError, Boolean corrected) {
+			if (!corrected) {
+				errors.add(lintError);
+			}
+			return null;
+		}
+	}
+
+	@Override
+	public String applyWithFile(String unix, File file) throws Exception {
+		errors.clear();
+		userData.put("file_path", file.getAbsolutePath());
+		String result = KtLint.INSTANCE.format(new Params(
+				file.getName(),
+				unix,
+				rulesets,
+				userData,
+				formatterCallback,
+				isScript,
+				null,
+				false));
+
+		if (!errors.isEmpty()) {
+			StringBuilder error = new StringBuilder();
+			error.append("There are ").append(errors.size()).append(" unfixed errors:");
+			for (LintError er : errors) {
+				error.append(System.lineSeparator())
+						.append("Error on line: ").append(er.getLine())
+						.append(", column: ").append(er.getCol())
+						.append(" cannot be fixed automatically")
+						.append(System.lineSeparator())
+						.append(er.getDetail());
+			}
+			throw new AssertionError(error);
+		}
+
+		return result;
+	}
+}

--- a/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
+++ b/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
@@ -67,7 +67,9 @@ public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 		errors.clear();
 		userData.put("file_path", file.getAbsolutePath());
 		String result = KtLint.INSTANCE.format(new Params(
-				file.getName(),
+				// Unlike Ktlint, Diktat requires full path to the file.
+				// See https://github.com/diffplug/spotless/issues/1189, https://github.com/analysis-dev/diktat/issues/1202
+				file.getAbsolutePath(),
 				unix,
 				rulesets,
 				userData,

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changes
+* Bump default `diktat` version to latest `1.0.1` -> `1.0.1`.
+  * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
 
 ## [6.5.1] - 2022-04-27
 ### Changes

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,8 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
-* Bump default `diktat` version to latest `1.0.1` -> `1.0.1`.
+* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`.
   * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
+  * Use the full path to a file in `diktat` integration ([#1189](https://github.com/diffplug/spotless/issues/1189))
 
 ## [6.5.1] - 2022-04-27
 ### Changes

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,9 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
-* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`.
-  * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
-  * Use the full path to a file in `diktat` integration ([#1189](https://github.com/diffplug/spotless/issues/1189))
+* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`. ([#1190](https://github.com/diffplug/spotless/pull/1190))
+  * Converted `diktat` integration to use a compile-only source set. (fixes [#524](https://github.com/diffplug/spotless/issues/524))
+  * Use the full path to a file in `diktat` integration. (fixes [#1189](https://github.com/diffplug/spotless/issues/1189))
 
 ## [6.5.1] - 2022-04-27
 ### Changes

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,8 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
-* Bump default `diktat` version to latest `1.0.1` -> `1.0.1`.
+* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`.
   * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
+  * Use the full path to a file in `diktat` integration ([#1189](https://github.com/diffplug/spotless/issues/1189))
 
 ## [2.22.3] - 2022-04-27
 ### Changes

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,9 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
-* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`.
-  * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
-  * Use the full path to a file in `diktat` integration ([#1189](https://github.com/diffplug/spotless/issues/1189))
+* Bump default `diktat` version to latest `1.0.1` -> `1.1.0`. ([#1190](https://github.com/diffplug/spotless/pull/1190))
+  * Converted `diktat` integration to use a compile-only source set. (fixes [#524](https://github.com/diffplug/spotless/issues/524))
+  * Use the full path to a file in `diktat` integration. (fixes [#1189](https://github.com/diffplug/spotless/issues/1189))
 
 ## [2.22.3] - 2022-04-27
 ### Changes

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+* Bump default `diktat` version to latest `1.0.1` -> `1.0.1`.
+  * Converted `diktat` integration to use a compile-only source set. ([#524](https://github.com/diffplug/spotless/issues/524))
 
 ## [2.22.3] - 2022-04-27
 ### Changes

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -38,9 +38,9 @@ class DiktatStepTest extends ResourceHarness {
 					assertion.isInstanceOf(AssertionError.class);
 					assertion.hasMessage("There are 2 unfixed errors:" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: " +
+							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared:  vs Unsolvable");
+							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable");
 				});
 	}
 
@@ -57,9 +57,9 @@ class DiktatStepTest extends ResourceHarness {
 					assertion.isInstanceOf(AssertionError.class);
 					assertion.hasMessage("There are 2 unfixed errors:" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: " +
+							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared:  vs Unsolvable");
+							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable");
 				});
 	}
 


### PR DESCRIPTION
* Convert diktat integration to use a compile-only sourceset (#524)
* Bump default diktat version to `1.1.0`
* Pass absolute path into `Params` object to resolve the problem with package name checking (as suggested by @HaukeRa in #1189)