### PR TITLE
Add support for KtLint editorConfigOverride

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,8 @@ indent_size = 2
 # Doc: https://youtrack.jetbrains.com/issue/IDEA-170643#focus=streamItem-27-3708697.0-0
 ij_java_imports_layout = java.**,|,javax.**,|,org.**,|,com.**,|,com.diffplug.**,|,*
 ij_java_use_single_class_imports = true
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
 
 [*.xml.mustache]
 indent_style = space

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+* Add support for `editorConfigOverride` in `ktlint`. ([#1218](https://github.com/diffplug/spotless/pull/1218) fixes [#1193](https://github.com/diffplug/spotless/issues/1193))
+
 ## [2.25.3] - 2022-05-10
 ### Fixed
 * Update the `black` version regex to fix `19.10b0` and earlier. (fixes [#1195](https://github.com/diffplug/spotless/issues/1195), regression introduced in `2.25.0`)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-
-* Add support for `editorConfigOverride` in `ktlint`. ([#1218](https://github.com/diffplug/spotless/pull/1218) fixes [#1193](https://github.com/diffplug/spotless/issues/1193))
+### Added
+* Support for `editorConfigOverride` in `ktlint`. ([#1218](https://github.com/diffplug/spotless/pull/1218) fixes [#1193](https://github.com/diffplug/spotless/issues/1193))
 
 ## [2.25.3] - 2022-05-10
 ### Fixed

--- a/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
+++ b/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
@@ -17,18 +17,26 @@ package com.diffplug.spotless.glue.ktlint;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.pinterest.ktlint.core.KtLint;
-import com.pinterest.ktlint.core.KtLint.Params;
+import com.pinterest.ktlint.core.KtLint.ExperimentalParams;
 import com.pinterest.ktlint.core.LintError;
 import com.pinterest.ktlint.core.RuleSet;
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties;
+import com.pinterest.ktlint.core.api.EditorConfigOverride;
+import com.pinterest.ktlint.core.api.UsesEditorConfigProperties;
 import com.pinterest.ktlint.ruleset.experimental.ExperimentalRuleSetProvider;
 import com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider;
 
 import com.diffplug.spotless.FormatterFunc;
 
+import kotlin.Pair;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 
@@ -38,8 +46,13 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 	private final Map<String, String> userData;
 	private final Function2<? super LintError, ? super Boolean, Unit> formatterCallback;
 	private final boolean isScript;
+	private final EditorConfigOverride editorConfigOverride;
 
-	public KtlintFormatterFunc(boolean isScript, boolean useExperimental, Map<String, String> userData) {
+	/**
+	 * Non-empty editorConfigOverrideMap requires KtLint 0.45.2.
+	 */
+	public KtlintFormatterFunc(boolean isScript, boolean useExperimental, Map<String, String> userData,
+			Map<String, Object> editorConfigOverrideMap) {
 		rulesets = new ArrayList<>();
 		rulesets.add(new StandardRuleSetProvider().get());
 
@@ -49,6 +62,46 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 		this.userData = userData;
 		formatterCallback = new FormatterCallback();
 		this.isScript = isScript;
+
+		if (editorConfigOverrideMap.isEmpty()) {
+			this.editorConfigOverride = null;
+		} else {
+			this.editorConfigOverride = createEditorConfigOverride(editorConfigOverrideMap);
+		}
+	}
+
+	/**
+	 * Create EditorConfigOverride from user provided parameters.
+	 * Calling this method requires KtLint 0.45.2.
+	 */
+	private EditorConfigOverride createEditorConfigOverride(Map<String, Object> editorConfigOverrideMap) {
+		// Get properties from rules in the rule sets
+		Stream<UsesEditorConfigProperties.EditorConfigProperty<?>> ruleProperties = rulesets.stream()
+				.flatMap(ruleSet -> Arrays.stream(ruleSet.getRules()))
+				.filter(rule -> rule instanceof UsesEditorConfigProperties)
+				.flatMap(rule -> ((UsesEditorConfigProperties) rule).getEditorConfigProperties().stream());
+
+		// Create a mapping of properties to their names based on rule properties and default properties
+		Map<String, UsesEditorConfigProperties.EditorConfigProperty<?>> supportedProperties = Stream
+				.concat(ruleProperties, DefaultEditorConfigProperties.INSTANCE.getDefaultEditorConfigProperties().stream())
+				.distinct()
+				.collect(Collectors.toMap(property -> property.getType().getName(), property -> property));
+
+		// Create config properties based on provided property names and values
+		@SuppressWarnings("unchecked")
+		Pair<UsesEditorConfigProperties.EditorConfigProperty<?>, ?>[] properties = editorConfigOverrideMap.entrySet().stream()
+				.map(entry -> {
+					UsesEditorConfigProperties.EditorConfigProperty<?> property = supportedProperties.get(entry.getKey());
+					if (property != null) {
+						return new Pair<>(property, entry.getValue());
+					} else {
+						return null;
+					}
+				})
+				.filter(Objects::nonNull)
+				.toArray(Pair[]::new);
+
+		return EditorConfigOverride.Companion.from(properties);
 	}
 
 	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
@@ -63,14 +116,31 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 
 	@Override
 	public String applyWithFile(String unix, File file) throws Exception {
-		return KtLint.INSTANCE.format(new Params(
-				file.getName(),
-				unix,
-				rulesets,
-				userData,
-				formatterCallback,
-				isScript,
-				null,
-				false));
+
+		if (editorConfigOverride != null) {
+			// Use ExperimentalParams with EditorConfigOverride which requires KtLint 0.45.2
+			return KtLint.INSTANCE.format(new ExperimentalParams(
+					file.getName(),
+					unix,
+					rulesets,
+					userData,
+					formatterCallback,
+					isScript,
+					null,
+					false,
+					editorConfigOverride,
+					false));
+		} else {
+			// Use Params for backward compatibility
+			return KtLint.INSTANCE.format(new KtLint.Params(
+					file.getName(),
+					unix,
+					rulesets,
+					userData,
+					formatterCallback,
+					isScript,
+					null,
+					false));
+		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/BadSemver.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/BadSemver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,18 @@ class BadSemver {
 		}
 		String major = matcher.group(1);
 		String minor = matcher.group(2);
-		return version(Integer.parseInt(major), Integer.parseInt(minor));
+		String patch = matcher.group(3);
+		return version(Integer.parseInt(major), Integer.parseInt(minor), patch != null ? Integer.parseInt(patch) : 0);
 	}
 
 	/** Ambiguous after 2147.483647.blah-blah */
-	protected static int version(int major, int minor) {
-		return major * 1_000_000 + minor;
+	protected static int version(int major, int minor, int patch) {
+		return major * 1_000_000 + minor * 1_000 + patch;
 	}
 
-	private static final Pattern BAD_SEMVER = Pattern.compile("(\\d+)\\.(\\d+)");
+	protected static int version(int major, int minor) {
+		return version(major, minor, 0);
+	}
+
+	private static final Pattern BAD_SEMVER = Pattern.compile("(\\d+)\\.(\\d+)\\.*(\\d+)*");
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,8 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
-
-* Add support for `editorConfigOverride` in `ktlint`. ([#1218](https://github.com/diffplug/spotless/pull/1218) fixes [#1193](https://github.com/diffplug/spotless/issues/1193))
+### Added
+* Support for `editorConfigOverride` in `ktlint`. ([#1218](https://github.com/diffplug/spotless/pull/1218) fixes [#1193](https://github.com/diffplug/spotless/issues/1193))
+  * If you are using properties like `indent_size`, you should pass now pass them as `editorConfigOverride` and not as `userData`.
 
 ## [6.6.1] - 2022-05-13
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+* Add support for `editorConfigOverride` in `ktlint`. ([#1218](https://github.com/diffplug/spotless/pull/1218) fixes [#1193](https://github.com/diffplug/spotless/issues/1193))
+
 ## [6.6.1] - 2022-05-13
 ### Fixed
 * More daemon memory consumption fixes ([#1206](https://github.com/diffplug/spotless/pull/1198) fixes [#1194](https://github.com/diffplug/spotless/issues/1194))

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -335,15 +335,18 @@ spotless {
 
 ### ktlint
 
-[homepage](https://github.com/pinterest/ktlint). [changelog](https://github.com/pinterest/ktlint/releases).  Spotless does not ([yet](https://github.com/diffplug/spotless/issues/142)) respect the `.editorconfig` settings ([ktlint docs](https://github.com/pinterest/ktlint#editorconfig)), but you can provide them manually as `userData`.
+[homepage](https://github.com/pinterest/ktlint). [changelog](https://github.com/pinterest/ktlint/releases).  Spotless does not ([yet](https://github.com/diffplug/spotless/issues/142)) respect the `.editorconfig` settings ([ktlint docs](https://github.com/pinterest/ktlint#editorconfig)), but you can provide them manually as `editorConfigOverride`.
 
 ```kotlin
 spotless {
   kotlin {
-    // version, setUseExperimental and userData are all optional
-    ktlint('0.43.2')
+    // version, setUseExperimental, userData and editorConfigOverride are all optional
+    ktlint("0.45.2")
       .setUseExperimental(true)
-      .userData(mapOf('indent_size' to '2', 'continuation_indent_size' to '2'))
+      .userData(mapOf("android" to "true"))
+      .editorConfigOverride(mapOf("indent_size" to 2))
+  }
+}
 ```
 
 ### diktat

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/KotlinGradleExtension.java
@@ -45,7 +45,7 @@ public class KotlinGradleExtension extends FormatExtension {
 	/** Adds the specified version of <a href="https://github.com/pinterest/ktlint">ktlint</a>. */
 	public KotlinFormatExtension ktlint(String version) {
 		Objects.requireNonNull(version, "version");
-		return new KotlinFormatExtension(version, false, Collections.emptyMap());
+		return new KotlinFormatExtension(version, false, Collections.emptyMap(), Collections.emptyMap());
 	}
 
 	public KotlinFormatExtension ktlint() {
@@ -57,11 +57,14 @@ public class KotlinGradleExtension extends FormatExtension {
 		private final String version;
 		private boolean useExperimental;
 		private Map<String, String> userData;
+		private Map<String, Object> editorConfigOverride;
 
-		KotlinFormatExtension(String version, boolean useExperimental, Map<String, String> config) {
+		KotlinFormatExtension(String version, boolean useExperimental, Map<String, String> config,
+				Map<String, Object> editorConfigOverride) {
 			this.version = version;
 			this.useExperimental = useExperimental;
 			this.userData = config;
+			this.editorConfigOverride = editorConfigOverride;
 			addStep(createStep());
 		}
 
@@ -79,8 +82,16 @@ public class KotlinGradleExtension extends FormatExtension {
 			return this;
 		}
 
+		public KotlinFormatExtension editorConfigOverride(Map<String, Object> editorConfigOverride) {
+			// Copy the map to a sorted map because up-to-date checking is based on binary-equals of the serialized
+			// representation.
+			this.editorConfigOverride = ImmutableSortedMap.copyOf(editorConfigOverride);
+			replaceStep(createStep());
+			return this;
+		}
+
 		private FormatterStep createStep() {
-			return KtLintStep.createForScript(version, provisioner(), useExperimental, userData);
+			return KtLintStep.createForScript(version, provisioner(), useExperimental, userData, editorConfigOverride);
 		}
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -16,6 +16,7 @@
 package com.diffplug.gradle.spotless;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 
 import java.io.IOException;
@@ -137,13 +138,13 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 				"}",
 				"repositories { mavenCentral() }",
 				"spotless {",
-				"    kotlin {",
+				"    kotlinGradle {",
 				"        ktlint().setUseExperimental(true)",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/experimental.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.clean");
+		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimental.clean");
 	}
 
 	@Test
@@ -155,13 +156,57 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 				"}",
 				"repositories { mavenCentral() }",
 				"spotless {",
-				"    kotlin {",
+				"    kotlinGradle {",
 				"        ktlint('0.32.0').setUseExperimental(true)",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktlint/basic.dirty");
+		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/basic.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktlint/basic.clean");
+		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/basic.clean");
+	}
+
+	@Test
+	void withExperimentalEditorConfigOverride() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlinGradle {",
+				"        ktlint().setUseExperimental(true)",
+				"            .editorConfigOverride([",
+				"        	    ij_kotlin_allow_trailing_comma: true,",
+				"        	    ij_kotlin_allow_trailing_comma_on_call_site: true",
+				"            ])",
+				"    }",
+				"}");
+		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
+	}
+
+	@Test
+	void withEditorConfigOverride_0_45_1() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    kotlinGradle {",
+				"        ktlint('0.45.1')",
+				"            .editorConfigOverride([",
+				"        	    indent_size: 5",
+				"            ])",
+				"    }",
+				"}");
+		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/basic.dirty");
+		Throwable error = assertThrows(Throwable.class,
+				() -> gradleRunner().withArguments("spotlessApply").build());
+		assertThat(error).hasMessageContaining("KtLint editorConfigOverride supported for version 0.45.2 and later");
 	}
 
 	/**
@@ -180,13 +225,13 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 				"}",
 				"repositories { mavenCentral() }",
 				"spotless {",
-				"    kotlin {",
+				"    kotlinGradle {",
 				"        ktlint()",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/experimental.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.dirty");
+		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimental.dirty");
 	}
 
 	@Test

--- a/testlib/src/main/resources/kotlin/ktlint/experimentalEditorConfigOverride.clean
+++ b/testlib/src/main/resources/kotlin/ktlint/experimentalEditorConfigOverride.clean
@@ -1,0 +1,5 @@
+fun main() {
+    val list = listOf(
+        "hello",
+    )
+}

--- a/testlib/src/main/resources/kotlin/ktlint/experimentalEditorConfigOverride.dirty
+++ b/testlib/src/main/resources/kotlin/ktlint/experimentalEditorConfigOverride.dirty
@@ -1,0 +1,5 @@
+fun main() {
+    val list = listOf(
+        "hello"
+    )
+}

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -78,6 +78,13 @@ class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
+	void worksPre0_45_2() throws Exception {
+		FormatterStep step = KtLintStep.create("0.45.1", TestProvisioner.mavenCentral());
+		StepHarness.forStep(step)
+				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
+	}
+
+	@Test
 	void equality() throws Exception {
 		new SerializableEqualityTester() {
 			String version = "0.32.0";


### PR DESCRIPTION
Addresses #1193 by adding support for `editorConfigOverride` with KtLint 0.45.2.
Using `editorConfigOverride` with a lower version of KtLint throws an error due to breaking changes to `ExperimentalParams` in 0.45.2.