### PR TITLE
Add spotless check and build with tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,7 @@ ij_java_names_count_to_use_import_on_demand = 999
 
 [*.xml.mustache]
 indent_style = space
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: ${{ matrix.java_version }}
           cache: gradle
       - name: Build project
-        run: ./gradlew build -x spotlessCheck
+        run: ./gradlew build -x spotlessCheck -S
   spotless:
     name: Check Spotless
     runs-on: ubuntu-latest
@@ -43,4 +43,4 @@ jobs:
           java-version: ${{ matrix.java_version }}
           cache: gradle
       - name: Check spotless
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck -S

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -46,3 +46,22 @@ jobs:
           cache: gradle
       - name: Check spotless
         run: ./gradlew spotlessCheck -S
+  buildTestOnWindows:
+      name: Build on Windows CI
+      runs-on: windows-latest
+      strategy:
+          fail-fast: false
+          matrix:
+              java_version: [11, 17]
+              distribution: ["temurin"]
+      steps:
+          - name: Checkout
+            uses: actions/checkout@v3
+          - name: Install JDK ${{ matrix.distribution }} ${{ matrix.java_version }}
+            uses: actions/setup-java@v3.9.0
+            with:
+                distribution: ${{ matrix.distribution }}
+                java-version: ${{ matrix.java_version }}
+                cache: gradle
+          - name: Build project
+            run: ./gradlew build -x spotlessCheck -S

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   pull_request:
-      types: [assigned, opened, synchronize, reopened]
+    types: [assigned, opened, synchronize, reopened]
 
 jobs:
   buildTest:
@@ -47,21 +47,21 @@ jobs:
       - name: Check spotless
         run: ./gradlew spotlessCheck -S
   buildTestOnWindows:
-      name: Build on Windows CI
-      runs-on: windows-latest
-      strategy:
-          fail-fast: false
-          matrix:
-              java_version: [11, 17]
-              distribution: ["temurin"]
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v3
-          - name: Install JDK ${{ matrix.distribution }} ${{ matrix.java_version }}
-            uses: actions/setup-java@v3.9.0
-            with:
-                distribution: ${{ matrix.distribution }}
-                java-version: ${{ matrix.java_version }}
-                cache: gradle
-          - name: Build project
-            run: ./gradlew build -x spotlessCheck -S
+    name: Build on Windows CI
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: [11, 17]
+        distribution: ["temurin"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.distribution }} ${{ matrix.java_version }}
+        uses: actions/setup-java@v3.9.0
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java_version }}
+          cache: gradle
+      - name: Build project
+        run: ./gradlew build -x spotlessCheck -S

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+      types: [assigned, opened, synchronize, reopened]
+
+jobs:
+  buildTest:
+    name: Build CI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: [11, 17]
+        distribution: ["temurin"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.distribution }} ${{ matrix.java_version }}
+        uses: actions/setup-java@v3.9.0
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java_version }}
+          cache: gradle
+      - name: Build project
+        run: ./gradlew build -x spotlessCheck
+  spotless:
+    name: Check Spotless
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: [11]
+        distribution: ["temurin"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install JDK ${{ matrix.distribution }} ${{ matrix.java_version }}
+        uses: actions/setup-java@v3.9.0
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java_version }}
+          cache: gradle
+      - name: Check spotless
+        run: ./gradlew spotlessCheck

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install JDK ${{ matrix.distribution }} ${{ matrix.java_version }}
         uses: actions/setup-java@v3.9.0
         with:


### PR DESCRIPTION
Basic CI build for the start.

* Windows platform is omited. 
* Test resuls left in the CI build unpublished
* No separation between maven plugin and gradle plugin. 

@nedtwigg  Could you answer a few questions for me?

1. Why we need to have a separate Windows build? I believe we just need to test API and if tool supports Windows, then we are good to go. Spotless doesn't have workers, so filename encoding is not a problem.
2. I found in all my projects, that CI results from a generic CI image is not needed in the most cases, as being reproducible locally
3. I don't see value for separation maven and gradle builds

If anything missed and needed, it can be added later on with no problem. I believe this minimal checks will cover 90% of issues.