### PR TITLE
Update `ktlint` to 0.46.1 and remove support for older versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
+### Changes
+* Bump default `ktlint` version to latest `0.45.2` -> `0.46.1` [#1239](https://github.com/diffplug/spotless/issues/1239)
+  * Note that we now require `ktlint >= 0.46.0` due to frequent compatibility breakages
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 		}
 	}
 
-	String VER_KTLINT='0.45.2'
+	String VER_KTLINT='0.46.1'
 	ktlintCompileOnly "com.pinterest:ktlint:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-core:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-experimental:$VER_KTLINT"

--- a/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
+++ b/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.pinterest.ktlint.core.KtLint;
 import com.pinterest.ktlint.core.KtLint.ExperimentalParams;
 import com.pinterest.ktlint.core.LintError;
@@ -46,6 +48,7 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 	private final Map<String, String> userData;
 	private final Function2<? super LintError, ? super Boolean, Unit> formatterCallback;
 	private final boolean isScript;
+	@NotNull
 	private final EditorConfigOverride editorConfigOverride;
 
 	/**
@@ -64,7 +67,7 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 		this.isScript = isScript;
 
 		if (editorConfigOverrideMap.isEmpty()) {
-			this.editorConfigOverride = null;
+			this.editorConfigOverride = EditorConfigOverride.Companion.getEmptyEditorConfigOverride();
 		} else {
 			this.editorConfigOverride = createEditorConfigOverride(editorConfigOverrideMap);
 		}
@@ -83,7 +86,7 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 
 		// Create a mapping of properties to their names based on rule properties and default properties
 		Map<String, UsesEditorConfigProperties.EditorConfigProperty<?>> supportedProperties = Stream
-				.concat(ruleProperties, DefaultEditorConfigProperties.INSTANCE.getDefaultEditorConfigProperties().stream())
+				.concat(ruleProperties, DefaultEditorConfigProperties.INSTANCE.getEditorConfigProperties().stream())
 				.distinct()
 				.collect(Collectors.toMap(property -> property.getType().getName(), property -> property));
 
@@ -116,31 +119,16 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 
 	@Override
 	public String applyWithFile(String unix, File file) throws Exception {
-
-		if (editorConfigOverride != null) {
-			// Use ExperimentalParams with EditorConfigOverride which requires KtLint 0.45.2
-			return KtLint.INSTANCE.format(new ExperimentalParams(
-					file.getName(),
-					unix,
-					rulesets,
-					userData,
-					formatterCallback,
-					isScript,
-					null,
-					false,
-					editorConfigOverride,
-					false));
-		} else {
-			// Use Params for backward compatibility
-			return KtLint.INSTANCE.format(new KtLint.Params(
-					file.getName(),
-					unix,
-					rulesets,
-					userData,
-					formatterCallback,
-					isScript,
-					null,
-					false));
-		}
+		return KtLint.INSTANCE.format(new ExperimentalParams(
+				file.getName(),
+				unix,
+				rulesets,
+				userData,
+				formatterCallback,
+				isScript,
+				null,
+				false,
+				editorConfigOverride,
+				false));
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -18,10 +18,6 @@ package com.diffplug.spotless.kotlin;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -31,18 +27,15 @@ import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.JarState;
 import com.diffplug.spotless.Provisioner;
-import com.diffplug.spotless.ThrowingEx;
 
 /** Wraps up <a href="https://github.com/pinterest/ktlint">ktlint</a> as a FormatterStep. */
 public class KtLintStep {
 	// prevent direct instantiation
 	private KtLintStep() {}
 
-	private static final String DEFAULT_VERSION = "0.45.2";
+	private static final String DEFAULT_VERSION = "0.46.1";
 	static final String NAME = "ktlint";
-	static final String PACKAGE_PRE_0_32 = "com.github.shyiko";
 	static final String PACKAGE = "com.pinterest";
-	static final String MAVEN_COORDINATE_PRE_0_32 = PACKAGE_PRE_0_32 + ":ktlint:";
 	static final String MAVEN_COORDINATE = PACKAGE + ":ktlint:";
 
 	public static FormatterStep create(Provisioner provisioner) {
@@ -85,95 +78,30 @@ public class KtLintStep {
 
 		/** Are the files being linted Kotlin script files. */
 		private final boolean isScript;
-		private final String pkg;
 		/** The jar that contains the formatter. */
 		final JarState jarState;
 		private final boolean useExperimental;
 		private final TreeMap<String, String> userData;
 		private final TreeMap<String, Object> editorConfigOverride;
-		private final boolean useParams;
 
 		State(String version, Provisioner provisioner, boolean isScript, boolean useExperimental,
 				Map<String, String> userData, Map<String, Object> editorConfigOverride) throws IOException {
 
-			if (!editorConfigOverride.isEmpty() &&
-					BadSemver.version(version) < BadSemver.version(0, 45, 2)) {
-				throw new IllegalStateException("KtLint editorConfigOverride supported for version 0.45.2 and later");
+			if (BadSemver.version(version) < BadSemver.version(0, 46, 0)) {
+				throw new IllegalStateException("KtLint versions < 0.46.0 not supported!");
 			}
 
 			this.useExperimental = useExperimental;
 			this.userData = new TreeMap<>(userData);
 			this.editorConfigOverride = new TreeMap<>(editorConfigOverride);
-			String coordinate;
-			if (BadSemver.version(version) < BadSemver.version(0, 32)) {
-				coordinate = MAVEN_COORDINATE_PRE_0_32;
-				this.pkg = PACKAGE_PRE_0_32;
-			} else {
-				coordinate = MAVEN_COORDINATE;
-				this.pkg = PACKAGE;
-			}
-			this.useParams = BadSemver.version(version) >= BadSemver.version(0, 34);
-			this.jarState = JarState.from(coordinate + version, provisioner);
+			this.jarState = JarState.from(MAVEN_COORDINATE + version, provisioner);
 			this.isScript = isScript;
 		}
 
 		FormatterFunc createFormat() throws Exception {
-			if (useParams) {
-				Class<?> formatterFunc = jarState.getClassLoader().loadClass("com.diffplug.spotless.glue.ktlint.KtlintFormatterFunc");
-				Constructor<?> constructor = formatterFunc.getConstructor(boolean.class, boolean.class, Map.class, Map.class);
-				return (FormatterFunc.NeedsFile) constructor.newInstance(isScript, useExperimental, userData, editorConfigOverride);
-			}
-
-			ClassLoader classLoader = jarState.getClassLoader();
-			// String KtLint::format(String input, Iterable<RuleSet> rules, Function2 errorCallback)
-
-			ArrayList<Object> ruleSets = new ArrayList<>();
-
-			// first, we get the standard rules
-			Class<?> standardRuleSetProviderClass = classLoader.loadClass(pkg + ".ktlint.ruleset.standard.StandardRuleSetProvider");
-			Object standardRuleSet = standardRuleSetProviderClass.getMethod("get").invoke(standardRuleSetProviderClass.newInstance());
-			ruleSets.add(standardRuleSet);
-
-			// second, we get the experimental rules if desired
-			if (useExperimental) {
-				Class<?> experimentalRuleSetProviderClass = classLoader.loadClass(pkg + ".ktlint.ruleset.experimental.ExperimentalRuleSetProvider");
-				Object experimentalRuleSet = experimentalRuleSetProviderClass.getMethod("get").invoke(experimentalRuleSetProviderClass.newInstance());
-				ruleSets.add(experimentalRuleSet);
-			}
-
-			// next, we create an error callback which throws an assertion error when the format is bad
-			Class<?> function2Interface = classLoader.loadClass("kotlin.jvm.functions.Function2");
-			Class<?> lintErrorClass = classLoader.loadClass(pkg + ".ktlint.core.LintError");
-			Method detailGetter = lintErrorClass.getMethod("getDetail");
-			Method lineGetter = lintErrorClass.getMethod("getLine");
-			Method colGetter = lintErrorClass.getMethod("getCol");
-			Object formatterCallback = Proxy.newProxyInstance(classLoader, new Class[]{function2Interface},
-					(proxy, method, args) -> {
-						Object lintError = args[0]; //ktlint.core.LintError
-						boolean corrected = (Boolean) args[1];
-						if (!corrected) {
-							String detail = (String) detailGetter.invoke(lintError);
-							int line = (Integer) lineGetter.invoke(lintError);
-							int col = (Integer) colGetter.invoke(lintError);
-							throw new AssertionError("Error on line: " + line + ", column: " + col + "\n" + detail);
-						}
-						return null;
-					});
-
-			// grab the KtLint singleton
-			Class<?> ktlintClass = classLoader.loadClass(pkg + ".ktlint.core.KtLint");
-			Object ktlint = ktlintClass.getDeclaredField("INSTANCE").get(null);
-
-			// and its format method
-			String formatterMethodName = isScript ? "formatScript" : "format";
-			Method formatterMethod = ktlintClass.getMethod(formatterMethodName, String.class, Iterable.class, Map.class, function2Interface);
-			return input -> {
-				try {
-					return (String) formatterMethod.invoke(ktlint, input, ruleSets, userData, formatterCallback);
-				} catch (InvocationTargetException e) {
-					throw ThrowingEx.unwrapCause(e);
-				}
-			};
+			Class<?> formatterFunc = jarState.getClassLoader().loadClass("com.diffplug.spotless.glue.ktlint.KtlintFormatterFunc");
+			Constructor<?> constructor = formatterFunc.getConstructor(boolean.class, boolean.class, Map.class, Map.class);
+			return (FormatterFunc.NeedsFile) constructor.newInstance(isScript, useExperimental, userData, editorConfigOverride);
 		}
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
+### Changes
+* Bump default `ktlint` version to latest `0.45.2` -> `0.46.1` [#1239](https://github.com/diffplug/spotless/issues/1239)
+  * Note that we now require `ktlint >= 0.46.0` due to frequent compatibility breakages
 
 ## [6.7.2] - 2022-06-11
 ### Fixed

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -177,31 +177,6 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
 	}
 
-	/**
-	 * Check that the sample used to verify the experimental ruleset is untouched by the default ruleset, to verify
-	 * that enabling the experimental ruleset is actually doing something.
-	 *
-	 * If this test fails, it's likely that the experimental rule being used as a test graduated into the standard
-	 * ruleset, and therefore a new experimental rule should be used to verify functionality.
-	 */
-	@Test
-	void experimentalSampleUnchangedWithDefaultRuleset() throws IOException {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
-				"    id 'com.diffplug.spotless'",
-				"}",
-				"repositories { mavenCentral() }",
-				"spotless {",
-				"    kotlin {",
-				"        ktlint()",
-				"    }",
-				"}");
-		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/experimental.dirty");
-		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/experimental.dirty");
-	}
-
 	@Test
 	void testWithHeader() throws IOException {
 		setFile("build.gradle").toLines(

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -15,13 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 
 import java.io.IOException;
 
-import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 
@@ -42,9 +39,9 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 				"        ktlint()",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktlint/basic.dirty");
+		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/basic.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktlint/basic.clean");
+		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/basic.clean");
 	}
 
 	@Test
@@ -132,12 +129,12 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 				"repositories { mavenCentral() }",
 				"spotless {",
 				"    kotlin {",
-				"        ktlint('0.32.0').userData(['indent_size': '6'])",
+				"        ktlint().editorConfigOverride(['indent_size': '6'])",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktlint/basic.dirty");
-		BuildResult result = gradleRunner().withArguments("spotlessApply").buildAndFail();
-		assertThat(result.getOutput()).contains("Unexpected indentation (4) (it should be 6)");
+		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/basic.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/basic.clean-indent6");
 	}
 
 	@Test
@@ -153,27 +150,9 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 				"        ktlint().setUseExperimental(true)",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/experimental.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.clean");
-	}
-
-	@Test
-	void withExperimental_0_32() throws IOException {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
-				"    id 'com.diffplug.spotless'",
-				"}",
-				"repositories { mavenCentral() }",
-				"spotless {",
-				"    kotlin {",
-				"        ktlint('0.32.0').setUseExperimental(true)",
-				"    }",
-				"}");
-		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktlint/basic.dirty");
-		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktlint/basic.clean");
+		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/experimental.clean");
 	}
 
 	@Test
@@ -193,31 +172,9 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 				"            ])",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
-	}
-
-	@Test
-	void withEditorConfigOverride_0_45_1() throws IOException {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
-				"    id 'com.diffplug.spotless'",
-				"}",
-				"repositories { mavenCentral() }",
-				"spotless {",
-				"    kotlin {",
-				"        ktlint('0.45.1')",
-				"            .editorConfigOverride([",
-				"        	    indent_size: 5",
-				"            ])",
-				"    }",
-				"}");
-		setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktlint/basic.dirty");
-		Throwable error = assertThrows(Throwable.class,
-				() -> gradleRunner().withArguments("spotlessApply").build());
-		assertThat(error).hasMessageContaining("KtLint editorConfigOverride supported for version 0.45.2 and later");
+		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
 	}
 
 	/**
@@ -240,9 +197,9 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 				"        ktlint()",
 				"    }",
 				"}");
-		setFile("src/main/kotlin/experimental.kt").toResource("kotlin/ktlint/experimental.dirty");
+		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/experimental.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/kotlin/experimental.kt").sameAsResource("kotlin/ktlint/experimental.dirty");
+		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/experimental.dirty");
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -16,7 +16,6 @@
 package com.diffplug.gradle.spotless;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 
 import java.io.IOException;

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -95,24 +95,6 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 	}
 
 	@Test
-	void integration_pinterest() throws IOException {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
-				"    id 'com.diffplug.spotless'",
-				"}",
-				"repositories { mavenCentral() }",
-				"spotless {",
-				"    kotlinGradle {",
-				"        ktlint('0.32.0')",
-				"    }",
-				"}");
-		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/basic.dirty");
-		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/basic.clean");
-	}
-
-	@Test
 	void indentStep() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
@@ -148,24 +130,6 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 	}
 
 	@Test
-	void withExperimental_0_32() throws IOException {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
-				"    id 'com.diffplug.spotless'",
-				"}",
-				"repositories { mavenCentral() }",
-				"spotless {",
-				"    kotlinGradle {",
-				"        ktlint('0.32.0').setUseExperimental(true)",
-				"    }",
-				"}");
-		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/basic.dirty");
-		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/basic.clean");
-	}
-
-	@Test
 	void withExperimentalEditorConfigOverride() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
@@ -185,53 +149,6 @@ class KotlinGradleExtensionTest extends GradleIntegrationHarness {
 		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
 		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
-	}
-
-	@Test
-	void withEditorConfigOverride_0_45_1() throws IOException {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
-				"    id 'com.diffplug.spotless'",
-				"}",
-				"repositories { mavenCentral() }",
-				"spotless {",
-				"    kotlinGradle {",
-				"        ktlint('0.45.1')",
-				"            .editorConfigOverride([",
-				"        	    indent_size: 5",
-				"            ])",
-				"    }",
-				"}");
-		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/basic.dirty");
-		Throwable error = assertThrows(Throwable.class,
-				() -> gradleRunner().withArguments("spotlessApply").build());
-		assertThat(error).hasMessageContaining("KtLint editorConfigOverride supported for version 0.45.2 and later");
-	}
-
-	/**
-	 * Check that the sample used to verify the experimental ruleset is untouched by the default ruleset, to verify
-	 * that enabling the experimental ruleset is actually doing something.
-	 *
-	 * If this test fails, it's likely that the experimental rule being used as a test graduated into the standard
-	 * ruleset, and therefore a new experimental rule should be used to verify functionality.
-	 */
-	@Test
-	void experimentalSampleUnchangedWithDefaultRuleset() throws IOException {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
-				"    id 'com.diffplug.spotless'",
-				"}",
-				"repositories { mavenCentral() }",
-				"spotless {",
-				"    kotlinGradle {",
-				"        ktlint()",
-				"    }",
-				"}");
-		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/experimental.dirty");
-		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimental.dirty");
 	}
 
 	@Test

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
+### Changes
+* Bump default `ktlint` version to latest `0.45.2` -> `0.46.1` [#1239](https://github.com/diffplug/spotless/issues/1239)
+  * Note that we now require `ktlint >= 0.46.0` due to frequent compatibility breakages
 
 ## [2.22.8] - 2022-06-11
 ### Fixed

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -24,31 +24,9 @@ class KtlintTest extends MavenIntegrationHarness {
 	void testKtlint() throws Exception {
 		writePomWithKotlinSteps("<ktlint/>");
 
-		String path1 = "src/main/kotlin/main1.kt";
-		String path2 = "src/main/kotlin/main2.kt";
-
-		setFile(path1).toResource("kotlin/ktlint/basic.dirty");
-		setFile(path2).toResource("kotlin/ktlint/basic.dirty");
-
+		String path = "src/main/kotlin/Main.kt";
+		setFile(path).toResource("kotlin/ktlint/basic.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-
-		assertFile(path1).sameAsResource("kotlin/ktlint/basic.clean");
-		assertFile(path2).sameAsResource("kotlin/ktlint/basic.clean");
-	}
-
-	@Test
-	void testKtlintShyiko() throws Exception {
-		writePomWithKotlinSteps("<ktlint><version>0.21.0</version></ktlint>");
-
-		String path1 = "src/main/kotlin/main1.kt";
-		String path2 = "src/main/kotlin/main2.kt";
-
-		setFile(path1).toResource("kotlin/ktlint/basic.dirty");
-		setFile(path2).toResource("kotlin/ktlint/basic.dirty");
-
-		mavenRunner().withArguments("spotless:apply").runNoError();
-
-		assertFile(path1).sameAsResource("kotlin/ktlint/basic.clean");
-		assertFile(path2).sameAsResource("kotlin/ktlint/basic.clean");
+		assertFile(path).sameAsResource("kotlin/ktlint/basic.clean");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/main/resources/kotlin/ktlint/basic.clean-indent6
+++ b/testlib/src/main/resources/kotlin/ktlint/basic.clean-indent6
@@ -1,0 +1,5 @@
+fun main() {
+      fun name() { a(); return b }
+      println(";")
+      println()
+}

--- a/testlib/src/main/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader.test
+++ b/testlib/src/main/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader.test
@@ -1,5 +1,6 @@
 // License Header 2012, 2014
 @file:JvmName("SomeFileName")
+
 package my.test
 
 object AnObject

--- a/testlib/src/main/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader2.test
+++ b/testlib/src/main/resources/kotlin/licenseheader/KotlinCodeWithMultiYearHeader2.test
@@ -1,5 +1,6 @@
 // License Header 2012-2014
 @file:JvmName("SomeFileName")
+
 package my.test
 
 object AnObject2

--- a/testlib/src/main/resources/kotlin/licenseheader/KotlinCodeWithoutHeader.test
+++ b/testlib/src/main/resources/kotlin/licenseheader/KotlinCodeWithoutHeader.test
@@ -1,4 +1,5 @@
 @file:JvmName("SomeFileName")
+
 package my.test
 
 object AnObject

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -23,11 +23,6 @@ import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
-/**
- * This class is the only one that uses jcenter, and it seems to be the only one that
- * causes these problems. The root is still a gradle bug, but in the meantime we don't
- * need to hold up *every* PR with this: https://github.com/gradle/gradle/issues/11752
- */
 class KtLintStepTest extends ResourceHarness {
 	@Test
 	void behavior() throws Exception {

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -42,8 +42,8 @@ class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
-	void worksShyiko() throws Exception {
-		FormatterStep step = KtLintStep.create("0.31.0", TestProvisioner.mavenCentral());
+	void worksPre0_46_1() throws Exception {
+		FormatterStep step = KtLintStep.create("0.46.0", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
@@ -51,50 +51,19 @@ class KtLintStepTest extends ResourceHarness {
 					assertion.hasMessage("Error on line: 1, column: 1\n" +
 							"Wildcard import");
 				});
-	}
-
-	// Regression test to ensure it works on the version it switched to Pinterest (version 0.32.0)
-	// but before 0.34.
-	// https://github.com/diffplug/spotless/issues/419
-	@Test
-	void worksPinterestAndPre034() throws Exception {
-		FormatterStep step = KtLintStep.create("0.32.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
-				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"Wildcard import");
-				});
-	}
-
-	// Regression test to handle alpha and 1.x version numbers
-	// https://github.com/diffplug/spotless/issues/668
-	@Test
-	void worksAlpha1() throws Exception {
-		FormatterStep step = KtLintStep.create("0.38.0-alpha01", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
-				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
-	}
-
-	@Test
-	void worksPre0_45_2() throws Exception {
-		FormatterStep step = KtLintStep.create("0.45.1", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
-				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
 	}
 
 	@Test
 	void equality() throws Exception {
 		new SerializableEqualityTester() {
-			String version = "0.32.0";
+			String version = "0.46.0";
 
 			@Override
 			protected void setupTest(API api) {
 				// same version == same
 				api.areDifferentThan();
 				// change the version, and it's different
-				version = "0.38.0-alpha01";
+				version = "0.46.1";
 				api.areDifferentThan();
 			}
 


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
