### PR TITLE
fix: maven plugin should identify skip config key

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `skip` config key should work again now. ([#1353](https://github.com/diffplug/spotless/pull/1353) fixes [#1227](https://github.com/diffplug/spotless/issues/1227) and [#491](https://github.com/diffplug/spotless/issues/491))
 
 ## [2.27.0] - 2022-09-19
 ### Added

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -91,6 +91,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${mojoExecution.goal}", required = true, readonly = true)
 	private String goal;
 
+	@Parameter(defaultValue = "false")
+	private boolean skip;
+
 	@Parameter(property = "spotless.apply.skip", defaultValue = "false")
 	private boolean applySkip;
 
@@ -200,6 +203,10 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private boolean shouldSkip() {
+		if (skip) {
+			return true;
+		}
+
 		switch (goal) {
 		case GOAL_CHECK:
 			return checkSkip;
@@ -208,6 +215,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		default:
 			break;
 		}
+
 		return false;
 	}
 


### PR DESCRIPTION
* This closes #1227.
* This closes #491.

CHANGES updates will be pushed later. I trigger the CI tasks first.
