### PR TITLE
Skip signature on SNAPSHOT

### DIFF
--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -170,11 +170,11 @@ model {
 	}
 }
 
-if (System.env['JITPACK'] == 'true') {
+if (System.env['JITPACK'] == 'true' || version.endsWith('-SNAPSHOT')) {
 	signing {
 		setRequired(false)
 	}
-} else if (!version.endsWith('-SNAPSHOT')) {
+} else {
 	signing {
 		String gpg_key = decode64('ORG_GRADLE_PROJECT_gpg_key64')
 		useInMemoryPgpKeys(gpg_key, System.env['ORG_GRADLE_PROJECT_gpg_passphrase'])


### PR DESCRIPTION
With this, I'm able to run `./gradlew publishToMavenLocal` (else it fails on `:plugin-gradle:signPluginMavenPublication FAILED`)