### PR TITLE
Add ktlint rule ID in formatter callback exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Add the `ktlint` rule in error messages when `ktlint` fails to apply a fix ([#1279](https://github.com/diffplug/spotless/pull/1279))
 
 ## [2.28.1] - 2022-08-10
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
 * Add the `ktlint` rule in error messages when `ktlint` fails to apply a fix ([#1279](https://github.com/diffplug/spotless/pull/1279))
 
 ## [2.28.1] - 2022-08-10

--- a/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
+++ b/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
@@ -111,7 +111,7 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {
 			if (!corrected) {
-				throw new AssertionError("Error on line: " + lint.getLine() + ", column: " + lint.getCol() + "\n" + lint.getDetail());
+				throw new AssertionError("Error on line: " + lint.getLine() + ", column: " + lint.getCol() + "\n" + lint.getRuleId() + "\n" + lint.getDetail());
 			}
 			return null;
 		}

--- a/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
+++ b/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
@@ -111,7 +111,7 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {
 			if (!corrected) {
-				throw new AssertionError("Error on line: " + lint.getLine() + ", column: " + lint.getCol() + "\n" + lint.getRuleId() + "\n" + lint.getDetail());
+				throw new AssertionError("Error on line: " + lint.getLine() + ", column: " + lint.getCol() + "\nrule: " + lint.getRuleId() + "\n" + lint.getDetail());
 			}
 			return null;
 		}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,7 +3,6 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
-
 ### Changes
 * Add the `ktlint` rule in error messages when `ktlint` fails to apply a fix ([#1279](https://github.com/diffplug/spotless/pull/1279))
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Changes
+* Add the `ktlint` rule in error messages when `ktlint` fails to apply a fix ([#1279](https://github.com/diffplug/spotless/pull/1279))
+
 ## [6.9.1] - 2022-08-10
 ### Fixed
 * Fix Clang not knowing the filename and changing the format ([#1268](https://github.com/diffplug/spotless/pull/1268) fixes [#1267](https://github.com/diffplug/spotless/issues/1267)).

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Add the `ktlint` rule in error messages when `ktlint` fails to apply a fix ([#1279](https://github.com/diffplug/spotless/pull/1279))
 
 ## [2.24.1] - 2022-08-10
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
 * Add the `ktlint` rule in error messages when `ktlint` fails to apply a fix ([#1279](https://github.com/diffplug/spotless/pull/1279))
 
 ## [2.24.1] - 2022-08-10

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -32,6 +32,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
 					assertion.hasMessage("Error on line: 1, column: 1\n" +
+							"rule: no-wildcard-imports\n" +
 							"Wildcard import");
 				});
 	}
@@ -44,6 +45,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
 					assertion.hasMessage("Error on line: 1, column: 1\n" +
+							"rule: no-wildcard-imports\n" +
 							"Wildcard import");
 				});
 	}


### PR DESCRIPTION
When `ktlint` fails to autocorrect an issue, you get an error:

```
Step 'ktlint' found problem in 'src/main/java/Main.kt':
Error on line: 337, column: 41
Unexpected whitespace
// stacktrace
```

This adds the rule to the error:
```
Step 'ktlint' found problem in 'src/main/java/Main.kt':
Error on line: 337, column: 41
rule: experimental:parameter-list-spacing
Unexpected whitespace
// stacktrace
```