### PR TITLE
Adding back the "style" option in Palantir Java Format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support configuration of mirrors for P2 repositories in `EquoBasedStepBuilder` ([#1629](https://github.com/diffplug/spotless/issues/1629)).
+* The `style` option in Palantir Java Format ([#1654](https://github.com/diffplug/spotless/pull/1654)).
 ### Changes
 * **POTENTIALLY BREAKING** Converted `googleJavaFormat` to a compile-only dependency and drop support for versions &lt; `1.8`. ([#1630](https://github.com/diffplug/spotless/pull/1630))
 * Bump default `googleJavaFormat` version `1.15.0` -> `1.16.0`. ([#1630](https://github.com/diffplug/spotless/pull/1630))

--- a/lib/src/palantirJavaFormat/java/com/diffplug/spotless/glue/pjf/PalantirJavaFormatFormatterFunc.java
+++ b/lib/src/palantirJavaFormat/java/com/diffplug/spotless/glue/pjf/PalantirJavaFormatFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,16 +26,19 @@ public class PalantirJavaFormatFormatterFunc implements FormatterFunc {
 
 	private final Formatter formatter;
 
-	public PalantirJavaFormatFormatterFunc() {
+	private final JavaFormatterOptions.Style formatterStyle;
+
+	public PalantirJavaFormatFormatterFunc(String style) {
+		this.formatterStyle = JavaFormatterOptions.Style.valueOf(style);
 		formatter = Formatter.createFormatter(JavaFormatterOptions.builder()
-				.style(JavaFormatterOptions.Style.PALANTIR)
+				.style(formatterStyle)
 				.build());
 	}
 
 	@Override
 	public String apply(String input) throws Exception {
 		String source = input;
-		source = ImportOrderer.reorderImports(source, JavaFormatterOptions.Style.PALANTIR);
+		source = ImportOrderer.reorderImports(source, formatterStyle);
 		source = RemoveUnusedImports.removeUnusedImports(source);
 		return formatter.formatSource(source);
 	}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -14,6 +14,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   ```
   Mirrors are selected by prefix match, for example `https://download.eclipse.org/eclipse/updates/4.26/` will be redirected to `https://some.internal.mirror/eclipse/eclipse/updates/4.26/`.
   The same configuration exists for `greclipse` and `eclipseCdt`.
+* The `style` option in Palantir Java Format ([#1654](https://github.com/diffplug/spotless/pull/1654)).
 ### Changes
 * **POTENTIALLY BREAKING** Drop support for `googleJavaFormat` versions &lt; `1.8`. ([#1630](https://github.com/diffplug/spotless/pull/1630))
 * Bump default `googleJavaFormat` version `1.15.0` -> `1.16.0`. ([#1630](https://github.com/diffplug/spotless/pull/1630))

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -200,8 +200,8 @@ spotless {
 spotless {
   java {
     palantirJavaFormat()
-    // optional: you can specify a specific version
-    palantirJavaFormat('2.9.0')
+    // optional: you can specify a specific version and/or switch to AOSP/GOOGLE style
+    palantirJavaFormat('2.9.0').style("GOOGLE")
 ```
 
 ### eclipse jdt

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -198,14 +198,22 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 	public class PalantirJavaFormatConfig {
 		final String version;
+		String style;
 
 		PalantirJavaFormatConfig(String version) {
 			this.version = Objects.requireNonNull(version);
+			this.style = PalantirJavaFormatStep.defaultStyle();
 			addStep(createStep());
 		}
 
+		public PalantirJavaFormatConfig style(String style) {
+			this.style = Objects.requireNonNull(style);
+			replaceStep(createStep());
+			return this;
+		}
+
 		private FormatterStep createStep() {
-			return PalantirJavaFormatStep.create(version, provisioner());
+			return PalantirJavaFormatStep.create(version, style, provisioner());
 		}
 	}
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* The `style` option in Palantir Java Format ([#1654](https://github.com/diffplug/spotless/pull/1654)).
 ### Changes
 * **POTENTIALLY BREAKING** Drop support for `googleJavaFormat` versions &lt; `1.8`. ([#1630](https://github.com/diffplug/spotless/pull/1630))
 * Bump default `googleJavaFormat` version `1.15.0` -> `1.16.0`. ([#1630](https://github.com/diffplug/spotless/pull/1630))

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -228,6 +228,7 @@ any other maven phase (i.e. compile) then it can be configured as below;
 ```xml
 <palantirJavaFormat>
   <version>2.10.0</version>                     <!-- optional -->
+  <style>PALANTIR</style>                       <!-- or AOSP/GOOGLE (optional) -->
 </palantirJavaFormat>
 ```
 

--- a/testlib/src/main/resources/java/palantirjavaformat/JavaCodeFormattedGoogle.test
+++ b/testlib/src/main/resources/java/palantirjavaformat/JavaCodeFormattedGoogle.test
@@ -1,0 +1,11 @@
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+  public static void main(String[] args) {
+    System.out.println(
+        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+    UsedB.someMethod();
+    UsedA.someMethod();
+  }
+}

--- a/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithLicenseFormattedGoogle.test
+++ b/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithLicenseFormattedGoogle.test
@@ -1,0 +1,16 @@
+/*
+ * Some license stuff.
+ * Very official.
+ */
+
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+  public static void main(String[] args) {
+    System.out.println(
+        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+    UsedB.someMethod();
+    UsedA.someMethod();
+  }
+}

--- a/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithPackageFormattedGoogle.test
+++ b/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithPackageFormattedGoogle.test
@@ -1,0 +1,13 @@
+package hello.world;
+
+import mylib.UsedA;
+import mylib.UsedB;
+
+public class Java {
+  public static void main(String[] args) {
+    System.out.println(
+        "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+    UsedB.someMethod();
+    UsedA.someMethod();
+  }
+}

--- a/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
@@ -55,9 +55,19 @@ class PalantirJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
+	void behaviorWithGoogleStyle() throws Exception {
+		FormatterStep step = PalantirJavaFormatStep.create("1.1.0", "GOOGLE", TestProvisioner.mavenCentral());
+		StepHarness.forStep(step)
+				.testResource("java/palantirjavaformat/JavaCodeUnformatted.test", "java/palantirjavaformat/JavaCodeFormattedGoogle.test")
+				.testResource("java/palantirjavaformat/JavaCodeWithLicenseUnformatted.test", "java/palantirjavaformat/JavaCodeWithLicenseFormattedGoogle.test")
+				.testResource("java/palantirjavaformat/JavaCodeWithPackageUnformatted.test", "java/palantirjavaformat/JavaCodeWithPackageFormattedGoogle.test");
+	}
+
+	@Test
 	void equality() {
 		new SerializableEqualityTester() {
 			String version = "1.1.0";
+			String style = "";
 
 			@Override
 			protected void setupTest(API api) {
@@ -66,12 +76,15 @@ class PalantirJavaFormatStepTest extends ResourceHarness {
 				// change the version, and it's different
 				version = "1.0.0";
 				api.areDifferentThan();
+				// change the style, and it's different
+				style = "AOSP";
+				api.areDifferentThan();
 			}
 
 			@Override
 			protected FormatterStep create() {
 				String finalVersion = this.version;
-				return PalantirJavaFormatStep.create(finalVersion, TestProvisioner.mavenCentral());
+				return PalantirJavaFormatStep.create(finalVersion, style, TestProvisioner.mavenCentral());
 			}
 		}.testEquals();
 	}


### PR DESCRIPTION
This change adds back the `style` option in Palantir Java Format, which was deleted in https://github.com/diffplug/spotless/pull/1083/commits/0d83dca8cc087a2773d1202ccf84e58a54d65631#diff-830a5283700594009966a40d62e47a1df49c3f685f111cbd1e078b6d43e9a0f6 .

The motivation is that our group in LinkedIn wants to use Palantir Java Format with a 2/4 indentation (2 spaces for indentation and 4 for a new line) instead of the default 4/8. This can be achieved by exposing the `style` option and feeding in the `GOOGLE` style.