### PR TITLE
Run with build cache by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: spotlessCheck
-        run: ./gradlew spotlessCheck --build-cache
+        run: ./gradlew spotlessCheck
       - name: assemble testClasses
-        run: ./gradlew assemble testClasses --build-cache
+        run: ./gradlew assemble testClasses
   build:
     needs: sanityCheck
     strategy:
@@ -71,13 +71,13 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: build (maven-only)
         if: matrix.kind == 'maven'
-        run: ./gradlew :plugin-maven:build -x spotlessCheck --build-cache
+        run: ./gradlew :plugin-maven:build -x spotlessCheck
       - name: build (everything-but-maven)
         if: matrix.kind == 'gradle'
-        run: ./gradlew build -x spotlessCheck --build-cache -PSPOTLESS_EXCLUDE_MAVEN=true
+        run: ./gradlew build -x spotlessCheck -PSPOTLESS_EXCLUDE_MAVEN=true
       - name: test npm
         if: matrix.kind == 'npm'
-        run: ./gradlew testNpm --build-cache
+        run: ./gradlew testNpm
       - name: junit result
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails


### PR DESCRIPTION
- Enable `--stacktrace` and `--info` flags for all `GradleRunner`s, easy to get more valuable info from test failures.
- Remove extra `--build-cache` flags on CI, cause I enabled caching in a9ad736a7b73d0edcbec17603091af0de4bdbf6d.