### PR TITLE
Breaking changes to Spotless' internal testing infrastructure `testlib`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changes
 * Bump the dev version of Gradle from `7.5.1` to `7.6` ([#1409](https://github.com/diffplug/spotless/pull/1409))
   * We also removed the no-longer-required dependency `org.codehaus.groovy:groovy-xml`
+* Breaking changes to Spotless' internal testing infrastructure `testlib` ([#1443](https://github.com/diffplug/spotless/pull/1443))
+  * `ResourceHarness` no longer has any duplicated functionality which was also present in `StepHarness`
+  * `StepHarness` now operates on `Formatter` rather than a `FormatterStep`
+  * `StepHarnessWithFile` now takes a `ResourceHarness` in its constructor to handle the file manipulation parts
+  * Standardized that we test exception *messages*, not types, which will ease the transition to linting later on
 
 ## [2.31.1] - 2023-01-02
 ### Fixed

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,24 +26,19 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.common.base.Errors;
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.ResourceHarness;
 
 class GitAttributesTest extends ResourceHarness {
 	private List<File> testFiles(String prefix) {
-		try {
-			List<File> result = new ArrayList<>();
-			for (String path : TEST_PATHS) {
-				String prefixedPath = prefix + path;
-				setFile(prefixedPath).toContent("");
-				result.add(newFile(prefixedPath));
-			}
-			return result;
-		} catch (IOException e) {
-			throw Errors.asRuntime(e);
+		List<File> result = new ArrayList<>();
+		for (String path : TEST_PATHS) {
+			String prefixedPath = prefix + path;
+			setFile(prefixedPath).toContent("");
+			result.add(newFile(prefixedPath));
 		}
+		return result;
 	}
 
 	private List<File> testFiles() {
@@ -53,7 +48,7 @@ class GitAttributesTest extends ResourceHarness {
 	private static final List<String> TEST_PATHS = Arrays.asList("someFile", "subfolder/someFile", "MANIFEST.MF", "subfolder/MANIFEST.MF");
 
 	@Test
-	void cacheTest() throws IOException {
+	void cacheTest() {
 		setFile(".gitattributes").toContent(StringPrinter.buildStringFromLines(
 				"* eol=lf",
 				"*.MF eol=crlf"));
@@ -84,7 +79,7 @@ class GitAttributesTest extends ResourceHarness {
 	}
 
 	@Test
-	void policyTest() throws IOException {
+	void policyTest() {
 		setFile(".gitattributes").toContent(StringPrinter.buildStringFromLines(
 				"* eol=lf",
 				"*.MF eol=crlf"));
@@ -96,7 +91,7 @@ class GitAttributesTest extends ResourceHarness {
 	}
 
 	@Test
-	void policyDefaultLineEndingTest() throws GitAPIException, IOException {
+	void policyDefaultLineEndingTest() throws GitAPIException {
 		Git git = Git.init().setDirectory(rootFolder()).call();
 		git.close();
 		setFile(".git/config").toContent(StringPrinter.buildStringFromLines(

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class ResourceHarness {
 	}
 
 	/** Returns a new child of the root folder. */
-	protected File newFile(String subpath) throws IOException {
+	protected File newFile(String subpath) {
 		return new File(rootFolder(), subpath);
 	}
 
@@ -85,16 +85,16 @@ public class ResourceHarness {
 	}
 
 	/** Returns the contents of the given file from the src/test/resources directory. */
-	protected static String getTestResource(String filename) throws IOException {
+	protected static String getTestResource(String filename) {
 		URL url = ResourceHarness.class.getResource("/" + filename);
 		if (url == null) {
 			throw new IllegalArgumentException("No such resource " + filename);
 		}
-		return Resources.toString(url, StandardCharsets.UTF_8);
+		return ThrowingEx.get(() -> LineEnding.toUnix(Resources.toString(url, StandardCharsets.UTF_8)));
 	}
 
 	/** Returns Files (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
-	protected List<File> createTestFiles(String... filenames) throws IOException {
+	protected List<File> createTestFiles(String... filenames) {
 		List<File> files = new ArrayList<>(filenames.length);
 		for (String filename : filenames) {
 			files.add(createTestFile(filename));
@@ -103,7 +103,7 @@ public class ResourceHarness {
 	}
 
 	/** Returns a File (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
-	protected File createTestFile(String filename) throws IOException {
+	protected File createTestFile(String filename) {
 		return createTestFile(filename, UnaryOperator.identity());
 	}
 
@@ -111,39 +111,22 @@ public class ResourceHarness {
 	 * Returns a File (in a temporary folder) which has the contents, possibly processed, of the given file from the
 	 * src/test/resources directory.
 	 */
-	protected File createTestFile(String filename, UnaryOperator<String> fileContentsProcessor) throws IOException {
+	protected File createTestFile(String filename, UnaryOperator<String> fileContentsProcessor) {
 		int lastSlash = filename.lastIndexOf('/');
 		String name = lastSlash >= 0 ? filename.substring(lastSlash) : filename;
 		File file = newFile(name);
 		file.getParentFile().mkdirs();
-		Files.write(file.toPath(), fileContentsProcessor.apply(getTestResource(filename)).getBytes(StandardCharsets.UTF_8));
+		ThrowingEx.run(() -> Files.write(file.toPath(), fileContentsProcessor.apply(getTestResource(filename)).getBytes(StandardCharsets.UTF_8)));
 		return file;
 	}
 
-	/** Reads the given resource from "before", applies the step, and makes sure the result is "after". */
-	protected void assertOnResources(FormatterStep step, String unformattedPath, String expectedPath) throws Throwable {
-		assertOnResources(rawUnix -> step.format(rawUnix, new File("")), unformattedPath, expectedPath);
-	}
-
-	/** Reads the given resource from "before", applies the step, and makes sure the result is "after". */
-	protected void assertOnResources(FormatterFunc step, String unformattedPath, String expectedPath) throws Throwable {
-		String unformatted = LineEnding.toUnix(getTestResource(unformattedPath)); // unix-ified input
-		String formatted = step.apply(unformatted);
-		// no windows newlines
-		assertThat(formatted).doesNotContain("\r");
-
-		// unix-ify the test resource output in case git screwed it up
-		String expected = LineEnding.toUnix(getTestResource(expectedPath)); // unix-ified output
-		assertThat(formatted).isEqualTo(expected);
-	}
-
 	@CheckReturnValue
-	protected ReadAsserter assertFile(String path) throws IOException {
+	protected ReadAsserter assertFile(String path) {
 		return new ReadAsserter(newFile(path));
 	}
 
 	@CheckReturnValue
-	protected ReadAsserter assertFile(File file) throws IOException {
+	protected ReadAsserter assertFile(File file) {
 		return new ReadAsserter(file);
 	}
 
@@ -176,7 +159,7 @@ public class ResourceHarness {
 		}
 	}
 
-	protected WriteAsserter setFile(String path) throws IOException {
+	protected WriteAsserter setFile(String path) {
 		return new WriteAsserter(newFile(path));
 	}
 
@@ -188,21 +171,25 @@ public class ResourceHarness {
 			this.file = file;
 		}
 
-		public File toLines(String... lines) throws IOException {
+		public File toLines(String... lines) {
 			return toContent(String.join("\n", Arrays.asList(lines)));
 		}
 
-		public File toContent(String content) throws IOException {
+		public File toContent(String content) {
 			return toContent(content, StandardCharsets.UTF_8);
 		}
 
-		public File toContent(String content, Charset charset) throws IOException {
-			Files.write(file.toPath(), content.getBytes(charset));
+		public File toContent(String content, Charset charset) {
+			ThrowingEx.run(() -> {
+				Files.write(file.toPath(), content.getBytes(charset));
+			});
 			return file;
 		}
 
-		public File toResource(String path) throws IOException {
-			Files.write(file.toPath(), getTestResource(path).getBytes(StandardCharsets.UTF_8));
+		public File toResource(String path) {
+			ThrowingEx.run(() -> {
+				Files.write(file.toPath(), getTestResource(path).getBytes(StandardCharsets.UTF_8));
+			});
 			return file;
 		}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -46,6 +46,7 @@ public class StepHarness implements AutoCloseable {
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
 				.encoding(StandardCharsets.UTF_8)
 				.rootDir(Paths.get(""))
+				.exceptionPolicy(new FormatExceptionPolicyStrict())
 				.build());
 	}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,31 +22,21 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.function.Consumer;
 
-import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 
 /** An api for testing a {@code FormatterStep} that doesn't depend on the File path. DO NOT ADD FILE SUPPORT TO THIS, use {@link StepHarnessWithFile} if you need that. */
 public class StepHarness implements AutoCloseable {
-	private final FormatterFunc formatter;
+	private final Formatter formatter;
 
-	private StepHarness(FormatterFunc formatter) {
+	private StepHarness(Formatter formatter) {
 		this.formatter = Objects.requireNonNull(formatter);
 	}
 
 	/** Creates a harness for testing steps which don't depend on the file. */
 	public static StepHarness forStep(FormatterStep step) {
-		// We don't care if an individual FormatterStep is misbehaving on line-endings, because
-		// Formatter fixes that.  No reason to care in tests either.  It's likely to pop up when
-		// running tests on Windows from time-to-time
-		return new StepHarness(FormatterFunc.Closeable.ofDangerous(
-				() -> {
-					if (step instanceof FormatterStepImpl.Standard) {
-						((FormatterStepImpl.Standard<?>) step).cleanupFormatterFunc();
-					}
-				},
-				input -> LineEnding.toUnix(step.format(input, new File("")))));
+		return forSteps(step);
 	}
 
 	/** Creates a harness for testing steps which don't depend on the file. */
@@ -61,55 +51,62 @@ public class StepHarness implements AutoCloseable {
 
 	/** Creates a harness for testing a formatter whose steps don't depend on the file. */
 	public static StepHarness forFormatter(Formatter formatter) {
-		return new StepHarness(FormatterFunc.Closeable.ofDangerous(
-				formatter::close,
-				input -> formatter.compute(input, new File(""))));
+		return new StepHarness(formatter);
 	}
 
 	/** Asserts that the given element is transformed as expected, and that the result is idempotent. */
-	public StepHarness test(String before, String after) throws Exception {
-		String actual = formatter.apply(before);
+	public StepHarness test(String before, String after) {
+		String actual = formatter.compute(LineEnding.toUnix(before), new File(""));
 		assertEquals(after, actual, "Step application failed");
 		return testUnaffected(after);
 	}
 
 	/** Asserts that the given element is idempotent w.r.t the step under test. */
-	public StepHarness testUnaffected(String idempotentElement) throws Exception {
-		String actual = formatter.apply(idempotentElement);
+	public StepHarness testUnaffected(String idempotentElement) {
+		String actual = formatter.compute(LineEnding.toUnix(idempotentElement), new File(""));
 		assertEquals(idempotentElement, actual, "Step is not idempotent");
 		return this;
 	}
 
 	/** Asserts that the given elements in  the resources directory are transformed as expected. */
-	public StepHarness testResource(String resourceBefore, String resourceAfter) throws Exception {
+	public StepHarness testResource(String resourceBefore, String resourceAfter) {
 		String before = ResourceHarness.getTestResource(resourceBefore);
 		String after = ResourceHarness.getTestResource(resourceAfter);
 		return test(before, after);
 	}
 
 	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarness testResourceUnaffected(String resourceIdempotent) throws Exception {
+	public StepHarness testResourceUnaffected(String resourceIdempotent) {
 		String idempotentElement = ResourceHarness.getTestResource(resourceIdempotent);
 		return testUnaffected(idempotentElement);
 	}
 
-	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarness testResourceException(String resourceBefore, Consumer<AbstractThrowableAssert<?, ? extends Throwable>> exceptionAssertion) throws Exception {
-		return testException(ResourceHarness.getTestResource(resourceBefore), exceptionAssertion);
+	public AbstractStringAssert<?> testResourceExceptionMsg(String resourceBefore) {
+		return testExceptionMsg(ResourceHarness.getTestResource(resourceBefore));
 	}
 
-	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarness testException(String before, Consumer<AbstractThrowableAssert<?, ? extends Throwable>> exceptionAssertion) throws Exception {
-		Throwable t = assertThrows(Throwable.class, () -> formatter.apply(before));
-		AbstractThrowableAssert<?, ? extends Throwable> abstractAssert = Assertions.assertThat(t);
-		exceptionAssertion.accept(abstractAssert);
-		return this;
+	public AbstractStringAssert<?> testExceptionMsg(String before) {
+		try {
+			formatter.compute(LineEnding.toUnix(before), FormatterStepImpl.SENTINEL);
+			throw new SecurityException("Expected exception");
+		} catch (Throwable e) {
+			if (e instanceof SecurityException) {
+				throw new AssertionError(e.getMessage());
+			} else {
+				Throwable rootCause = e;
+				while (rootCause.getCause() != null) {
+					if (rootCause instanceof IllegalStateException) {
+						break;
+					}
+					rootCause = rootCause.getCause();
+				}
+				return Assertions.assertThat(rootCause.getMessage());
+			}
+		}
 	}
 
 	@Override
 	public void close() {
-		if (formatter instanceof FormatterFunc.Closeable) {
-			((FormatterFunc.Closeable) formatter).close();
-		}
+		formatter.close();
 	}
 }

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -42,6 +42,7 @@ public class StepHarnessWithFile implements AutoCloseable {
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
 				.steps(Collections.singletonList(step))
 				.rootDir(harness.rootFolder().toPath())
+				.exceptionPolicy(new FormatExceptionPolicyStrict())
 				.build());
 	}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,78 +18,99 @@ package com.diffplug.spotless;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Objects;
+
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.Assertions;
 
 /** An api for testing a {@code FormatterStep} that depends on the File path. */
 public class StepHarnessWithFile implements AutoCloseable {
-	private final FormatterFunc formatter;
+	private final Formatter formatter;
+	private final ResourceHarness harness;
 
-	private StepHarnessWithFile(FormatterFunc formatter) {
+	private StepHarnessWithFile(ResourceHarness harness, Formatter formatter) {
+		this.harness = Objects.requireNonNull(harness);
 		this.formatter = Objects.requireNonNull(formatter);
 	}
 
 	/** Creates a harness for testing steps which do depend on the file. */
-	public static StepHarnessWithFile forStep(FormatterStep step) {
-		// We don't care if an individual FormatterStep is misbehaving on line-endings, because
-		// Formatter fixes that.  No reason to care in tests either.  It's likely to pop up when
-		// running tests on Windows from time-to-time
-		return new StepHarnessWithFile(FormatterFunc.Closeable.ofDangerous(
-				() -> {
-					if (step instanceof FormatterStepImpl.Standard) {
-						((FormatterStepImpl.Standard<?>) step).cleanupFormatterFunc();
-					}
-				},
-				new FormatterFunc() {
-					@Override
-					public String apply(String unix) throws Exception {
-						return apply(unix, new File(""));
-					}
-
-					@Override
-					public String apply(String unix, File file) throws Exception {
-						return LineEnding.toUnix(step.format(unix, file));
-					}
-				}));
+	public static StepHarnessWithFile forStep(ResourceHarness harness, FormatterStep step) {
+		return new StepHarnessWithFile(harness, Formatter.builder()
+				.encoding(StandardCharsets.UTF_8)
+				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
+				.steps(Collections.singletonList(step))
+				.rootDir(harness.rootFolder().toPath())
+				.build());
 	}
 
 	/** Creates a harness for testing a formatter whose steps do depend on the file. */
-	public static StepHarnessWithFile forFormatter(Formatter formatter) {
-		return new StepHarnessWithFile(FormatterFunc.Closeable.ofDangerous(
-				formatter::close,
-				input -> formatter.compute(input, new File(""))));
+	public static StepHarnessWithFile forFormatter(ResourceHarness harness, Formatter formatter) {
+		return new StepHarnessWithFile(harness, formatter);
 	}
 
 	/** Asserts that the given element is transformed as expected, and that the result is idempotent. */
-	public StepHarnessWithFile test(File file, String before, String after) throws Exception {
-		String actual = formatter.apply(before, file);
+	public StepHarnessWithFile test(File file, String before, String after) {
+		String actual = formatter.compute(LineEnding.toUnix(before), file);
 		assertEquals(after, actual, "Step application failed");
 		return testUnaffected(file, after);
 	}
 
 	/** Asserts that the given element is idempotent w.r.t the step under test. */
-	public StepHarnessWithFile testUnaffected(File file, String idempotentElement) throws Exception {
-		String actual = formatter.apply(idempotentElement, file);
+	public StepHarnessWithFile testUnaffected(File file, String idempotentElement) {
+		String actual = formatter.compute(LineEnding.toUnix(idempotentElement), file);
 		assertEquals(idempotentElement, actual, "Step is not idempotent");
 		return this;
 	}
 
 	/** Asserts that the given elements in  the resources directory are transformed as expected. */
-	public StepHarnessWithFile testResource(File file, String resourceBefore, String resourceAfter) throws Exception {
-		String before = ResourceHarness.getTestResource(resourceBefore);
-		String after = ResourceHarness.getTestResource(resourceAfter);
-		return test(file, before, after);
+	public StepHarnessWithFile testResource(String resourceBefore, String resourceAfter) {
+		return testResource(resourceBefore, resourceBefore, resourceAfter);
+	}
+
+	public StepHarnessWithFile testResource(String filename, String resourceBefore, String resourceAfter) {
+		String contentBefore = ResourceHarness.getTestResource(resourceBefore);
+		File file = harness.setFile(filename).toContent(contentBefore);
+		return test(file, contentBefore, ResourceHarness.getTestResource(resourceAfter));
 	}
 
 	/** Asserts that the given elements in the resources directory are transformed as expected. */
-	public StepHarnessWithFile testResourceUnaffected(File file, String resourceIdempotent) throws Exception {
-		String idempotentElement = ResourceHarness.getTestResource(resourceIdempotent);
-		return testUnaffected(file, idempotentElement);
+	public StepHarnessWithFile testResourceUnaffected(String resourceIdempotent) {
+		String contentBefore = ResourceHarness.getTestResource(resourceIdempotent);
+		File file = harness.setFile(resourceIdempotent).toContent(contentBefore);
+		return testUnaffected(file, contentBefore);
+	}
+
+	public AbstractStringAssert<?> testResourceExceptionMsg(String resourceBefore) {
+		return testResourceExceptionMsg(resourceBefore, resourceBefore);
+	}
+
+	public AbstractStringAssert<?> testResourceExceptionMsg(String filename, String resourceBefore) {
+		String contentBefore = ResourceHarness.getTestResource(resourceBefore);
+		File file = harness.setFile(filename).toContent(contentBefore);
+		return testExceptionMsg(file, contentBefore);
+	}
+
+	public AbstractStringAssert<?> testExceptionMsg(File file, String before) {
+		try {
+			formatter.compute(LineEnding.toUnix(before), file);
+			throw new SecurityException("Expected exception");
+		} catch (Throwable e) {
+			if (e instanceof SecurityException) {
+				throw new AssertionError(e.getMessage());
+			} else {
+				Throwable rootCause = e;
+				while (rootCause.getCause() != null) {
+					rootCause = rootCause.getCause();
+				}
+				return Assertions.assertThat(rootCause.getMessage());
+			}
+		}
 	}
 
 	@Override
 	public void close() {
-		if (formatter instanceof FormatterFunc.Closeable) {
-			((FormatterFunc.Closeable) formatter).close();
-		}
+		formatter.close();
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/antlr4/Antlr4FormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/antlr4/Antlr4FormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,13 @@ package com.diffplug.spotless.antlr4;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.ResourceHarness;
+import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
-class Antlr4FormatterStepTest extends ResourceHarness {
-
+class Antlr4FormatterStepTest {
 	@Test
 	void formatGrammar() throws Throwable {
 		FormatterStep step = Antlr4FormatterStep.create(TestProvisioner.mavenCentral());
-		assertOnResources(step, "antlr4/Hello.unformatted.g4", "antlr4/Hello.formatted.g4");
+		StepHarness.forStep(step).testResource("antlr4/Hello.unformatted.g4", "antlr4/Hello.formatted.g4");
 	}
-
 }

--- a/testlib/src/test/java/com/diffplug/spotless/cpp/ClangFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/cpp/ClangFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,26 @@
  */
 package com.diffplug.spotless.cpp;
 
-import java.io.File;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.tag.ClangTest;
 
 @ClangTest
-class ClangFormatStepTest {
+class ClangFormatStepTest extends ResourceHarness {
 	@Test
-	void test() throws Exception {
-		try (StepHarnessWithFile harness = StepHarnessWithFile.forStep(ClangFormatStep.withVersion(ClangFormatStep.defaultVersion()).create())) {
+	void test() {
+		try (StepHarnessWithFile harness = StepHarnessWithFile.forStep(this, ClangFormatStep.withVersion(ClangFormatStep.defaultVersion()).create())) {
 			// can't be named java or it gets compiled into .class file
-			harness.testResource(new File("example.java"), "clang/example.java.dirty", "clang/example.java.clean");
+			harness.testResource("example.java", "clang/example.java.dirty", "clang/example.java.clean");
 			// test every other language clang supports
 			for (String ext : Arrays.asList("c", "cs", "js", "m", "proto")) {
 				String filename = "example." + ext;
 				String root = "clang/" + filename;
-				harness.testResource(new File(filename), root, root + ".clean");
+				harness.testResource(filename, root, root + ".clean");
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/IndentStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,46 +15,42 @@
  */
 package com.diffplug.spotless.generic;
 
-import java.io.File;
-
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 
-class IndentStepTest extends ResourceHarness {
+class IndentStepTest {
 	@Test
-	void tabToTab() throws Throwable {
+	void tabToTab() {
 		FormatterStep indent = IndentStep.Type.TAB.create(4);
-		assertOnResources(indent, "indent/IndentedWithTab.test", "indent/IndentedWithTab.test");
+		StepHarness.forStep(indent).testResource("indent/IndentedWithTab.test", "indent/IndentedWithTab.test");
 	}
 
 	@Test
-	void spaceToSpace() throws Throwable {
+	void spaceToSpace() {
 		FormatterStep indent = IndentStep.Type.SPACE.create(4);
-		assertOnResources(indent, "indent/IndentedWithSpace.test", "indent/IndentedWithSpace.test");
+		StepHarness.forStep(indent).testResource("indent/IndentedWithSpace.test", "indent/IndentedWithSpace.test");
 	}
 
 	@Test
-	void spaceToTab() throws Throwable {
+	void spaceToTab() {
 		FormatterStep indent = IndentStep.Type.TAB.create(4);
-		assertOnResources(indent, "indent/IndentedWithSpace.test", "indent/IndentedWithTab.test");
+		StepHarness.forStep(indent).testResource("indent/IndentedWithSpace.test", "indent/IndentedWithTab.test");
 	}
 
 	@Test
-	void tabToSpace() throws Throwable {
+	void tabToSpace() {
 		FormatterStep indent = IndentStep.Type.SPACE.create(4);
-		assertOnResources(indent, "indent/IndentedWithTab.test", "indent/IndentedWithSpace.test");
+		StepHarness.forStep(indent).testResource("indent/IndentedWithTab.test", "indent/IndentedWithSpace.test");
 	}
 
 	@Test
-	void doesntClipNewlines() throws Throwable {
+	void doesntClipNewlines() {
 		FormatterStep indent = IndentStep.Type.SPACE.create(4);
 		String blankNewlines = "\n\n\n\n";
-		Assertions.assertEquals(blankNewlines, indent.format(blankNewlines, new File("")));
+		StepHarness.forStep(indent).testUnaffected(blankNewlines);
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/generic/PipeStepPairTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/PipeStepPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import com.diffplug.spotless.StepHarness;
 
 class PipeStepPairTest {
 	@Test
-	void single() throws Exception {
+	void single() {
 		PipeStepPair pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on").buildPair();
 		FormatterStep lowercase = FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT));
 		StepHarness harness = StepHarness.forSteps(pair.in(), lowercase, pair.out());
@@ -47,7 +47,7 @@ class PipeStepPairTest {
 	}
 
 	@Test
-	void multiple() throws Exception {
+	void multiple() {
 		PipeStepPair pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on").buildPair();
 		FormatterStep lowercase = FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT));
 		StepHarness harness = StepHarness.forSteps(pair.in(), lowercase, pair.out());
@@ -81,23 +81,21 @@ class PipeStepPairTest {
 	}
 
 	@Test
-	void broken() throws Exception {
+	void broken() {
 		PipeStepPair pair = PipeStepPair.named("underTest").openClose("spotless:off", "spotless:on").buildPair();
 		FormatterStep uppercase = FormatterStep.createNeverUpToDate("uppercase", str -> str.toUpperCase(Locale.ROOT));
 		StepHarness harness = StepHarness.forSteps(pair.in(), uppercase, pair.out());
 		// this fails because uppercase turns spotless:off into SPOTLESS:OFF, etc
-		harness.testException(StringPrinter.buildStringFromLines(
+		harness.testExceptionMsg(StringPrinter.buildStringFromLines(
 				"A B C",
 				"spotless:off",
 				"D E F",
 				"spotless:on",
-				"G H I"), exception -> {
-					exception.hasMessage("An intermediate step removed a match of spotless:off spotless:on");
-				});
+				"G H I")).isEqualTo("An intermediate step removed a match of spotless:off spotless:on");
 	}
 
 	@Test
-	void andApply() throws Exception {
+	void andApply() {
 		FormatterStep lowercase = FormatterStep.createNeverUpToDate("lowercase", str -> str.toLowerCase(Locale.ROOT));
 		FormatterStep lowercaseSometimes = PipeStepPair.named("lowercaseSometimes").openClose("<lower>", "</lower>")
 				.buildStepWhichAppliesSubSteps(Paths.get(""), Arrays.asList(lowercase));

--- a/testlib/src/test/java/com/diffplug/spotless/java/FormatAnnotationsStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/FormatAnnotationsStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,26 +20,26 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
-import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
+import com.diffplug.spotless.StepHarness;
 
-class FormatAnnotationsStepTest extends ResourceHarness {
+class FormatAnnotationsStepTest {
 	@Test
-	void formatAnnotations() throws Throwable {
+	void formatAnnotations() {
 		FormatterStep step = FormatAnnotationsStep.create();
-		assertOnResources(step, "java/formatannotations/FormatAnnotationsTestInput.test", "java/formatannotations/FormatAnnotationsTestOutput.test");
+		StepHarness.forStep(step).testResource("java/formatannotations/FormatAnnotationsTestInput.test", "java/formatannotations/FormatAnnotationsTestOutput.test");
 	}
 
 	@Test
-	void formatAnnotationsInComments() throws Throwable {
+	void formatAnnotationsInComments() {
 		FormatterStep step = FormatAnnotationsStep.create();
-		assertOnResources(step, "java/formatannotations/FormatAnnotationsInCommentsInput.test", "java/formatannotations/FormatAnnotationsInCommentsOutput.test");
+		StepHarness.forStep(step).testResource("java/formatannotations/FormatAnnotationsInCommentsInput.test", "java/formatannotations/FormatAnnotationsInCommentsOutput.test");
 	}
 
 	@Test
-	void formatAnnotationsAddRemove() throws Throwable {
+	void formatAnnotationsAddRemove() {
 		FormatterStep step = FormatAnnotationsStep.create(Arrays.asList("Empty", "NonEmpty"), Arrays.asList("Localized"));
-		assertOnResources(step, "java/formatannotations/FormatAnnotationsAddRemoveInput.test", "java/formatannotations/FormatAnnotationsAddRemoveOutput.test");
+		StepHarness.forStep(step).testResource("java/formatannotations/FormatAnnotationsAddRemoveInput.test", "java/formatannotations/FormatAnnotationsAddRemoveOutput.test");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,72 +20,73 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
+import com.diffplug.spotless.StepHarness;
 
 class ImportOrderStepTest extends ResourceHarness {
 	@Test
-	void sortImportsDefault() throws Throwable {
+	void sortImportsDefault() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom();
-		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImportsDefault.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImportsDefault.test");
 	}
 
 	@Test
-	void sortImportsFromArray() throws Throwable {
+	void sortImportsFromArray() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom("java", "javax", "org", "\\#com");
-		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
-	void sortImportsFromArrayWithSubgroups() throws Throwable {
+	void sortImportsFromArrayWithSubgroups() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom("java|javax", "org|\\#com", "\\#");
-		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImportsSubgroups.test", "java/importsorter/JavaCodeSortedImportsSubgroups.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedImportsSubgroups.test", "java/importsorter/JavaCodeSortedImportsSubgroups.test");
 	}
 
 	@Test
-	void sortImportsFromFile() throws Throwable {
+	void sortImportsFromFile() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
-		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
-	void sortImportsUnmatched() throws Throwable {
+	void sortImportsUnmatched() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
-		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
 	}
 
 	@Test
-	void sortImportsWildcardsLast() throws Throwable {
+	void sortImportsWildcardsLast() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(true);
-		assertOnResources(step, "java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImportsWildcardsLast.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImportsWildcardsLast.test");
 	}
 
 	@Test
-	void removeDuplicates() throws Throwable {
+	void removeDuplicates() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import_unmatched.properties"));
-		assertOnResources(step, "java/importsorter/JavaCodeSortedDuplicateImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeSortedDuplicateImportsUnmatched.test", "java/importsorter/JavaCodeSortedImportsUnmatched.test");
 	}
 
 	@Test
-	void removeComments() throws Throwable {
+	void removeComments() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
-		assertOnResources(step, "java/importsorter/JavaCodeImportComments.test", "java/importsorter/JavaCodeSortedImports.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeImportComments.test", "java/importsorter/JavaCodeSortedImports.test");
 	}
 
 	@Test
-	void misplacedImports() throws Throwable {
+	void misplacedImports() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
-		assertOnResources(step, "java/importsorter/JavaCodeUnsortedMisplacedImports.test", "java/importsorter/JavaCodeSortedMisplacedImports.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedMisplacedImports.test", "java/importsorter/JavaCodeSortedMisplacedImports.test");
 	}
 
 	@Test
-	void empty() throws Throwable {
+	void empty() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
-		assertOnResources(step, "java/importsorter/JavaCodeEmptyFile.test", "java/importsorter/JavaCodeEmptyFile.test");
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeEmptyFile.test", "java/importsorter/JavaCodeEmptyFile.test");
 	}
 
 	@Test
-	void groovyImports() throws Throwable {
+	void groovyImports() {
 		FormatterStep step = ImportOrderStep.forGroovy().createFrom(createTestFile("java/importsorter/import.properties"));
-		assertOnResources(step, "java/importsorter/GroovyCodeUnsortedMisplacedImports.test", "java/importsorter/GroovyCodeSortedMisplacedImports.test");
+		StepHarness.forStep(step).testResource("java/importsorter/GroovyCodeUnsortedMisplacedImports.test", "java/importsorter/GroovyCodeSortedMisplacedImports.test");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonFormatterStepCommonTests.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonFormatterStepCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,10 +95,9 @@ public abstract class JsonFormatterStepCommonTests {
 		return StepHarness.forStep(createFormatterStep(INDENT, TestProvisioner.mavenCentral()));
 	}
 
-	protected void doWithResource(String name) throws Exception {
+	protected void doWithResource(String name) {
 		String before = String.format("json/%sBefore.json", name);
 		String after = String.format("json/%sAfter.json", name);
 		getStepHarness().testResource(before, after);
 	}
-
 }

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,48 +19,115 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.spotless.*;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.SerializableEqualityTester;
+import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.TestProvisioner;
 
-class JsonSimpleStepTest extends JsonFormatterStepCommonTests {
+class JsonSimpleStepTest {
+
+	private static final int INDENT = 4;
+
+	private final FormatterStep step = JsonSimpleStep.create(INDENT, TestProvisioner.mavenCentral());
+	private final StepHarness stepHarness = StepHarness.forStep(step);
 
 	@Test
-	void handlesSingletonObject() throws Exception {
-		doWithResource("singletonObject");
+	void cannotProvidedNullProvisioner() {
+		assertThatThrownBy(() -> JsonSimpleStep.create(INDENT, null)).isInstanceOf(NullPointerException.class).hasMessage("provisioner cannot be null");
 	}
 
 	@Test
-	void handlesSingletonObjectWithArray() throws Exception {
-		doWithResource("singletonObjectWithArray");
+	void handlesSingletonObject() {
+		doWithResource(stepHarness, "singletonObject");
 	}
 
 	@Test
-	void handlesComplexNestedObject() throws Exception {
-		doWithResource("cucumberJsonSample");
+	void handlesSingletonObjectWithArray() {
+		doWithResource(stepHarness, "singletonObjectWithArray");
 	}
 
 	@Test
-	void handlesObjectWithNull() throws Exception {
-		doWithResource("objectWithNull");
+	void handlesNestedObject() {
+		doWithResource(stepHarness, "nestedObject");
+	}
+
+	@Test
+	void handlesSingletonArray() {
+		doWithResource(stepHarness, "singletonArray");
+	}
+
+	@Test
+	void handlesEmptyFile() {
+		doWithResource(stepHarness, "empty");
+	}
+
+	@Test
+	void handlesComplexNestedObject() {
+		doWithResource(stepHarness, "cucumberJsonSample");
+	}
+
+	@Test
+	void handlesObjectWithNull() {
+		doWithResource(stepHarness, "objectWithNull");
 	}
 
 	@Test
 	void handlesInvalidJson() {
-		assertThatThrownBy(() -> doWithResource("invalidJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to format JSON")
-				.hasRootCauseMessage("Expected a ',' or '}' at 9 [character 0 line 3]");
+		stepHarness.testResourceExceptionMsg("json/invalidJsonBefore.json")
+				.contains("Expected a ',' or '}' at 9 [character 0 line 3]");
 	}
 
 	@Test
 	void handlesNotJson() {
-		assertThatThrownBy(() -> doWithResource("notJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to determine JSON type, expected a '{' or '[' but found '#'")
-				.hasNoCause();
+		stepHarness.testResourceExceptionMsg("json/notJsonBefore.json")
+				.contains("Unable to determine JSON type, expected a '{' or '[' but found '#'");
 	}
 
-	@Override
-	protected FormatterStep createFormatterStep(int indent, Provisioner provisioner) {
-		return JsonSimpleStep.create(indent, provisioner);
+	@Test
+	void canSetCustomIndentationLevel() {
+		FormatterStep step = JsonSimpleStep.create(6, TestProvisioner.mavenCentral());
+		StepHarness stepHarness = StepHarness.forStep(step);
+
+		String before = "json/singletonArrayBefore.json";
+		String after = "json/singletonArrayAfter6Spaces.json";
+		stepHarness.testResource(before, after);
+	}
+
+	@Test
+	void canSetIndentationLevelTo0() {
+		FormatterStep step = JsonSimpleStep.create(0, TestProvisioner.mavenCentral());
+		StepHarness stepHarness = StepHarness.forStep(step);
+
+		String before = "json/singletonArrayBefore.json";
+		String after = "json/singletonArrayAfter0Spaces.json";
+		stepHarness.testResource(before, after);
+	}
+
+	@Test
+	void equality() {
+		new SerializableEqualityTester() {
+			int spaces = 0;
+
+			@Override
+			protected void setupTest(API api) {
+				// no changes, are the same
+				api.areDifferentThan();
+
+				// with different spacing
+				spaces = 1;
+				api.areDifferentThan();
+			}
+
+			@Override
+			protected FormatterStep create() {
+				return JsonSimpleStep.create(spaces, TestProvisioner.mavenCentral());
+			}
+		}.testEquals();
+	}
+
+	private static void doWithResource(StepHarness stepHarness, String name) {
+		String before = String.format("json/%sBefore.json", name);
+		String after = String.format("json/%sAfter.json", name);
+		stepHarness.testResource(before, after);
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.json.gson;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.io.File;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -30,54 +31,47 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 	private static final String DEFAULT_VERSION = "2.8.9";
 
 	@Test
-	void handlesComplexNestedObject() throws Exception {
+	void handlesComplexNestedObject() {
 		doWithResource("cucumberJsonSampleGson");
 	}
 
 	@Test
-	void handlesObjectWithNull() throws Exception {
+	void handlesObjectWithNull() {
 		doWithResource("objectWithNullGson");
 	}
 
 	@Test
 	void handlesInvalidJson() {
-		assertThatThrownBy(() -> doWithResource("invalidJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to format JSON")
-				.hasRootCauseMessage("End of input at line 3 column 1 path $.a");
+		getStepHarness().testResourceExceptionMsg("json/invalidJsonBefore.json").isEqualTo("End of input at line 3 column 1 path $.a");
 	}
 
 	@Test
 	void handlesNotJson() {
-		assertThatThrownBy(() -> doWithResource("notJson"))
-				.isInstanceOf(AssertionError.class)
-				.hasMessage("Unable to format JSON")
-				.hasNoCause();
+		getStepHarness().testResourceExceptionMsg("json/notJsonBefore.json").isEqualTo("Unable to format JSON");
 	}
 
 	@Test
-	void handlesSortingWhenSortByKeyEnabled() throws Exception {
+	void handlesSortingWhenSortByKeyEnabled() {
 		FormatterStep step = GsonStep.create(INDENT, true, false, DEFAULT_VERSION, TestProvisioner.mavenCentral());
-		StepHarness stepHarness = StepHarness.forStep(step);
-		stepHarness.testResource("json/sortByKeysBefore.json", "json/sortByKeysAfter.json");
+		StepHarness.forStep(step).testResource("json/sortByKeysBefore.json", "json/sortByKeysAfter.json");
 	}
 
 	@Test
-	void doesNoSortingWhenSortByKeyDisabled() throws Exception {
+	void doesNoSortingWhenSortByKeyDisabled() {
 		FormatterStep step = GsonStep.create(INDENT, false, false, DEFAULT_VERSION, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("json/sortByKeysBefore.json", "json/sortByKeysAfterDisabled.json");
 	}
 
 	@Test
-	void handlesHtmlEscapeWhenEnabled() throws Exception {
+	void handlesHtmlEscapeWhenEnabled() {
 		FormatterStep step = GsonStep.create(INDENT, false, true, DEFAULT_VERSION, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("json/escapeHtmlGsonBefore.json", "json/escapeHtmlGsonAfter.json");
 	}
 
 	@Test
-	void writesRawHtmlWhenHtmlEscapeDisabled() throws Exception {
+	void writesRawHtmlWhenHtmlEscapeDisabled() {
 		FormatterStep step = GsonStep.create(INDENT, false, false, DEFAULT_VERSION, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("json/escapeHtmlGsonBefore.json", "json/escapeHtmlGsonAfterDisabled.json");
@@ -86,8 +80,7 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 	@Test
 	void handlesVersionIncompatibility() {
 		FormatterStep step = GsonStep.create(INDENT, false, false, "1.7", TestProvisioner.mavenCentral());
-		StepHarness stepHarness = StepHarness.forStep(step);
-		assertThatThrownBy(() -> stepHarness.testResource("json/cucumberJsonSampleGsonBefore.json", "json/cucumberJsonSampleGsonAfter.json"))
+		Assertions.assertThatThrownBy(() -> step.format("", new File("")))
 				.isInstanceOf(IllegalStateException.class)
 				.hasMessage("There was a problem interacting with Gson; maybe you set an incompatible version?");
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,27 +25,19 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
-import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 
 class DiktatStepTest extends ResourceHarness {
 
 	@Test
-	void behavior() throws Exception {
+	void behavior() {
 		FormatterStep step = DiktatStep.create(TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
-				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 4 unfixed errors:" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
-							System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
-				});
+		StepHarnessWithFile.forStep(this, step).testResourceExceptionMsg("kotlin/diktat/Unsolvable.kt").isEqualTo("There are 2 unfixed errors:" +
+				System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
+				System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
 	}
 
 	@Test
@@ -55,19 +47,11 @@ class DiktatStepTest extends ResourceHarness {
 		FileSignature config = signAsList(conf);
 
 		FormatterStep step = DiktatStep.create("1.2.1", TestProvisioner.mavenCentral(), config);
-		StepHarness.forStep(step)
-				.testResourceException("kotlin/diktat/Unsolvable.kt", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("There are 4 unfixed errors:" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_INCORRECT] file name is incorrect - it should end with .kt extension and be in PascalCase: testlib" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[FILE_NAME_MATCH_CLASS] file name is incorrect - it should match with the class described in it if there is the only one class declared: testlib vs Unsolvable" +
-							System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
-							System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
-							System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
-				});
+		StepHarnessWithFile.forStep(this, step).testResourceExceptionMsg("kotlin/diktat/Unsolvable.kt").isEqualTo("There are 2 unfixed errors:" +
+				System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
+				System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
+				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -22,62 +22,56 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 
 class KtLintStepTest extends ResourceHarness {
 	@Test
-	void behavior() throws Exception {
+	void behavior() {
 		FormatterStep step = KtLintStep.create(TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo(
+						"Error on line: 1, column: 1\n" +
+								"rule: no-wildcard-imports\n" +
+								"Wildcard import");
 	}
 
 	@Test
-	void worksShyiko() throws Exception {
+	void worksShyiko() {
 		FormatterStep step = KtLintStep.create("0.31.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo(
+						"Error on line: 1, column: 1\n" +
+								"rule: no-wildcard-imports\n" +
+								"Wildcard import");
 	}
 
 	// Regression test to ensure it works on the version it switched to Pinterest (version 0.32.0)
 	// but before 0.34.
 	// https://github.com/diffplug/spotless/issues/419
 	@Test
-	void worksPinterestAndPre034() throws Exception {
+	void worksPinterestAndPre034() {
 		FormatterStep step = KtLintStep.create("0.32.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	// Regression test to handle alpha and 1.x version numbers
 	// https://github.com/diffplug/spotless/issues/668
 	@Test
-	void worksAlpha1() throws Exception {
+	void worksAlpha1() {
 		FormatterStep step = KtLintStep.create("0.38.0-alpha01", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
 	}
 
 	@Test
-	void works0_44_0() throws Exception {
+	void works0_44_0() {
 		FormatterStep step = KtLintStep.create("0.44.0", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
@@ -85,80 +79,68 @@ class KtLintStepTest extends ResourceHarness {
 
 	@Disabled("https://github.com/pinterest/ktlint/issues/1421")
 	@Test
-	void works0_45_0() throws Exception {
+	void works0_45_0() {
 		FormatterStep step = KtLintStep.create("0.45.0", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
 	}
 
 	@Test
-	void works0_45_1() throws Exception {
+	void works0_45_1() {
 		FormatterStep step = KtLintStep.create("0.45.1", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
 	}
 
 	@Test
-	void works0_45_2() throws Exception {
+	void works0_45_2() {
 		FormatterStep step = KtLintStep.create("0.45.2", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean");
 	}
 
 	@Test
-	void works0_46_0() throws Exception {
+	void works0_46_0() {
 		FormatterStep step = KtLintStep.create("0.46.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test
-	void works0_47_0() throws Exception {
+	void works0_47_0() {
 		FormatterStep step = KtLintStep.create("0.47.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test
-	void works0_47_1() throws Exception {
+	void works0_47_1() {
 		FormatterStep step = KtLintStep.create("0.47.1", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test
-	void works0_48_0() throws Exception {
+	void works0_48_0() {
 		FormatterStep step = KtLintStep.create("0.48.0", TestProvisioner.mavenCentral());
-		StepHarness.forStep(step)
+		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceException("kotlin/ktlint/unsolvable.dirty", assertion -> {
-					assertion.isInstanceOf(AssertionError.class);
-					assertion.hasMessage("Error on line: 1, column: 1\n" +
-							"rule: no-wildcard-imports\n" +
-							"Wildcard import");
-				});
+				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
+						"rule: no-wildcard-imports\n" +
+						"Wildcard import");
 	}
 
 	@Test
-	void equality() throws Exception {
+	void equality() {
 		new SerializableEqualityTester() {
 			String version = "0.32.0";
 

--- a/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
@@ -111,8 +111,8 @@ class PrettierFormatterStepTest extends ResourceHarness {
 					npmPathResolver(),
 					new PrettierConfig(null, ImmutableMap.of("parser", "postcss")));
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
-				stepHarness.testResourceExceptionMsg("npm/prettier/filetypes/scss/scss.dirty").startsWith(
-						"com.diffplug.spotless.npm.SimpleRestClient$SimpleRestResponseException: Unexpected response status code at /prettier/format [HTTP 501] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")");
+				stepHarness.testResourceExceptionMsg("npm/prettier/filetypes/scss/scss.dirty").isEqualTo(
+						"Unexpected response status code at /prettier/format [HTTP 501] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")");
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,13 +25,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.diffplug.common.collect.ImmutableMap;
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.tag.NpmTest;
 
 @NpmTest
-class PrettierFormatterStepTest {
+class PrettierFormatterStepTest extends ResourceHarness {
 
 	@NpmTest
 	@Nested
@@ -96,8 +97,8 @@ class PrettierFormatterStepTest {
 					npmPathResolver(),
 					new PrettierConfig(null, Collections.emptyMap()));
 
-			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(formatterStep)) {
-				stepHarness.testResource(new File("test.json"), dirtyFile, cleanFile);
+			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
+				stepHarness.testResource("test.json", dirtyFile, cleanFile);
 			}
 		}
 
@@ -109,11 +110,9 @@ class PrettierFormatterStepTest {
 					buildDir(),
 					npmPathResolver(),
 					new PrettierConfig(null, ImmutableMap.of("parser", "postcss")));
-			try (StepHarness stepHarness = StepHarness.forStep(formatterStep)) {
-				stepHarness.testResourceException("npm/prettier/filetypes/scss/scss.dirty", exception -> {
-					exception.hasMessageContaining("HTTP 501");
-					exception.hasMessageContaining("Couldn't resolve parser \"postcss\"");
-				});
+			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
+				stepHarness.testResourceExceptionMsg("npm/prettier/filetypes/scss/scss.dirty").startsWith(
+						"com.diffplug.spotless.npm.SimpleRestClient$SimpleRestResponseException: Unexpected response status code at /prettier/format [HTTP 501] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")");
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,9 @@
  */
 package com.diffplug.spotless.scala;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -33,43 +29,43 @@ import com.diffplug.spotless.TestProvisioner;
 
 class ScalaFmtStepTest extends ResourceHarness {
 	@Test
-	void behaviorDefaultConfig() throws Exception {
+	void behaviorDefaultConfig() {
 		StepHarness.forStep(ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), null))
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.clean_3.0.0");
 	}
 
 	@Test
-	void behaviorCustomConfig() throws Exception {
+	void behaviorCustomConfig() {
 		StepHarness.forStep(ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf")))
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basic.cleanWithCustomConf_3.0.0");
 	}
 
 	@Test
-	void behaviorDefaultConfigVersion_3_0_0() throws Exception {
+	void behaviorDefaultConfigVersion_3_0_0() {
 		FormatterStep step = ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), null);
 		StepHarness.forStep(step)
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basicPost3.0.0.clean");
 	}
 
 	@Test
-	void behaviorCustomConfigVersion_3_0_0() throws Exception {
+	void behaviorCustomConfigVersion_3_0_0() {
 		FormatterStep step = ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf"));
 		StepHarness.forStep(step)
 				.testResource("scala/scalafmt/basic.dirty", "scala/scalafmt/basicPost3.0.0.cleanWithCustomConf");
 	}
 
 	@Test
-	void equality() throws Exception {
+	void equality() {
 		new SerializableEqualityTester() {
-			String version = "3.5.9";
+			String version = "3.6.1";
 			File configFile = null;
 
 			@Override
-			protected void setupTest(API api) throws IOException {
+			protected void setupTest(API api) {
 				// same version == same
 				api.areDifferentThan();
 				// change the version, and it's different
-				version = "3.5.8";
+				version = "3.0.0";
 				api.areDifferentThan();
 				// add a config file, and its different
 				configFile = createTestFile("scala/scalafmt/scalafmt.conf");
@@ -87,12 +83,11 @@ class ScalaFmtStepTest extends ResourceHarness {
 	}
 
 	@Test
-	void invalidConfiguration() throws Exception {
+	void invalidConfiguration() {
 		File invalidConfFile = createTestFile("scala/scalafmt/scalafmt.invalid.conf");
 		Provisioner provisioner = TestProvisioner.mavenCentral();
-
-		InvocationTargetException exception = assertThrows(InvocationTargetException.class,
-				() -> StepHarness.forStep(ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile)).test("", ""));
-		assertThat(exception.getCause().getMessage()).contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
+		Assertions.assertThatThrownBy(() -> {
+			ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile).format("", new File(""));
+		}).cause().message().contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
 	}
 }


### PR DESCRIPTION
Our tests have accumulated a lot of cruft (multiple ways to do things, different naming conventions in different places). Fixing this is a merge conflict nightmare for open PRs, but it has to happen someday. It's especially important to make the transition to "lint"-based error reporting which will be a big win for us.

Apologies to all the open PRs, but this is the slowest time we get :)

Breaking changes to Spotless' internal testing infrastructure `testlib`
  * `ResourceHarness` no longer has any duplicated functionality which was also present in `StepHarness`
  * `StepHarness` now operates internally on `Formatter` rather than a `FormatterStep`
  * `StepHarnessWithFile` now takes a `ResourceHarness` in its constructor to handle the file manipulation parts
  * Standardized that we test exception *messages*, not types, which will ease the transition to linting later on
