### PR TITLE
Sort by keys inside json arrays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changes
 * **POTENTIALLY BREAKING** Bump bytecode from Java 8 to 11 ([#1530](https://github.com/diffplug/spotless/pull/1530) part 2 of [#1337](https://github.com/diffplug/spotless/issues/1337))
+* **POTENTIALLY BREAKING** `sortByKeys` for JSON formatting now takes into account objects inside arrays ([#1546](https://github.com/diffplug/spotless/pull/1546))
 
 ## [2.34.0] - 2023-01-26
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changes
+* **POTENTIALLY BREAKING** `sortByKeys` for JSON formatting now takes into account objects inside arrays ([#1546](https://github.com/diffplug/spotless/pull/1546))
 
 ## [6.14.0] - 2023-01-26
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * A synthesis log with the number of considered files is added after each formatter execution ([#1507](https://github.com/diffplug/spotless/pull/1507))
+### Changes
+* **POTENTIALLY BREAKING** `sortByKeys` for JSON formatting now takes into account objects inside arrays ([#1546](https://github.com/diffplug/spotless/pull/1546))
 
 ## [2.31.0] - 2023-01-26
 ### Added

--- a/testlib/src/main/resources/json/sortByKeysAfter.json
+++ b/testlib/src/main/resources/json/sortByKeysAfter.json
@@ -8,7 +8,7 @@
     ],
     "_objectsInArraysAreSorted": [
         {
-            "a": "1",
+            "a": 1,
             "b": 2
         }
     ],

--- a/testlib/src/main/resources/json/sortByKeysAfter.json
+++ b/testlib/src/main/resources/json/sortByKeysAfter.json
@@ -6,6 +6,12 @@
         2,
         1
     ],
+    "_objectsInArraysAreSorted": [
+        {
+            "a": "1",
+            "b": 2
+        }
+    ],
     "a": 3,
     "c": 4,
     "x": 5,

--- a/testlib/src/main/resources/json/sortByKeysAfterDisabled.json
+++ b/testlib/src/main/resources/json/sortByKeysAfterDisabled.json
@@ -15,5 +15,11 @@
         3,
         2,
         1
+    ],
+    "_objectsInArraysAreSorted": [
+        {
+            "b": 2,
+            "a": "1"
+        }
     ]
 }

--- a/testlib/src/main/resources/json/sortByKeysAfterDisabled.json
+++ b/testlib/src/main/resources/json/sortByKeysAfterDisabled.json
@@ -19,7 +19,7 @@
     "_objectsInArraysAreSorted": [
         {
             "b": 2,
-            "a": "1"
+            "a": 1
         }
     ]
 }

--- a/testlib/src/main/resources/json/sortByKeysAfterDisabled_Simple.json
+++ b/testlib/src/main/resources/json/sortByKeysAfterDisabled_Simple.json
@@ -11,6 +11,10 @@
         "x": 5,
         "X": 2
     },
+    "_objectsInArraysAreSorted": [{
+        "a": 1,
+        "b": 2
+    }],
     "_arraysNotSorted": [
         3,
         2,

--- a/testlib/src/main/resources/json/sortByKeysAfter_Jackson.json
+++ b/testlib/src/main/resources/json/sortByKeysAfter_Jackson.json
@@ -2,6 +2,10 @@
   "A": 1,
   "X": 2,
   "_arraysNotSorted": [ 3, 2, 1 ],
+  "_objectsInArraysAreSorted": [ {
+    "a": 1,
+    "b": 2
+  } ],
   "a": 3,
   "c": 4,
   "x": 5,

--- a/testlib/src/main/resources/json/sortByKeysAfter_Jackson_spaceAfterKeySeparator.json
+++ b/testlib/src/main/resources/json/sortByKeysAfter_Jackson_spaceAfterKeySeparator.json
@@ -2,6 +2,10 @@
   "A": 1,
   "X": 2,
   "_arraysNotSorted": [ 3, 2, 1 ],
+  "_objectsInArraysAreSorted": [ {
+    "a": 1,
+    "b": 2
+  } ],
   "a": 3,
   "c": 4,
   "x": 5,

--- a/testlib/src/main/resources/json/sortByKeysBefore.json
+++ b/testlib/src/main/resources/json/sortByKeysBefore.json
@@ -15,5 +15,11 @@
         3,
         2,
         1
+    ],
+    "_objectsInArraysAreSorted": [
+        {
+            "b": 2,
+            "a": "1"
+        }
     ]
 }

--- a/testlib/src/main/resources/json/sortByKeysBefore.json
+++ b/testlib/src/main/resources/json/sortByKeysBefore.json
@@ -19,7 +19,7 @@
     "_objectsInArraysAreSorted": [
         {
             "b": 2,
-            "a": "1"
+            "a": 1
         }
     ]
 }


### PR DESCRIPTION
Hi team!
I'd like to propose an improvement of JSON formatting feature implemented in https://github.com/diffplug/spotless/pull/1125
Now, if `sortByKeys` is enabled, objects are recursively sorted but arrays are skipped. Take a look at this JSON for example:
```json
{
  "array": [
    {
      "b": "b",
      "a": "a"
    }
  ]
}
```
Note that keys are not sorted now and will not be sorted after applying the formatter. My proposal is to sort these keys too.
I'm not sure whether existing configuration property should be reused as this changes the behaviour of GSON formatter. If it's not acceptable I can add another property like `sortByKeysInArrays` to preserve backwards compatibility. When we choose which one is better, I'll certainly add some tests.
Let me know, what do you think about it.