### PR TITLE
Make sure the order of formatters is deterministic, fixes #1642

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changes
 * **POTENTIALLY BREAKING** Drop support for `googleJavaFormat` versions &lt; `1.8`. ([#1630](https://github.com/diffplug/spotless/pull/1630))
 * Bump default `googleJavaFormat` version `1.15.0` -> `1.16.0`. ([#1630](https://github.com/diffplug/spotless/pull/1630))
+* Fix non deterministic computation of cache fingerprint when using multiple formatters. ([#1643](https://github.com/diffplug/spotless/pull/1643) fixes [#1642](https://github.com/diffplug/spotless/pull/1642))
 
 ## [2.35.0] - 2023-03-13
 ### Added

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -211,7 +212,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		List<FormatterFactory> formatterFactories = getFormatterFactories();
 		FormatterConfig config = getFormatterConfig();
 
-		Map<FormatterFactory, Supplier<Iterable<File>>> formatterFactoryToFiles = new HashMap<>();
+		Map<FormatterFactory, Supplier<Iterable<File>>> formatterFactoryToFiles = new LinkedHashMap<>();
 		for (FormatterFactory formatterFactory : formatterFactories) {
 			Supplier<Iterable<File>> filesToFormat = () -> collectFiles(formatterFactory, config);
 			formatterFactoryToFiles.put(formatterFactory, filesToFormat);

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
@@ -17,6 +17,7 @@ package com.diffplug.spotless.maven;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -33,7 +34,7 @@ class FormattersHolder implements AutoCloseable {
 	}
 
 	static FormattersHolder create(Map<FormatterFactory, Supplier<Iterable<File>>> formatterFactoryToFiles, FormatterConfig config) {
-		Map<Formatter, Supplier<Iterable<File>>> formatterToFiles = new HashMap<>();
+		Map<Formatter, Supplier<Iterable<File>>> formatterToFiles = new LinkedHashMap<>();
 		try {
 			for (Entry<FormatterFactory, Supplier<Iterable<File>>> entry : formatterFactoryToFiles.entrySet()) {
 				FormatterFactory formatterFactory = entry.getKey();

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormattersHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.diffplug.spotless.maven;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;


### PR DESCRIPTION
This PR fixes #1642 which causes the serialised fingerprint to not be deterministic, as it depends on the order in which the map holding the formatters is iterated.
Using a `LinkedHashMap` to hold the `Formatter` list solves the problem.

@nedtwigg