### PR TITLE
Upgrade diktat to 1.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,10 +12,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
-### Fixed
-* Bump default `diktat` version to latest `1.1.0` -> `1.2.1`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
-  * Note that support `diktat` version `1.2.1` is or higher
-  * The property `userData` is removed
+### Changed
+* Minimum required `diktat` version bumped to `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
+  * Default bumped from `1.1.0` -> `1.2.1`
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 ### Fixed
-* Bump default `diktat` version to latest `1.1.0` -> `1.2.0`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
+* Bump default `diktat` version to latest `1.1.0` -> `1.2.1`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
+  * Note that support `diktat` version `1.2.1` is or higher
+  * The property `userData` is removed
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
+### Fixed
+* Bump default `diktat` version to latest `1.1.0` -> `1.2.0`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 ### Changed
-* Minimum required `diktat` version bumped to `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
-  * Default bumped from `1.1.0` -> `1.2.1`
+* Minimum required `diktat` version bumped to `1.2.0` ([#1246](https://github.com/diffplug/spotless/pull/1246))
+  * Default bumped from `1.1.0` -> `1.2.0`
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-experimental:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-standard:$VER_KTLINT"
 
-	String VER_DIKTAT = "1.1.0"
+	String VER_DIKTAT = "1.2.0"
 	diktatCompileOnly "org.cqfn.diktat:diktat-rules:$VER_DIKTAT"
 
 	// used for markdown formatting

--- a/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
+++ b/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
@@ -20,8 +20,8 @@ import java.util.*;
 
 import org.cqfn.diktat.ruleset.rules.DiktatRuleSetProvider;
 
+import com.pinterest.ktlint.core.api.EditorConfigOverride;
 import com.pinterest.ktlint.core.KtLint;
-import com.pinterest.ktlint.core.KtLint.Params;
 import com.pinterest.ktlint.core.LintError;
 import com.pinterest.ktlint.core.RuleSet;
 
@@ -33,15 +33,13 @@ import kotlin.jvm.functions.Function2;
 public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 
 	private final List<RuleSet> rulesets;
-	private final Map<String, String> userData;
 	private final Function2<? super LintError, ? super Boolean, Unit> formatterCallback;
 	private final boolean isScript;
 
 	private final ArrayList<LintError> errors = new ArrayList<>();
 
-	public DiktatFormatterFunc(boolean isScript, Map<String, String> userData) {
+	public DiktatFormatterFunc(boolean isScript) {
 		rulesets = Collections.singletonList(new DiktatRuleSetProvider().get());
-		this.userData = userData;
 		this.formatterCallback = new FormatterCallback(errors);
 		this.isScript = isScript;
 	}
@@ -65,17 +63,18 @@ public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 	@Override
 	public String applyWithFile(String unix, File file) throws Exception {
 		errors.clear();
-		userData.put("file_path", file.getAbsolutePath());
-		String result = KtLint.INSTANCE.format(new Params(
+		String result = KtLint.INSTANCE.format(new KtLint.ExperimentalParams(
 				// Unlike Ktlint, Diktat requires full path to the file.
 				// See https://github.com/diffplug/spotless/issues/1189, https://github.com/analysis-dev/diktat/issues/1202
 				file.getAbsolutePath(),
 				unix,
 				rulesets,
-				userData,
+				Collections.emptyMap(),
 				formatterCallback,
 				isScript,
 				null,
+				false,
+				new EditorConfigOverride(),
 				false));
 
 		if (!errors.isEmpty()) {

--- a/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
+++ b/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
@@ -20,10 +20,10 @@ import java.util.*;
 
 import org.cqfn.diktat.ruleset.rules.DiktatRuleSetProvider;
 
-import com.pinterest.ktlint.core.api.EditorConfigOverride;
 import com.pinterest.ktlint.core.KtLint;
 import com.pinterest.ktlint.core.LintError;
 import com.pinterest.ktlint.core.RuleSet;
+import com.pinterest.ktlint.core.api.EditorConfigOverride;
 
 import com.diffplug.spotless.FormatterFunc;
 

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -30,9 +30,9 @@ public class DiktatStep {
 	// prevent direct instantiation
 	private DiktatStep() {}
 
-	private static final String MIN_SUPPORTED_VERSION = "1.2.1";
+	private static final String MIN_SUPPORTED_VERSION = "1.2.0";
 
-	private static final String DEFAULT_VERSION = "1.2.1";
+	private static final String DEFAULT_VERSION = "1.2.0";
 	static final String NAME = "diktat";
 	static final String PACKAGE_DIKTAT = "org.cqfn.diktat";
 	static final String MAVEN_COORDINATE = PACKAGE_DIKTAT + ":diktat-rules:";

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -30,7 +30,7 @@ public class DiktatStep {
 	// prevent direct instantiation
 	private DiktatStep() {}
 
-	private static final String DEFAULT_VERSION = "1.1.0";
+	private static final String DEFAULT_VERSION = "1.2.0";
 	static final String NAME = "diktat";
 	static final String PACKAGE_DIKTAT = "org.cqfn.diktat";
 	static final String MAVEN_COORDINATE = PACKAGE_DIKTAT + ":diktat-rules:";
@@ -44,30 +44,22 @@ public class DiktatStep {
 	}
 
 	public static FormatterStep create(String versionDiktat, Provisioner provisioner) {
-		return create(versionDiktat, provisioner, Collections.emptyMap(), null);
+		return create(versionDiktat, provisioner, null);
 	}
 
 	public static FormatterStep create(String versionDiktat, Provisioner provisioner, @Nullable FileSignature config) {
-		return create(versionDiktat, provisioner, Collections.emptyMap(), config);
-	}
-
-	public static FormatterStep create(String versionDiktat, Provisioner provisioner, Map<String, String> userData, @Nullable FileSignature config) {
-		return create(versionDiktat, provisioner, false, userData, config);
+		return create(versionDiktat, provisioner, false, config);
 	}
 
 	public static FormatterStep createForScript(String versionDiktat, Provisioner provisioner, @Nullable FileSignature config) {
-		return createForScript(versionDiktat, provisioner, Collections.emptyMap(), config);
+		return create(versionDiktat, provisioner, true, config);
 	}
 
-	public static FormatterStep createForScript(String versionDiktat, Provisioner provisioner, Map<String, String> userData, @Nullable FileSignature config) {
-		return create(versionDiktat, provisioner, true, userData, config);
-	}
-
-	public static FormatterStep create(String versionDiktat, Provisioner provisioner, boolean isScript, Map<String, String> userData, @Nullable FileSignature config) {
+	public static FormatterStep create(String versionDiktat, Provisioner provisioner, boolean isScript, @Nullable FileSignature config) {
 		Objects.requireNonNull(versionDiktat, "versionDiktat");
 		Objects.requireNonNull(provisioner, "provisioner");
 		return FormatterStep.createLazy(NAME,
-				() -> new DiktatStep.State(versionDiktat, provisioner, isScript, userData, config),
+				() -> new DiktatStep.State(versionDiktat, provisioner, isScript, config),
 				DiktatStep.State::createFormat);
 	}
 
@@ -79,14 +71,12 @@ public class DiktatStep {
 		private final boolean isScript;
 		private final @Nullable FileSignature config;
 		final JarState jar;
-		private final TreeMap<String, String> userData;
 
-		State(String versionDiktat, Provisioner provisioner, boolean isScript, Map<String, String> userData, @Nullable FileSignature config) throws IOException {
+		State(String versionDiktat, Provisioner provisioner, boolean isScript, @Nullable FileSignature config) throws IOException {
 
 			HashSet<String> pkgSet = new HashSet<>();
 			pkgSet.add(MAVEN_COORDINATE + versionDiktat);
 
-			this.userData = new TreeMap<>(userData);
 			this.jar = JarState.from(pkgSet, provisioner);
 			this.isScript = isScript;
 			this.config = config;
@@ -98,8 +88,8 @@ public class DiktatStep {
 			}
 
 			Class<?> formatterFunc = jar.getClassLoader().loadClass("com.diffplug.spotless.glue.diktat.DiktatFormatterFunc");
-			Constructor<?> constructor = formatterFunc.getConstructor(boolean.class, Map.class);
-			return (FormatterFunc.NeedsFile) constructor.newInstance(isScript, userData);
+			Constructor<?> constructor = formatterFunc.getConstructor(boolean.class);
+			return (FormatterFunc.NeedsFile) constructor.newInstance(isScript);
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -59,7 +59,7 @@ public class DiktatStep {
 
 	public static FormatterStep create(String versionDiktat, Provisioner provisioner, boolean isScript, @Nullable FileSignature config) {
 		if (BadSemver.version(versionDiktat) < BadSemver.version(MIN_SUPPORTED_VERSION)) {
-			throw new IllegalStateException("Diktat supported for version " + MIN_SUPPORTED_VERSION + " and later");
+			throw new IllegalStateException("Minimum required Diktat version is " + MIN_SUPPORTED_VERSION + ", you tried " + versionDiktat + " which is too old");
 		}
 		Objects.requireNonNull(versionDiktat, "versionDiktat");
 		Objects.requireNonNull(provisioner, "provisioner");

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -30,7 +30,9 @@ public class DiktatStep {
 	// prevent direct instantiation
 	private DiktatStep() {}
 
-	private static final String DEFAULT_VERSION = "1.2.0";
+	private static final String MIN_SUPPORTED_VERSION = "1.2.1";
+
+	private static final String DEFAULT_VERSION = "1.2.1";
 	static final String NAME = "diktat";
 	static final String PACKAGE_DIKTAT = "org.cqfn.diktat";
 	static final String MAVEN_COORDINATE = PACKAGE_DIKTAT + ":diktat-rules:";
@@ -56,6 +58,9 @@ public class DiktatStep {
 	}
 
 	public static FormatterStep create(String versionDiktat, Provisioner provisioner, boolean isScript, @Nullable FileSignature config) {
+		if (BadSemver.version(versionDiktat) < BadSemver.version(MIN_SUPPORTED_VERSION)) {
+			throw new IllegalStateException("Diktat supported for version " + MIN_SUPPORTED_VERSION + " and later");
+		}
 		Objects.requireNonNull(versionDiktat, "versionDiktat");
 		Objects.requireNonNull(provisioner, "provisioner");
 		return FormatterStep.createLazy(NAME,

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,7 +6,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 ### Fixed
-* Bump default `diktat` version to latest `1.1.0` -> `1.2.0`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
+* Bump default `diktat` version to latest `1.1.0` -> `1.2.1`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
+  * Note that support `diktat` version `1.2.1` is or higher
+  * The property `userData` is removed
 
 ## [6.7.2] - 2022-06-11
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,10 +5,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
-### Fixed
-* Bump default `diktat` version to latest `1.1.0` -> `1.2.1`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
-  * Note that support `diktat` version `1.2.1` is or higher
-  * The property `userData` is removed
+### Changed
+* Minimum required `diktat` version bumped to `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
+  * Default bumped from `1.1.0` -> `1.2.1`
 
 ## [6.7.2] - 2022-06-11
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
+### Fixed
+* Bump default `diktat` version to latest `1.1.0` -> `1.2.0`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
 
 ## [6.7.2] - 2022-06-11
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,8 +6,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 ### Changed
-* Minimum required `diktat` version bumped to `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
-  * Default bumped from `1.1.0` -> `1.2.1`
+* Minimum required `diktat` version bumped to `1.2.0` ([#1246](https://github.com/diffplug/spotless/pull/1246))
+  * Default bumped from `1.1.0` -> `1.2.0`
 
 ## [6.7.2] - 2022-06-11
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,10 +5,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
-### Fixed
-* Bump default `diktat` version to latest `1.1.0` -> `1.2.1`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
-  * Note that support `diktat` version `1.2.1` is or higher
-  * The property `userData` is removed
+### Changed
+* Minimum required `diktat` version bumped to `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
+  * Default bumped from `1.1.0` -> `1.2.1`
 
 ## [2.22.8] - 2022-06-11
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
+### Fixed
+* Bump default `diktat` version to latest `1.1.0` -> `1.2.0`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
 
 ## [2.22.8] - 2022-06-11
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,8 +6,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 ### Changed
-* Minimum required `diktat` version bumped to `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
-  * Default bumped from `1.1.0` -> `1.2.1`
+* Minimum required `diktat` version bumped to `1.2.0` ([#1246](https://github.com/diffplug/spotless/pull/1246))
+  * Default bumped from `1.1.0` -> `1.2.0`
 
 ## [2.22.8] - 2022-06-11
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,7 +6,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
 ### Fixed
-* Bump default `diktat` version to latest `1.1.0` -> `1.2.0`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
+* Bump default `diktat` version to latest `1.1.0` -> `1.2.1`. ([saveourtool/diktat#1399](https://github.com/saveourtool/diktat/issues/1399))
+  * Note that support `diktat` version `1.2.1` is or higher
+  * The property `userData` is removed
 
 ## [2.22.8] - 2022-06-11
 ### Fixed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Diktat.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Diktat.java
@@ -41,6 +41,6 @@ public class Diktat implements FormatterStepFactory {
 			config = ThrowingEx.get(() -> FileSignature.signAsList(stepConfig.getFileLocator().locateFile(configFile)));
 		}
 		String diktatVersion = version != null ? version : DiktatStep.defaultVersionDiktat();
-		return DiktatStep.create(diktatVersion, stepConfig.getProvisioner(), Collections.emptyMap(), config);
+		return DiktatStep.create(diktatVersion, stepConfig.getProvisioner(), config);
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Diktat.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Diktat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.spotless.maven.kotlin;
-
-import java.util.Collections;
 
 import org.apache.maven.plugins.annotations.Parameter;
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
@@ -40,7 +40,7 @@ class DiktatTest extends MavenIntegrationHarness {
 
 		writePomWithKotlinSteps(
 				"<diktat>",
-				"  <version>1.0.1</version>",
+				"  <version>1.2.0</version>",
 				"</diktat>");
 
 		String path = "src/main/kotlin/Main.kt";
@@ -56,7 +56,7 @@ class DiktatTest extends MavenIntegrationHarness {
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		writePomWithKotlinSteps(
 				"<diktat>",
-				"  <version>1.0.1</version>",
+				"  <version>1.2.0</version>",
 				"  <configFile>" + conf.getAbsolutePath() + "</configFile>",
 				"</diktat>");
 

--- a/testlib/src/main/resources/kotlin/diktat/main.clean
+++ b/testlib/src/main/resources/kotlin/diktat/main.clean
@@ -1,7 +1,7 @@
 package org.cqfn.diktat.example.gradle.multiproject
 
 /**
- * @return print.
+ * @return something
  */
 class Main {
     /**
@@ -9,7 +9,7 @@ class Main {
      *
      */
     fun foo() {
-        println(";")
-        println()
+        bar(";")
+        bar()
     }
 }

--- a/testlib/src/main/resources/kotlin/diktat/main.dirty
+++ b/testlib/src/main/resources/kotlin/diktat/main.dirty
@@ -1,6 +1,6 @@
 package org.cqfn.diktat.example.gradle.multiproject
 /**
- * @return print.
+ * @return something
  */
 class Main {
 	/**
@@ -8,7 +8,7 @@ class Main {
 	 *
 	 */
 	fun foo() {
-		println(";")
-		println();
+		bar(";")
+		bar();
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -36,11 +36,15 @@ class DiktatStepTest extends ResourceHarness {
 		StepHarness.forStep(step)
 				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:" +
+					assertion.hasMessage("There are 4 unfixed errors:" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
 							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable");
+							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable" +
+							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
+							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
+							System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
+							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
 				});
 	}
 
@@ -51,15 +55,19 @@ class DiktatStepTest extends ResourceHarness {
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		FileSignature config = signAsList(conf);
 
-		FormatterStep step = DiktatStep.create("1.0.1", TestProvisioner.mavenCentral(), Collections.emptyMap(), config);
+		FormatterStep step = DiktatStep.create("1.2.0", TestProvisioner.mavenCentral(), config);
 		StepHarness.forStep(step)
 				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:" +
+					assertion.hasMessage("There are 4 unfixed errors:" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
 							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
 							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable");
+							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable" +
+							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
+							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
+							System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
+							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
 				});
 	}
 

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -54,7 +54,7 @@ class DiktatStepTest extends ResourceHarness {
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		FileSignature config = signAsList(conf);
 
-		FormatterStep step = DiktatStep.create("1.2.1", TestProvisioner.mavenCentral(), config);
+		FormatterStep step = DiktatStep.create("1.2.0", TestProvisioner.mavenCentral(), config);
 		StepHarness.forStep(step)
 				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
@@ -73,9 +73,9 @@ class DiktatStepTest extends ResourceHarness {
 	@Test
 	void notSupportedVersion() {
 		final IllegalStateException notSupportedException = Assertions.assertThrows(IllegalStateException.class,
-				() -> DiktatStep.create("1.2.0", TestProvisioner.mavenCentral()));
+				() -> DiktatStep.create("1.1.0", TestProvisioner.mavenCentral()));
 		Assertions.assertTrue(
-				notSupportedException.getMessage().contains("Diktat supported for version 1.2.1 and later"));
+				notSupportedException.getMessage().contains("Minimum required Diktat version is 1.2.0, you tried 1.1.0 which is too old"));
 
 		Assertions.assertDoesNotThrow(() -> DiktatStep.create("1.2.1", TestProvisioner.mavenCentral()));
 		Assertions.assertDoesNotThrow(() -> DiktatStep.create("2.0.0", TestProvisioner.mavenCentral()));

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -73,10 +73,9 @@ class DiktatStepTest extends ResourceHarness {
 	@Test
 	void notSupportedVersion() {
 		final IllegalStateException notSupportedException = Assertions.assertThrows(IllegalStateException.class,
-			() -> DiktatStep.create("1.2.0", TestProvisioner.mavenCentral()));
+				() -> DiktatStep.create("1.2.0", TestProvisioner.mavenCentral()));
 		Assertions.assertTrue(
-			notSupportedException.getMessage().contains("Diktat supported for version 1.2.1 and later")
-		);
+				notSupportedException.getMessage().contains("Diktat supported for version 1.2.1 and later"));
 
 		Assertions.assertDoesNotThrow(() -> DiktatStep.create("1.2.1", TestProvisioner.mavenCentral()));
 		Assertions.assertDoesNotThrow(() -> DiktatStep.create("2.0.0", TestProvisioner.mavenCentral()));

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -18,8 +18,8 @@ package com.diffplug.spotless.kotlin;
 import static com.diffplug.spotless.FileSignature.signAsList;
 
 import java.io.File;
-import java.util.Collections;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FileSignature;
@@ -50,12 +50,11 @@ class DiktatStepTest extends ResourceHarness {
 
 	@Test
 	void behaviorConf() throws Exception {
-
 		String configPath = "src/main/kotlin/diktat-analysis.yml";
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		FileSignature config = signAsList(conf);
 
-		FormatterStep step = DiktatStep.create("1.2.0", TestProvisioner.mavenCentral(), config);
+		FormatterStep step = DiktatStep.create("1.2.1", TestProvisioner.mavenCentral(), config);
 		StepHarness.forStep(step)
 				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
@@ -71,4 +70,15 @@ class DiktatStepTest extends ResourceHarness {
 				});
 	}
 
+	@Test
+	void notSupportedVersion() {
+		final IllegalStateException notSupportedException = Assertions.assertThrows(IllegalStateException.class,
+			() -> DiktatStep.create("1.2.0", TestProvisioner.mavenCentral()));
+		Assertions.assertTrue(
+			notSupportedException.getMessage().contains("Diktat supported for version 1.2.1 and later")
+		);
+
+		Assertions.assertDoesNotThrow(() -> DiktatStep.create("1.2.1", TestProvisioner.mavenCentral()));
+		Assertions.assertDoesNotThrow(() -> DiktatStep.create("2.0.0", TestProvisioner.mavenCentral()));
+	}
 }


### PR DESCRIPTION
Bump default `diktat` version to latest `1.1.0` -> `1.2.0`

It closes https://github.com/saveourtool/diktat/issues/1399
