### PR TITLE
Respect `sourceDirectory` & `testSourceDirectory` configs for Java formatters

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * A synthesis log with the number of considered files is added after each formatter execution ([#1507](https://github.com/diffplug/spotless/pull/1507))
+### Fixed
+* Respect `sourceDirectory` and `testSourceDirectory` POM configurations for Java formatters ([#1553](https://github.com/diffplug/spotless/pull/1553))
 ### Changes
 * **POTENTIALLY BREAKING** `sortByKeys` for JSON formatting now takes into account objects inside arrays ([#1546](https://github.com/diffplug/spotless/pull/1546))
 * Any commit of the Spotless maven plugin now available via JitPack ([#1547](https://github.com/diffplug/spotless/pull/1547))

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -320,7 +320,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	private Set<String> getIncludes(FormatterFactory formatterFactory) {
 		Set<String> configuredIncludes = formatterFactory.includes();
-		Set<String> includes = configuredIncludes.isEmpty() ? formatterFactory.defaultIncludes() : configuredIncludes;
+		Set<String> includes = configuredIncludes.isEmpty() ? formatterFactory.defaultIncludes(project) : configuredIncludes;
 		if (includes.isEmpty()) {
 			throw new PluginException("You must specify some files to include, such as '<includes><include>src/**/*.blah</include></includes>'");
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 import com.diffplug.common.collect.Sets;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
@@ -71,7 +72,7 @@ public abstract class FormatterFactory {
 
 	private ToggleOffOn toggle;
 
-	public abstract Set<String> defaultIncludes();
+	public abstract Set<String> defaultIncludes(MavenProject project);
 
 	public abstract String licenseHeaderDelimiter();
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/antlr4/Antlr4.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/antlr4/Antlr4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.diffplug.spotless.maven.antlr4;
 
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.common.collect.ImmutableSet;
 import com.diffplug.spotless.antlr4.Antlr4Defaults;
 import com.diffplug.spotless.maven.FormatterFactory;
@@ -30,7 +32,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
  */
 public class Antlr4 extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return ImmutableSet.of(Antlr4Defaults.includes());
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/Cpp.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/Cpp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.cpp;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.cpp.CppDefaults;
 import com.diffplug.spotless.maven.FormatterFactory;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
@@ -30,7 +32,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
  */
 public class Cpp extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Format.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Format.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.generic;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 
 /**
@@ -29,7 +31,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Format extends FormatterFactory {
 
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/groovy/Groovy.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/groovy/Groovy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.diffplug.spotless.maven.groovy;
 
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.common.collect.ImmutableSet;
 import com.diffplug.spotless.maven.FormatterFactory;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
@@ -33,7 +35,7 @@ public class Groovy extends FormatterFactory {
 	private static final String LICENSE_HEADER_DELIMITER = "package ";
 
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return DEFAULT_INCLUDES;
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Java.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Java.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,17 @@
  */
 package com.diffplug.spotless.maven.java;
 
-import java.util.Set;
+import static java.util.stream.Collectors.toSet;
 
-import com.diffplug.common.collect.ImmutableSet;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
 
@@ -29,12 +37,17 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
  */
 public class Java extends FormatterFactory {
 
-	private static final Set<String> DEFAULT_INCLUDES = ImmutableSet.of("src/main/java/**/*.java", "src/test/java/**/*.java");
 	private static final String LICENSE_HEADER_DELIMITER = "package ";
 
 	@Override
-	public Set<String> defaultIncludes() {
-		return DEFAULT_INCLUDES;
+	public Set<String> defaultIncludes(MavenProject project) {
+		Path projectDir = project.getBasedir().toPath();
+		Build build = project.getBuild();
+		return Stream.of(build.getSourceDirectory(), build.getTestSourceDirectory())
+				.map(Paths::get)
+				.map(projectDir::relativize)
+				.map(Java::fileMask)
+				.collect(toSet());
 	}
 
 	@Override
@@ -64,5 +77,13 @@ public class Java extends FormatterFactory {
 
 	public void addFormatAnnotations(FormatAnnotations formatAnnotations) {
 		addStepFactory(formatAnnotations);
+	}
+
+	private static String fileMask(Path path) {
+		String dir = path.toString();
+		if (!dir.endsWith(File.separator)) {
+			dir += File.separator;
+		}
+		return dir + "**" + File.separator + "*.java";
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/javascript/Javascript.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/javascript/Javascript.java
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.javascript;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 
 /**
@@ -27,7 +29,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
  */
 public class Javascript extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.json;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 
 /**
@@ -27,7 +29,7 @@ public class Json extends FormatterFactory {
 	public static final int DEFAULT_INDENTATION = 4;
 
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Kotlin.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Kotlin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import static com.diffplug.spotless.kotlin.KotlinConstants.LICENSE_HEADER_DELIMI
 
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.common.collect.ImmutableSet;
 import com.diffplug.spotless.maven.FormatterFactory;
 
@@ -27,7 +29,7 @@ public class Kotlin extends FormatterFactory {
 	private static final Set<String> DEFAULT_INCLUDES = ImmutableSet.of("src/main/kotlin/**/*.kt", "src/test/kotlin/**/*.kt");
 
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return DEFAULT_INCLUDES;
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.markdown;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
 
@@ -29,7 +31,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
  */
 public class Markdown extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/pom/Pom.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/pom/Pom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.diffplug.spotless.maven.pom;
 
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.common.collect.ImmutableSet;
 import com.diffplug.spotless.maven.FormatterFactory;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
@@ -29,7 +31,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
  */
 public class Pom extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return ImmutableSet.of("pom.xml");
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/python/Python.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/python/Python.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.python;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 import com.diffplug.spotless.maven.generic.LicenseHeader;
 
@@ -30,7 +32,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
 public class Python extends FormatterFactory {
 
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/scala/Scala.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/scala/Scala.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package com.diffplug.spotless.maven.scala;
 
 import java.util.Set;
+
+import org.apache.maven.project.MavenProject;
 
 import com.diffplug.common.collect.ImmutableSet;
 import com.diffplug.spotless.maven.FormatterFactory;
@@ -34,7 +36,7 @@ public class Scala extends FormatterFactory {
 	private static final String LICENSE_HEADER_DELIMITER = "package ";
 
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return DEFAULT_INCLUDES;
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/sql/Sql.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/sql/Sql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.sql;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 
 /**
@@ -27,7 +29,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
  */
 public class Sql extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/typescript/Typescript.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/typescript/Typescript.java
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.typescript;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 
 /**
@@ -27,7 +29,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
  */
 public class Typescript extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/yaml/Yaml.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/yaml/Yaml.java
@@ -18,6 +18,8 @@ package com.diffplug.spotless.maven.yaml;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.maven.project.MavenProject;
+
 import com.diffplug.spotless.maven.FormatterFactory;
 
 /**
@@ -25,7 +27,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
  */
 public class Yaml extends FormatterFactory {
 	@Override
-	public Set<String> defaultIncludes() {
+	public Set<String> defaultIncludes(MavenProject project) {
 		return Collections.emptySet();
 	}
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -54,7 +54,9 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	 */
 	private static final String SPOTLESS_MAVEN_VERSION_IDE = null;
 
+	private static final String POM_TEMPLATE = "/pom-test.xml.mustache";
 	private static final String SPOTLESS_MAVEN_PLUGIN_VERSION = "spotlessMavenPluginVersion";
+	private static final String BUILD = "build";
 	private static final String CONFIGURATION = "configuration";
 	private static final String EXECUTIONS = "executions";
 	private static final String MODULES = "modules";
@@ -209,16 +211,21 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	}
 
 	protected String createPomXmlContent(String pluginVersion, String[] executions, String[] configuration, String[] dependencies, String[] plugins) throws IOException {
-		return createPomXmlContent("/pom-test.xml.mustache", pluginVersion, executions, configuration, dependencies, plugins);
+		return createPomXmlContent(POM_TEMPLATE, pluginVersion, executions, configuration, dependencies, plugins);
 	}
 
 	protected String createPomXmlContent(String pomTemplate, String pluginVersion, String[] executions, String[] configuration, String[] dependencies, String[] plugins) throws IOException {
-		Map<String, Object> params = buildPomXmlParams(pluginVersion, executions, configuration, null, dependencies, plugins);
+		Map<String, Object> params = buildPomXmlParams(pluginVersion, null, executions, configuration, null, dependencies, plugins);
 		return createPomXmlContent(pomTemplate, params);
 	}
 
 	protected String createPomXmlContent(String pluginVersion, String[] executions, String[] configuration) throws IOException {
 		return createPomXmlContent(pluginVersion, executions, configuration, null, null);
+	}
+
+	protected String createPomXmlContent(String[] build, String[] configuration) throws IOException {
+		Map<String, Object> params = buildPomXmlParams(null, build, null, configuration, null, null, null);
+		return createPomXmlContent(POM_TEMPLATE, params);
 	}
 
 	protected String createPomXmlContent(String pomTemplate, Map<String, Object> params) throws IOException {
@@ -231,9 +238,13 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		}
 	}
 
-	protected static Map<String, Object> buildPomXmlParams(String pluginVersion, String[] executions, String[] configuration, String[] modules, String[] dependencies, String[] plugins) {
+	protected static Map<String, Object> buildPomXmlParams(String pluginVersion, String[] build, String[] executions, String[] configuration, String[] modules, String[] dependencies, String[] plugins) {
 		Map<String, Object> params = new HashMap<>();
 		params.put(SPOTLESS_MAVEN_PLUGIN_VERSION, pluginVersion == null ? getSystemProperty(SPOTLESS_MAVEN_PLUGIN_VERSION) : pluginVersion);
+
+		if (build != null) {
+			params.put(BUILD, String.join("\n", build));
+		}
 
 		if (configuration != null) {
 			params.put(CONFIGURATION, String.join("\n", configuration));

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
@@ -145,7 +145,7 @@ class MultiModuleProjectTest extends MavenIntegrationHarness {
 			modulesList.addAll(subProjects.keySet());
 			String[] modules = modulesList.toArray(new String[0]);
 
-			Map<String, Object> rootPomParams = buildPomXmlParams(null, null, configuration, modules, null, null);
+			Map<String, Object> rootPomParams = buildPomXmlParams(null, null, null, configuration, modules, null, null);
 			setFile("pom.xml").toContent(createPomXmlContent("/multi-module/pom-parent.xml.mustache", rootPomParams));
 		}
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/JavaDefaultIncludesTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/JavaDefaultIncludesTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.java;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+public class JavaDefaultIncludesTest extends MavenIntegrationHarness {
+
+	private static final String UNFORMATTED = "java/removeunusedimports/JavaCodeWithPackageUnformatted.test";
+	private static final String FORMATTED = "java/removeunusedimports/JavaCodeWithPackageFormatted.test";
+
+	private static final String FILE_1 = "src/main/java/com/diffplug/spotless/One.java";
+	private static final String FILE_2 = "src/test/java/com/diffplug/spotless/Two.java";
+	private static final String FILE_3 = "src/com/diffplug/spotless/Three.java";
+	private static final String FILE_4 = "test/com/diffplug/spotless/Four.java";
+	private static final String FILE_5 = "foo/bar/Five.java";
+
+	@BeforeEach
+	void beforeEach() {
+		for (String file : Arrays.asList(FILE_1, FILE_2, FILE_3, FILE_4, FILE_5)) {
+			setFile(file).toResource(UNFORMATTED);
+		}
+	}
+
+	@Test
+	void noCustomConfiguration() throws Exception {
+		writePomWithBuildConfiguration();
+
+		mavenRunner().withArguments("spotless:apply").runNoError();
+
+		// Files 1, 2 are formatted because they live under default Maven source & test source dirs
+		assertFile(FILE_1).sameAsResource(FORMATTED);
+		assertFile(FILE_2).sameAsResource(FORMATTED);
+
+		// Files 3, 4, 5 are not formatted because they live outside default Maven source & test source dirs
+		assertFile(FILE_3).sameAsResource(UNFORMATTED);
+		assertFile(FILE_4).sameAsResource(UNFORMATTED);
+		assertFile(FILE_5).sameAsResource(UNFORMATTED);
+	}
+
+	@Test
+	void customSourceDirConfiguration() throws Exception {
+		writePomWithBuildConfiguration("<sourceDirectory>src</sourceDirectory>");
+
+		mavenRunner().withArguments("spotless:apply").runNoError();
+
+		// Files 1, 2, 3 are formatted because they live under the custom-configured source dir
+		assertFile(FILE_1).sameAsResource(FORMATTED);
+		assertFile(FILE_2).sameAsResource(FORMATTED);
+		assertFile(FILE_3).sameAsResource(FORMATTED);
+
+		// File 4, 5 are not formatted because they live outside the custom-configured source dir and default test source dir
+		assertFile(FILE_4).sameAsResource(UNFORMATTED);
+		assertFile(FILE_5).sameAsResource(UNFORMATTED);
+	}
+
+	@Test
+	void customTestSourceDirConfiguration() throws Exception {
+		writePomWithBuildConfiguration("<testSourceDirectory>test</testSourceDirectory>");
+
+		mavenRunner().withArguments("spotless:apply").runNoError();
+
+		// File 1 is formatted because it lives under the default source dir
+		assertFile(FILE_1).sameAsResource(FORMATTED);
+		// File 4 is formatted because it lives under the custom-configured test source dir
+		assertFile(FILE_4).sameAsResource(FORMATTED);
+
+		// Files 2, 3, 5 are not formatted because they live outside the default source dir and custom-configured test source dir
+		assertFile(FILE_2).sameAsResource(UNFORMATTED);
+		assertFile(FILE_3).sameAsResource(UNFORMATTED);
+		assertFile(FILE_5).sameAsResource(UNFORMATTED);
+	}
+
+	@Test
+	void customSourceDirAndTestSourceDirConfiguration() throws Exception {
+		writePomWithBuildConfiguration(
+				"<sourceDirectory>src</sourceDirectory>",
+				"<testSourceDirectory>test</testSourceDirectory>");
+
+		mavenRunner().withArguments("spotless:apply").runNoError();
+
+		// Files 1, 2, 3, 4 are formatted because they live under custom-configured source and test source dirs
+		assertFile(FILE_1).sameAsResource(FORMATTED);
+		assertFile(FILE_2).sameAsResource(FORMATTED);
+		assertFile(FILE_3).sameAsResource(FORMATTED);
+		assertFile(FILE_4).sameAsResource(FORMATTED);
+
+		// File 5 is not formatted because it lives outside custom-configured source and test source dirs
+		assertFile(FILE_5).sameAsResource(UNFORMATTED);
+	}
+
+	@Test
+	void sameCustomSourceDirAndTestSourceDirConfiguration() throws Exception {
+		writePomWithBuildConfiguration(
+				"<sourceDirectory>foo/bar</sourceDirectory>",
+				"<testSourceDirectory>foo/bar</testSourceDirectory>");
+
+		mavenRunner().withArguments("spotless:apply").runNoError();
+
+		// Files 1, 2, 3, 4 are not formatted because they live outside custom-configured source and test source dirs
+		assertFile(FILE_1).sameAsResource(UNFORMATTED);
+		assertFile(FILE_2).sameAsResource(UNFORMATTED);
+		assertFile(FILE_3).sameAsResource(UNFORMATTED);
+		assertFile(FILE_4).sameAsResource(UNFORMATTED);
+
+		// File 5 is formatted because it lives under the custom-configured source/test source dir
+		assertFile(FILE_5).sameAsResource(FORMATTED);
+	}
+
+	@Test
+	void nestedCustomSourceDirAndTestSourceDirConfiguration() throws Exception {
+		writePomWithBuildConfiguration(
+				"<sourceDirectory>foo</sourceDirectory>",
+				"<testSourceDirectory>foo/bar</testSourceDirectory>");
+
+		mavenRunner().withArguments("spotless:apply").runNoError();
+
+		// Files 1, 2, 3, 4 are not formatted because they live outside custom-configured source and test source dirs
+		assertFile(FILE_1).sameAsResource(UNFORMATTED);
+		assertFile(FILE_2).sameAsResource(UNFORMATTED);
+		assertFile(FILE_3).sameAsResource(UNFORMATTED);
+		assertFile(FILE_4).sameAsResource(UNFORMATTED);
+
+		// File 5 is formatted because it lives under the custom-configured source/test source dir
+		assertFile(FILE_5).sameAsResource(FORMATTED);
+	}
+
+	private void writePomWithBuildConfiguration(String... build) throws IOException {
+		String xml = createPomXmlContent(build, new String[]{"<java>", "<removeUnusedImports/>", "</java>"});
+		setFile("pom.xml").toContent(xml);
+	}
+}

--- a/plugin-maven/src/test/resources/pom-test.xml.mustache
+++ b/plugin-maven/src/test/resources/pom-test.xml.mustache
@@ -20,6 +20,7 @@
     </properties>
 
     <build>
+        {{{build}}}
         <plugins>
             {{{plugins}}}
             <plugin>


### PR DESCRIPTION
Change Java formatters in the Maven plugin to respect `sourceDirectory` and `testSourceDirectory`. These are standard `<build>` configuration options to support projects with non-standard directory layout.

Maven plugin will now use `sourceDirectory` and `testSourceDirectory` to determine default include file masks for Java files. It will not use these configurations if an explicit `<includes>` configuration is present.

This change should be backward-compatible because Maven's default `sourceDirectory` and `testSourceDirectory` match the previously hardcoded default includes.

Closes https://github.com/diffplug/spotless/issues/1214.