### PR TITLE
Specify additional task outputs

### DIFF
--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -17,7 +17,6 @@ apply plugin: 'com.github.spotbugs'
 spotbugs {
 	toolVersion = VER_SPOTBUGS
 	ignoreFailures = false 	// bug free or it doesn't ship!
-	reportsDir = file('build/spotbugs')
 	reportLevel = 'medium'	// low|medium|high (low = sensitive to even minor mistakes)
 	omitVisitors = [
 		'FindReturnRef'] // https://spotbugs.readthedocs.io/en/latest/detectors.html#findreturnref
@@ -25,6 +24,15 @@ spotbugs {
 tasks.named('spotbugsTest') {
 	enabled = false
 }
+
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
+	outputs.file("$buildDir/reports/spotbugs/${it.name}.html")
+	outputs.file("$buildDir/spotbugs/auxclasspath/${it.name}")
+	reports {
+		html.enabled = true
+	}
+}
+
 tasks.named('spotbugsMain') {
 	// only run on Java 8 (no benefit to running twice)
 	enabled = org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_11

--- a/gradle/java-setup.gradle
+++ b/gradle/java-setup.gradle
@@ -26,8 +26,8 @@ tasks.named('spotbugsTest') {
 }
 
 tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
-	outputs.file("$buildDir/reports/spotbugs/${it.name}.html")
-	outputs.file("$buildDir/spotbugs/auxclasspath/${it.name}")
+	outputs.file(project.layout.buildDirectory.file("reports/spotbugs/${it.name}.html"))
+	outputs.file(project.layout.buildDirectory.file("spotbugs/auxclasspath/${it.name}"))
 	reports {
 		html.enabled = true
 	}

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -24,7 +24,6 @@ visteg {
 import com.github.mustachejava.DefaultMustacheFactory
 
 import java.nio.file.Files
-import java.nio.file.Paths
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static java.nio.file.StandardOpenOption.CREATE
@@ -35,10 +34,8 @@ version = spotlessChangelog.versionNext
 apply from: rootProject.file("gradle/java-setup.gradle")
 apply from: rootProject.file("gradle/java-publish.gradle")
 
-final PROJECT_DIR = project.projectDir.toString()
-final BUILD_DIR = project.buildDir.toString()
-final MAVEN_PROJECT_DIR = "${BUILD_DIR}/mavenProject"
-final LOCAL_MAVEN_REPO_DIR = "${BUILD_DIR}/localMavenRepository"
+final MAVEN_PROJECT_DIR = project.layout.buildDirectory.dir("mavenProject").get()
+final LOCAL_MAVEN_REPO_DIR = project.layout.buildDirectory.dir("localMavenRepository").get()
 
 def mvnw(String args) {
 	boolean isWin = System.getProperty('os.name').toLowerCase().contains('win')
@@ -93,7 +90,7 @@ dependencies {
 
 task copySourceFiles(type: Sync) {
 	from "src/main/java"
-	into "${MAVEN_PROJECT_DIR}/src/main/java"
+	into MAVEN_PROJECT_DIR.dir("src/main/java")
 }
 
 task copyMvnw(type: Copy, dependsOn: copySourceFiles) {
@@ -120,7 +117,7 @@ libs.each {
 		workingDir MAVEN_PROJECT_DIR
 
 		inputs.file(file)
-		outputs.dir(project.file("${LOCAL_MAVEN_REPO_DIR}/${groupId.replace('.', '/')}/${artifactId}/${version}"))
+		outputs.dir(LOCAL_MAVEN_REPO_DIR.file(groupId.replace('.', '/') + "/" + artifactId + "/" + version))
 		commandLine mvnw("org.apache.maven.plugins:maven-install-plugin:2.3.1:install-file " +
 				"-Dfile=${file} " +
 				"-DgroupId=${groupId} " +
@@ -135,7 +132,7 @@ libs.each {
 }
 
 task createPomXml(dependsOn: installLocalDependencies) {
-	def newPomXml = Paths.get(MAVEN_PROJECT_DIR, "pom.xml")
+	def newPomXml = MAVEN_PROJECT_DIR.file("pom.xml").asFile.toPath()
 
 	outputs.file(newPomXml)
 	doLast {
@@ -158,7 +155,7 @@ task createPomXml(dependsOn: installLocalDependencies) {
 			additionalDependencies    : additionalDependencies
 		]
 
-		def pomXmlTemplate = Paths.get(PROJECT_DIR, "src/test/resources/pom-build.xml.mustache")
+		def pomXmlTemplate = project.layout.projectDirectory.file("src/test/resources/pom-build.xml.mustache").asFile.toPath()
 
 		Files.newBufferedReader(pomXmlTemplate).withCloseable { reader ->
 			Files.newBufferedWriter(newPomXml, UTF_8, CREATE, TRUNCATE_EXISTING).withCloseable { writer ->
@@ -183,7 +180,7 @@ task runMavenBuild(type: Exec, dependsOn: [
 
 jar.setActions Arrays.asList()
 jar.dependsOn(runMavenBuild)
-File jarIn = file("${MAVEN_PROJECT_DIR}/target/spotless-maven-plugin-${version}.jar")
+File jarIn = MAVEN_PROJECT_DIR.file("target/spotless-maven-plugin-${version}.jar").asFile
 File jarOut = jar.archivePath
 jar.inputs.file(jarIn)
 jar.outputs.file(jarOut)
@@ -196,7 +193,7 @@ test { useJUnitPlatform() }
 apply from: rootProject.file('gradle/special-tests.gradle')
 
 tasks.withType(Test) {
-	systemProperty "localMavenRepositoryDir", LOCAL_MAVEN_REPO_DIR
+	systemProperty "localMavenRepositoryDir", LOCAL_MAVEN_REPO_DIR.asFile
 	systemProperty "spotlessMavenPluginVersion", project.version
 	dependsOn(jar)
 }

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -27,7 +27,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import static java.nio.charset.StandardCharsets.UTF_8
-import static java.nio.file.StandardOpenOption.CREATE_NEW
+import static java.nio.file.StandardOpenOption.CREATE
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
 
 ext.artifactId = project.artifactIdMaven
@@ -91,9 +91,7 @@ dependencies {
 	testImplementation "org.apache.maven:maven-core:${VER_MAVEN_API}"
 }
 
-task cleanMavenProjectDir(type: Delete) { delete MAVEN_PROJECT_DIR }
-
-task copySourceFiles(type: Sync, dependsOn: cleanMavenProjectDir) {
+task copySourceFiles(type: Sync) {
 	from "src/main/java"
 	into "${MAVEN_PROJECT_DIR}/src/main/java"
 }
@@ -137,6 +135,9 @@ libs.each {
 }
 
 task createPomXml(dependsOn: installLocalDependencies) {
+	def newPomXml = Paths.get(MAVEN_PROJECT_DIR, "pom.xml")
+
+	outputs.file(newPomXml)
 	doLast {
 		def additionalDependencies = project.configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.findAll {
 			return !libs.contains(it.moduleVersion.id.name)
@@ -158,10 +159,9 @@ task createPomXml(dependsOn: installLocalDependencies) {
 		]
 
 		def pomXmlTemplate = Paths.get(PROJECT_DIR, "src/test/resources/pom-build.xml.mustache")
-		def newPomXml = Paths.get(MAVEN_PROJECT_DIR, "pom.xml")
 
 		Files.newBufferedReader(pomXmlTemplate).withCloseable { reader ->
-			Files.newBufferedWriter(newPomXml, UTF_8, CREATE_NEW, TRUNCATE_EXISTING).withCloseable { writer ->
+			Files.newBufferedWriter(newPomXml, UTF_8, CREATE, TRUNCATE_EXISTING).withCloseable { writer ->
 				def mustache = new DefaultMustacheFactory().compile(reader, "pom")
 				mustache.execute(writer, versions)
 			}
@@ -170,11 +170,12 @@ task createPomXml(dependsOn: installLocalDependencies) {
 }
 
 task runMavenBuild(type: Exec, dependsOn: [
-	cleanMavenProjectDir,
 	copySourceFiles,
 	copyMvnw,
 	createPomXml
 ]) {
+	outputs.dir(LOCAL_MAVEN_REPO_DIR)
+
 	workingDir MAVEN_PROJECT_DIR
 	// -B batch mode to make dependency download logging less verbose
 	commandLine mvnw("clean install -B -Dmaven.repo.local=${LOCAL_MAVEN_REPO_DIR}")


### PR DESCRIPTION
Hi everyone!

In order to optimise the build process in terms of incremental build and enable additional caching possibilities (https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks and https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_enable), I've specified additional task outputs.

Those mainly concern spotbugs set up and maven-plugin build process. 
With these changes, incremental build is fully supported for all tasks and spotbugs runs are fully cached as well.

Additional caching can also be done for maven-plugin tests, but those changes may involve more extensive build rewrite, so if you're interested, I can create a separate issue about that, so that we can discuss it outside of this PR.

Looking forward to your feedback!
Thanks!