### PR TITLE
Add @DisableCachingByDefault as hint why outputs are not cached

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -19,6 +19,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   Mirrors are selected by prefix match, for example `https://download.eclipse.org/eclipse/updates/4.26/` will be redirected to `https://some.internal.mirror/eclipse/eclipse/updates/4.26/`.
   The same configuration exists for `greclipse` and `eclipseCdt`.
 * The `style` option in Palantir Java Format ([#1654](https://github.com/diffplug/spotless/pull/1654)).
+* Added `@DisableCachingByDefault` to `RegisterDependenciesTask`.
+
 ### Fixed
 * Stop using deprecated conventions when used in Gradle >= `7.1`. ([#1618](https://github.com/diffplug/spotless/pull/1618))
 ### Changes

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Added `@DisableCachingByDefault` to `RegisterDependenciesTask`.
 
 ## [6.18.0] - 2023-04-06
 ### Added
@@ -19,7 +21,6 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   Mirrors are selected by prefix match, for example `https://download.eclipse.org/eclipse/updates/4.26/` will be redirected to `https://some.internal.mirror/eclipse/eclipse/updates/4.26/`.
   The same configuration exists for `greclipse` and `eclipseCdt`.
 * The `style` option in Palantir Java Format ([#1654](https://github.com/diffplug/spotless/pull/1654)).
-* Added `@DisableCachingByDefault` to `RegisterDependenciesTask`.
 ### Fixed
 * Stop using deprecated conventions when used in Gradle >= `7.1`. ([#1618](https://github.com/diffplug/spotless/pull/1618))
 ### Changes

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -20,7 +20,6 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   The same configuration exists for `greclipse` and `eclipseCdt`.
 * The `style` option in Palantir Java Format ([#1654](https://github.com/diffplug/spotless/pull/1654)).
 * Added `@DisableCachingByDefault` to `RegisterDependenciesTask`.
-
 ### Fixed
 * Stop using deprecated conventions when used in Gradle >= `7.1`. ([#1618](https://github.com/diffplug/spotless/pull/1618))
 ### Changes

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -47,7 +47,7 @@ import com.diffplug.spotless.FormatterStep;
  * - When this "registerDependencies" task does its up-to-date check, it queries the task execution graph to see which
  *   SpotlessTasks are at risk of being executed, and causes them all to be evaluated safely in the root buildscript.
  */
-@DisableCachingByDefault(because = "I/O bound task not worth caching")
+@DisableCachingByDefault(because = "This task coordinates the setup and execution of other tasks, and should not be cached")
 public abstract class RegisterDependenciesTask extends DefaultTask {
 	static final String TASK_NAME = "spotlessInternalRegisterDependencies";
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.build.event.BuildEventsListenerRegistry;
+import org.gradle.work.DisableCachingByDefault;
 
 import com.diffplug.common.base.Preconditions;
 import com.diffplug.common.io.Files;
@@ -46,6 +47,7 @@ import com.diffplug.spotless.FormatterStep;
  * - When this "registerDependencies" task does its up-to-date check, it queries the task execution graph to see which
  *   SpotlessTasks are at risk of being executed, and causes them all to be evaluated safely in the root buildscript.
  */
+@DisableCachingByDefault(because = "I/O bound task not worth caching")
 public abstract class RegisterDependenciesTask extends DefaultTask {
 	static final String TASK_NAME = "spotlessInternalRegisterDependencies";
 


### PR DESCRIPTION
The `@DisableCachingByDefault` annotation ([JavaDoc](https://docs.gradle.org/current/javadoc/org/gradle/work/DisableCachingByDefault.html)) will make it easier to determine why this task was not cached when inspecting a Build Scan. 

Without this annotation, a gradle Build Scan will only show a generic message:
![image](https://user-images.githubusercontent.com/317179/230329636-ed95e742-bda5-48dd-b839-89ec8ea2e2b3.png)

With the annotation, the Build Scan will show a more useful hint as to why this task was not cached:

![image](https://user-images.githubusercontent.com/317179/230336153-daceef03-a44d-41e3-808b-320d1c7e515c.png)
