### PR TITLE
Docs: additional info about Eclipse formatter (Maven Plugin)

### DIFF
--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -241,7 +241,7 @@ any other maven phase (i.e. compile) then it can be configured as below;
 
 ```xml
 <eclipse>
-  <version>4.13.0</version>                     <!-- optional -->
+  <version>4.13.0</version>                     <!-- optional version of Eclipse Formatter -->
   <file>${project.basedir}/eclipse-formatter.xml</file> <!-- optional -->
 </eclipse>
 ```
@@ -316,7 +316,7 @@ These mechanisms already exist for the Gradle plugin.
 
 ```xml
 <greclipse>
-  <version>4.13.0</version>                     <!-- optional -->
+  <version>4.13.0</version>                     <!-- optional version of Eclipse Formatter -->
   <file>${project.basedir}/greclipse.properties</file> <!-- optional -->
 </greclipse>
 ```
@@ -466,7 +466,7 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 
 ```xml
 <eclipseCdt>
-  <version>4.13.0</version>               <!-- optional -->
+  <version>4.13.0</version>               <!-- optional version of Eclipse Formatter -->
   <file>${project.basedir}/eclipse-cdt.xml</file> <!-- optional -->
 </eclipseCdt>
 ```
@@ -1052,7 +1052,7 @@ Alternatively you can supply spotless with a location of the `.npmrc` file to us
           <file>${project.basedir}/xml.prefs</file>
           <file>${project.basedir}/additional.properties</file>
         </files>
-        <version>4.13.0</version> <!-- optional -->
+        <version>4.13.0</version> <!-- optional version of Eclipse Formatter -->
       </eclipseWtp>
     </format>
   </formats>

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1035,7 +1035,7 @@ Alternatively you can supply spotless with a location of the `.npmrc` file to us
 
 ## Eclipse web tools platform
 
-[changelog](https://www.eclipse.org/webtools/). [compatible versions](https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatters).
+[changelog](https://www.eclipse.org/webtools/). [compatible versions](https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatter).
 
 ```xml
 <configuration>

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -241,7 +241,7 @@ any other maven phase (i.e. compile) then it can be configured as below;
 
 ```xml
 <eclipse>
-  <version>4.13.0</version>                     <!-- optional version of Eclipse Formatter -->
+  <version>4.21.0</version>                     <!-- optional version of Eclipse Formatter -->
   <file>${project.basedir}/eclipse-formatter.xml</file> <!-- optional -->
 </eclipse>
 ```
@@ -316,7 +316,7 @@ These mechanisms already exist for the Gradle plugin.
 
 ```xml
 <greclipse>
-  <version>4.13.0</version>                     <!-- optional version of Eclipse Formatter -->
+  <version>4.21.0</version>                     <!-- optional version of Eclipse Formatter -->
   <file>${project.basedir}/greclipse.properties</file> <!-- optional -->
 </greclipse>
 ```
@@ -466,7 +466,7 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 
 ```xml
 <eclipseCdt>
-  <version>4.13.0</version>               <!-- optional version of Eclipse Formatter -->
+  <version>4.21.0</version>               <!-- optional version of Eclipse Formatter -->
   <file>${project.basedir}/eclipse-cdt.xml</file> <!-- optional -->
 </eclipseCdt>
 ```
@@ -1052,7 +1052,7 @@ Alternatively you can supply spotless with a location of the `.npmrc` file to us
           <file>${project.basedir}/xml.prefs</file>
           <file>${project.basedir}/additional.properties</file>
         </files>
-        <version>4.13.0</version> <!-- optional version of Eclipse Formatter -->
+        <version>4.21.0</version> <!-- optional version of Eclipse Formatter -->
       </eclipseWtp>
     </format>
   </formats>


### PR DESCRIPTION
3 changes if Maven Plugin docs:
* Docs: additional info about Eclipse formatter version (https://github.com/diffplug/spotless/commit/0d6e8ea33bd4f77c60acfafe8c4b7c3c0df9b701)
* Docs: update version of Eclipse formatter (4.13.0 -> 4.21.0) (https://github.com/diffplug/spotless/commit/e9c840f9b15bffa7a377c35df07a489f6744e9d9) 
* Docs: fixed broken link to Eclipse WTP compatible versions (https://github.com/diffplug/spotless/commit/a43274a225331fa753a5d70980fb33bcaaacdafc)

Maybe I'm a moron, but for me it's not clear that `version` is not about Eclipse version but rather formatter version. For some time if looks like this was the same, but now Eclipse has stable 4.25, but formatter is 4.22 and the latest supported version by Spotless is 4.21 ([for now](https://github.com/diffplug/spotless/issues/1059)).

If you want I can break this PR in two. Since fixing a broken link is rather straight forward.