### PR TITLE
Update Cleanthat to 2.2. Tests workaround lack of OptionalNotEmpty

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/java/CleanthatJavaStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/CleanthatJavaStep.java
@@ -40,7 +40,7 @@ public final class CleanthatJavaStep {
 	private static final String MAVEN_COORDINATE = "io.github.solven-eu.cleanthat:java";
 
 	// CleanThat changelog is available at https://github.com/solven-eu/cleanthat/blob/master/CHANGES.MD
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "2.1");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "2.2");
 
 	// prevent direct instantiation
 	private CleanthatJavaStep() {}
@@ -71,8 +71,7 @@ public final class CleanthatJavaStep {
 	 * @return
 	 */
 	public static List<String> defaultMutators() {
-		// see JavaRefactorerProperties.WILDCARD
-		return List.of("*");
+		return List.of("eu.solven.cleanthat.engine.java.refactorer.mutators.composite.SafeAndConsensualMutators");
 	}
 
 	/** Creates a step which apply selected CleanThat mutators. */

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Bump default `cleanthat` version to latest `2.1` -> `2.2` ([#1569](https://github.com/diffplug/spotless/pull/1569))
 
 ## [6.15.0] - 2023-02-10
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -19,6 +19,7 @@ import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElem
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -283,9 +284,9 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 		private String sourceJdk = CleanthatJavaStep.defaultSourceJdk();
 
-		private List<String> mutators = CleanthatJavaStep.defaultMutators();
+		private List<String> mutators = new ArrayList<>(CleanthatJavaStep.defaultMutators());
 
-		private List<String> excludedMutators = CleanthatJavaStep.defaultExcludedMutators();
+		private List<String> excludedMutators = new ArrayList<>(CleanthatJavaStep.defaultExcludedMutators());
 
 		CleanthatJavaConfig() {
 			addStep(createStep());
@@ -319,10 +320,16 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			return this;
 		}
 
-		// The fully qualified name of a class implementing eu.solven.cleanthat.engine.java.refactorer.meta.IMutator
-		// or '*' to include all default mutators
+		// An id of a mutator (see IMutator.getIds()) or
+		// tThe fully qualified name of a class implementing eu.solven.cleanthat.engine.java.refactorer.meta.IMutator
 		public CleanthatJavaConfig addMutator(String mutator) {
 			this.mutators.add(mutator);
+			replaceStep(createStep());
+			return this;
+		}
+
+		public CleanthatJavaConfig addMutators(Collection<String> mutators) {
+			this.mutators.addAll(mutators);
 			replaceStep(createStep());
 			return this;
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/CleanthatJavaIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/CleanthatJavaIntegrationTest.java
@@ -31,7 +31,9 @@ class CleanthatJavaIntegrationTest extends GradleIntegrationHarness {
 				"spotless {",
 				"    java {",
 				"        target file('test.java')",
-				"        cleanthat().sourceCompatibility('11')",
+				"        cleanthat()" +
+				"          .sourceCompatibility('11')",
+				"          .addMutators(['LiteralsFirstInComparisons', 'OptionalNotEmpty'])",
 				"    }",
 				"}");
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/CleanthatJavaIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/CleanthatJavaIntegrationTest.java
@@ -31,7 +31,7 @@ class CleanthatJavaIntegrationTest extends GradleIntegrationHarness {
 				"spotless {",
 				"    java {",
 				"        target file('test.java')",
-				"        cleanthat()" +
+				"        cleanthat()",
 				"          .sourceCompatibility('11')",
 				"          .addMutators(['LiteralsFirstInComparisons', 'OptionalNotEmpty'])",
 				"    }",

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+* Bump default `cleanthat` version to latest `2.1` -> `2.2` ([#1569](https://github.com/diffplug/spotless/pull/1569))
 
 ## [2.33.0] - 2023-02-10
 ### Added

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
@@ -29,6 +29,9 @@ class CleanthatJavaRefactorerTest extends MavenIntegrationHarness {
 	void testLiteralsFirstInComparisons() throws Exception {
 		writePomWithJavaSteps(
 				"<cleanthat>",
+				"  <mutators>",
+				"    <mutator>LiteralsFirstInComparisons</mutator>",
+				"  </mutators>",
 				"</cleanthat>");
 
 		runTest("LiteralsFirstInComparisons.dirty.java", "LiteralsFirstInComparisons.clean.java");
@@ -36,8 +39,13 @@ class CleanthatJavaRefactorerTest extends MavenIntegrationHarness {
 
 	@Test
 	void testMultipleMutators_defaultIsJdk7() throws Exception {
+		// OptionalNotEmpty will be excluded as it is not compatible with JDK7
 		writePomWithJavaSteps(
 				"<cleanthat>",
+				"  <mutators>",
+				"    <mutator>LiteralsFirstInComparisons</mutator>",
+				"    <mutator>OptionalNotEmpty</mutator>",
+				"  </mutators>",
 				"</cleanthat>");
 
 		runTest("MultipleMutators.dirty.java", "MultipleMutators.clean.onlyLiteralsFirst.java");
@@ -47,7 +55,11 @@ class CleanthatJavaRefactorerTest extends MavenIntegrationHarness {
 	void testMultipleMutators_Jdk11IntroducedOptionalisPresent() throws Exception {
 		writePomWithJavaSteps(
 				"<cleanthat>",
-				"<sourceJdk>11</sourceJdk>",
+				"  <sourceJdk>11</sourceJdk>",
+				"  <mutators>",
+				"    <mutator>LiteralsFirstInComparisons</mutator>",
+				"    <mutator>OptionalNotEmpty</mutator>",
+				"  </mutators>",
 				"</cleanthat>");
 
 		runTest("MultipleMutators.dirty.java", "MultipleMutators.clean.java");
@@ -57,6 +69,10 @@ class CleanthatJavaRefactorerTest extends MavenIntegrationHarness {
 	void testExcludeOptionalNotEmpty() throws Exception {
 		writePomWithJavaSteps(
 				"<cleanthat>",
+				"  <mutators>",
+				"    <mutator>LiteralsFirstInComparisons</mutator>",
+				"    <mutator>OptionalNotEmpty</mutator>",
+				"  </mutators>",
 				"  <excludedMutators>",
 				"    <excludedMutator>OptionalNotEmpty</excludedMutator>",
 				"  </excludedMutators>",


### PR DESCRIPTION
Upgrade CleanThat to 2.2.

Leave the not-consensual '*' by default (activating all available mutators), to the safer and more consensual [SafeAndConsensualMutators](https://github.com/solven-eu/cleanthat/blob/master/java/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/composite/SafeAndConsensualMutators.java)

https://github.com/solven-eu/cleanthat/blob/master/CHANGES.MD