### PR TITLE
Updated diktat version to 1.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `ktlint` version to latest `0.45.2` -> `0.46.1` ([#1239](https://github.com/diffplug/spotless/issues/1239))
   * Minimum supported version also bumped to `0.46.0` (we have abandoned strong backward compatibility for `ktlint`, from here on out Spotless will only support the most-recent breaking change).
 * Bump default `diktat` version to latest `1.1.0` -> `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
-  * Minimum supported version also bumped to `1.2.0` (diktat is based on ktlint and has the same backward compatibility issues).
+  * Minimum supported version also bumped to `1.2.1` (diktat is based on ktlint and has the same backward compatibility issues).
 * Bump default `ktfmt` version to latest `0.37` -> `0.39` ([#1240](https://github.com/diffplug/spotless/pull/1240))
 
 ## [2.26.2] - 2022-06-11

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-experimental:$VER_KTLINT"
 	ktlintCompileOnly "com.pinterest.ktlint:ktlint-ruleset-standard:$VER_KTLINT"
 
-	String VER_DIKTAT = "1.2.0"
+	String VER_DIKTAT = "1.2.1"
 	diktatCompileOnly "org.cqfn.diktat:diktat-rules:$VER_DIKTAT"
 
 	// used for markdown formatting

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -30,9 +30,9 @@ public class DiktatStep {
 	// prevent direct instantiation
 	private DiktatStep() {}
 
-	private static final String MIN_SUPPORTED_VERSION = "1.2.0";
+	private static final String MIN_SUPPORTED_VERSION = "1.2.1";
 
-	private static final String DEFAULT_VERSION = "1.2.0";
+	private static final String DEFAULT_VERSION = "1.2.1";
 	static final String NAME = "diktat";
 	static final String PACKAGE_DIKTAT = "org.cqfn.diktat";
 	static final String MAVEN_COORDINATE = PACKAGE_DIKTAT + ":diktat-rules:";

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,7 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `ktlint` version to latest `0.45.2` -> `0.46.1` ([#1239](https://github.com/diffplug/spotless/issues/1239))
   * Minimum supported version also bumped to `0.46.0` (we have abandoned strong backward compatibility for `ktlint`, from here on out Spotless will only support the most-recent breaking change).
 * Bump default `diktat` version to latest `1.1.0` -> `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
-  * Minimum supported version also bumped to `1.2.0` (diktat is based on ktlint and has the same backward compatibility issues).
+  * Minimum supported version also bumped to `1.2.1` (diktat is based on ktlint and has the same backward compatibility issues).
 * Bump default `ktfmt` version to latest `0.37` -> `0.39` ([#1240](https://github.com/diffplug/spotless/pull/1240))
 
 ## [6.7.2] - 2022-06-11

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -9,7 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `ktlint` version to latest `0.45.2` -> `0.46.1` ([#1239](https://github.com/diffplug/spotless/issues/1239))
   * Minimum supported version also bumped to `0.46.0` (we have abandoned strong backward compatibility for `ktlint`, from here on out Spotless will only support the most-recent breaking change).
 * Bump default `diktat` version to latest `1.1.0` -> `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
-  * Minimum supported version also bumped to `1.2.0` (diktat is based on ktlint and has the same backward compatibility issues).
+  * Minimum supported version also bumped to `1.2.1` (diktat is based on ktlint and has the same backward compatibility issues).
 * Bump default `ktfmt` version to latest `0.37` -> `0.39` ([#1240](https://github.com/diffplug/spotless/pull/1240))
 
 ## [2.22.8] - 2022-06-11

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
@@ -40,7 +40,7 @@ class DiktatTest extends MavenIntegrationHarness {
 
 		writePomWithKotlinSteps(
 				"<diktat>",
-				"  <version>1.2.0</version>",
+				"  <version>1.2.1</version>",
 				"</diktat>");
 
 		String path = "src/main/kotlin/Main.kt";
@@ -56,7 +56,7 @@ class DiktatTest extends MavenIntegrationHarness {
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		writePomWithKotlinSteps(
 				"<diktat>",
-				"  <version>1.2.0</version>",
+				"  <version>1.2.1</version>",
 				"  <configFile>" + conf.getAbsolutePath() + "</configFile>",
 				"</diktat>");
 

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -75,7 +75,7 @@ class DiktatStepTest extends ResourceHarness {
 		final IllegalStateException notSupportedException = Assertions.assertThrows(IllegalStateException.class,
 				() -> DiktatStep.create("1.1.0", TestProvisioner.mavenCentral()));
 		Assertions.assertTrue(
-				notSupportedException.getMessage().contains("Minimum required Diktat version is 1.2.0, you tried 1.1.0 which is too old"));
+				notSupportedException.getMessage().contains("Minimum required Diktat version is 1.2.1, you tried 1.1.0 which is too old"));
 
 		Assertions.assertDoesNotThrow(() -> DiktatStep.create("1.2.1", TestProvisioner.mavenCentral()));
 		Assertions.assertDoesNotThrow(() -> DiktatStep.create("2.0.0", TestProvisioner.mavenCentral()));

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -54,7 +54,7 @@ class DiktatStepTest extends ResourceHarness {
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		FileSignature config = signAsList(conf);
 
-		FormatterStep step = DiktatStep.create("1.2.0", TestProvisioner.mavenCentral(), config);
+		FormatterStep step = DiktatStep.create("1.2.1", TestProvisioner.mavenCentral(), config);
 		StepHarness.forStep(step)
 				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);


### PR DESCRIPTION
### What’s done:
- Updated diktat version to a stable 1.2.1 release with minor bug fixes (after a non-stable 1.2.0)