### PR TITLE
README.md: Added missing parenthesis at ktfmt example code

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -363,6 +363,8 @@ spotless { // if you are using build.gradle.kts, instead of 'spotless {' use:
 spotless {
   kotlin {
     ktfmt('0.30').dropboxStyle() // version and dropbox style are optional
+  }
+}
 ```
 
 <a name="applying-ktlint-to-kotlin-files"></a>


### PR DESCRIPTION
Simple change at documentation "README.md" file.

There was just a very simple syntax error where some closing parenthesis were missing.