### PR TITLE
fixes continuation indent in ktfmt default formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Maven plugin with `ktfmt` default style uses correct continuation indent ([#1562](https://github.com/diffplug/spotless/pull/1562))
 
 ## [2.34.1] - 2023-02-05
 ### Changes

--- a/lib/src/ktfmt/java/com/diffplug/spotless/glue/ktfmt/KtfmtFormatterFunc.java
+++ b/lib/src/ktfmt/java/com/diffplug/spotless/glue/ktfmt/KtfmtFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/ktfmt/java/com/diffplug/spotless/glue/ktfmt/KtfmtFormatterFunc.java
+++ b/lib/src/ktfmt/java/com/diffplug/spotless/glue/ktfmt/KtfmtFormatterFunc.java
@@ -78,7 +78,7 @@ public final class KtfmtFormatterFunc implements FormatterFunc {
 					formattingOptions.getStyle(),
 					ktfmtFormattingOptions.getMaxWidth().orElse(formattingOptions.getMaxWidth()),
 					ktfmtFormattingOptions.getBlockIndent().orElse(formattingOptions.getBlockIndent()),
-					ktfmtFormattingOptions.getContinuationIndent().orElse(formattingOptions.getBlockIndent()),
+					ktfmtFormattingOptions.getContinuationIndent().orElse(formattingOptions.getContinuationIndent()),
 					ktfmtFormattingOptions.getRemoveUnusedImport().orElse(formattingOptions.getRemoveUnusedImports()),
 					formattingOptions.getDebuggingPrintOpsAfterFormatting());
 		}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Maven plugin with `ktfmt` default style uses correct continuation indent ([#1562](https://github.com/diffplug/spotless/pull/1562))
 
 ## [6.14.1] - 2023-02-05
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Maven plugin with `ktfmt` default style uses correct continuation indent ([#1562](https://github.com/diffplug/spotless/pull/1562))
 
 ## [2.32.0] - 2023-02-05
 ### Added

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtfmtTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtfmtTest.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
 
-import java.io.IOException;
-
 class KtfmtTest extends MavenIntegrationHarness {
 	@Test
 	void testKtfmt() throws Exception {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtfmtTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtfmtTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
 
+import java.io.IOException;
+
 class KtfmtTest extends MavenIntegrationHarness {
 	@Test
 	void testKtfmt() throws Exception {
@@ -34,6 +36,15 @@ class KtfmtTest extends MavenIntegrationHarness {
 
 		assertFile(path1).sameAsResource("kotlin/ktfmt/basic.clean");
 		assertFile(path2).sameAsResource("kotlin/ktfmt/basic.clean");
+	}
+
+	@Test
+	void testContinuation() throws Exception {
+		writePomWithKotlinSteps("<ktfmt/>");
+
+		setFile("src/main/kotlin/main.kt").toResource("kotlin/ktfmt/continuation.dirty");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile("src/main/kotlin/main.kt").sameAsResource("kotlin/ktfmt/continuation.clean");
 	}
 
 	@Test

--- a/testlib/src/main/resources/kotlin/ktfmt/continuation.clean
+++ b/testlib/src/main/resources/kotlin/ktfmt/continuation.clean
@@ -1,0 +1,6 @@
+fun myFunction() {
+  val location =
+      restTemplate.postForLocation(
+          "/v1/my-api", mapOf("name" to "some-name", "url" to "https://www.google.com"))
+  return location
+}

--- a/testlib/src/main/resources/kotlin/ktfmt/continuation.dirty
+++ b/testlib/src/main/resources/kotlin/ktfmt/continuation.dirty
@@ -1,0 +1,4 @@
+fun myFunction() {
+    val location = restTemplate.postForLocation("/v1/my-api", mapOf("name" to "some-name", "url" to "https://www.google.com"))
+    return location
+}


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
