### PR TITLE
Update Diktat version to 1.2.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 * Don't treat `@Value` as a type annotation [#1367](https://github.com/diffplug/spotless/pull/1367)
 * Support `ktlint_disabled_rules` in `ktlint` 0.47.x [#1378](https://github.com/diffplug/spotless/pull/1378)
+* Bump default `diktat` version to latest `1.2.3` -> `1.2.4` ([#1396](https://github.com/diffplug/spotless/pull/1396))
 
 ## [2.30.0] - 2022-09-14
 ### Added

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -94,7 +94,7 @@ dependencies {
 	String VER_SCALAFMT="3.5.9"
 	scalafmtCompileOnly "org.scalameta:scalafmt-core_2.13:$VER_SCALAFMT"
 
-	String VER_DIKTAT = "1.2.3"
+	String VER_DIKTAT = "1.2.4"
 	diktatCompileOnly "org.cqfn.diktat:diktat-rules:$VER_DIKTAT"
 
 	// used for markdown formatting

--- a/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
+++ b/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
@@ -19,10 +19,12 @@ import java.io.File;
 import java.util.*;
 
 import org.cqfn.diktat.ruleset.rules.DiktatRuleSetProvider;
+import org.ec4j.core.model.EditorConfig;
 
 import com.pinterest.ktlint.core.KtLint;
 import com.pinterest.ktlint.core.LintError;
 import com.pinterest.ktlint.core.RuleSet;
+import com.pinterest.ktlint.core.api.EditorConfigDefaults;
 import com.pinterest.ktlint.core.api.EditorConfigOverride;
 
 import com.diffplug.spotless.FormatterFunc;
@@ -32,12 +34,14 @@ import kotlin.jvm.functions.Function2;
 
 public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 
+	@SuppressWarnings("deprecation")
 	private final List<RuleSet> rulesets;
 	private final Function2<? super LintError, ? super Boolean, Unit> formatterCallback;
 	private final boolean isScript;
 
 	private final ArrayList<LintError> errors = new ArrayList<>();
 
+	@SuppressWarnings("deprecation")
 	public DiktatFormatterFunc(boolean isScript) {
 		rulesets = Collections.singletonList(new DiktatRuleSetProvider().get());
 		this.formatterCallback = new FormatterCallback(errors);
@@ -69,11 +73,13 @@ public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 				file.getAbsolutePath(),
 				unix,
 				rulesets,
+				Collections.emptySet(),
 				Collections.emptyMap(),
 				formatterCallback,
 				isScript,
 				null,
 				false,
+				new EditorConfigDefaults(EditorConfig.builder().build()),
 				new EditorConfigOverride(),
 				false));
 

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -30,9 +30,9 @@ public class DiktatStep {
 	// prevent direct instantiation
 	private DiktatStep() {}
 
-	private static final String MIN_SUPPORTED_VERSION = "1.2.1";
+	private static final String MIN_SUPPORTED_VERSION = "1.2.4";
 
-	private static final String DEFAULT_VERSION = "1.2.3";
+	private static final String DEFAULT_VERSION = "1.2.4";
 	static final String NAME = "diktat";
 	static final String PACKAGE_DIKTAT = "org.cqfn.diktat";
 	static final String MAVEN_COORDINATE = PACKAGE_DIKTAT + ":diktat-rules:";

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -54,7 +54,7 @@ class DiktatStepTest extends ResourceHarness {
 		File conf = setFile(configPath).toResource("kotlin/diktat/diktat-analysis.yml");
 		FileSignature config = signAsList(conf);
 
-		FormatterStep step = DiktatStep.create("1.2.1", TestProvisioner.mavenCentral(), config);
+		FormatterStep step = DiktatStep.create("1.2.4", TestProvisioner.mavenCentral(), config);
 		StepHarness.forStep(step)
 				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
@@ -75,9 +75,9 @@ class DiktatStepTest extends ResourceHarness {
 		final IllegalStateException notSupportedException = Assertions.assertThrows(IllegalStateException.class,
 				() -> DiktatStep.create("1.1.0", TestProvisioner.mavenCentral()));
 		Assertions.assertTrue(
-				notSupportedException.getMessage().contains("Minimum required Diktat version is 1.2.1, you tried 1.1.0 which is too old"));
+				notSupportedException.getMessage().contains("Minimum required Diktat version is 1.2.4, you tried 1.1.0 which is too old"));
 
-		Assertions.assertDoesNotThrow(() -> DiktatStep.create("1.2.1", TestProvisioner.mavenCentral()));
+		Assertions.assertDoesNotThrow(() -> DiktatStep.create("1.2.4", TestProvisioner.mavenCentral()));
 		Assertions.assertDoesNotThrow(() -> DiktatStep.create("2.0.0", TestProvisioner.mavenCentral()));
 	}
 }


### PR DESCRIPTION
* The default and the minimum _Diktat_ versions have been bumped to **1.2.4**.
* Earler versions are incompatible because of API changes in _KtLint_ **0.47.x**.

This is based on #1393 by @renovatebot.
