### PR TITLE
Allow to output multiple errors when using ktlint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 * Don't treat `@Value` as a type annotation [#1367](https://github.com/diffplug/spotless/pull/1367)
 * Support `ktlint_disabled_rules` in `ktlint` 0.47.x [#1378](https://github.com/diffplug/spotless/pull/1378)
+* Allow to output multiple errors when using `ktlint` [#1403](https://github.com/diffplug/spotless/pull/1403)
 
 ## [2.30.0] - 2022-09-14
 ### Added

--- a/lib/src/compatKtLint0Dot31Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot31Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot31Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot31Dot0Adapter.java
@@ -29,12 +29,19 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot31Dot0Adapter implements KtLintCompatAdapter {
+	private final ArrayList<String> errors = new ArrayList<>();
 
 	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
+		private final ArrayList<String> errors;
+
+		FormatterCallback(final ArrayList<String> errors) {
+			this.errors = errors;
+		}
+
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {
 			if (!corrected) {
-				KtLintCompatReporting.report(lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
+				KtLintCompatReporting.addReport(errors, lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
 			}
 			return null;
 		}
@@ -45,7 +52,7 @@ public class KtLintCompat0Dot31Dot0Adapter implements KtLintCompatAdapter {
 			final boolean useExperimental,
 			final Map<String, String> userData,
 			final Map<String, Object> editorConfigOverrideMap) {
-		final FormatterCallback formatterCallback = new FormatterCallback();
+		final FormatterCallback formatterCallback = new FormatterCallback(errors);
 
 		final List<RuleSet> rulesets = new ArrayList<>();
 		rulesets.add(new StandardRuleSetProvider().get());
@@ -54,10 +61,16 @@ public class KtLintCompat0Dot31Dot0Adapter implements KtLintCompatAdapter {
 			rulesets.add(new ExperimentalRuleSetProvider().get());
 		}
 
-		return KtLint.INSTANCE.format(
+		final String result = KtLint.INSTANCE.format(
 				text,
 				rulesets,
 				userData,
 				formatterCallback);
+
+		if (!errors.isEmpty()) {
+			KtLintCompatReporting.report(errors);
+		}
+
+		return result;
 	}
 }

--- a/lib/src/compatKtLint0Dot32Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot32Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot32Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot32Dot0Adapter.java
@@ -29,12 +29,19 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot32Dot0Adapter implements KtLintCompatAdapter {
+	private final ArrayList<String> errors = new ArrayList<>();
 
 	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
+		private final ArrayList<String> errors;
+
+		FormatterCallback(final ArrayList<String> errors) {
+			this.errors = errors;
+		}
+
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {
 			if (!corrected) {
-				KtLintCompatReporting.report(lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
+				KtLintCompatReporting.addReport(errors, lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
 			}
 			return null;
 		}
@@ -45,7 +52,7 @@ public class KtLintCompat0Dot32Dot0Adapter implements KtLintCompatAdapter {
 			final boolean useExperimental,
 			final Map<String, String> userData,
 			final Map<String, Object> editorConfigOverrideMap) {
-		final FormatterCallback formatterCallback = new FormatterCallback();
+		final FormatterCallback formatterCallback = new FormatterCallback(errors);
 
 		final List<RuleSet> rulesets = new ArrayList<>();
 		rulesets.add(new StandardRuleSetProvider().get());
@@ -54,10 +61,16 @@ public class KtLintCompat0Dot32Dot0Adapter implements KtLintCompatAdapter {
 			rulesets.add(new ExperimentalRuleSetProvider().get());
 		}
 
-		return KtLint.INSTANCE.format(
+		final String result = KtLint.INSTANCE.format(
 				text,
 				rulesets,
 				userData,
 				formatterCallback);
+
+		if (!errors.isEmpty()) {
+			KtLintCompatReporting.report(errors);
+		}
+
+		return result;
 	}
 }

--- a/lib/src/compatKtLint0Dot34Dot2/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot34Dot2Adapter.java
+++ b/lib/src/compatKtLint0Dot34Dot2/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot34Dot2Adapter.java
@@ -29,12 +29,19 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot34Dot2Adapter implements KtLintCompatAdapter {
+	private final ArrayList<String> errors = new ArrayList<>();
 
 	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
+		private final ArrayList<String> errors;
+
+		FormatterCallback(final ArrayList<String> errors) {
+			this.errors = errors;
+		}
+
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {
 			if (!corrected) {
-				KtLintCompatReporting.report(lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
+				KtLintCompatReporting.addReport(errors, lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
 			}
 			return null;
 		}
@@ -45,7 +52,7 @@ public class KtLintCompat0Dot34Dot2Adapter implements KtLintCompatAdapter {
 			final boolean useExperimental,
 			final Map<String, String> userData,
 			final Map<String, Object> editorConfigOverrideMap) {
-		final FormatterCallback formatterCallback = new FormatterCallback();
+		final FormatterCallback formatterCallback = new FormatterCallback(errors);
 
 		final List<RuleSet> rulesets = new ArrayList<>();
 		rulesets.add(new StandardRuleSetProvider().get());
@@ -54,7 +61,7 @@ public class KtLintCompat0Dot34Dot2Adapter implements KtLintCompatAdapter {
 			rulesets.add(new ExperimentalRuleSetProvider().get());
 		}
 
-		return KtLint.INSTANCE.format(new KtLint.Params(
+		final String result = KtLint.INSTANCE.format(new KtLint.Params(
 				name,
 				text,
 				rulesets,
@@ -63,5 +70,11 @@ public class KtLintCompat0Dot34Dot2Adapter implements KtLintCompatAdapter {
 				isScript,
 				null,
 				false));
+
+		if (!errors.isEmpty()) {
+			KtLintCompatReporting.report(errors);
+		}
+
+		return result;
 	}
 }

--- a/lib/src/compatKtLint0Dot45Dot2/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot45Dot2Adapter.java
+++ b/lib/src/compatKtLint0Dot45Dot2/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot45Dot2Adapter.java
@@ -37,12 +37,19 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot45Dot2Adapter implements KtLintCompatAdapter {
+	private ArrayList<String> errors = new ArrayList<>();
 
 	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
+		private ArrayList<String> errors;
+
+		FormatterCallback(final ArrayList<String> errors) {
+			this.errors = errors;
+		}
+
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {
 			if (!corrected) {
-				KtLintCompatReporting.report(lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
+				KtLintCompatReporting.addReport(errors, lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
 			}
 			return null;
 		}
@@ -53,7 +60,7 @@ public class KtLintCompat0Dot45Dot2Adapter implements KtLintCompatAdapter {
 			final boolean useExperimental,
 			final Map<String, String> userData,
 			final Map<String, Object> editorConfigOverrideMap) {
-		final FormatterCallback formatterCallback = new FormatterCallback();
+		final FormatterCallback formatterCallback = new FormatterCallback(errors);
 
 		final List<RuleSet> rulesets = new ArrayList<>();
 		rulesets.add(new StandardRuleSetProvider().get());
@@ -69,7 +76,7 @@ public class KtLintCompat0Dot45Dot2Adapter implements KtLintCompatAdapter {
 			editorConfigOverride = createEditorConfigOverride(rulesets, editorConfigOverrideMap);
 		}
 
-		return KtLint.INSTANCE.format(new KtLint.ExperimentalParams(
+		final String result = KtLint.INSTANCE.format(new KtLint.ExperimentalParams(
 				name,
 				text,
 				rulesets,
@@ -80,6 +87,12 @@ public class KtLintCompat0Dot45Dot2Adapter implements KtLintCompatAdapter {
 				false,
 				editorConfigOverride,
 				false));
+
+		if (!errors.isEmpty()) {
+			KtLintCompatReporting.report(errors);
+		}
+
+		return result;
 	}
 
 	/**

--- a/lib/src/compatKtLint0Dot46Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot46Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot46Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot46Dot0Adapter.java
@@ -37,14 +37,14 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot46Dot0Adapter implements KtLintCompatAdapter {
-        private final ArrayList<String> errors = new ArrayList<>();
+	private final ArrayList<String> errors = new ArrayList<>();
 
 	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
-                private final ArrayList<String> errors;
+		private final ArrayList<String> errors;
 
-                FormatterCallback(ArrayList<String> errors) {
-                        this.errors = errors;
-                }
+		FormatterCallback(ArrayList<String> errors) {
+			this.errors = errors;
+		}
 
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {

--- a/lib/src/compatKtLint0Dot47Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot47Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot47Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot47Dot0Adapter.java
@@ -42,12 +42,19 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot47Dot0Adapter implements KtLintCompatAdapter {
+	private final ArrayList<String> errors = new ArrayList<>();
 
 	static class FormatterCallback implements Function2<LintError, Boolean, Unit> {
+		private final ArrayList<String> errors;
+
+		FormatterCallback(ArrayList<String> errors) {
+			this.errors = errors;
+		}
+
 		@Override
 		public Unit invoke(LintError lint, Boolean corrected) {
 			if (!corrected) {
-				KtLintCompatReporting.report(lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
+				KtLintCompatReporting.addReport(errors, lint.getLine(), lint.getCol(), lint.getRuleId(), lint.getDetail());
 			}
 			return null;
 		}
@@ -58,7 +65,7 @@ public class KtLintCompat0Dot47Dot0Adapter implements KtLintCompatAdapter {
 			final boolean useExperimental,
 			final Map<String, String> userData,
 			final Map<String, Object> editorConfigOverrideMap) {
-		final FormatterCallback formatterCallback = new FormatterCallback();
+		final FormatterCallback formatterCallback = new FormatterCallback(errors);
 
 		Set<RuleProvider> allRuleProviders = new LinkedHashSet<>(
 				new StandardRuleSetProvider().getRuleProviders());
@@ -76,7 +83,8 @@ public class KtLintCompat0Dot47Dot0Adapter implements KtLintCompatAdapter {
 					editorConfigOverrideMap);
 		}
 
-		return KtLint.INSTANCE.format(new KtLint.ExperimentalParams(
+		errors.clear();
+		final String result = KtLint.INSTANCE.format(new KtLint.ExperimentalParams(
 				name,
 				text,
 				emptySet(),
@@ -89,6 +97,12 @@ public class KtLintCompat0Dot47Dot0Adapter implements KtLintCompatAdapter {
 				EditorConfigDefaults.Companion.getEmptyEditorConfigDefaults(),
 				editorConfigOverride,
 				false));
+
+		if (!errors.isEmpty()) {
+			KtLintCompatReporting.report(errors);
+		}
+
+		return result;
 	}
 
 	/**

--- a/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
+++ b/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
@@ -23,7 +23,7 @@ final class KtLintCompatReporting {
 
 	static void addReport(ArrayList<String> errors, int line, int column, String ruleId, String detail) {
 		StringBuilder sb = new StringBuilder("Error on line: ");
-		sb.append(line).append(", column: ").append(column).append("\nrule: ").append(ruleId).append("\n").append(detail);
+		sb.append(line).append(", column: ").append(column).append(System.lineSeparator()).append("rule: ").append(ruleId).append(System.lineSeparator()).append(detail);
 		errors.add(sb.toString());
 	}
 

--- a/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
+++ b/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
@@ -15,11 +15,24 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
+import java.util.ArrayList;
+
 final class KtLintCompatReporting {
 
 	private KtLintCompatReporting() {}
 
-	static void report(int line, int column, String ruleId, String detail) {
-		throw new AssertionError("Error on line: " + line + ", column: " + column + "\nrule: " + ruleId + "\n" + detail);
+	static void addReport(ArrayList<String> errors, int line, int column, String ruleId, String detail) {
+                StringBuilder sb = new StringBuilder("Error on line: ");
+                sb.append(line).append(", column: ").append(column).append("\nrule: ").append(ruleId).append("\n").append(detail);
+                errors.add(sb.toString());
 	}
+
+	static String report(final ArrayList<String> errors) {
+		StringBuilder output = new StringBuilder();
+		output.append("There are ").append(errors.size()).append(" unfixed errors:").append(System.lineSeparator());
+		for (final String error : errors) {
+			output.append(error).append(System.lineSeparator());
+		}
+		throw new AssertionError(output);
+	 }
 }

--- a/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
+++ b/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
@@ -22,9 +22,9 @@ final class KtLintCompatReporting {
 	private KtLintCompatReporting() {}
 
 	static void addReport(ArrayList<String> errors, int line, int column, String ruleId, String detail) {
-                StringBuilder sb = new StringBuilder("Error on line: ");
-                sb.append(line).append(", column: ").append(column).append("\nrule: ").append(ruleId).append("\n").append(detail);
-                errors.add(sb.toString());
+		StringBuilder sb = new StringBuilder("Error on line: ");
+		sb.append(line).append(", column: ").append(column).append("\nrule: ").append(ruleId).append("\n").append(detail);
+		errors.add(sb.toString());
 	}
 
 	static String report(final ArrayList<String> errors) {
@@ -34,5 +34,5 @@ final class KtLintCompatReporting {
 			output.append(error).append(System.lineSeparator());
 		}
 		throw new AssertionError(output);
-	 }
+	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 * Don't treat `@Value` as a type annotation [#1367](https://github.com/diffplug/spotless/pull/1367)
 * Support `ktlint_disabled_rules` in `ktlint` 0.47.x [#1378](https://github.com/diffplug/spotless/pull/1378)
+* Allow to output multiple errors when using `ktlint` [#1403](https://github.com/diffplug/spotless/pull/1403)
 
 ## [6.11.0] - 2022-09-14
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 * Don't treat `@Value` as a type annotation [#1367](https://github.com/diffplug/spotless/pull/1367)
 * Support `ktlint_disabled_rules` in `ktlint` 0.47.x [#1378](https://github.com/diffplug/spotless/pull/1378)
+* Allow to output multiple errors when using `ktlint` [#1403](https://github.com/diffplug/spotless/pull/1403)
 
 ## [2.27.2] - 2022-10-10
 ### Fixed

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -32,9 +32,9 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
+                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
+							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
 	}
 
@@ -45,9 +45,9 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
+                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
+							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
 	}
 
@@ -61,9 +61,9 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
+                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
+							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
 	}
 
@@ -112,9 +112,9 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
+                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
+							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
 	}
 
@@ -125,9 +125,9 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
+                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
+							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
 	}
 
@@ -138,9 +138,9 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
+                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
+							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
 	}
 

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -32,9 +32,14 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:\n" +
-							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
-							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
+					assertion.hasMessage("There are 2 unfixed errors:" +
+							System.lineSeparator() + "Error on line: 1, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator() + "Error on line: 2, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator());
 				});
 	}
 
@@ -45,9 +50,14 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:\n" +
-							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
-							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
+					assertion.hasMessage("There are 2 unfixed errors:" +
+							System.lineSeparator() + "Error on line: 1, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator() + "Error on line: 2, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator());
 				});
 	}
 
@@ -61,9 +71,14 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:\n" +
-							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
-							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
+					assertion.hasMessage("There are 2 unfixed errors:" +
+							System.lineSeparator() + "Error on line: 1, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator() + "Error on line: 2, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator());
 				});
 	}
 
@@ -112,9 +127,14 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:\n" +
-							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
-							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
+					assertion.hasMessage("There are 2 unfixed errors:" +
+							System.lineSeparator() + "Error on line: 1, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator() + "Error on line: 2, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator());
 				});
 	}
 
@@ -125,9 +145,14 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:\n" +
-							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
-							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
+					assertion.hasMessage("There are 2 unfixed errors:" +
+							System.lineSeparator() + "Error on line: 1, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator() + "Error on line: 2, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator());
 				});
 	}
 
@@ -138,9 +163,14 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 2 unfixed errors:\n" +
-							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
-							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
+					assertion.hasMessage("There are 2 unfixed errors:" +
+							System.lineSeparator() + "Error on line: 1, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator() + "Error on line: 2, column: 1" +
+							System.lineSeparator() + "rule: no-wildcard-imports" +
+							System.lineSeparator() + "Wildcard import" +
+							System.lineSeparator());
 				});
 	}
 

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -32,7 +32,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+					assertion.hasMessage("There are 2 unfixed errors:\n" +
 							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
 							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
@@ -45,7 +45,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+					assertion.hasMessage("There are 2 unfixed errors:\n" +
 							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
 							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
@@ -61,7 +61,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+					assertion.hasMessage("There are 2 unfixed errors:\n" +
 							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
 							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
@@ -112,7 +112,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+					assertion.hasMessage("There are 2 unfixed errors:\n" +
 							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
 							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
@@ -125,7 +125,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+					assertion.hasMessage("There are 2 unfixed errors:\n" +
 							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
 							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});
@@ -138,7 +138,7 @@ class KtLintStepTest extends ResourceHarness {
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
 				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
 					assertion.isInstanceOf(AssertionError.class);
-                                        assertion.hasMessage("There are 2 unfixed errors:\n" +
+					assertion.hasMessage("There are 2 unfixed errors:\n" +
 							"Error on line: 1, column: 1\nrule: no-wildcard-imports\nWildcard import\n" +
 							"Error on line: 2, column: 1\nrule: no-wildcard-imports\nWildcard import\n");
 				});


### PR DESCRIPTION
Fixes https://github.com/diffplug/spotless/issues/287

[diktat](https://github.com/diffplug/spotless/blob/d951b890fe741cfde981ea3a2e2466bcf6253924/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java#L57) doesn't throw an exception immediately when ktlint find lint error even if using ktlint, so ktlint shouldn't throw it like diktat, too.
