### PR TITLE
Enable json in maven plugin

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [2.29.0] - 2023-01-02
 ### Added
 * Added support for M2E's incremental compilation ([#1414](https://github.com/diffplug/spotless/pull/1414) fixes [#1413](https://github.com/diffplug/spotless/issues/1413))
+* Add JSON support ([#1446](https://github.com/diffplug/spotless/pull/1446))
 ### Fixed
 * Improve memory usage when using git ratchet ([#1426](https://github.com/diffplug/spotless/pull/1426))
 * Support `ktlint` 0.48+ ([#1432](https://github.com/diffplug/spotless/pull/1432)) fixes ([#1430](https://github.com/diffplug/spotless/issues/1430))

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -724,8 +724,8 @@ Uses a JSON pretty-printer that optionally allows configuring the number of spac
 
 ```xml
 <simple>
-	<indentSpaces>4</indentSpaces>    <!-- optional: specify the number of spaces to use -->
-</simple> 
+  <indentSpaces>4</indentSpaces>    <!-- optional: specify the number of spaces to use -->
+</simple>
 ```
 
 ### Gson
@@ -734,10 +734,10 @@ Uses Google Gson to also allow sorting by keys besides custom indentation - usef
 
 ```xml
 <gson>
-	<indentSpaces>4</indentSpaces>        <!-- optional: specify the number of spaces to use -->
-	<sortByKeys>false</sortByKeys>        <!-- optional: sort JSON by its keys -->
-	<escapeHtml>false</indentSpaces>      <!-- optional: escape HTML in values -->
-	<version>2.8.1</version>              <!-- optional: specify version -->
+  <indentSpaces>4</indentSpaces>        <!-- optional: specify the number of spaces to use -->
+  <sortByKeys>false</sortByKeys>        <!-- optional: sort JSON by its keys -->
+  <escapeHtml>false</indentSpaces>      <!-- optional: escape HTML in values -->
+  <version>2.8.1</version>              <!-- optional: specify version -->
 </gson>
 ```
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -703,7 +703,7 @@ For details, see the [npm detection](#npm-detection) and [`.npmrc` detection](#n
 
 ## JSON
 
-- `com.diffplug.spotless.maven.json.Json` [javadoc](https://javadoc.io/doc/com.diffplug.spotless/spotless-plugin-gradle/6.12.1/com/diffplug/gradle/spotless/JsonExtension.html), [code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java)
+- `com.diffplug.spotless.maven.json.Json` [code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/json.java)
 
 ```xml
 <configuration>

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -58,6 +58,7 @@ user@machine repo % mvn spotless:check
   - [Maven Pom](#maven-pom) ([sortPom](#sortpom))
   - [Markdown](#markdown) ([flexmark](#flexmark))
   - [Typescript](#typescript) ([tsfmt](#tsfmt), [prettier](#prettier))
+  - [JSON](#json)
   - Multiple languages
     - [Prettier](#prettier) ([plugins](#prettier-plugins), [npm detection](#npm-detection), [`.npmrc` detection](#npmrc-detection))
     - [eclipse web tools platform](#eclipse-web-tools-platform)
@@ -431,7 +432,7 @@ Groovy-Eclipse formatting errors/warnings lead per default to a build failure. T
 <configuration>
   <cpp>
     <includes> <!-- You have to set the target manually -->
-      <include>src/native/**</inclue>
+      <include>src/native/**</include>
     </includes>
 
     <eclipseCdt /> <!-- has its own section below -->
@@ -699,6 +700,53 @@ The auto-discovery of config files (up the file tree) will not work when using t
 **Prerequisite: tsfmt requires a working NodeJS version**
 
 For details, see the [npm detection](#npm-detection) and [`.npmrc` detection](#npmrc-detection) sections of prettier, which apply also to tsfmt.
+
+## JSON
+
+- `com.diffplug.spotless.maven.json.Json` [javadoc](https://javadoc.io/doc/com.diffplug.spotless/spotless-plugin-gradle/6.12.1/com/diffplug/gradle/spotless/JsonExtension.html), [code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java)
+
+```xml
+<configuration>
+  <json>
+    <includes>    <!-- You have to set the target manually -->
+      <include>src/**/*.json</include>
+    </includes>
+
+    <simple />    <!-- has its own section below -->
+    <gson />      <!-- has its own section below -->
+  </json>
+</configuration>
+```
+
+### simple
+
+Uses a JSON pretty-printer that optionally allows configuring the number of spaces that are used to pretty print objects:
+
+```xml
+<simple>
+	<indentSpaces>4</indentSpaces>    <!-- optional: specify the number of spaces to use -->
+</simple> 
+```
+
+### Gson
+
+Uses Google Gson to also allow sorting by keys besides custom indentation - useful for i18n files.
+
+```xml
+<gson>
+	<indentSpaces>4</indentSpaces>        <!-- optional: specify the number of spaces to use -->
+	<sortByKeys>false</sortByKeys>        <!-- optional: sort JSON by its keys -->
+	<escapeHtml>false</indentSpaces>      <!-- optional: escape HTML in values -->
+	<version>2.8.1</version>              <!-- optional: specify version -->
+</gson>
+```
+
+Notes:
+* There's no option in Gson to leave HTML as-is (i.e. escaped HTML would remain escaped, raw would remain raw). Either
+all HTML characters are written escaped or none. Set `escapeHtml` if you prefer the former.
+* `sortByKeys` will apply lexicographic order on the keys of the input JSON. See the
+[javadoc of String](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#compareTo(java.lang.String))
+for details.
 
 <a name="applying-prettier-to-javascript--flow--typescript--css--scss--less--jsx--graphql--yaml--etc"></a>
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Gson.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Gson.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.json;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.json.gson.GsonStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+
+public class Gson implements FormatterStepFactory {
+	private static final String DEFAULT_GSON_VERSION = "2.8.9";
+
+	@Parameter
+	int indentSpaces = Json.DEFAULT_INDENTATION;
+
+	@Parameter
+	boolean sortByKeys = false;
+
+	@Parameter
+	boolean escapeHtml = false;
+
+	@Parameter
+	String version = DEFAULT_GSON_VERSION;
+
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
+		int indentSpaces = this.indentSpaces;
+		return GsonStep.create(indentSpaces, sortByKeys, escapeHtml, version, stepConfig.getProvisioner());
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Gson.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Gson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.json;
+
+import java.util.Collections;
+import java.util.Set;
+
+import com.diffplug.spotless.maven.FormatterFactory;
+
+/**
+ * A {@link FormatterFactory} implementation that corresponds to {@code <json>...</json>} configuration element.
+ */
+public class Json extends FormatterFactory {
+	public static final int DEFAULT_INDENTATION = 4;
+	
+	@Override
+	public Set<String> defaultIncludes() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public String licenseHeaderDelimiter() {
+		return null;
+	}
+
+	public void addSimple(Simple simple) {
+		addStepFactory(simple);
+	}
+
+	public void addGson(Gson gson) {
+		addStepFactory(gson);
+	}
+
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
@@ -25,7 +25,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
  */
 public class Json extends FormatterFactory {
 	public static final int DEFAULT_INDENTATION = 4;
-	
+
 	@Override
 	public Set<String> defaultIncludes() {
 		return Collections.emptySet();

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Simple.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Simple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Simple.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Simple.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.json;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.json.JsonSimpleStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+
+public class Simple implements FormatterStepFactory {
+
+	@Parameter
+	int indentSpaces = Json.DEFAULT_INDENTATION;
+
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
+		int indentSpaces = this.indentSpaces;
+		return JsonSimpleStep.create(indentSpaces, stepConfig.getProvisioner());
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -156,6 +156,10 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		writePom(groupWithSteps("markdown", including("**/*.md"), steps));
 	}
 
+	protected void writePomWithJsonSteps(String... steps) throws IOException {
+		writePom(groupWithSteps("json", including("**/*.json"), steps));
+	}
+
 	protected void writePom(String... configuration) throws IOException {
 		writePom(null, configuration, null);
 	}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/json/JsonTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/json/JsonTest.java
@@ -22,19 +22,19 @@ import com.diffplug.spotless.maven.MavenIntegrationHarness;
 public class JsonTest extends MavenIntegrationHarness {
 	@Test
 	public void testFormatJson_WithSimple_defaultConfig() throws Exception {
-		writePomWithPomSteps("<json><simple/></json>");
+		writePomWithJsonSteps("<json><simple/></json>");
 
-		setFile("json_test.json").toResource("json/json_dirty.json");
+		setFile("json_test.json").toResource("json/sortByKeysBefore.json");
 		mavenRunner().withArguments("spotless:apply").runNoError().error();
-		assertFile("json_test.json").sameAsResource("json/json_clean_default.json");
+		assertFile("json_test.json").sameAsResource("json/sortByKeysAfterDisabled.json");
 	}
 
 	@Test
 	public void testFormatJson_WithGson_defaultConfig() throws Exception {
-		writePomWithPomSteps("<json><gson/></json>");
+		writePomWithJsonSteps("<json><gson/></json>");
 
-		setFile("json_test.json").toResource("json/json_dirty.json");
+		setFile("json_test.json").toResource("json/sortByKeysBefore.json");
 		mavenRunner().withArguments("spotless:apply").runNoError().error();
-		assertFile("json_test.json").sameAsResource("json/json_clean_default.json");
+		assertFile("json_test.json").sameAsResource("json/sortByKeysAfterDisabled.json");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/json/JsonTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/json/JsonTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.json;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+public class JsonTest extends MavenIntegrationHarness {
+	@Test
+	public void testFormatJson_WithSimple_defaultConfig() throws Exception {
+		writePomWithPomSteps("<json><simple/></json>");
+
+		setFile("json_test.json").toResource("json/json_dirty.json");
+		mavenRunner().withArguments("spotless:apply").runNoError().error();
+		assertFile("json_test.json").sameAsResource("json/json_clean_default.json");
+	}
+
+	@Test
+	public void testFormatJson_WithGson_defaultConfig() throws Exception {
+		writePomWithPomSteps("<json><gson/></json>");
+
+		setFile("json_test.json").toResource("json/json_dirty.json");
+		mavenRunner().withArguments("spotless:apply").runNoError().error();
+		assertFile("json_test.json").sameAsResource("json/json_clean_default.json");
+	}
+}


### PR DESCRIPTION
Following https://github.com/diffplug/spotless/issues/1445

---

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
