### PR TITLE
docs: update ktfmt comment with all available options

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+## [2.23.1] - 2022-07-01
+### Updated
+* Comment with examples of available style options for ktfmt.
+
 ## [2.23.0] - 2022-06-30
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,10 +4,6 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
-## [2.23.1] - 2022-07-01
-### Updated
-* Comment with examples of available style options for ktfmt.
-
 ## [2.23.0] - 2022-06-30
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -329,8 +329,8 @@ Groovy-Eclipse formatting errors/warnings lead per default to a build failure. T
 
 ```xml
 <ktfmt>
-  <version>0.30</version> <!-- optional -->
-  <style>DEFAULT</style> <!-- optional, other option is DROPBOX -->
+  <version>0.39</version> <!-- optional -->
+  <style>DEFAULT</style> <!-- optional, other options are DROPBOX, GOOGLE and KOTLINLANG -->
 </ktfmt>
 ```
 


### PR DESCRIPTION
There are more working options than the current comment says: https://github.com/diffplug/spotless/blob/main/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java#L53

Both GOOGLE and KOTLINLANG also work. 