### PR TITLE
Enable up-to-date checking in Maven plugin by default

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,6 +7,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * You can now put the filename into a license header template with `$FILE`. ([#1605](https://github.com/diffplug/spotless/pull/1605) fixes [#1147](https://github.com/diffplug/spotless/issues/1147))
 ### Fixed
 * `licenseHeader` default pattern for Java files is updated to `(package|import|public|class|module) `. ([#1614](https://github.com/diffplug/spotless/pull/1614))
+### Changes
+* Enable incremental up-to-date checking by default. ([#1621](https://github.com/diffplug/spotless/pull/1621))
 
 ## [2.34.0] - 2023-02-27
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1262,7 +1262,7 @@ To define what lines to skip at the beginning of such files, fill the `skipLines
 
 ## Incremental up-to-date checking and formatting
 
-**This feature is turned off by default.**
+**This feature is enabled by default starting from version 2.35.0.**
 
 Execution of `spotless:check` and `spotless:apply` for large projects can take time.
 By default, Spotless Maven plugin needs to read and format each source file.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -187,7 +187,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	private String setLicenseHeaderYearsFromGitHistory;
 
 	@Parameter
-	private UpToDateChecking upToDateChecking;
+	private UpToDateChecking upToDateChecking = UpToDateChecking.enabled();
 
 	protected abstract void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException;
 
@@ -373,9 +373,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		}
 		final UpToDateChecker checker;
 		if (upToDateChecking != null && upToDateChecking.isEnabled()) {
-			getLog().info("Up-to-date checking enabled");
 			checker = UpToDateChecker.forProject(project, indexFile, formatters, getLog());
 		} else {
+			getLog().info("Up-to-date checking disabled");
 			checker = UpToDateChecker.noop(project, indexFile, getLog());
 		}
 		return UpToDateChecker.wrapWithBuildContext(checker, buildContext);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecking.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,5 +37,11 @@ public class UpToDateChecking {
 	@Nullable
 	public Path getIndexFile() {
 		return indexFile == null ? null : new File(indexFile).toPath();
+	}
+
+	public static UpToDateChecking enabled() {
+		UpToDateChecking upToDateChecking = new UpToDateChecking();
+		upToDateChecking.enabled = true;
+		return upToDateChecking;
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MultiModuleProjectTest.java
@@ -32,31 +32,31 @@ class MultiModuleProjectTest extends MavenIntegrationHarness {
 	@Test
 	void testConfigurationDependency() throws Exception {
 		/*
-		create a multi-module project with the following stucture:
+		create a multi-module project with the following structure:
 
 		    /junit-tmp-dir
 		    ├── config
-		    │   ├── pom.xml
-		    │   └── src/main/resources/configs
-		    │       ├── eclipse-formatter.xml
-		    │       └── scalafmt.conf
+		    │   ├── pom.xml
+		    │   └── src/main/resources/configs
+		    │       ├── eclipse-formatter.xml
+		    │       └── scalafmt.conf
 		    ├── mvnw
 		    ├── mvnw.cmd
 		    ├── one
-		    │   ├── pom.xml
-		    │   └── src
-		    │       ├── main/java/test1.java
-		    │       └── test/java/test2.java
+		    │   ├── pom.xml
+		    │   └── src
+		    │       ├── main/java/test1.java
+		    │       └── test/java/test2.java
 		    ├── two
-		    │   ├── pom.xml
-		    │   └── src
-		    │       ├── main/java/test1.java
-		    │       └── test/java/test2.java
+		    │   ├── pom.xml
+		    │   └── src
+		    │       ├── main/java/test1.java
+		    │       └── test/java/test2.java
 		    ├── three
-		    │   ├── pom.xml
-		    │   └── src
-		    │       ├── main/scala/test1.scala
-		    │       └── test/scala/test2.scala
+		    │   ├── pom.xml
+		    │   └── src
+		    │       ├── main/scala/test1.scala
+		    │       └── test/scala/test2.scala
 		    ├── pom.xml
 		    ├── .mvn
 		    ├── mvnw

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
@@ -31,8 +31,10 @@ import com.diffplug.spotless.maven.MavenRunner;
 
 class UpToDateCheckingTest extends MavenIntegrationHarness {
 
+	private static final String DISABLED_MESSAGE = "Up-to-date checking disabled";
+
 	@Test
-	void upToDateCheckingDisabledByDefault() throws Exception {
+	void upToDateCheckingEnabledByDefault() throws Exception {
 		writePom(
 				"<java>",
 				"  <googleJavaFormat/>",
@@ -41,18 +43,29 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 		List<File> files = writeUnformattedFiles(1);
 		String output = runSpotlessApply();
 
-		assertThat(output).doesNotContain("Up-to-date checking enabled");
+		assertThat(output).doesNotContain(DISABLED_MESSAGE);
 		assertFormatted(files);
 	}
 
 	@Test
-	void enableUpToDateChecking() throws Exception {
+	void explicitlyEnableUpToDateChecking() throws Exception {
 		writePomWithUpToDateCheckingEnabled(true);
 
 		List<File> files = writeUnformattedFiles(1);
 		String output = runSpotlessApply();
 
-		assertThat(output).contains("Up-to-date checking enabled");
+		assertThat(output).doesNotContain(DISABLED_MESSAGE);
+		assertFormatted(files);
+	}
+
+	@Test
+	void explicitlyDisableUpToDateChecking() throws Exception {
+		writePomWithUpToDateCheckingEnabled(false);
+
+		List<File> files = writeUnformattedFiles(1);
+		String output = runSpotlessApply();
+
+		assertThat(output).contains(DISABLED_MESSAGE);
 		assertFormatted(files);
 	}
 
@@ -63,7 +76,7 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 		List<File> files = writeUnformattedFiles(1);
 		String output = runSpotlessApply();
 
-		assertThat(output).contains("Up-to-date checking enabled");
+		assertThat(output).doesNotContain(DISABLED_MESSAGE);
 		assertFormatted(files);
 	}
 
@@ -76,40 +89,7 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 		List<File> files = writeUnformattedFiles(1);
 		String output = runSpotlessApply();
 
-		assertThat(output).contains("Up-to-date checking enabled");
-		assertFormatted(files);
-	}
-
-	private void writePomWithPluginManagementAndDependency() throws IOException {
-		setFile("pom.xml").toContent(createPomXmlContent("/pom-test-management.xml.mustache",
-				null,
-				null,
-				new String[]{
-						"<java>",
-						"  <googleJavaFormat/>",
-						"</java>",
-						"<upToDateChecking>",
-						"  <enabled>true</enabled>",
-						"</upToDateChecking>"},
-				new String[]{
-						"<dependencies>",
-						"  <dependency>",
-						"    <groupId>javax.inject</groupId>",
-						"    <artifactId>javax.inject</artifactId>",
-						"    <version>1</version>",
-						"  </dependency>",
-						"</dependencies>"},
-				null));
-	}
-
-	@Test
-	void disableUpToDateChecking() throws Exception {
-		writePomWithUpToDateCheckingEnabled(false);
-
-		List<File> files = writeUnformattedFiles(1);
-		String output = runSpotlessApply();
-
-		assertThat(output).doesNotContain("Up-to-date checking enabled");
+		assertThat(output).doesNotContain(DISABLED_MESSAGE);
 		assertFormatted(files);
 	}
 
@@ -124,7 +104,7 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 		List<File> files = writeUnformattedFiles(1);
 		String output = runSpotlessApply();
 
-		assertThat(output).contains("Up-to-date checking enabled");
+		assertThat(output).doesNotContain(DISABLED_MESSAGE);
 		assertFormatted(files);
 		assertThat(indexFile.getParent()).exists();
 		assertThat(indexFile).exists();
@@ -143,7 +123,7 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 		List<File> files = writeUnformattedFiles(1);
 		String output = runSpotlessApply();
 
-		assertThat(output).doesNotContain("Up-to-date checking enabled");
+		assertThat(output).contains(DISABLED_MESSAGE);
 		assertFormatted(files);
 		assertThat(indexFile.getParent()).exists();
 		assertThat(indexFile).doesNotExist();
@@ -213,6 +193,25 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 
 		String checkOutput3 = runSpotlessCheck();
 		assertSpotlessCheckSkipped(files, checkOutput3);
+	}
+
+	private void writePomWithPluginManagementAndDependency() throws IOException {
+		setFile("pom.xml").toContent(createPomXmlContent("/pom-test-management.xml.mustache",
+				null,
+				null,
+				new String[]{
+						"<java>",
+						"  <googleJavaFormat/>",
+						"</java>"},
+				new String[]{
+						"<dependencies>",
+						"  <dependency>",
+						"    <groupId>javax.inject</groupId>",
+						"    <artifactId>javax.inject</artifactId>",
+						"    <version>1</version>",
+						"  </dependency>",
+						"</dependencies>"},
+				null));
 	}
 
 	private void writePomWithUpToDateCheckingEnabled(boolean enabled) throws IOException {


### PR DESCRIPTION
Up-to-date checking has been supported for a long time. We haven't received any negative feedback about it. Neo4j is an example project that has up-to-date checking enabled to improve performance and haven't had problems with it: [link](https://github.com/neo4j/neo4j/blob/6ebc409772cea13354adb6a11aab4ed38da9d53e/pom.xml#L745-L747).

It should be safe to enable up-to-date checking for all users of the Spotless Maven plugin.

This PR also fixes a problem where plugin execution would fail on a parent of a multimodule Maven project with up-to-date checking enabled. A parent project can configure Spotless as:

```xml
<build>
  <pluginManagement>
    <plugins>
      <plugin>
        <groupId>com.diffplug.spotless</groupId>
        <artifactId>spotless-maven-plugin</artifactId>
        ...
      </plugin>
    </plugins>
  </pluginManagement>
</build>
```

It allows child projects to inherit plugin's version and configuration but the plugin is not enables by default.

`PluginFingerprint` did not handle such configuration correctly. It could only handle a simple configuration like:

```xml
<build>
  <plugins>
    <plugin>
      <groupId>com.diffplug.spotless</groupId>
      <artifactId>spotless-maven-plugin</artifactId>
      ...
    </plugin>
  </plugins>
</build>
```

And failed with "Spotless plugin absent from the project" error for a multimodule parent project with Spotless in `<pluginManagement>`.