### PR TITLE
Add cleanthat to spotless config

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -17,6 +17,7 @@ spotless {
 		java {
 			ratchetFrom 'origin/main'
 			bumpThisNumberIfACustomStepChanges(1)
+			cleanthat().version("2.4").sourceCompatibility("11").clearMutators().addMutators(['RSPEC-6212'])
 			licenseHeaderFile rootProject.file('gradle/spotless.license')
 			importOrderFile   rootProject.file('gradle/spotless.importorder')
 			eclipse().configFile rootProject.file('gradle/spotless.eclipseformat.xml')


### PR DESCRIPTION
This refers to https://github.com/diffplug/spotless/issues/1532, considering `var` usage enforcement.

It does not implement `unless the line has a comment` part of the spec. I wonder how much this is a strict requirement. (Also, does it include comment before the variable declaration ? What if the variable declaration stands on multiple rows?)

This fails with spotless-gradle 6.15.0 ; the fix is pending for next spotless-gradle release.