### PR TITLE
docs: fix typo in scalafmt configuration

### DIFF
--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -458,7 +458,7 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 <scalafmt>
   <version>3.5.9</version>              <!-- optional -->
   <file>${project.basedir}/scalafmt.conf</file> <!-- optional -->
-  <majorScalaVersion>2.13</majorScalaVersion> <!-- optional -->
+  <scalaMajorVersion>2.13</scalaMajorVersion> <!-- optional -->
 </scalafmt>
 ```
 


### PR DESCRIPTION
Everything is in the title, there was a typo in scalafmt configuration example: `majorScalaVersion` vs. `scalaMajorVersion`.

I did not update the CHANGELOG for this but I can if you feel it's better.