### PR TITLE
Suggested feature - Adding a synthesis at the end of spotlessApply

### DIFF
--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ImpactedFilesTracker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ImpactedFilesTracker.java
@@ -1,0 +1,24 @@
+package com.diffplug.spotless.maven;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ImpactedFilesTracker {
+	protected final AtomicInteger nbChecked = new AtomicInteger();
+	protected final AtomicInteger nbCleaned = new AtomicInteger();
+
+	public void checked() {
+		nbChecked.incrementAndGet();
+	}
+
+	public int getChecked() {
+		return nbChecked.get();
+	}
+
+	public void cleaned() {
+		nbCleaned.incrementAndGet();
+	}
+
+	public int getCleaned() {
+		return nbCleaned.get();
+	}
+}


### PR DESCRIPTION
This PR would like to discuss a new feature in the maven plugin. I'd like to see some information in the plugin logs related to the files being successfully formatted (at the very least the number of reformatted file, and optionally number of processed+skipped+readonly).

An alternative maven plugin for formatting implemented it this way: https://github.com/revelc/formatter-maven-plugin/blob/main/src/main/java/net/revelc/code/formatter/FormatterMojo.java#L454-L482

Is this relevant ?