### PR TITLE
Switch from System.err to SLF4J

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ import org.eclipse.jgit.lib.CoreConfig.EOL;
 import org.eclipse.jgit.storage.file.FileBasedConfig;
 import org.eclipse.jgit.util.FS;
 import org.eclipse.jgit.util.SystemReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.googlecode.concurrenttrees.radix.ConcurrentRadixTree;
 import com.googlecode.concurrenttrees.radix.node.concrete.DefaultCharSequenceNodeFactory;
@@ -61,6 +63,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * back to the platform native.
  */
 public final class GitAttributesLineEndings {
+	private static final Logger LOGGER = LoggerFactory.getLogger(GitAttributesLineEndings.class);
+
 	// prevent direct instantiation
 	private GitAttributesLineEndings() {}
 
@@ -261,7 +265,7 @@ public final class GitAttributesLineEndings {
 			case "crlf":
 				return LineEnding.WINDOWS.str();
 			default:
-				System.err.println(".gitattributes file has unspecified eol value: " + eol + " for " + file + ", defaulting to platform native");
+				LOGGER.warn(".gitattributes file has unspecified eol value: {} for {}, defaulting to platform native", eol, file);
 				return LineEnding.PLATFORM_NATIVE.str();
 			}
 		}
@@ -341,8 +345,7 @@ public final class GitAttributesLineEndings {
 				return parsed.getRules();
 			} catch (IOException e) {
 				// no need to crash the whole plugin
-				System.err.println("Problem parsing " + file.getAbsolutePath());
-				e.printStackTrace();
+				LOGGER.warn("Problem parsing {}", file.getAbsolutePath(), e);
 			}
 		}
 		return Collections.emptyList();

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -31,6 +31,9 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -42,6 +45,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Prefixes a license header before the package statement. */
 public final class LicenseHeaderStep {
+	private static final Logger LOGGER = LoggerFactory.getLogger(LicenseHeaderStep.class);
+
 	public enum YearMode {
 		PRESERVE, UPDATE_TO_TODAY, SET_FROM_GIT
 	}
@@ -381,7 +386,7 @@ public final class LicenseHeaderStep {
 					}
 				}
 			} else {
-				System.err.println("Can't parse copyright year '" + content + "', defaulting to " + yearToday);
+				LOGGER.warn("Can't parse copyright year '{}', defaulting to {}", content, yearToday);
 				// couldn't recognize the year format
 				return yearToday;
 			}

--- a/lib/src/main/java/com/diffplug/spotless/java/ModuleHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ModuleHelper.java
@@ -75,7 +75,7 @@ final class ModuleHelper {
 				}
 			}
 		} catch (Throwable e) {
-			LOGGER.error("WARNING: Failed to check for unavailable JDK packages.", e);
+			LOGGER.error("WARNING: Failed to check for available JDK packages.", e);
 		}
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/java/ModuleHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ModuleHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,17 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.diffplug.spotless.Jvm;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import sun.misc.Unsafe;
 
 final class ModuleHelper {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ModuleHelper.class);
+
 	// prevent direct instantiation
 	private ModuleHelper() {}
 
@@ -66,11 +71,11 @@ final class ModuleHelper {
 					for (String name : failedToOpen) {
 						message.append(String.format("--add-opens jdk.compiler/%s=ALL-UNNAMED", name));
 					}
-					System.err.println(message);
+					LOGGER.warn("{}", message);
 				}
 			}
 		} catch (Throwable e) {
-			System.err.println("WARNING: Failed to check for unavailable JDK packages. Reason: " + e.getMessage());
+			LOGGER.error("WARNING: Failed to check for unavailable JDK packages.", e);
 		}
 	}
 


### PR DESCRIPTION
In a few cases, Spotless reports logs in System.err instead of SLF4J. While SLF4J seems not a lot used in the project, I feel awkward to get these System.err in logs.

e.g.:

> Can't parse copyright year '', defaulting to 2023

I cleaned a few related cases.

I did not change IdeHook as it seems on purpose relying on System.out/System.err. It makes me think other unexpected System.err (like in licenseHeader) may pollute IdeHook.