### PR TITLE
add ability to specify node executable for npm based formatters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * `ProcessRunner` has added some convenience methods so it can be used for maven testing. ([#1496](https://github.com/diffplug/spotless/pull/1496))
+* Allow to specify node executable for node-based formatters using `nodeExecutable` parameter ([#1500](https://github.com/diffplug/spotless/pull/1500))
 ### Fixed
 * The default list of type annotations used by `formatAnnotations` has had 8 more annotations from the Checker Framework added [#1494](https://github.com/diffplug/spotless/pull/1494)
 ### Changes

--- a/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
@@ -94,9 +94,11 @@ public class EslintFormatterStep {
 									"/com/diffplug/spotless/npm/common-serve.js",
 									"/com/diffplug/spotless/npm/eslint-serve.js"),
 							npmPathResolver.resolveNpmrcContent()),
-					projectDir,
-					buildDir,
-					npmPathResolver.resolveNpmExecutable());
+					new NpmFormatterStepLocations(
+							projectDir,
+							buildDir,
+							npmPathResolver.resolveNpmExecutable(),
+							npmPathResolver.resolveNodeExecutable()));
 			this.eslintConfig = localCopyFiles(requireNonNull(eslintConfig));
 		}
 
@@ -119,7 +121,7 @@ public class EslintFormatterStep {
 				FormattedPrinter.SYSOUT.print("creating formatter function (starting server)");
 				ServerProcessInfo eslintRestServer = npmRunServer();
 				EslintRestService restService = new EslintRestService(eslintRestServer.getBaseUrl());
-				return Closeable.ofDangerous(() -> endServer(restService, eslintRestServer), new EslintFilePathPassingFormatterFunc(projectDir, nodeModulesDir, eslintConfig, restService));
+				return Closeable.ofDangerous(() -> endServer(restService, eslintRestServer), new EslintFilePathPassingFormatterFunc(locations.projectDir(), nodeModulesDir, eslintConfig, restService));
 			} catch (IOException e) {
 				throw ThrowingEx.asRuntime(e);
 			}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeExecutableResolver.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeExecutableResolver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.npm;
+
+import java.io.File;
+import java.util.Optional;
+
+class NodeExecutableResolver {
+
+	private NodeExecutableResolver() {
+		// no instance
+	}
+
+	static String nodeExecutableName() {
+		String nodeName = "node";
+		if (PlatformInfo.normalizedOS() == PlatformInfo.OS.WINDOWS) {
+			nodeName += ".exe";
+		}
+		return nodeName;
+	}
+
+	static Optional<File> tryFindNextTo(File npmExecutable) {
+		if (npmExecutable == null) {
+			return Optional.empty();
+		}
+		File nodeExecutable = new File(npmExecutable.getParentFile(), nodeExecutableName());
+		if (nodeExecutable.exists() && nodeExecutable.isFile() && nodeExecutable.canExecute()) {
+			return Optional.of(nodeExecutable);
+		}
+		return Optional.empty();
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeExecutableResolver.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeExecutableResolver.java
@@ -42,4 +42,9 @@ class NodeExecutableResolver {
 		}
 		return Optional.empty();
 	}
+
+	public static String explainMessage() {
+		return "Spotless was unable to find a node executable.\n" +
+				"Either specify the node executable explicitly or make sure it can be found next to the npm executable.";
+	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepLocations.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepLocations.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.npm;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.io.Serializable;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+class NpmFormatterStepLocations implements Serializable {
+
+	private static final long serialVersionUID = -1055408537924029969L;
+	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+	private final transient File projectDir;
+
+	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+	private final transient File buildDir;
+
+	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+	private final transient File npmExecutable;
+
+	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+	private final transient File nodeExecutable;
+
+	public NpmFormatterStepLocations(File projectDir, File buildDir, File npmExecutable, File nodeExecutable) {
+		this.projectDir = requireNonNull(projectDir);
+		this.buildDir = requireNonNull(buildDir);
+		this.npmExecutable = requireNonNull(npmExecutable);
+		this.nodeExecutable = requireNonNull(nodeExecutable);
+	}
+
+	public File projectDir() {
+		return projectDir;
+	}
+
+	public File buildDir() {
+		return buildDir;
+	}
+
+	public File npmExecutable() {
+		return npmExecutable;
+	}
+
+	public File nodeExecutable() {
+		return nodeExecutable;
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmPathResolver.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmPathResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 package com.diffplug.spotless.npm;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,20 +25,29 @@ public class NpmPathResolver {
 
 	private final File explicitNpmExecutable;
 
+	private final File explicitNodeExecutable;
+
 	private final File explicitNpmrcFile;
 
 	private final List<File> additionalNpmrcLocations;
 
-	public NpmPathResolver(File explicitNpmExecutable, File explicitNpmrcFile, File... additionalNpmrcLocations) {
+	public NpmPathResolver(File explicitNpmExecutable, File explicitNodeExecutable, File explicitNpmrcFile, List<File> additionalNpmrcLocations) {
 		this.explicitNpmExecutable = explicitNpmExecutable;
+		this.explicitNodeExecutable = explicitNodeExecutable;
 		this.explicitNpmrcFile = explicitNpmrcFile;
-		this.additionalNpmrcLocations = Arrays.asList(additionalNpmrcLocations);
+		this.additionalNpmrcLocations = Collections.unmodifiableList(new ArrayList<>(additionalNpmrcLocations));
 	}
 
 	public File resolveNpmExecutable() {
 		return Optional.ofNullable(this.explicitNpmExecutable)
 				.orElseGet(() -> NpmExecutableResolver.tryFind()
 						.orElseThrow(() -> new IllegalStateException("Can't automatically determine npm executable and none was specifically supplied!\n\n" + NpmExecutableResolver.explainMessage())));
+	}
+
+	public File resolveNodeExecutable() {
+		return Optional.ofNullable(this.explicitNodeExecutable)
+				.orElseGet(() -> NodeExecutableResolver.tryFindNextTo(resolveNpmExecutable())
+						.orElseThrow(() -> new IllegalStateException("Can't automatically determine node executable and none was specifically supplied!\n\n" + NpmExecutableResolver.explainMessage())));
 	}
 
 	public String resolveNpmrcContent() {

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmProcess.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmProcess.java
@@ -28,9 +28,12 @@ class NpmProcess {
 
 	private final File npmExecutable;
 
-	NpmProcess(File workingDir, File npmExecutable) {
+	private final File nodeExecutable;
+
+	NpmProcess(File workingDir, File npmExecutable, File nodeExecutable) {
 		this.workingDir = workingDir;
 		this.npmExecutable = npmExecutable;
+		this.nodeExecutable = nodeExecutable;
 	}
 
 	void install() {
@@ -61,11 +64,12 @@ class NpmProcess {
 	private Process npm(String... args) {
 		List<String> processCommand = processCommand(args);
 		try {
-			return new ProcessBuilder()
+			ProcessBuilder processBuilder = new ProcessBuilder()
 					.inheritIO()
 					.directory(this.workingDir)
-					.command(processCommand)
-					.start();
+					.command(processCommand);
+			addEnvironmentVariables(processBuilder);
+			return processBuilder.start();
 		} catch (IOException e) {
 			throw new NpmProcessException("Failed to launch npm command '" + commandLine(args) + "'.", e);
 		}
@@ -76,6 +80,10 @@ class NpmProcess {
 		command.add(this.npmExecutable.getAbsolutePath());
 		command.addAll(Arrays.asList(args));
 		return command;
+	}
+
+	private void addEnvironmentVariables(ProcessBuilder processBuilder) {
+		processBuilder.environment().put("PATH", this.nodeExecutable.getParentFile().getAbsolutePath() + File.pathSeparator + System.getenv("PATH"));
 	}
 
 	private String commandLine(String... args) {

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -74,9 +74,11 @@ public class PrettierFormatterStep {
 									"/com/diffplug/spotless/npm/common-serve.js",
 									"/com/diffplug/spotless/npm/prettier-serve.js"),
 							npmPathResolver.resolveNpmrcContent()),
-					projectDir,
-					buildDir,
-					npmPathResolver.resolveNpmExecutable());
+					new NpmFormatterStepLocations(
+							projectDir,
+							buildDir,
+							npmPathResolver.resolveNpmExecutable(),
+							npmPathResolver.resolveNodeExecutable()));
 			this.prettierConfig = requireNonNull(prettierConfig);
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
@@ -80,9 +80,11 @@ public class TsFmtFormatterStep {
 									"/com/diffplug/spotless/npm/common-serve.js",
 									"/com/diffplug/spotless/npm/tsfmt-serve.js"),
 							npmPathResolver.resolveNpmrcContent()),
-					projectDir,
-					buildDir,
-					npmPathResolver.resolveNpmExecutable());
+					new NpmFormatterStepLocations(
+							projectDir,
+							buildDir,
+							npmPathResolver.resolveNpmExecutable(),
+							npmPathResolver.resolveNodeExecutable()));
 			this.buildDir = requireNonNull(buildDir);
 			this.configFile = configFile;
 			this.inlineTsFmtSettings = inlineTsFmtSettings == null ? new TreeMap<>() : new TreeMap<>(inlineTsFmtSettings);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
+* Allow to specify node executable for node-based formatters using `nodeExecutable` parameter ([#1500](https://github.com/diffplug/spotless/pull/1500))
 ### Fixed
 * The default list of type annotations used by `formatAnnotations` has had 8 more annotations from the Checker Framework added [#1494](https://github.com/diffplug/spotless/pull/1494)
 ### Changes

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -844,18 +844,23 @@ spotless {
 ### npm detection
 
 Prettier is based on NodeJS, so a working NodeJS installation (especially npm) is required on the host running spotless.
-Spotless will try to auto-discover an npm installation. If that is not working for you, it is possible to directly configure the npm binary to use.
+Spotless will try to auto-discover an npm installation. If that is not working for you, it is possible to directly configure the npm
+and/or node binary to use.
 
 ```gradle
 spotless {
   format 'javascript', {
-    prettier().npmExecutable('/usr/bin/npm').config(...)
+    prettier().npmExecutable('/usr/bin/npm').nodeExecutable('/usr/bin/node').config(...)
 ```
+
+If you provide both `npmExecutable` and `nodeExecutable`, spotless will use these paths. If you specify only one of the
+two, spotless will assume the other one is in the same directory.
 
 ### `.npmrc` detection
 
 Spotless picks up npm configuration stored in a `.npmrc` file either in the project directory or in your user home.
-Alternatively you can supply spotless with a location of the `.npmrc` file to use. (This can be combined with `npmExecutable`, of course.)
+Alternatively you can supply spotless with a location of the `.npmrc` file to use. (This can be combined with
+`npmExecutable` and `nodeExecutable`, of course.)
 
 ```gradle
 spotless {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -525,6 +526,9 @@ public class FormatExtension {
 		protected Object npmFile;
 
 		@Nullable
+		protected Object nodeFile;
+
+		@Nullable
 		protected Object npmrcFile;
 
 		protected Project project;
@@ -543,6 +547,13 @@ public class FormatExtension {
 			return (T) this;
 		}
 
+		@SuppressWarnings("unchecked")
+		public T nodeExecutable(final Object nodeFile) {
+			this.nodeFile = nodeFile;
+			replaceStep();
+			return (T) this;
+		}
+
 		public T npmrc(final Object npmrcFile) {
 			this.npmrcFile = npmrcFile;
 			replaceStep();
@@ -551,6 +562,10 @@ public class FormatExtension {
 
 		File npmFileOrNull() {
 			return fileOrNull(npmFile);
+		}
+
+		File nodeFileOrNull() {
+			return fileOrNull(nodeFile);
 		}
 
 		File npmrcFileOrNull() {
@@ -604,7 +619,7 @@ public class FormatExtension {
 					provisioner(),
 					project.getProjectDir(),
 					project.getBuildDir(),
-					new NpmPathResolver(npmFileOrNull(), npmrcFileOrNull(), project.getProjectDir(), project.getRootDir()),
+					new NpmPathResolver(npmFileOrNull(), nodeFileOrNull(), npmrcFileOrNull(), Arrays.asList(project.getProjectDir(), project.getRootDir())),
 					new com.diffplug.spotless.npm.PrettierConfig(
 							this.prettierConfigFile != null ? project.file(this.prettierConfigFile) : null,
 							this.prettierConfig));

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavascriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavascriptExtension.java
@@ -17,6 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -107,7 +108,7 @@ public class JavascriptExtension extends FormatExtension {
 					provisioner(),
 					project.getProjectDir(),
 					project.getBuildDir(),
-					new NpmPathResolver(npmFileOrNull(), npmrcFileOrNull(), project.getProjectDir(), project.getRootDir()),
+					new NpmPathResolver(npmFileOrNull(), nodeFileOrNull(), npmrcFileOrNull(), Arrays.asList(project.getProjectDir(), project.getRootDir())),
 					eslintConfig());
 		}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
@@ -17,6 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -116,7 +117,7 @@ public class TypescriptExtension extends FormatExtension {
 					provisioner(),
 					project.getProjectDir(),
 					project.getBuildDir(),
-					new NpmPathResolver(npmFileOrNull(), npmrcFileOrNull(), project.getProjectDir(), project.getRootDir()),
+					new NpmPathResolver(npmFileOrNull(), nodeFileOrNull(), npmrcFileOrNull(), Arrays.asList(project.getProjectDir(), project.getRootDir())),
 					typedConfigFile(),
 					config);
 		}
@@ -212,7 +213,7 @@ public class TypescriptExtension extends FormatExtension {
 					provisioner(),
 					project.getProjectDir(),
 					project.getBuildDir(),
-					new NpmPathResolver(npmFileOrNull(), npmrcFileOrNull(), project.getProjectDir(), project.getRootDir()),
+					new NpmPathResolver(npmFileOrNull(), nodeFileOrNull(), npmrcFileOrNull(), Arrays.asList(project.getProjectDir(), project.getRootDir())),
 					eslintConfig());
 		}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -17,6 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
@@ -54,6 +55,46 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 		// make sure node binary is there
 		gradleRunner().withArguments("nodeSetup", "npmSetup").build();
 		// then run spotless using that node installation
+		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+	}
+
+	@Test
+	@Disabled("This test is disabled because we currently don't support using npm/node installed by the" +
+			"node-gradle-plugin as the installation takes place in the *execution* phase, but spotless needs it in the *configuration* phase.")
+	void useNodeAndNpmFromNodeGradlePluginInOneSweep() throws Exception {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"    id 'com.github.node-gradle.node' version '3.5.1'",
+				"}",
+				"repositories { mavenCentral() }",
+				"node {",
+				"    download = true",
+				"    version = '18.13.0'",
+				"    npmVersion = '8.19.2'",
+				"    workDir = file(\"${buildDir}/nodejs\")",
+				"    npmWorkDir = file(\"${buildDir}/npm\")",
+				"}",
+				"def prettierConfig = [:]",
+				"prettierConfig['printWidth'] = 50",
+				"prettierConfig['parser'] = 'typescript'",
+				"def npmExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.cmd' : ''",
+				"def nodeExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.exe' : ''",
+				"spotless {",
+				"    format 'mytypescript', {",
+				"        target 'test.ts'",
+				"        prettier()",
+				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm${npmExecExtension}\")",
+				"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}/bin/node${nodeExecExtension}\")",
+				"            .config(prettierConfig)",
+				"    }",
+				"}",
+				"tasks.named('spotlessMytypescript').configure {",
+				"    it.dependsOn('nodeSetup', 'npmSetup')",
+				"}");
+		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
 		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -20,151 +20,179 @@ import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import com.diffplug.common.base.Predicates;
+
 class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 
 	@Test
 	void useNodeAndNpmFromNodeGradlePlugin() throws Exception {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'com.diffplug.spotless'",
-				"    id 'com.github.node-gradle.node' version '3.5.1'",
-				"}",
-				"repositories { mavenCentral() }",
-				"node {",
-				"    download = true",
-				"    version = '18.13.0'",
-				"    npmVersion = '8.19.2'",
-				"    workDir = file(\"${buildDir}/nodejs\")",
-				"    npmWorkDir = file(\"${buildDir}/npm\")",
-				"}",
-				"def prettierConfig = [:]",
-				"prettierConfig['printWidth'] = 50",
-				"prettierConfig['parser'] = 'typescript'",
-				"def npmExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.cmd' : ''",
-				"def nodeExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.exe' : ''",
-				"spotless {",
-				"    format 'mytypescript', {",
-				"        target 'test.ts'",
-				"        prettier()",
-				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm${npmExecExtension}\")",
-				"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}/bin/node${nodeExecExtension}\")",
-				"            .config(prettierConfig)",
-				"    }",
-				"}");
-		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
-		// make sure node binary is there
-		gradleRunner().withArguments("nodeSetup", "npmSetup").build();
-		// then run spotless using that node installation
-		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
-		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		try {
+			setFile("build.gradle").toLines(
+					"plugins {",
+					"    id 'com.diffplug.spotless'",
+					"    id 'com.github.node-gradle.node' version '3.5.1'",
+					"}",
+					"repositories { mavenCentral() }",
+					"node {",
+					"    download = true",
+					"    version = '18.13.0'",
+					"    npmVersion = '8.19.2'",
+					"    workDir = file(\"${buildDir}/nodejs\")",
+					"    npmWorkDir = file(\"${buildDir}/npm\")",
+					"}",
+					"def prettierConfig = [:]",
+					"prettierConfig['printWidth'] = 50",
+					"prettierConfig['parser'] = 'typescript'",
+					"def npmExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/npm.cmd' : '/bin/npm'",
+					"def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'",
+					"spotless {",
+					"    format 'mytypescript', {",
+					"        target 'test.ts'",
+					"        prettier()",
+					"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}${npmExec}\")",
+					"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}${nodeExec}\")",
+					"            .config(prettierConfig)",
+					"    }",
+					"}");
+			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+			// make sure node binary is there
+			gradleRunner().withArguments("nodeSetup", "npmSetup").build();
+			// then run spotless using that node installation
+			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		} catch (Exception e) {
+			printContents();
+			throw e;
+		}
+	}
+
+	private void printContents() {
+		System.out.println("************* Folder contents **************************");
+		System.out.println(listFiles(Predicates.and(path -> !path.startsWith(".gradle"), path -> !path.contains("/node_modules/"), path -> !path.contains("/include/"))));
+		System.out.println("********************************************************");
 	}
 
 	@Test
 	@Disabled("This test is disabled because we currently don't support using npm/node installed by the" +
 			"node-gradle-plugin as the installation takes place in the *execution* phase, but spotless needs it in the *configuration* phase.")
 	void useNodeAndNpmFromNodeGradlePluginInOneSweep() throws Exception {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'com.diffplug.spotless'",
-				"    id 'com.github.node-gradle.node' version '3.5.1'",
-				"}",
-				"repositories { mavenCentral() }",
-				"node {",
-				"    download = true",
-				"    version = '18.13.0'",
-				"    npmVersion = '8.19.2'",
-				"    workDir = file(\"${buildDir}/nodejs\")",
-				"    npmWorkDir = file(\"${buildDir}/npm\")",
-				"}",
-				"def prettierConfig = [:]",
-				"prettierConfig['printWidth'] = 50",
-				"prettierConfig['parser'] = 'typescript'",
-				"def npmExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.cmd' : ''",
-				"def nodeExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.exe' : ''",
-				"spotless {",
-				"    format 'mytypescript', {",
-				"        target 'test.ts'",
-				"        prettier()",
-				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm${npmExecExtension}\")",
-				"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}/bin/node${nodeExecExtension}\")",
-				"            .config(prettierConfig)",
-				"    }",
-				"}",
-				"tasks.named('spotlessMytypescript').configure {",
-				"    it.dependsOn('nodeSetup', 'npmSetup')",
-				"}");
-		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
-		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
-		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		try {
+			setFile("build.gradle").toLines(
+					"plugins {",
+					"    id 'com.diffplug.spotless'",
+					"    id 'com.github.node-gradle.node' version '3.5.1'",
+					"}",
+					"repositories { mavenCentral() }",
+					"node {",
+					"    download = true",
+					"    version = '18.13.0'",
+					"    npmVersion = '8.19.2'",
+					"    workDir = file(\"${buildDir}/nodejs\")",
+					"    npmWorkDir = file(\"${buildDir}/npm\")",
+					"}",
+					"def prettierConfig = [:]",
+					"prettierConfig['printWidth'] = 50",
+					"prettierConfig['parser'] = 'typescript'",
+					"def npmExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/npm.cmd' : '/bin/npm'",
+					"def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'",
+					"spotless {",
+					"    format 'mytypescript', {",
+					"        target 'test.ts'",
+					"        prettier()",
+					"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}${npmExec}\")",
+					"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}${nodeExec}\")",
+					"            .config(prettierConfig)",
+					"    }",
+					"}",
+					"tasks.named('spotlessMytypescript').configure {",
+					"    it.dependsOn('nodeSetup', 'npmSetup')",
+					"}");
+			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		} catch (Exception e) {
+			printContents();
+			throw e;
+		}
 	}
 
 	@Test
 	void useNpmFromNodeGradlePlugin() throws Exception {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'com.diffplug.spotless'",
-				"    id 'com.github.node-gradle.node' version '3.5.1'",
-				"}",
-				"repositories { mavenCentral() }",
-				"node {",
-				"    download = true",
-				"    version = '18.13.0'",
-				"    workDir = file(\"${buildDir}/nodejs\")",
-				"}",
-				"def prettierConfig = [:]",
-				"prettierConfig['printWidth'] = 50",
-				"prettierConfig['parser'] = 'typescript'",
-				"def npmExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.cmd' : ''",
-				"spotless {",
-				"    format 'mytypescript', {",
-				"        target 'test.ts'",
-				"        prettier()",
-				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm${npmExecExtension}\")",
-				"            .config(prettierConfig)",
-				"    }",
-				"}");
-		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
-		// make sure node binary is there
-		gradleRunner().withArguments("nodeSetup", "npmSetup").build();
-		// then run spotless using that node installation
-		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
-		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		try {
+			setFile("build.gradle").toLines(
+					"plugins {",
+					"    id 'com.diffplug.spotless'",
+					"    id 'com.github.node-gradle.node' version '3.5.1'",
+					"}",
+					"repositories { mavenCentral() }",
+					"node {",
+					"    download = true",
+					"    version = '18.13.0'",
+					"    workDir = file(\"${buildDir}/nodejs\")",
+					"}",
+					"def prettierConfig = [:]",
+					"prettierConfig['printWidth'] = 50",
+					"prettierConfig['parser'] = 'typescript'",
+					"def npmExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/npm.cmd' : '/bin/npm'",
+					"spotless {",
+					"    format 'mytypescript', {",
+					"        target 'test.ts'",
+					"        prettier()",
+					"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}${npmExec}\")",
+					"            .config(prettierConfig)",
+					"    }",
+					"}");
+			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+			// make sure node binary is there
+			gradleRunner().withArguments("nodeSetup", "npmSetup").build();
+			// then run spotless using that node installation
+			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		} catch (Exception e) {
+			printContents();
+			throw e;
+		}
 	}
 
 	@Test
 	void useNpmNextToConfiguredNodePluginFromNodeGradlePlugin() throws Exception {
-		setFile("build.gradle").toLines(
-				"plugins {",
-				"    id 'com.diffplug.spotless'",
-				"    id 'com.github.node-gradle.node' version '3.5.1'",
-				"}",
-				"repositories { mavenCentral() }",
-				"node {",
-				"    download = true",
-				"    version = '18.13.0'",
-				"    workDir = file(\"${buildDir}/nodejs\")",
-				"}",
-				"def prettierConfig = [:]",
-				"prettierConfig['printWidth'] = 50",
-				"prettierConfig['parser'] = 'typescript'",
-				"def nodeExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.exe' : ''",
-				"spotless {",
-				"    format 'mytypescript', {",
-				"        target 'test.ts'",
-				"        prettier()",
-				"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}/bin/node${nodeExecExtension}\")",
-				"            .config(prettierConfig)",
-				"    }",
-				"}");
-		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
-		// make sure node binary is there
-		gradleRunner().withArguments("nodeSetup", "npmSetup").build();
-		// then run spotless using that node installation
-		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
-		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		try {
+			setFile("build.gradle").toLines(
+					"plugins {",
+					"    id 'com.diffplug.spotless'",
+					"    id 'com.github.node-gradle.node' version '3.5.1'",
+					"}",
+					"repositories { mavenCentral() }",
+					"node {",
+					"    download = true",
+					"    version = '18.13.0'",
+					"    workDir = file(\"${buildDir}/nodejs\")",
+					"}",
+					"def prettierConfig = [:]",
+					"prettierConfig['printWidth'] = 50",
+					"prettierConfig['parser'] = 'typescript'",
+					"def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'",
+					"spotless {",
+					"    format 'mytypescript', {",
+					"        target 'test.ts'",
+					"        prettier()",
+					"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}${nodeExec}\")",
+					"            .config(prettierConfig)",
+					"    }",
+					"}");
+			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+			// make sure node binary is there
+			gradleRunner().withArguments("nodeSetup", "npmSetup").build();
+			// then run spotless using that node installation
+			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		} catch (Exception e) {
+			printContents();
+			throw e;
+		}
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016-2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import org.assertj.core.api.Assertions;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.Test;
+
+class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
+
+	@Test
+	void useNodeFromNodeGradlePlugin() throws Exception {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"    id 'com.github.node-gradle.node' version '3.5.1'",
+				"}",
+				"repositories { mavenCentral() }",
+				"node {",
+				"    download = true",
+				"    version = '18.13.0'",
+				"    npmVersion = '8.19.2'",
+				"    workDir = file(\"${buildDir}/nodejs\")",
+				"    npmWorkDir = file(\"${buildDir}/npm\")",
+				"}",
+				"def prettierConfig = [:]",
+				"prettierConfig['printWidth'] = 50",
+				"prettierConfig['parser'] = 'typescript'",
+				"spotless {",
+				"    format 'mytypescript', {",
+				"        target 'test.ts'",
+				"        prettier()",
+				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm\")",
+				"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}/bin/node\")",
+				"            .config(prettierConfig)",
+				"    }",
+				"}");
+		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+		// make sure node binary is there
+		gradleRunner().withArguments("nodeSetup", "npmSetup").build();
+		// then run spotless using that node installation
+		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 
 	@Test
-	void useNodeFromNodeGradlePlugin() throws Exception {
+	void useNodeAndNpmFromNodeGradlePlugin() throws Exception {
 		setFile("build.gradle").toLines(
 				"plugins {",
 				"    id 'com.diffplug.spotless'",
@@ -39,12 +39,48 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 				"def prettierConfig = [:]",
 				"prettierConfig['printWidth'] = 50",
 				"prettierConfig['parser'] = 'typescript'",
+				"def npmExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.cmd' : ''",
+				"def nodeExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.exe' : ''",
 				"spotless {",
 				"    format 'mytypescript', {",
 				"        target 'test.ts'",
 				"        prettier()",
-				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm\")",
-				"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}/bin/node\")",
+				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm${npmExecExtension}\")",
+				"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}/bin/node${nodeExecExtension}\")",
+				"            .config(prettierConfig)",
+				"    }",
+				"}");
+		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+		// make sure node binary is there
+		gradleRunner().withArguments("nodeSetup", "npmSetup").build();
+		// then run spotless using that node installation
+		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+	}
+
+	@Test
+	void useNpmFromNodeGradlePlugin() throws Exception {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"    id 'com.github.node-gradle.node' version '3.5.1'",
+				"}",
+				"repositories { mavenCentral() }",
+				"node {",
+				"    download = true",
+				"    version = '18.13.0'",
+				"    workDir = file(\"${buildDir}/nodejs\")",
+				"}",
+				"def prettierConfig = [:]",
+				"prettierConfig['printWidth'] = 50",
+				"prettierConfig['parser'] = 'typescript'",
+				"def npmExecExtension = System.getProperty('os.name').toLowerCase().contains('windows') ? '.cmd' : ''",
+				"spotless {",
+				"    format 'mytypescript', {",
+				"        target 'test.ts'",
+				"        prettier()",
+				"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}/bin/npm${npmExecExtension}\")",
 				"            .config(prettierConfig)",
 				"    }",
 				"}");

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
+* Allow to specify node executable for node-based formatters using `nodeExecutable` parameter ([#1500](https://github.com/diffplug/spotless/pull/1500))
 ### Fixed
 * The default list of type annotations used by `formatAnnotations` has had 8 more annotations from the Checker Framework added [#1494](https://github.com/diffplug/spotless/pull/1494)
 ### Changes

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1050,17 +1050,23 @@ Since spotless uses the actual npm prettier package behind the scenes, it is pos
 ### npm detection
 
 Prettier is based on NodeJS, so to use it, a working NodeJS installation (especially npm) is required on the host running spotless.
-Spotless will try to auto-discover an npm installation. If that is not working for you, it is possible to directly configure the npm binary to use.
+Spotless will try to auto-discover an npm installation. If that is not working for you, it is possible to directly configure the npm
+and/or node binary to use.
 
 ```xml
 <prettier>
   <npmExecutable>/usr/bin/npm</npmExecutable>
+  <nodeExecutable>/usr/bin/node</nodeExecutable>
 ```
+
+If you provide both `npmExecutable` and `nodeExecutable`, spotless will use these paths. If you specify only one of the
+two, spotless will assume the other one is in the same directory.
 
 ### `.npmrc` detection
 
 Spotless picks up npm configuration stored in a `.npmrc` file either in the project directory or in your user home.
-Alternatively you can supply spotless with a location of the `.npmrc` file to use. (This can be combined with `npmExecutable`, of course.)
+Alternatively you can supply spotless with a location of the `.npmrc` file to use. (This can be combined with
+`npmExecutable` and `nodeExecutable`, of course.)
 
 ```xml
 <prettier>

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/npm/AbstractNpmFormatterStepFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/npm/AbstractNpmFormatterStepFactory.java
@@ -18,6 +18,7 @@ package com.diffplug.spotless.maven.npm;
 import java.io.File;
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -35,11 +36,19 @@ public abstract class AbstractNpmFormatterStepFactory implements FormatterStepFa
 	private String npmExecutable;
 
 	@Parameter
+	private String nodeExecutable;
+
+	@Parameter
 	private String npmrc;
 
 	protected File npm(FormatterStepConfig stepConfig) {
 		File npm = npmExecutable != null ? stepConfig.getFileLocator().locateFile(npmExecutable) : null;
 		return npm;
+	}
+
+	protected File node(FormatterStepConfig stepConfig) {
+		File node = nodeExecutable != null ? stepConfig.getFileLocator().locateFile(nodeExecutable) : null;
+		return node;
 	}
 
 	protected File npmrc(FormatterStepConfig stepConfig) {
@@ -56,7 +65,7 @@ public abstract class AbstractNpmFormatterStepFactory implements FormatterStepFa
 	}
 
 	protected NpmPathResolver npmPathResolver(FormatterStepConfig stepConfig) {
-		return new NpmPathResolver(npm(stepConfig), npmrc(stepConfig), baseDir(stepConfig));
+		return new NpmPathResolver(npm(stepConfig), node(stepConfig), npmrc(stepConfig), Collections.singletonList(baseDir(stepConfig)));
 	}
 
 	protected boolean moreThanOneNonNull(Object... objects) {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -59,6 +59,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	private static final String EXECUTIONS = "executions";
 	private static final String MODULES = "modules";
 	private static final String DEPENDENCIES = "dependencies";
+	private static final String PLUGINS = "plugins";
 	private static final String MODULE_NAME = "name";
 	private static final int REMOTE_DEBUG_PORT = 5005;
 
@@ -151,6 +152,10 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		writePom(formats(groupWithSteps("format", including(includes), steps)));
 	}
 
+	protected void writePomWithPrettierSteps(String[] plugins, String includes, String... steps) throws IOException {
+		writePom(null, formats(groupWithSteps("format", including(includes), steps)), null, plugins);
+	}
+
 	protected void writePomWithPomSteps(String... steps) throws IOException {
 		writePom(groupWithSteps("pom", including("pom_test.xml"), steps));
 	}
@@ -168,11 +173,11 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	}
 
 	protected void writePom(String... configuration) throws IOException {
-		writePom(null, configuration, null);
+		writePom(null, configuration, null, null);
 	}
 
-	protected void writePom(String[] executions, String[] configuration, String[] dependencies) throws IOException {
-		String pomXmlContent = createPomXmlContent(null, executions, configuration, dependencies);
+	protected void writePom(String[] executions, String[] configuration, String[] dependencies, String[] plugins) throws IOException {
+		String pomXmlContent = createPomXmlContent(null, executions, configuration, dependencies, plugins);
 		setFile("pom.xml").toContent(pomXmlContent);
 	}
 
@@ -203,17 +208,17 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		return mavenRunner().withRemoteDebug(REMOTE_DEBUG_PORT);
 	}
 
-	protected String createPomXmlContent(String pluginVersion, String[] executions, String[] configuration, String[] dependencies) throws IOException {
-		return createPomXmlContent("/pom-test.xml.mustache", pluginVersion, executions, configuration, dependencies);
+	protected String createPomXmlContent(String pluginVersion, String[] executions, String[] configuration, String[] dependencies, String[] plugins) throws IOException {
+		return createPomXmlContent("/pom-test.xml.mustache", pluginVersion, executions, configuration, dependencies, plugins);
 	}
 
-	protected String createPomXmlContent(String pomTemplate, String pluginVersion, String[] executions, String[] configuration, String[] dependencies) throws IOException {
-		Map<String, Object> params = buildPomXmlParams(pluginVersion, executions, configuration, null, dependencies);
+	protected String createPomXmlContent(String pomTemplate, String pluginVersion, String[] executions, String[] configuration, String[] dependencies, String[] plugins) throws IOException {
+		Map<String, Object> params = buildPomXmlParams(pluginVersion, executions, configuration, null, dependencies, plugins);
 		return createPomXmlContent(pomTemplate, params);
 	}
 
 	protected String createPomXmlContent(String pluginVersion, String[] executions, String[] configuration) throws IOException {
-		return createPomXmlContent(pluginVersion, executions, configuration, null);
+		return createPomXmlContent(pluginVersion, executions, configuration, null, null);
 	}
 
 	protected String createPomXmlContent(String pomTemplate, Map<String, Object> params) throws IOException {
@@ -226,7 +231,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		}
 	}
 
-	protected static Map<String, Object> buildPomXmlParams(String pluginVersion, String[] executions, String[] configuration, String[] modules, String[] dependencies) {
+	protected static Map<String, Object> buildPomXmlParams(String pluginVersion, String[] executions, String[] configuration, String[] modules, String[] dependencies, String[] plugins) {
 		Map<String, Object> params = new HashMap<>();
 		params.put(SPOTLESS_MAVEN_PLUGIN_VERSION, pluginVersion == null ? getSystemProperty(SPOTLESS_MAVEN_PLUGIN_VERSION) : pluginVersion);
 
@@ -245,6 +250,10 @@ public class MavenIntegrationHarness extends ResourceHarness {
 
 		if (dependencies != null) {
 			params.put(DEPENDENCIES, String.join("\n", dependencies));
+		}
+
+		if (plugins != null) {
+			params.put(PLUGINS, String.join("\n", plugins));
 		}
 
 		return params;

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
@@ -145,7 +145,7 @@ class MultiModuleProjectTest extends MavenIntegrationHarness {
 			modulesList.addAll(subProjects.keySet());
 			String[] modules = modulesList.toArray(new String[0]);
 
-			Map<String, Object> rootPomParams = buildPomXmlParams(null, null, configuration, modules, null);
+			Map<String, Object> rootPomParams = buildPomXmlParams(null, null, configuration, modules, null, null);
 			setFile("pom.xml").toContent(createPomXmlContent("/multi-module/pom-parent.xml.mustache", rootPomParams));
 		}
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
@@ -62,6 +62,7 @@ class SpotlessCheckMojoTest extends MavenIntegrationHarness {
 						"    <file>${basedir}/license.txt</file>",
 						"  </licenseHeader>",
 						"</java>"},
+				null,
 				null);
 
 		testSpotlessCheck(UNFORMATTED_FILE, "verify", true);

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
@@ -98,7 +98,8 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 						"    <artifactId>javax.inject</artifactId>",
 						"    <version>1</version>",
 						"  </dependency>",
-						"</dependencies>"}));
+						"</dependencies>"},
+				null));
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmFrontendMavenPlugin.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmFrontendMavenPlugin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.npm;
+
+/**
+ * Helper class to configure a maven pom to use frontend-maven-plugin.
+ * @see <a href="https://github.com/eirslett/frontend-maven-plugin">frontend-maven-plugin on github</a>
+ */
+public final class NpmFrontendMavenPlugin {
+
+	public static final String GROUP_ID = "com.github.eirslett";
+	public static final String ARTIFACT_ID = "frontend-maven-plugin";
+	public static final String VERSION = "1.11.3"; // for now, we stick with this version, as it is the last to support maven 3.1 (see pom-test.xml.mustache)
+
+	public static final String GOAL_INSTALL_NODE_AND_NPM = "install-node-and-npm";
+
+	public static final String INSTALL_DIRECTORY = "target";
+
+	private NpmFrontendMavenPlugin() {
+		// prevent instantiation
+	}
+
+	public static String[] pomPluginLines(String nodeVersion, String npmVersion) {
+		return new String[]{
+				"<plugin>",
+				String.format("  <groupId>%s</groupId>", GROUP_ID),
+				String.format("  <artifactId>%s</artifactId>", ARTIFACT_ID),
+				String.format("  <version>%s</version>", VERSION),
+				"  <executions>",
+				"    <execution>",
+				"      <id>install node and npm</id>",
+				"      <goals>",
+				String.format("        <goal>%s</goal>", GOAL_INSTALL_NODE_AND_NPM),
+				"      </goals>",
+				"    </execution>",
+				"  </executions>",
+				"  <configuration>",
+				(nodeVersion != null ? "    <nodeVersion>" + nodeVersion + "</nodeVersion>" : ""),
+				(npmVersion != null ? "     <npmVersion>" + npmVersion + "</npmVersion>" : ""),
+				String.format("    <installDirectory>%s</installDirectory>", INSTALL_DIRECTORY),
+				"  </configuration>",
+				"</plugin>"
+		};
+	}
+
+	public static String installNpmMavenGoal() {
+		return String.format("%s:%s:%s", GROUP_ID, ARTIFACT_ID, GOAL_INSTALL_NODE_AND_NPM);
+	}
+
+	public static String installedNpmPath() {
+		return String.format("%s/node/npm", INSTALL_DIRECTORY);
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmFrontendMavenPlugin.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmFrontendMavenPlugin.java
@@ -61,6 +61,6 @@ public final class NpmFrontendMavenPlugin {
 	}
 
 	public static String installedNpmPath() {
-		return String.format("%s/node/npm", INSTALL_DIRECTORY);
+		return String.format("%s/node/npm%s", INSTALL_DIRECTORY, System.getProperty("os.name").toLowerCase().contains("win") ? ".cmd" : "");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmTestsWithDynamicallyInstalledNpmInstallationTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmTestsWithDynamicallyInstalledNpmInstallationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.npm;
+
+import static com.diffplug.spotless.maven.npm.NpmFrontendMavenPlugin.installNpmMavenGoal;
+import static com.diffplug.spotless.maven.npm.NpmFrontendMavenPlugin.installedNpmPath;
+import static com.diffplug.spotless.maven.npm.NpmFrontendMavenPlugin.pomPluginLines;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+public class NpmTestsWithDynamicallyInstalledNpmInstallationTest extends MavenIntegrationHarness {
+
+	@Test
+	void useDownloadedNpmInstallation() throws Exception {
+		writePomWithPrettierSteps(
+				pomPluginLines("v18.13.0", null),
+				"src/main/typescript/test.ts",
+				"<prettier>",
+				"    <npmExecutable>" + installedNpmPath() + "</npmExecutable>",
+				"</prettier>");
+
+		String kind = "typescript";
+		String suffix = "ts";
+		String configPath = ".prettierrc.yml";
+		setFile(configPath).toResource("npm/prettier/filetypes/" + kind + "/" + ".prettierrc.yml");
+		String path = "src/main/" + kind + "/test." + suffix;
+		setFile(path).toResource("npm/prettier/filetypes/" + kind + "/" + kind + ".dirty");
+
+		mavenRunner().withArguments(installNpmMavenGoal(), "spotless:apply").runNoError();
+		assertFile(path).sameAsResource("npm/prettier/filetypes/" + kind + "/" + kind + ".clean");
+	}
+
+}

--- a/plugin-maven/src/test/resources/pom-test.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-test.xml.mustache
@@ -21,6 +21,7 @@
 
     <build>
         <plugins>
+            {{{plugins}}}
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>

--- a/testlib/src/test/java/com/diffplug/spotless/npm/NpmFormatterStepCommonTests.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/NpmFormatterStepCommonTests.java
@@ -17,17 +17,22 @@ package com.diffplug.spotless.npm;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 
 import com.diffplug.spotless.ResourceHarness;
 
 public abstract class NpmFormatterStepCommonTests extends ResourceHarness {
 
 	protected NpmPathResolver npmPathResolver() {
-		return new NpmPathResolver(npmExecutable(), npmrc());
+		return new NpmPathResolver(npmExecutable(), nodeExecutable(), npmrc(), Collections.emptyList());
 	}
 
 	private File npmExecutable() {
-		return NpmExecutableResolver.tryFind().orElseThrow(() -> new IllegalStateException("cannot detect node binary"));
+		return NpmExecutableResolver.tryFind().orElseThrow(() -> new IllegalStateException("cannot detect npm binary"));
+	}
+
+	private File nodeExecutable() {
+		return NodeExecutableResolver.tryFindNextTo(npmExecutable()).orElseThrow(() -> new IllegalStateException("cannot detect node binary"));
 	}
 
 	private File npmrc() {


### PR DESCRIPTION
Using the discussed `nodeExecutable`-approach, this PR resolves #1381 - the issue when node is not on the path.
