### PR TITLE
Fix minor bugs related of Spotless SQL config extension docs (#1256)

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -528,7 +528,7 @@ spotless {
 ```gradle
 spotless {
   sql {
-    dbeaver().configFile('dbeaver.props') // configFile is optional
+    dbeaver().configFile('dbeaver.properties') // configFile is optional
 ```
 
 Default configuration file, other options [available here](https://github.com/diffplug/spotless/blob/main/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java).

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -524,7 +524,7 @@ Groovy-Eclipse formatting errors/warnings lead per default to a build failure. T
 
 ```xml
 <dbeaver>
-    <configFile>dbeaver.props</configFile> <!-- configFile is optional -->
+    <configFile>dbeaver.properties</configFile> <!-- configFile is optional -->
 </dbeaver>
 ```
 


### PR DESCRIPTION
## Purpose of the pull request

* Fix minor bugs related of Spotless SQL config extension docs.
* This PR closes: #1256 

## Brief change log

* Change `dbeaver.props` to `dbeaver.properties` in docs, as `.props` is not a supported extension for sql formatter configurations.

## Verify this pull request

* Verified by manual tests.