### PR TITLE
fix(ktlint): support ktlint_disabled_rules in 0.47+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 * Don't treat `@Value` as a type annotation [#1367](https://github.com/diffplug/spotless/pull/1367)
+* Support `ktlint_disabled_rules` in `ktlint` 0.47.x [#1378](https://github.com/diffplug/spotless/pull/1378)
 
 ## [2.30.0] - 2022-09-14
 ### Added

--- a/lib/src/compatKtLint0Dot47Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot47Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot47Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot47Dot0Adapter.java
@@ -17,6 +17,7 @@ package com.diffplug.spotless.glue.ktlint.compat;
 
 import static java.util.Collections.emptySet;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -101,7 +102,7 @@ public class KtLintCompat0Dot47Dot0Adapter implements KtLintCompatAdapter {
 				.flatMap(rule -> ((UsesEditorConfigProperties) rule).getEditorConfigProperties().stream());
 
 		// get complete list of supported properties in DefaultEditorConfigProperties.INSTANCE
-		List<UsesEditorConfigProperties.EditorConfigProperty<?>> editorConfigProperties = DefaultEditorConfigProperties.INSTANCE.getEditorConfigProperties();
+		List<UsesEditorConfigProperties.EditorConfigProperty<?>> editorConfigProperties = new ArrayList<>(DefaultEditorConfigProperties.INSTANCE.getEditorConfigProperties());
 		editorConfigProperties.add(DefaultEditorConfigProperties.INSTANCE.getKtlintDisabledRulesProperty());
 
 		// Create a mapping of properties to their names based on rule properties and default properties

--- a/lib/src/compatKtLint0Dot47Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot47Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot47Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot47Dot0Adapter.java
@@ -100,9 +100,13 @@ public class KtLintCompat0Dot47Dot0Adapter implements KtLintCompatAdapter {
 				.filter(rule -> rule instanceof UsesEditorConfigProperties)
 				.flatMap(rule -> ((UsesEditorConfigProperties) rule).getEditorConfigProperties().stream());
 
+		// get complete list of supported properties in DefaultEditorConfigProperties.INSTANCE
+		List<UsesEditorConfigProperties.EditorConfigProperty<?>> editorConfigProperties = DefaultEditorConfigProperties.INSTANCE.getEditorConfigProperties();
+		editorConfigProperties.add(DefaultEditorConfigProperties.INSTANCE.getKtlintDisabledRulesProperty());
+
 		// Create a mapping of properties to their names based on rule properties and default properties
 		Map<String, UsesEditorConfigProperties.EditorConfigProperty<?>> supportedProperties = Stream
-				.concat(ruleProperties, DefaultEditorConfigProperties.INSTANCE.getEditorConfigProperties().stream())
+				.concat(ruleProperties, editorConfigProperties.stream())
 				.distinct()
 				.collect(Collectors.toMap(property -> property.getType().getName(), property -> property));
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 * Don't treat `@Value` as a type annotation [#1367](https://github.com/diffplug/spotless/pull/1367)
+* Support `ktlint_disabled_rules` in `ktlint` 0.47.x [#1378](https://github.com/diffplug/spotless/pull/1378)
 
 ## [6.11.0] - 2022-09-14
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 * Don't treat `@Value` as a type annotation [#1367](https://github.com/diffplug/spotless/pull/1367)
+* Support `ktlint_disabled_rules` in `ktlint` 0.47.x [#1378](https://github.com/diffplug/spotless/pull/1378)
 
 ## [2.27.2] - 2022-10-10
 ### Fixed


### PR DESCRIPTION
A fix for the `ktlint_disabled_rules` issue reported in https://github.com/diffplug/spotless/issues/1374.

`ktlintDisabledRulesProperty` is not enumerated in `DefaultEditorConfigProperties.INSTANCE.getEditorConfigProperties()` for some reason, so in order to support it in a backwards compatible (down to 0.47) way, we have to manually add it.