### PR TITLE
Allow replacement to be null for Replace and ReplaceRegex of plugin maven

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `replace` and `replaceRegex` steps now allow you to replace something with an empty string, previously this would generate a null pointer exception. (fixes [#1359](https://github.com/diffplug/spotless/issues/1359))
 
 ## [2.27.1] - 2022-09-28
 ### Fixed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Replace.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Replace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,12 @@ public class Replace implements FormatterStepFactory {
 
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
-		if (name == null || search == null || replacement == null) {
-			throw new IllegalArgumentException("Must specify 'name', 'search' and 'replacement'.");
+		if (name == null || search == null) {
+			throw new IllegalArgumentException("Must specify 'name' and 'search'.");
 		}
-
-		return ReplaceStep.create(name, search, replacement);
+		// Use empty string if replacement is not provided. In pom.xml there is no way to specify
+		// an empty string as a property value as maven will always trim the value and if it is
+		// empty, maven will consider the property as not provided.
+		return ReplaceStep.create(name, search, replacement != null ? replacement : "");
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ReplaceRegex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/ReplaceRegex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,12 @@ public class ReplaceRegex implements FormatterStepFactory {
 
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
-		if (name == null || searchRegex == null || replacement == null) {
-			throw new IllegalArgumentException("Must specify 'name', 'searchRegex' and 'replacement'.");
+		if (name == null || searchRegex == null) {
+			throw new IllegalArgumentException("Must specify 'name' and 'searchRegex'.");
 		}
-
-		return ReplaceRegexStep.create(name, searchRegex, replacement);
+		// Use empty string if replacement is not provided. In pom.xml there is no way to specify
+		// an empty string as a property value as maven will always trim the value and if it is
+		// empty, maven will consider the property as not provided.
+		return ReplaceRegexStep.create(name, searchRegex, replacement != null ? replacement : "");
 	}
 }


### PR DESCRIPTION
As the title described, we want to add the ability to replace a char sequence or regex by an empty string for plugin maven.

This is for fixing #1359 