### PR TITLE
Cleanup usages of gradle/gradle-build-action

### DIFF
--- a/.github/workflows/changelog-print.yml
+++ b/.github/workflows/changelog-print.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-          cache: 'gradle'
       - name: gradle caching
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
       - run: ./gradlew changelogPrint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 11
-          cache: gradle
+      - name: gradle caching
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
       - name: spotlessCheck
         run: ./gradlew spotlessCheck --build-cache
       - name: assemble testClasses
@@ -60,7 +63,10 @@ jobs:
         with:
           distribution: "temurin"
           java-version: ${{ matrix.jre }}
-          cache: gradle
+      - name: gradle caching
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
       - name: build (maven-only)
         if: matrix.kind == 'maven'
         run: ./gradlew :plugin-maven:build -x spotlessCheck --build-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,9 +42,10 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-          cache: 'gradle'
       - name: gradle caching
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
       - name: publish all
         if: "${{ github.event.inputs.to_publish == 'all' }}"
         run: |


### PR DESCRIPTION
- Remove cache from `actions/setup-java`.
- Enable `gradle-home-cache-cleanup` flag, see https://github.com/gradle/gradle-build-action/blob/main/README.md#removing-unused-files-from-gradle-user-home-before-saving-to-cache.