### PR TITLE
Fix ANTLR 4 formatter maven configuration in readme

### DIFF
--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -481,7 +481,7 @@ Groovy-Eclipse formatting errors/warnings lead per default to a build failure. T
       <include>src/*/antlr4/**/*.g4</include>
     </includes>
 
-    <antlr4formatter /> <!-- has its own section below -->
+    <antlr4Formatter /> <!-- has its own section below -->
 
     <licenseHeader>
       <content>/* (C)$YEAR */</content>  <!-- or <file>${project.basedir}/license-header</file> -->
@@ -490,14 +490,14 @@ Groovy-Eclipse formatting errors/warnings lead per default to a build failure. T
 </configuration>
 ```
 
-### antlr4formatter
+### antlr4Formatter
 
 [homepage](https://github.com/antlr/Antlr4Formatter). [available versions](https://search.maven.org/artifact/com.khubla.antlr4formatter/antlr4-formatter). [code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/antlr4/Antlr4Formatter.java).
 
 ```xml
-<antlr4formatter>
+<antlr4Formatter>
   <version>1.2.1</version> <!-- optional -->
-</antlr4formatter>
+</antlr4Formatter>
 ```
 
 ## SQL


### PR DESCRIPTION
Just fixes the maven readme, as the formatter step was written in lowercase in the example configuration, which causes an error when running `mvn spotless:apply`. The correct name is `<antlr4Formatter>` and not `<antlr4formatter>` (upper case F).

https://github.com/diffplug/spotless/blob/3878d363c9e28f121784362a659c72b1fbdcb6d8/lib/src/main/java/com/diffplug/spotless/antlr4/Antlr4FormatterStep.java#L27