### PR TITLE
add support for MAC_CLASSIC (\r only)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -41,8 +41,10 @@ public enum LineEnding {
 	PLATFORM_NATIVE,
 	/** {@code \r\n} */
 	WINDOWS,
-	/** {@code \n} */
-	UNIX;
+    /** {@code \n} */
+    UNIX,
+    /** {@code \r} */
+    MAC_CLASSIC;
 	// @formatter:on
 
 	/** Returns a {@link Policy} appropriate for files which are contained within the given rootFolder. */
@@ -75,6 +77,7 @@ public enum LineEnding {
 		case PLATFORM_NATIVE:	return _platformNativePolicy;
 		case WINDOWS:			return WINDOWS_POLICY;
 		case UNIX:				return UNIX_POLICY;
+        case MAC_CLASSIC:       return MAC_CLASSIC_POLICY;
 		default:	throw new UnsupportedOperationException(this + " is a path-specific line ending.");
 		}
 	}
@@ -96,6 +99,7 @@ public enum LineEnding {
 
 	private static final Policy WINDOWS_POLICY = new ConstantLineEndingPolicy(WINDOWS.str());
 	private static final Policy UNIX_POLICY = new ConstantLineEndingPolicy(UNIX.str());
+    private static final Policy MAC_CLASSIC_POLICY = new ConstantLineEndingPolicy(MAC_CLASSIC.str());
 	private static final String _platformNative = System.getProperty("line.separator");
 	private static final Policy _platformNativePolicy = new ConstantLineEndingPolicy(_platformNative);
 	private static final boolean nativeIsWin = _platformNative.equals(WINDOWS.str());
@@ -117,6 +121,7 @@ public enum LineEnding {
 		case PLATFORM_NATIVE:	return _platformNative;
 		case WINDOWS:			return "\r\n";
 		case UNIX:				return "\n";
+		case MAC_CLASSIC:       return "\r";
 		default:	throw new UnsupportedOperationException(this + " is a path-specific line ending.");
 		}
 	}
@@ -137,12 +142,14 @@ public enum LineEnding {
 
 	/** Returns a string with exclusively unix line endings. */
 	public static String toUnix(String input) {
-		int firstNewline = input.lastIndexOf('\n');
-		if (firstNewline == -1) {
+		if (input.lastIndexOf(WINDOWS.str()) > -1) {
+			return input.replace("\r", "");
+		} else if (input.lastIndexOf(MAC_CLASSIC.str()) > -1) {
+			// replace mac classic '\r' with unix line endings '\n'
+			return input.replace(MAC_CLASSIC.str(), UNIX.str());
+		} else {
 			// fastest way to detect if a string is already unix-only
 			return input;
-		} else {
-			return input.replace("\r", "");
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -142,14 +142,17 @@ public enum LineEnding {
 
 	/** Returns a string with exclusively unix line endings. */
 	public static String toUnix(String input) {
-		if (input.lastIndexOf(WINDOWS.str()) > -1) {
-			return input.replace("\r", "");
-		} else if (input.lastIndexOf(MAC_CLASSIC.str()) > -1) {
-			// replace mac classic '\r' with unix line endings '\n'
-			return input.replace(MAC_CLASSIC.str(), UNIX.str());
-		} else {
-			// fastest way to detect if a string is already unix-only
+		int lastCarriageReturn = input.lastIndexOf('\r');
+		if (lastCarriageReturn == -1) {
 			return input;
+		} else {
+			if (input.lastIndexOf("\r\n") == -1) {
+				// it is MAC_CLASSIC \r
+				return input.replace('\r', '\n');
+			} else {
+				// it is WINDOWS \r\n
+				return input.replace("\r", "");
+			}
 		}
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 
 ## [6.7.2] - 2022-06-11
 ### Fixed

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -866,7 +866,7 @@ spotless {
     encoding 'Cp1252' // except java, which will be Cp1252
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `PLATFORM_NATIVE`, and `GIT_ATTRIBUTES`.  The default value is `GIT_ATTRIBUTES`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time.
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, and `GIT_ATTRIBUTES`.  The default value is `GIT_ATTRIBUTES`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time.
 
 You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 
 ## [2.22.8] - 2022-06-11
 ### Fixed

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1034,7 +1034,7 @@ Spotless uses UTF-8 by default, but you can use [any encoding which Java support
 </configuration>
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `PLATFORM_NATIVE`, and `GIT_ATTRIBUTES`.  The default value is `GIT_ATTRIBUTES`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time.
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, and `GIT_ATTRIBUTES`.  The default value is `GIT_ATTRIBUTES`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time.
 
 You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
 

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,20 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.StandardSystemProperty;
 import com.diffplug.spotless.generic.EndWithNewlineStep;
 
 class FormatterTest {
+	@Test
+	void toUnix() {
+		Assertions.assertEquals("1\n2\n3", LineEnding.toUnix("1\n2\n3"));
+		Assertions.assertEquals("1\n2\n3", LineEnding.toUnix("1\r2\r3"));
+		Assertions.assertEquals("1\n2\n3", LineEnding.toUnix("1\r\n2\r\n3"));
+	}
+
 	// Formatter normally needs to be closed, but no resources will be leaked in this special case
 	@Test
 	void equality() {


### PR DESCRIPTION
this PR add support for MAC_CLASSIC (\r only)

- https://github.com/diffplug/spotless/issues/1196