### PR TITLE
Lazily check for foreign exes which may not be necessary for the curr…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Clang and Black no longer break the build when the binary is unavailable, if they will not be run during that build ([#1257](https://github.com/diffplug/spotless/pull/1257))
+* Clang and Black no longer break the build when the binary is unavailable, if they will not be run during that build ([#1257](https://github.com/diffplug/spotless/pull/1257)).
+
 ## [2.27.0] - 2022-06-30
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-
+### Added
+* Clang and Black no longer break the build when the binary is unavailable, if they will not be run during that build ([#1257](https://github.com/diffplug/spotless/pull/1257))
 ## [2.27.0] - 2022-06-30
 ### Added
 * Support for `MAC_CLASSIC` (`\r`) line ending ([#1243](https://github.com/diffplug/spotless/pull/1243) fixes [#1196](https://github.com/diffplug/spotless/issues/1196))
@@ -20,7 +21,6 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `diktat` version to latest `1.1.0` -> `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
   * Minimum supported version also bumped to `1.2.1` (diktat is based on ktlint and has the same backward compatibility issues).
 * Bump default `ktfmt` version to latest `0.37` -> `0.39` ([#1240](https://github.com/diffplug/spotless/pull/1240))
-* Clang and Black no longer break the build when the binary is unavailable, if they will not be run during that build ([#1257](https://github.com/diffplug/spotless/pull/1257))
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `diktat` version to latest `1.1.0` -> `1.2.1` ([#1246](https://github.com/diffplug/spotless/pull/1246))
   * Minimum supported version also bumped to `1.2.1` (diktat is based on ktlint and has the same backward compatibility issues).
 * Bump default `ktfmt` version to latest `0.37` -> `0.39` ([#1240](https://github.com/diffplug/spotless/pull/1240))
+* Clang and Black no longer break the build when the binary is unavailable, if they will not be run during that build ([#1257](https://github.com/diffplug/spotless/pull/1257))
 
 ## [2.26.2] - 2022-06-11
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,19 +69,19 @@ public class ClangFormatStep {
 
 	private State createState() throws IOException, InterruptedException {
 		String howToInstall = "" +
-			"You can download clang-format from https://releases.llvm.org and " +
-			"then point Spotless to it with {@code pathToExe('/path/to/clang-format')} " +
-			"or you can use your platform's package manager:" +
-			"\n  win:   choco install llvm --version {version}  (try dropping version if it fails)" +
-			"\n  mac:   brew install clang-format (TODO: how to specify version?)" +
-			"\n  linux: apt install clang-format  (try clang-format-{version} with dropped minor versions)" +
-			"\n    github issue to handle this better: https://github.com/diffplug/spotless/issues/673";
-		final ForeignExe exe =  ForeignExe.nameAndVersion("clang-format", version)
-			.pathToExe(pathToExe)
-			.fixCantFind(howToInstall)
-			.fixWrongVersion(
-					"You can tell Spotless to use the version you already have with {@code clangFormat('{versionFound}')}" +
-							"or you can download the currently specified version, {version}.\n" + howToInstall);
+				"You can download clang-format from https://releases.llvm.org and " +
+				"then point Spotless to it with {@code pathToExe('/path/to/clang-format')} " +
+				"or you can use your platform's package manager:" +
+				"\n  win:   choco install llvm --version {version}  (try dropping version if it fails)" +
+				"\n  mac:   brew install clang-format (TODO: how to specify version?)" +
+				"\n  linux: apt install clang-format  (try clang-format-{version} with dropped minor versions)" +
+				"\n    github issue to handle this better: https://github.com/diffplug/spotless/issues/673";
+		final ForeignExe exe = ForeignExe.nameAndVersion("clang-format", version)
+				.pathToExe(pathToExe)
+				.fixCantFind(howToInstall)
+				.fixWrongVersion(
+						"You can tell Spotless to use the version you already have with {@code clangFormat('{versionFound}')}" +
+								"or you can download the currently specified version, {version}.\n" + howToInstall);
 		return new State(this, exe);
 	}
 
@@ -106,7 +106,7 @@ public class ClangFormatStep {
 				final List<String> tmpArgs = new ArrayList<>();
 				tmpArgs.add(exe.confirmVersionAndGetAbsolutePath());
 				if (style != null) {
-					tmpArgs.add("--style="+ style);	
+					tmpArgs.add("--style=" + style);
 				}
 				args = tmpArgs;
 			}

--- a/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
@@ -91,9 +91,9 @@ public class ClangFormatStep {
 		// used for up-to-date checks and caching
 		final String version;
 		final @Nullable String style;
-		final ForeignExe exe;
+		final transient ForeignExe exe;
 		// used for executing
-		private @Nullable List<String> args;
+		private transient @Nullable List<String> args;
 
 		State(ClangFormatStep step, ForeignExe pathToExe) {
 			this.version = step.version;

--- a/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
@@ -74,9 +74,9 @@ public class BlackStep {
 		private static final long serialVersionUID = -1825662356883926318L;
 		// used for up-to-date checks and caching
 		final String version;
-		final ForeignExe exe;
+		final transient ForeignExe exe;
 		// used for executing
-		private @Nullable String[] args;
+		private transient @Nullable String[] args;
 
 		State(BlackStep step, ForeignExe exeAbsPath) {
 			this.version = step.version;

--- a/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
@@ -85,7 +85,7 @@ public class BlackStep {
 
 		String format(ProcessRunner runner, String input) throws IOException, InterruptedException {
 			if (args == null) {
-				args = new String[] {exe.confirmVersionAndGetAbsolutePath(), "-"};
+				args = new String[]{exe.confirmVersionAndGetAbsolutePath(), "-"};
 			}
 			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
@@ -18,8 +18,7 @@ package com.diffplug.spotless.python;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -62,12 +61,11 @@ public class BlackStep {
 
 	private State createState() throws IOException, InterruptedException {
 		String trackingIssue = "\n  github issue to handle this better: https://github.com/diffplug/spotless/issues/674";
-		String exeAbsPath = ForeignExe.nameAndVersion("black", version)
+		ForeignExe exeAbsPath = ForeignExe.nameAndVersion("black", version)
 				.pathToExe(pathToExe)
 				.versionRegex(Pattern.compile("(?:black, version|black,|version) (\\S*)"))
 				.fixCantFind("Try running {@code pip install black=={version}}, or else tell Spotless where it is with {@code black().pathToExe('path/to/executable')}" + trackingIssue)
-				.fixWrongVersion("Try running {@code pip install --force-reinstall black=={version}}, or else specify {@code black('{versionFound}')} to Spotless" + trackingIssue)
-				.confirmVersionAndGetAbsolutePath();
+				.fixWrongVersion("Try running {@code pip install --force-reinstall black=={version}}, or else specify {@code black('{versionFound}')} to Spotless" + trackingIssue);
 		return new State(this, exeAbsPath);
 	}
 
@@ -76,15 +74,19 @@ public class BlackStep {
 		private static final long serialVersionUID = -1825662356883926318L;
 		// used for up-to-date checks and caching
 		final String version;
+		final ForeignExe exe;
 		// used for executing
-		final transient List<String> args;
+		private @Nullable String[] args;
 
-		State(BlackStep step, String exeAbsPath) {
+		State(BlackStep step, ForeignExe exeAbsPath) {
 			this.version = step.version;
-			this.args = Arrays.asList(exeAbsPath, "-");
+			this.exe = Objects.requireNonNull(exeAbsPath);
 		}
 
 		String format(ProcessRunner runner, String input) throws IOException, InterruptedException {
+			if (args == null) {
+				args = new String[] {exe.confirmVersionAndGetAbsolutePath(), "-"};
+			}
 			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
 		}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Clang and Black no longer break the build when the binary is unavailable, if they will not be run during that build ([#1257](https://github.com/diffplug/spotless/pull/1257)).
 
 ## [6.8.0] - 2022-06-30
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Clang and Black no longer break the build when the binary is unavailable, if they will not be run during that build ([#1257](https://github.com/diffplug/spotless/pull/1257)).
 
 ## [2.23.0] - 2022-06-30
 ### Added


### PR DESCRIPTION
Run ForeignExe#confirmVersionAndGetAbsolutePath only once it is necessary.

Discussed in https://github.com/diffplug/spotless/issues/673, I decided to make the 2 State implementations lazy with resolving the arguments.