### PR TITLE
If `EquoBasedStepBuilder.get` fails, indicate the formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ### Added
 * `Jvm.Support` now accepts `-SNAPSHOT` versions, treated as the non`-SNAPSHOT`. ([#1583](https://github.com/diffplug/spotless/issues/1583))
+### Fixed
+* When P2 download fails, indicate the responsible formatter. ([#1698](https://github.com/diffplug/spotless/issues/1698))
 
 ## [2.38.0] - 2023-04-06
 ### Added

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.extra;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +37,7 @@ import dev.equo.solstice.NestedJars;
 import dev.equo.solstice.p2.P2ClientCache;
 import dev.equo.solstice.p2.P2Model;
 import dev.equo.solstice.p2.P2QueryCache;
+import dev.equo.solstice.p2.P2QueryResult;
 
 /**
  * Generic Eclipse based formatter step {@link State} builder.
@@ -100,7 +102,12 @@ public abstract class EquoBasedStepBuilder {
 
 	/** Creates the state of the configuration. */
 	EquoBasedStepBuilder.State get() throws Exception {
-		var query = createModelWithMirrors().query(P2ClientCache.PREFER_OFFLINE, P2QueryCache.ALLOW);
+		P2QueryResult query;
+		try {
+			query = createModelWithMirrors().query(P2ClientCache.PREFER_OFFLINE, P2QueryCache.ALLOW);
+		} catch (Exception x) {
+			throw new IOException("Failed to load " + formatterName + ": " + x, x);
+		}
 		var classpath = new ArrayList<File>();
 		var mavenDeps = new ArrayList<String>();
 		mavenDeps.add("dev.equo.ide:solstice:1.0.3");

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 * Added `@DisableCachingByDefault` to `RegisterDependenciesTask`.
+* When P2 download fails, indicate the responsible formatter. ([#1698](https://github.com/diffplug/spotless/issues/1698))
 
 ## [6.18.0] - 2023-04-06
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 * `palantir` step now accepts a `style` parameter, which is documentation had already claimed to do. ([#1694](https://github.com/diffplug/spotless/pull/1694))
+* When P2 download fails, indicate the responsible formatter. ([#1698](https://github.com/diffplug/spotless/issues/1698))
 
 ## [2.36.0] - 2023-04-06
 ### Added


### PR DESCRIPTION
Produce a better error message and stack trace for the Maven plugin when P2 downloads fail. Used to investigate https://github.com/diffplug/spotless/issues/1697#issuecomment-1542081765.

----

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
