### PR TITLE
Reduce spurious invalidations of the up-to-date index in Maven plugin

### DIFF
--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ class FileIndex {
 			PluginFingerprint computedFingerprint = config.getPluginFingerprint();
 			PluginFingerprint storedFingerprint = PluginFingerprint.from(firstLine);
 			if (!computedFingerprint.equals(storedFingerprint)) {
-				log.info("Fingerprint mismatch in the index file. Fallback to an empty index");
+				log.info("Index file corresponds to a different configuration of the plugin. Either the plugin version or its configuration has changed. Fallback to an empty index");
 				return emptyIndexFallback(config);
 			} else {
 				Content content = readIndexContent(reader, config.getProjectDir(), log);

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/FileIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class FileIndexTest extends FileIndexHarness {
 		FileIndex index = FileIndex.read(config, log);
 
 		assertThat(index.size()).isZero();
-		verify(log).info("Fingerprint mismatch in the index file. Fallback to an empty index");
+		verify(log).info("Index file corresponds to a different configuration of the plugin. Either the plugin version or its configuration has changed. Fallback to an empty index");
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,126 +43,22 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 	private static final String VERSION_1 = "1.0.0";
 	private static final String VERSION_2 = "2.0.0";
 
-	private static final String[] EXECUTION_1 = {
-			"<execution>",
-			"  <id>check</id>",
-			"  <goals>",
-			"    <goal>check</goal>",
-			"  </goals>",
-			"</execution>"
-	};
-	private static final String[] EXECUTION_2 = {};
-
-	private static final String[] CONFIGURATION_1 = {
-			"<googleJavaFormat>",
-			"  <version>1.2</version>",
-			"</googleJavaFormat>"
-	};
-	private static final String[] CONFIGURATION_2 = {
-			"<googleJavaFormat>",
-			"  <version>1.8</version>",
-			"  <reflowLongStrings>true</reflowLongStrings>",
-			"</googleJavaFormat>"
-	};
-
-	private static final String[] DEPENDENCIES_1 = {
-			"<dependencies>",
-			"  <dependency>",
-			"    <groupId>unknown</groupId>",
-			"    <artifactId>unknown</artifactId>",
-			"    <version>1.0</version>",
-			"  </dependency>",
-			"</dependencies>"
-	};
-	private static final String[] DEPENDENCIES_2 = {
-			"<dependencies>",
-			"  <dependency>",
-			"    <groupId>unknown</groupId>",
-			"    <artifactId>unknown</artifactId>",
-			"    <version>2.0</version>",
-			"  </dependency>",
-			"</dependencies>"
-	};
-
 	private static final List<Formatter> FORMATTERS = singletonList(formatter(formatterStep("default")));
 
 	@Test
-	void sameFingerprint() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
-		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
+	void sameFingerprintWhenVersionAndFormattersAreTheSame() throws Exception {
+		MavenProject project = mavenProject(VERSION_1);
 
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
-
-		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
-		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
+		PluginFingerprint fingerprint1 = PluginFingerprint.from(project, FORMATTERS);
+		PluginFingerprint fingerprint2 = PluginFingerprint.from(project, FORMATTERS);
 
 		assertThat(fingerprint1).isEqualTo(fingerprint2);
 	}
 
 	@Test
-	void sameFingerprintWithDependencies() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_1);
-		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_1);
-
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
-
-		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
-		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
-
-		assertThat(fingerprint1).isEqualTo(fingerprint2);
-	}
-
-	@Test
-	void differentFingerprintForDifferentDependencies() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_1);
-		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1, DEPENDENCIES_2);
-
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
-
-		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
-		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
-
-		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
-	}
-
-	@Test
-	void differentFingerprintForDifferentPluginVersion() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
-		String xml2 = createPomXmlContent(VERSION_2, EXECUTION_1, CONFIGURATION_1);
-
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
-
-		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
-		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
-
-		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
-	}
-
-	@Test
-	void differentFingerprintForDifferentExecution() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_2, EXECUTION_1, CONFIGURATION_1);
-		String xml2 = createPomXmlContent(VERSION_2, EXECUTION_2, CONFIGURATION_1);
-
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
-
-		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
-		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
-
-		assertThat(fingerprint1).isNotEqualTo(fingerprint2);
-	}
-
-	@Test
-	void differentFingerprintForDifferentConfiguration() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_2, CONFIGURATION_2);
-		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_2, CONFIGURATION_1);
-
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
+	void differentFingerprintForDifferentPluginVersions() throws Exception {
+		MavenProject project1 = mavenProject(VERSION_1);
+		MavenProject project2 = mavenProject(VERSION_2);
 
 		PluginFingerprint fingerprint1 = PluginFingerprint.from(project1, FORMATTERS);
 		PluginFingerprint fingerprint2 = PluginFingerprint.from(project2, FORMATTERS);
@@ -172,11 +68,8 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 
 	@Test
 	void differentFingerprintForFormattersWithDifferentSteps() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
-		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
-
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
+		MavenProject project1 = mavenProject(VERSION_1);
+		MavenProject project2 = mavenProject(VERSION_1);
 
 		FormatterStep step1 = formatterStep("step1");
 		FormatterStep step2 = formatterStep("step2");
@@ -192,11 +85,8 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 
 	@Test
 	void differentFingerprintForFormattersWithDifferentLineEndings() throws Exception {
-		String xml1 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
-		String xml2 = createPomXmlContent(VERSION_1, EXECUTION_1, CONFIGURATION_1);
-
-		MavenProject project1 = mavenProject(xml1);
-		MavenProject project2 = mavenProject(xml2);
+		MavenProject project1 = mavenProject(VERSION_1);
+		MavenProject project2 = mavenProject(VERSION_1);
 
 		FormatterStep step = formatterStep("step");
 		List<Formatter> formatters1 = singletonList(formatter(LineEnding.UNIX, step));
@@ -224,7 +114,8 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 				.hasMessageContaining("Spotless plugin absent from the project");
 	}
 
-	private static MavenProject mavenProject(String xml) throws Exception {
+	private MavenProject mavenProject(String spotlessVersion) throws Exception {
+		String xml = createPomXmlContent(spotlessVersion, new String[0], new String[0]);
 		return new MavenProject(readPom(xml));
 	}
 


### PR DESCRIPTION
#### Improve selectivity in Maven plugin fingerprint

`PluginFingerprint` captures a particular configuration of the Spotless Maven plugin. It is used to invalidate the up-to-date index when plugin's configuration changes.

Invalidations of the index file seem to be too frequent because `PluginFingerprint` includes the effective (as in Effective POM) configuration of the Spotless plugin. For example, it includes dependencies declared outside of the `<plugin </plugin>` XML element. So addition of an unrelated project dependency will invalidate the index file.

Spotless Maven plugin manages its own dependencies using `ArtifactResolver`. There's no need to include the effective `<plugin>` object into `PluginFingerprint`. This PR simplifies the fingerprint to include only the plugin's version and serialized configuration of all formatters. It should be backward-compatible because fingerprint format change will simply trigger an invalidation of the index file.
  
#### Improve index file invalidation message in Maven plugin

Do not mention plugin fingerprint because it is an implementation detail and can be confusing to users. Explain why index file invalidation could happen.

---

This PR is related to https://github.com/diffplug/spotless/issues/1372.