### PR TITLE
add ability to use npm and node executables installed by node gradle plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * ** POTENTIALLY BREAKING** Removed support for KtLint 0.3x and 0.45.2 ([#1475](https://github.com/diffplug/spotless/pull/1475))
   * `KtLint` does not maintain a stable API - before this PR, we supported every breaking change in the API since 2019.
   * From now on, we will support no more than 2 breaking changes at a time.
+* NpmFormatterStepStateBase delays `npm install` call until the formatter is first used. This enables better integration
+  with `gradle-node-plugin`. ([#1522](https://github.com/diffplug/spotless/pull/1522))
 
 ## [2.32.0] - 2023-01-13
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
@@ -39,6 +39,8 @@ import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.ThrowingEx;
 import com.diffplug.spotless.npm.EslintRestService.FormatOption;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class EslintFormatterStep {
 
 	private static final Logger logger = LoggerFactory.getLogger(EslintFormatterStep.class);
@@ -83,6 +85,7 @@ public class EslintFormatterStep {
 		private static final long serialVersionUID = -539537027004745812L;
 		private final EslintConfig origEslintConfig;
 
+		@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 		private transient EslintConfig eslintConfigInUse;
 
 		State(String stepName, Map<String, String> devDependencies, File projectDir, File buildDir, NpmPathResolver npmPathResolver, EslintConfig eslintConfig) throws IOException {

--- a/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
@@ -81,7 +81,9 @@ public class EslintFormatterStep {
 	private static class State extends NpmFormatterStepStateBase implements Serializable {
 
 		private static final long serialVersionUID = -539537027004745812L;
-		private final EslintConfig eslintConfig;
+		private final EslintConfig origEslintConfig;
+
+		private transient EslintConfig eslintConfigInUse;
 
 		State(String stepName, Map<String, String> devDependencies, File projectDir, File buildDir, NpmPathResolver npmPathResolver, EslintConfig eslintConfig) throws IOException {
 			super(stepName,
@@ -97,21 +99,23 @@ public class EslintFormatterStep {
 					new NpmFormatterStepLocations(
 							projectDir,
 							buildDir,
-							npmPathResolver.resolveNpmExecutable(),
-							npmPathResolver.resolveNodeExecutable()));
-			this.eslintConfig = localCopyFiles(requireNonNull(eslintConfig));
+							npmPathResolver::resolveNpmExecutable,
+							npmPathResolver::resolveNodeExecutable));
+			this.origEslintConfig = requireNonNull(eslintConfig.verify());
+			this.eslintConfigInUse = eslintConfig;
 		}
 
-		private EslintConfig localCopyFiles(EslintConfig orig) {
-			if (orig.getEslintConfigPath() == null) {
-				return orig.verify();
+		@Override
+		protected void prepareNodeServerLayout() throws IOException {
+			super.prepareNodeServerLayout();
+			if (origEslintConfig.getEslintConfigPath() != null) {
+				// If any config files are provided, we need to make sure they are at the same location as the node modules
+				// as eslint will try to resolve plugin/config names relatively to the config file location and some
+				// eslint configs contain relative paths to additional config files (such as tsconfig.json e.g.)
+				FormattedPrinter.SYSOUT.print("Copying config file <%s> to <%s> and using the copy", origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
+				File configFileCopy = NpmResourceHelper.copyFileToDir(origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
+				this.eslintConfigInUse = this.origEslintConfig.withEslintConfigPath(configFileCopy).verify();
 			}
-			// If any config files are provided, we need to make sure they are at the same location as the node modules
-			// as eslint will try to resolve plugin/config names relatively to the config file location and some
-			// eslint configs contain relative paths to additional config files (such as tsconfig.json e.g.)
-			FormattedPrinter.SYSOUT.print("Copying config file <%s> to <%s> and using the copy", orig.getEslintConfigPath(), nodeModulesDir);
-			File configFileCopy = NpmResourceHelper.copyFileToDir(orig.getEslintConfigPath(), nodeModulesDir);
-			return orig.withEslintConfigPath(configFileCopy).verify();
 		}
 
 		@Override
@@ -121,7 +125,7 @@ public class EslintFormatterStep {
 				FormattedPrinter.SYSOUT.print("creating formatter function (starting server)");
 				ServerProcessInfo eslintRestServer = npmRunServer();
 				EslintRestService restService = new EslintRestService(eslintRestServer.getBaseUrl());
-				return Closeable.ofDangerous(() -> endServer(restService, eslintRestServer), new EslintFilePathPassingFormatterFunc(locations.projectDir(), nodeModulesDir, eslintConfig, restService));
+				return Closeable.ofDangerous(() -> endServer(restService, eslintRestServer), new EslintFilePathPassingFormatterFunc(locations.projectDir(), nodeServerLayout.nodeModulesDir(), eslintConfigInUse, restService));
 			} catch (IOException e) {
 				throw ThrowingEx.asRuntime(e);
 			}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,11 @@
 package com.diffplug.spotless.npm;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import com.diffplug.spotless.ThrowingEx;
 
 class NodeServerLayout {
 
@@ -49,5 +54,32 @@ class NodeServerLayout {
 
 	static File getBuildDirFromNodeModulesDir(File nodeModulesDir) {
 		return nodeModulesDir.getParentFile();
+	}
+
+	public boolean isLayoutPrepared() {
+		if (!nodeModulesDir().isDirectory()) {
+			return false;
+		}
+		if (!packageJsonFile().isFile()) {
+			return false;
+		}
+		if (!serveJsFile().isFile()) {
+			return false;
+		}
+		// npmrc is optional, so must not be checked here
+		return true;
+	}
+
+	public boolean isNodeModulesPrepared() {
+		Path nodeModulesInstallDirPath = new File(nodeModulesDir(), "node_modules").toPath();
+		if (!Files.isDirectory(nodeModulesInstallDirPath)) {
+			return false;
+		}
+		// check if it is NOT empty
+		return ThrowingEx.get(() -> {
+			try (Stream<Path> entries = Files.list(nodeModulesInstallDirPath)) {
+				return entries.findFirst().isPresent();
+			}
+		});
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepLocations.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepLocations.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.function.Supplier;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -32,12 +33,12 @@ class NpmFormatterStepLocations implements Serializable {
 	private final transient File buildDir;
 
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	private final transient File npmExecutable;
+	private final transient Supplier<File> npmExecutable;
 
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-	private final transient File nodeExecutable;
+	private final transient Supplier<File> nodeExecutable;
 
-	public NpmFormatterStepLocations(File projectDir, File buildDir, File npmExecutable, File nodeExecutable) {
+	public NpmFormatterStepLocations(File projectDir, File buildDir, Supplier<File> npmExecutable, Supplier<File> nodeExecutable) {
 		this.projectDir = requireNonNull(projectDir);
 		this.buildDir = requireNonNull(buildDir);
 		this.npmExecutable = requireNonNull(npmExecutable);
@@ -53,10 +54,10 @@ class NpmFormatterStepLocations implements Serializable {
 	}
 
 	public File npmExecutable() {
-		return npmExecutable;
+		return npmExecutable.get();
 	}
 
 	public File nodeExecutable() {
-		return nodeExecutable;
+		return nodeExecutable.get();
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -81,14 +81,22 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 	}
 
 	protected void assertNodeServerDirReady() throws IOException {
-		if (!this.nodeServerLayout.nodeModulesDir().exists() || !this.nodeServerLayout.packageJsonFile().isFile()) {
+		if (needsPrepareNodeServerLayout()) {
 			// reinstall if missing
 			prepareNodeServerLayout();
 		}
-		if (!new File(this.nodeServerLayout.nodeModulesDir(), "node_modules").isDirectory()) {
+		if (needsPrepareNodeServer()) {
 			// run npm install if node_modules is missing
 			prepareNodeServer();
 		}
+	}
+
+	protected boolean needsPrepareNodeServer() {
+		return this.nodeServerLayout.isNodeModulesPrepared();
+	}
+
+	protected boolean needsPrepareNodeServerLayout() {
+		return !this.nodeServerLayout.isLayoutPrepared();
 	}
 
 	protected ServerProcessInfo npmRunServer() throws ServerStartException, IOException {

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -94,7 +94,7 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 	}
 
 	protected boolean needsPrepareNodeServer() {
-		return this.nodeServerLayout.isNodeModulesPrepared();
+		return !this.nodeServerLayout.isNodeModulesPrepared();
 	}
 
 	protected boolean needsPrepareNodeServerLayout() {

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -77,8 +77,8 @@ public class PrettierFormatterStep {
 					new NpmFormatterStepLocations(
 							projectDir,
 							buildDir,
-							npmPathResolver.resolveNpmExecutable(),
-							npmPathResolver.resolveNodeExecutable()));
+							npmPathResolver::resolveNpmExecutable,
+							npmPathResolver::resolveNodeExecutable));
 			this.prettierConfig = requireNonNull(prettierConfig);
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
@@ -83,8 +83,8 @@ public class TsFmtFormatterStep {
 					new NpmFormatterStepLocations(
 							projectDir,
 							buildDir,
-							npmPathResolver.resolveNpmExecutable(),
-							npmPathResolver.resolveNodeExecutable()));
+							npmPathResolver::resolveNpmExecutable,
+							npmPathResolver::resolveNodeExecutable));
 			this.buildDir = requireNonNull(buildDir);
 			this.configFile = configFile;
 			this.inlineTsFmtSettings = inlineTsFmtSettings == null ? new TreeMap<>() : new TreeMap<>(inlineTsFmtSettings);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -15,6 +15,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * **POTENTIALLY BREAKING** Removed support for KtLint 0.3x and 0.45.2 ([#1475](https://github.com/diffplug/spotless/pull/1475))
   * `KtLint` does not maintain a stable API - before this PR, we supported every breaking change in the API since 2019.
   * From now on, we will support no more than 2 breaking changes at a time.
+* `npm`-based formatters `ESLint`, `prettier` and `tsfmt` delay their `npm install` call until the formatters are first
+  used. For gradle this effectively moves the `npm install` call out of the configuration phase and as such enables
+  better integration with `gradle-node-plugin`. ([#1522](https://github.com/diffplug/spotless/pull/1522))
 
 ## [6.13.0] - 2023-01-14
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -907,6 +907,13 @@ spotless {
 If you provide both `npmExecutable` and `nodeExecutable`, spotless will use these paths. If you specify only one of the
 two, spotless will assume the other one is in the same directory.
 
+If you use the `gradle-node-plugin` ([github](https://github.com/node-gradle/gradle-node-plugin)), it is possible to use the
+node- and npm-binaries dynamically installed by this plugin. See
+[this](https://github.com/diffplug/spotless/blob/main/plugin-gradle/src/test/resources/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_1.gradle)
+or [this](https://github.com/diffplug/spotless/blob/main/plugin-gradle/src/test/resources/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_2.gradle) example.
+
+```gradle
+
 ### `.npmrc` detection
 
 Spotless picks up npm configuration stored in a `.npmrc` file either in the project directory or in your user home.

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
@@ -166,7 +166,7 @@ public class TypescriptExtension extends FormatExtension {
 
 		private void fixParserToTypescript() {
 			if (this.prettierConfig == null) {
-				this.prettierConfig = Collections.singletonMap("parser", "typescript");
+				this.prettierConfig = new TreeMap<>(Collections.singletonMap("parser", "typescript"));
 			} else {
 				final Object replaced = this.prettierConfig.put("parser", "typescript");
 				if (replaced != null) {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -17,7 +17,6 @@ package com.diffplug.gradle.spotless;
 
 import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.Predicates;
@@ -74,8 +73,6 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 	}
 
 	@Test
-	@Disabled("This test is disabled because we currently don't support using npm/node installed by the" +
-			"node-gradle-plugin as the installation takes place in the *execution* phase, but spotless needs it in the *configuration* phase.")
 	void useNodeAndNpmFromNodeGradlePluginInOneSweep() throws Exception {
 		try {
 			setFile("build.gradle").toLines(

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -73,38 +73,23 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 	}
 
 	@Test
-	void useNodeAndNpmFromNodeGradlePluginInOneSweep() throws Exception {
+	void useNodeAndNpmFromNodeGradlePlugin_example1() throws Exception {
 		try {
-			setFile("build.gradle").toLines(
-					"plugins {",
-					"    id 'com.diffplug.spotless'",
-					"    id 'com.github.node-gradle.node' version '3.5.1'",
-					"}",
-					"repositories { mavenCentral() }",
-					"node {",
-					"    download = true",
-					"    version = '18.13.0'",
-					"    npmVersion = '8.19.2'",
-					"    workDir = file(\"${buildDir}/nodejs\")",
-					"    npmWorkDir = file(\"${buildDir}/npm\")",
-					"}",
-					"def prettierConfig = [:]",
-					"prettierConfig['printWidth'] = 50",
-					"prettierConfig['parser'] = 'typescript'",
-					"def npmExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/npm.cmd' : '/bin/npm'",
-					"def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'",
-					"spotless {",
-					"    format 'mytypescript', {",
-					"        target 'test.ts'",
-					"        prettier()",
-					"            .npmExecutable(\"${tasks.named('npmSetup').get().npmDir.get()}${npmExec}\")",
-					"            .nodeExecutable(\"${tasks.named('nodeSetup').get().nodeDir.get()}${nodeExec}\")",
-					"            .config(prettierConfig)",
-					"    }",
-					"}",
-					"tasks.named('spotlessMytypescript').configure {",
-					"    it.dependsOn('nodeSetup', 'npmSetup')",
-					"}");
+			setFile("build.gradle").toResource("com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_1.gradle");
+			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
+			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile.clean");
+		} catch (Exception e) {
+			printContents();
+			throw e;
+		}
+	}
+
+	@Test
+	void useNpmFromNodeGradlePlugin_example2() throws Exception {
+		try {
+			setFile("build.gradle").toResource("com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_2.gradle");
 			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
 			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");

--- a/plugin-gradle/src/test/resources/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_1.gradle
+++ b/plugin-gradle/src/test/resources/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_1.gradle
@@ -1,0 +1,38 @@
+/**
+ * This example shows how to use the gradle-node-plugin to install node and npm in separate directories
+ * and use these binaries with the prettier formatter.
+ */
+plugins {
+    id 'com.diffplug.spotless'
+    id 'com.github.node-gradle.node' version '3.5.1'
+}
+repositories { mavenCentral() }
+node {
+    download = true
+    version = '18.13.0'
+    npmVersion = '8.19.2'
+	// when setting both these directories, npm and node will be in separate directories
+    workDir = file("${buildDir}/nodejs")
+    npmWorkDir = file("${buildDir}/npm")
+}
+def prettierConfig = [:]
+prettierConfig['printWidth'] = 50
+prettierConfig['parser'] = 'typescript'
+
+// the executable names
+def npmExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/npm.cmd' : '/bin/npm'
+def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'
+
+spotless {
+    format 'mytypescript', {
+        target 'test.ts'
+        prettier()
+            .npmExecutable("${tasks.named('npmSetup').get().npmDir.get()}${npmExec}") // get the npm executable path from gradle-node-plugin
+            .nodeExecutable("${tasks.named('nodeSetup').get().nodeDir.get()}${nodeExec}") // get the node executable path from gradle-node-plugin
+            .config(prettierConfig)
+    }
+}
+
+tasks.named('spotlessMytypescript').configure {
+    it.dependsOn('nodeSetup', 'npmSetup')
+}

--- a/plugin-gradle/src/test/resources/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_2.gradle
+++ b/plugin-gradle/src/test/resources/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_2.gradle
@@ -1,0 +1,35 @@
+/**
+ * This example shows how to use the gradle-node-plugin to install node and npm together and
+ * use these binaries with the prettier formatter.
+ */
+plugins {
+    id 'com.diffplug.spotless'
+    id 'com.github.node-gradle.node' version '3.5.1'
+}
+repositories { mavenCentral() }
+node {
+    download = true
+    version = '18.13.0'
+	// when not setting an explicit `npmWorkDir`, the npm binary will be installed next to the node binary
+    workDir = file("${buildDir}/nodejs")
+}
+def prettierConfig = [:]
+prettierConfig['printWidth'] = 50
+prettierConfig['parser'] = 'typescript'
+
+// the executable name
+def npmExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/npm.cmd' : '/bin/npm'
+
+spotless {
+    typescript {
+        target 'test.ts'
+        prettier()
+            .npmExecutable("${tasks.named('npmSetup').get().npmDir.get()}${npmExec}") // get the npm executable path from gradle-node-plugin
+		    // setting the nodeExecutable is not necessary, since it will be found in the same directory as the npm executable (see above)
+            .config(prettierConfig)
+    }
+}
+
+tasks.named('spotlessTypescript').configure {
+    it.dependsOn('nodeSetup', 'npmSetup')
+}

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -18,6 +18,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * **POTENTIALLY BREAKING** Removed support for KtLint 0.3x and 0.45.2 ([#1475](https://github.com/diffplug/spotless/pull/1475))
   * `KtLint` does not maintain a stable API - before this PR, we supported every breaking change in the API since 2019.
   * From now on, we will support no more than 2 breaking changes at a time.
+* `npm`-based formatters `ESLint`, `prettier` and `tsfmt` delay their `npm install` call until the formatters are first used. ([#1522](https://github.com/diffplug/spotless/pull/1522)
 
 ## [2.30.0] - 2023-01-13
 ### Added


### PR DESCRIPTION
In this PR the `npm install`-call for npm-based formatters is delayed until the first formatting call is executed. This enables integration with node-gradle-plugin which is showecased and tested in two example build-files.

This resolves #1499.