### PR TITLE
Add semantics-aware sorting for Java imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * `Jvm.Support` now accepts `-SNAPSHOT` versions, treated as the non`-SNAPSHOT`. ([#1583](https://github.com/diffplug/spotless/issues/1583))
 * Support Rome as a formatter for JavaScript and TypeScript code. Adds a new `rome` step to `javascript` and `typescript` formatter configurations. ([#1663](https://github.com/diffplug/spotless/pull/1663))
+* Add semantics-aware Java import ordering (i.e. sort by package, then class, then member). ([#522](https://github.com/diffplug/spotless/issues/522))
 ### Fixed
 * When P2 download fails, indicate the responsible formatter. ([#1698](https://github.com/diffplug/spotless/issues/1698))
 * Fixed a regression which changed the import sorting order in `googleJavaFormat` introduced in `2.38.0`. ([#1680](https://github.com/diffplug/spotless/pull/1680))

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,6 +40,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public final class ImportOrderStep {
 	private static final boolean WILDCARDS_LAST_DEFAULT = false;
+	private static final boolean SEMANTIC_SORT_DEFAULT = true;
+	private static final Set<String> TREAT_AS_PACKAGE_DEFAULT = null;
+	private static final Set<String> TREAT_AS_CLASS_DEFAULT = null;
 
 	private final String lineFormat;
 
@@ -55,27 +59,34 @@ public final class ImportOrderStep {
 	}
 
 	public FormatterStep createFrom(String... importOrder) {
-		return createFrom(WILDCARDS_LAST_DEFAULT, importOrder);
+		return createFrom(WILDCARDS_LAST_DEFAULT, SEMANTIC_SORT_DEFAULT, TREAT_AS_PACKAGE_DEFAULT,
+				TREAT_AS_CLASS_DEFAULT, importOrder);
 	}
 
-	public FormatterStep createFrom(boolean wildcardsLast, String... importOrder) {
+	public FormatterStep createFrom(boolean wildcardsLast, boolean semanticSort, Set<String> treatAsPackage,
+			Set<String> treatAsClass, String... importOrder) {
 		// defensive copying and null checking
 		List<String> importOrderList = requireElementsNonNull(Arrays.asList(importOrder));
-		return createFrom(wildcardsLast, () -> importOrderList);
+		return createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass, () -> importOrderList);
 	}
 
 	public FormatterStep createFrom(File importsFile) {
-		return createFrom(WILDCARDS_LAST_DEFAULT, importsFile);
+		return createFrom(WILDCARDS_LAST_DEFAULT, SEMANTIC_SORT_DEFAULT, TREAT_AS_PACKAGE_DEFAULT,
+				TREAT_AS_CLASS_DEFAULT, importsFile);
 	}
 
-	public FormatterStep createFrom(boolean wildcardsLast, File importsFile) {
+	public FormatterStep createFrom(boolean wildcardsLast, boolean semanticSort, Set<String> treatAsPackage,
+			Set<String> treatAsClass, File importsFile) {
 		Objects.requireNonNull(importsFile);
-		return createFrom(wildcardsLast, () -> getImportOrder(importsFile));
+		return createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass, () -> getImportOrder(importsFile));
 	}
 
-	private FormatterStep createFrom(boolean wildcardsLast, Supplier<List<String>> importOrder) {
+	private FormatterStep createFrom(boolean wildcardsLast, boolean semanticSort, Set<String> treatAsPackage,
+			Set<String> treatAsClass, Supplier<List<String>> importOrder) {
 		return FormatterStep.createLazy("importOrder",
-				() -> new State(importOrder.get(), lineFormat, wildcardsLast),
+				() -> new State(importOrder.get(), lineFormat, wildcardsLast, semanticSort,
+						treatAsPackage == null ? Set.of() : treatAsPackage,
+						treatAsClass == null ? Set.of() : treatAsClass),
 				State::toFormatter);
 	}
 
@@ -106,15 +117,23 @@ public final class ImportOrderStep {
 		private final List<String> importOrder;
 		private final String lineFormat;
 		private final boolean wildcardsLast;
+		private final boolean semanticSort;
+		private final Set<String> treatAsPackage;
+		private final Set<String> treatAsClass;
 
-		State(List<String> importOrder, String lineFormat, boolean wildcardsLast) {
+		State(List<String> importOrder, String lineFormat, boolean wildcardsLast, boolean semanticSort,
+				Set<String> treatAsPackage, Set<String> treatAsClass) {
 			this.importOrder = importOrder;
 			this.lineFormat = lineFormat;
 			this.wildcardsLast = wildcardsLast;
+			this.semanticSort = semanticSort;
+			this.treatAsPackage = treatAsPackage;
+			this.treatAsClass = treatAsClass;
 		}
 
 		FormatterFunc toFormatter() {
-			return raw -> new ImportSorter(importOrder, wildcardsLast).format(raw, lineFormat);
+			return raw -> new ImportSorter(importOrder, wildcardsLast, semanticSort, treatAsPackage, treatAsClass)
+					.format(raw, lineFormat);
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -42,8 +42,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public final class ImportOrderStep {
 	private static final boolean WILDCARDS_LAST_DEFAULT = false;
 	private static final boolean SEMANTIC_SORT_DEFAULT = false;
-	private static final Set<String> TREAT_AS_PACKAGE_DEFAULT = null;
-	private static final Set<String> TREAT_AS_CLASS_DEFAULT = null;
+	private static final Set<String> TREAT_AS_PACKAGE_DEFAULT = Set.of();
+	private static final Set<String> TREAT_AS_CLASS_DEFAULT = Set.of();
 
 	private final String lineFormat;
 

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,7 +41,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public final class ImportOrderStep {
 	private static final boolean WILDCARDS_LAST_DEFAULT = false;
-	private static final boolean SEMANTIC_SORT_DEFAULT = true;
+	private static final boolean SEMANTIC_SORT_DEFAULT = false;
 	private static final Set<String> TREAT_AS_PACKAGE_DEFAULT = null;
 	private static final Set<String> TREAT_AS_CLASS_DEFAULT = null;
 
@@ -84,9 +85,8 @@ public final class ImportOrderStep {
 	private FormatterStep createFrom(boolean wildcardsLast, boolean semanticSort, Set<String> treatAsPackage,
 			Set<String> treatAsClass, Supplier<List<String>> importOrder) {
 		return FormatterStep.createLazy("importOrder",
-				() -> new State(importOrder.get(), lineFormat, wildcardsLast, semanticSort,
-						treatAsPackage == null ? Set.of() : treatAsPackage,
-						treatAsClass == null ? Set.of() : treatAsClass),
+				() -> new State(importOrder.get(), lineFormat, wildcardsLast, semanticSort, treatAsPackage,
+						treatAsClass),
 				State::toFormatter);
 	}
 
@@ -118,8 +118,8 @@ public final class ImportOrderStep {
 		private final String lineFormat;
 		private final boolean wildcardsLast;
 		private final boolean semanticSort;
-		private final Set<String> treatAsPackage;
-		private final Set<String> treatAsClass;
+		private final TreeSet<String> treatAsPackage;
+		private final TreeSet<String> treatAsClass;
 
 		State(List<String> importOrder, String lineFormat, boolean wildcardsLast, boolean semanticSort,
 				Set<String> treatAsPackage, Set<String> treatAsClass) {
@@ -127,8 +127,8 @@ public final class ImportOrderStep {
 			this.lineFormat = lineFormat;
 			this.wildcardsLast = wildcardsLast;
 			this.semanticSort = semanticSort;
-			this.treatAsPackage = treatAsPackage;
-			this.treatAsClass = treatAsClass;
+			this.treatAsPackage = treatAsPackage == null ? null : new TreeSet<>(treatAsPackage);
+			this.treatAsClass = treatAsClass == null ? null : new TreeSet<>(treatAsClass);
 		}
 
 		FormatterFunc toFormatter() {

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
@@ -18,6 +18,7 @@ package com.diffplug.spotless.java;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Set;
 
 /**
  * @author Vojtech Krasa
@@ -30,10 +31,17 @@ final class ImportSorter {
 
 	private final List<String> importsOrder;
 	private final boolean wildcardsLast;
+	private final boolean semanticSort;
+	private final Set<String> treatAsPackage;
+	private final Set<String> treatAsClass;
 
-	ImportSorter(List<String> importsOrder, boolean wildcardsLast) {
+	ImportSorter(List<String> importsOrder, boolean wildcardsLast, boolean semanticSort, Set<String> treatAsPackage,
+			Set<String> treatAsClass) {
 		this.importsOrder = new ArrayList<>(importsOrder);
 		this.wildcardsLast = wildcardsLast;
+		this.semanticSort = semanticSort;
+		this.treatAsPackage = treatAsPackage;
+		this.treatAsClass = treatAsClass;
 	}
 
 	String format(String raw, String lineFormat) {
@@ -81,7 +89,8 @@ final class ImportSorter {
 		}
 		scanner.close();
 
-		List<String> sortedImports = ImportSorterImpl.sort(imports, importsOrder, wildcardsLast, lineFormat);
+		List<String> sortedImports = ImportSorterImpl.sort(imports, importsOrder, wildcardsLast, semanticSort,
+				treatAsPackage, treatAsClass, lineFormat);
 		return applyImportsToDocument(raw, firstImportLine, lastImportLine, sortedImports);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -291,10 +291,10 @@ final class ImportSorterImpl {
 			 * Ordering uses semantics of the import string by splitting it into package,
 			 * class name(s) and static member (for static imports) and then comparing by
 			 * each of those three substrings in sequence.
-			 * 
+			 *
 			 * When comparing static imports, the last segment in the dot-separated string
 			 * is considered to be the member (field, method, type) name.
-			 * 
+			 *
 			 * The first segment starting with an upper case letter is considered to be the
 			 * (first) class name. Since this comparator has no actual type information,
 			 * this auto-detection will fail for upper case package names and lower case
@@ -359,7 +359,7 @@ final class ImportSorterImpl {
 				member = null;
 			}
 
-			return new String[] { fqcn, member };
+			return new String[]{fqcn, member};
 		}
 
 		/**
@@ -406,7 +406,7 @@ final class ImportSorterImpl {
 				classNames = fqcn.substring(i + 1);
 			}
 
-			return new String[] { packageNames, classNames };
+			return new String[]{packageNames, classNames};
 		}
 
 		/**

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -62,8 +62,10 @@ final class ImportSorterImpl {
 		}
 	}
 
-	static List<String> sort(List<String> imports, List<String> importsOrder, boolean wildcardsLast, String lineFormat) {
-		ImportSorterImpl importsSorter = new ImportSorterImpl(importsOrder, wildcardsLast);
+	static List<String> sort(List<String> imports, List<String> importsOrder, boolean wildcardsLast,
+			boolean semanticSort, Set<String> treatAsPackage, Set<String> treatAsClass, String lineFormat) {
+		ImportSorterImpl importsSorter = new ImportSorterImpl(importsOrder, wildcardsLast, semanticSort, treatAsPackage,
+				treatAsClass);
 		return importsSorter.sort(imports, lineFormat);
 	}
 
@@ -76,12 +78,17 @@ final class ImportSorterImpl {
 		return getResult(sortedImported, lineFormat);
 	}
 
-	private ImportSorterImpl(List<String> importOrder, boolean wildcardsLast) {
+	private ImportSorterImpl(List<String> importOrder, boolean wildcardsLast, boolean semanticSort,
+			Set<String> treatAsPackage, Set<String> treatAsClass) {
 		importsGroups = importOrder.stream().filter(Objects::nonNull).map(ImportsGroup::new).collect(Collectors.toList());
 		putStaticItemIfNotExists(importsGroups);
 		putCatchAllGroupIfNotExists(importsGroups);
 
-		ordering = new OrderingComparator(wildcardsLast);
+		if (semanticSort) {
+			ordering = new SemanticOrderingComparator(wildcardsLast, treatAsPackage, treatAsClass);
+		} else {
+			ordering = new LexicographicalOrderingComparator(wildcardsLast);
+		}
 
 		List<String> subgroups = importsGroups.stream().map(ImportsGroup::getSubGroups).flatMap(Collection::stream).collect(Collectors.toList());
 		this.allImportOrderItems.addAll(subgroups);
@@ -233,30 +240,192 @@ final class ImportSorterImpl {
 		return null;
 	}
 
-	private static class OrderingComparator implements Comparator<String>, Serializable {
+	private static int compareWithWildcare(String string1, String string2, boolean wildcardsLast) {
+		int string1WildcardIndex = string1.indexOf('*');
+		int string2WildcardIndex = string2.indexOf('*');
+		boolean string1IsWildcard = string1WildcardIndex >= 0;
+		boolean string2IsWildcard = string2WildcardIndex >= 0;
+		if (string1IsWildcard == string2IsWildcard) {
+			return string1.compareTo(string2);
+		}
+		int prefixLength = string1IsWildcard ? string1WildcardIndex : string2WildcardIndex;
+		boolean samePrefix = string1.regionMatches(0, string2, 0, prefixLength);
+		if (!samePrefix) {
+			return string1.compareTo(string2);
+		}
+		return (string1IsWildcard == wildcardsLast) ? 1 : -1;
+	}
+
+	private static class LexicographicalOrderingComparator implements Comparator<String>, Serializable {
 		private static final long serialVersionUID = 1;
 
 		private final boolean wildcardsLast;
 
-		private OrderingComparator(boolean wildcardsLast) {
+		private LexicographicalOrderingComparator(boolean wildcardsLast) {
 			this.wildcardsLast = wildcardsLast;
 		}
 
 		@Override
 		public int compare(String string1, String string2) {
-			int string1WildcardIndex = string1.indexOf('*');
-			int string2WildcardIndex = string2.indexOf('*');
-			boolean string1IsWildcard = string1WildcardIndex >= 0;
-			boolean string2IsWildcard = string2WildcardIndex >= 0;
-			if (string1IsWildcard == string2IsWildcard) {
-				return string1.compareTo(string2);
-			}
-			int prefixLength = string1IsWildcard ? string1WildcardIndex : string2WildcardIndex;
-			boolean samePrefix = string1.regionMatches(0, string2, 0, prefixLength);
-			if (!samePrefix) {
-				return string1.compareTo(string2);
-			}
-			return (string1IsWildcard == wildcardsLast) ? 1 : -1;
+			return compareWithWildcare(string1, string2, wildcardsLast);
 		}
+	}
+
+	private static class SemanticOrderingComparator implements Comparator<String>, Serializable {
+		private static final long serialVersionUID = 1;
+
+		private final boolean wildcardsLast;
+		private final Set<String> treatAsPackage;
+		private final Set<String> treatAsClass;
+
+		private SemanticOrderingComparator(boolean wildcardsLast, Set<String> treatAsPackage,
+				Set<String> treatAsClass) {
+			this.wildcardsLast = wildcardsLast;
+			this.treatAsPackage = treatAsPackage;
+			this.treatAsClass = treatAsClass;
+		}
+
+		@Override
+		public int compare(String string1, String string2) {
+			/*
+			 * Ordering uses semantics of the import string by splitting it into package,
+			 * class name(s) and static member (for static imports) and then comparing by
+			 * each of those three substrings in sequence.
+			 * 
+			 * When comparing static imports, the last segment in the dot-separated string
+			 * is considered to be the member (field, method, type) name.
+			 * 
+			 * The first segment starting with an upper case letter is considered to be the
+			 * (first) class name. Since this comparator has no actual type information,
+			 * this auto-detection will fail for upper case package names and lower case
+			 * class names. treatAsPackage and treatAsClass can be used respectively to
+			 * provide hints to the auto-detection.
+			 */
+			if (string1.startsWith(STATIC_KEYWORD)) {
+				String[] split = splitFqcnAndMember(string1);
+				String fqcn1 = split[0];
+				String member1 = split[1];
+
+				split = splitFqcnAndMember(string2);
+				String fqcn2 = split[0];
+				String member2 = split[1];
+
+				int result = compareFullyQualifiedClassName(fqcn1, fqcn2);
+				if (result != 0)
+					return result;
+
+				return compareWithWildcare(member1, member2, wildcardsLast);
+			} else {
+				return compareFullyQualifiedClassName(string1, string2);
+			}
+		}
+
+		/**
+		 * Compares two fully qualified class names by splitting them into package and
+		 * (nested) class names.
+		 */
+		private int compareFullyQualifiedClassName(String fqcn1, String fqcn2) {
+			String[] split = splitPackageAndClasses(fqcn1);
+			String p1 = split[0];
+			String c1 = split[1];
+
+			split = splitPackageAndClasses(fqcn2);
+			String p2 = split[0];
+			String c2 = split[1];
+
+			int result = p1.compareTo(p2);
+			if (result != 0)
+				return result;
+
+			return compareWithWildcare(c1, c2, wildcardsLast);
+		}
+
+		/**
+		 * Splits the provided static import string into fully qualified class name and
+		 * the imported static member (field, method or type).
+		 */
+		private String[] splitFqcnAndMember(String importString) {
+			String s = importString.substring(STATIC_KEYWORD.length()).trim();
+
+			String fqcn;
+			String member;
+
+			int dot = s.lastIndexOf(".");
+			if (!Character.isUpperCase(s.charAt(dot + 1))) {
+				fqcn = s.substring(0, dot);
+				member = s.substring(dot + 1);
+			} else {
+				fqcn = s;
+				member = null;
+			}
+
+			return new String[] { fqcn, member };
+		}
+
+		/**
+		 * Splits the fully qualified class name into package and class name(s).
+		 */
+		private String[] splitPackageAndClasses(String fqcn) {
+			String packageNames = null;
+			String classNames = null;
+
+			/*
+			 * The first segment that starts with an upper case letter starts the class
+			 * name(s), unless it matches treatAsPackage (then it's explicitly declared as
+			 * package via configuration). If no segment starts with an upper case letter
+			 * then the last segment must be a class name (unless the method input is
+			 * garbage).
+			 */
+			int dot = fqcn.indexOf('.');
+			while (dot > -1) {
+				int nextDot = fqcn.indexOf('.', dot + 1);
+				if (nextDot > -1) {
+					if (Character.isUpperCase(fqcn.charAt(dot + 1))) {
+						// if upper case, check if should be treated as package nonetheless
+						if (!treatAsPackage(fqcn.substring(0, nextDot))) {
+							packageNames = fqcn.substring(0, dot);
+							classNames = fqcn.substring(dot + 1);
+							break;
+						}
+					} else {
+						// if lower case, check if should be treated as class nonetheless
+						if (treatAsClass(fqcn.substring(0, nextDot))) {
+							packageNames = fqcn.substring(0, dot);
+							classNames = fqcn.substring(dot + 1);
+							break;
+						}
+					}
+				}
+
+				dot = nextDot;
+			}
+
+			if (packageNames == null) {
+				int i = fqcn.lastIndexOf(".");
+				packageNames = fqcn.substring(0, i);
+				classNames = fqcn.substring(i + 1);
+			}
+
+			return new String[] { packageNames, classNames };
+		}
+
+		/**
+		 * Returns whether the provided prefix matches any entry of
+		 * {@code treatAsPackage}.
+		 */
+		private boolean treatAsPackage(String prefix) {
+			// This would be the place to introduce wild cards or even regex matching.
+			return treatAsPackage.contains(prefix);
+		}
+
+		/**
+		 * Returns whether the provided prefix name matches any entry of
+		 * {@code treatAsClass}.
+		 */
+		private boolean treatAsClass(String prefix) {
+			// This would be the place to introduce wild cards or even regex matching.
+			return treatAsClass.contains(prefix);
+		}
+
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -415,7 +415,7 @@ final class ImportSorterImpl {
 		 */
 		private boolean treatAsPackage(String prefix) {
 			// This would be the place to introduce wild cards or even regex matching.
-			return treatAsPackage.contains(prefix);
+			return treatAsPackage != null && treatAsPackage.contains(prefix);
 		}
 
 		/**
@@ -424,7 +424,7 @@ final class ImportSorterImpl {
 		 */
 		private boolean treatAsClass(String prefix) {
 			// This would be the place to introduce wild cards or even regex matching.
-			return treatAsClass.contains(prefix);
+			return treatAsClass != null && treatAsClass.contains(prefix);
 		}
 
 	}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support Rome as a formatter for JavaScript and TypeScript code. Adds a new `rome` step to `javascript` and `typescript` formatter configurations. ([#1663](https://github.com/diffplug/spotless/pull/1663))
+* Add semantics-aware Java import ordering (i.e. sort by package, then class, then member). ([#522](https://github.com/diffplug/spotless/issues/522))
 ### Fixed
 * Added `@DisableCachingByDefault` to `RegisterDependenciesTask`. ([#1666](https://github.com/diffplug/spotless/pull/1666))
 * When P2 download fails, indicate the responsible formatter. ([#1698](https://github.com/diffplug/spotless/issues/1698))

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -19,10 +19,13 @@ import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElem
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -74,6 +77,9 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		final File importOrderFile;
 
 		boolean wildcardsLast = false;
+		boolean semanticSort = true;
+		Set<String> treatAsPackage = Set.of();
+		Set<String> treatAsClass = Set.of();
 
 		ImportOrderConfig(String[] importOrder) {
 			this.importOrder = importOrder;
@@ -98,12 +104,42 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			return this;
 		}
 
+		public ImportOrderConfig semanticSort() {
+			return semanticSort(true);
+		}
+
+		public ImportOrderConfig semanticSort(boolean semanticSort) {
+			this.semanticSort = semanticSort;
+			replaceStep(createStep());
+			return this;
+		}
+
+		public ImportOrderConfig treatAsPackage(String... treatAsPackage) {
+			return treatAsPackage(Arrays.asList(treatAsPackage));
+		}
+
+		public ImportOrderConfig treatAsPackage(Collection<String> treatAsPackage) {
+			this.treatAsPackage = new HashSet<>(treatAsPackage);
+			replaceStep(createStep());
+			return this;
+		}
+
+		public ImportOrderConfig treatAsClass(String... treatAsClass) {
+			return treatAsClass(Arrays.asList(treatAsClass));
+		}
+		
+		public ImportOrderConfig treatAsClass(Collection<String> treatAsClass) {
+			this.treatAsClass = new HashSet<>(treatAsClass);
+			replaceStep(createStep());
+			return this;
+		}
+		
 		private FormatterStep createStep() {
 			ImportOrderStep importOrderStep = ImportOrderStep.forJava();
 
 			return importOrderFile != null
-					? importOrderStep.createFrom(wildcardsLast, getProject().file(importOrderFile))
-					: importOrderStep.createFrom(wildcardsLast, importOrder);
+					? importOrderStep.createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass, getProject().file(importOrderFile))
+					: importOrderStep.createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass, importOrder);
 		}
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -127,13 +127,13 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		public ImportOrderConfig treatAsClass(String... treatAsClass) {
 			return treatAsClass(Arrays.asList(treatAsClass));
 		}
-		
+
 		public ImportOrderConfig treatAsClass(Collection<String> treatAsClass) {
 			this.treatAsClass = new HashSet<>(treatAsClass);
 			replaceStep(createStep());
 			return this;
 		}
-		
+
 		private FormatterStep createStep() {
 			ImportOrderStep importOrderStep = ImportOrderStep.forJava();
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -77,7 +77,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		final File importOrderFile;
 
 		boolean wildcardsLast = false;
-		boolean semanticSort = true;
+		boolean semanticSort = false;
 		Set<String> treatAsPackage = Set.of();
 		Set<String> treatAsClass = Set.of();
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support Rome as a formatter for JavaScript and TypeScript code. Adds a new `rome` step to `javascript` and `typescript` formatter configurations. ([#1663](https://github.com/diffplug/spotless/pull/1663))
+* Add semantics-aware Java import ordering (i.e. sort by package, then class, then member). ([#522](https://github.com/diffplug/spotless/issues/522))
 ### Fixed
 * `palantir` step now accepts a `style` parameter, which is documentation had already claimed to do. ([#1694](https://github.com/diffplug/spotless/pull/1694))
 * When P2 download fails, indicate the responsible formatter. ([#1698](https://github.com/diffplug/spotless/issues/1698))

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -196,6 +196,13 @@ any other maven phase (i.e. compile) then it can be configured as below;
       <wildcardsLast>false</wildcardsLast> <!-- Optional, default false. Sort wildcard import after specific imports -->
       <order>java|javax,org,com,com.diffplug,,\#com.diffplug,\#</order>  <!-- or use <file>${project.basedir}/eclipse.importorder</file> -->
       <!-- you can use an empty string for all the imports you didn't specify explicitly, '|' to join group without blank line, and '\#` prefix for static imports. -->
+      <semanticSort>false</semanticSort> <!-- Optional, default true. Sort by package, then class, then member (for static imports). Splitting is based on common conventions (packages are lower case, classes start with upper case). Use <treatAsPackage> and <treatAsClass> for exceptions. -->
+      <treatAsPackage> <!-- Packages starting with upper case letters. -->
+        <package>com.example.MyPackage</package>
+      </treatAsPackage>
+      <treatAsClass> <!-- Classes starting with lower case letters. -->
+        <class>com.example.myClass</class>
+      </treatAsClass>
     </importOrder>
 
     <removeUnusedImports /> <!-- self-explanatory -->

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
@@ -16,6 +16,8 @@
 package com.diffplug.spotless.maven.java;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -34,17 +36,43 @@ public class ImportOrder implements FormatterStepFactory {
 	@Parameter
 	private boolean wildcardsLast = false;
 
+	/**
+	 * Whether imports should be sorted based on semantics (i.e. sorted by package,
+	 * class and then static member). This considers <code>treatAsPackage</code> and
+	 * <code>treatAsClass</code>, and assumes default upper and lower case
+	 * conventions otherwise. When turned off, imports are sorted purely
+	 * lexicographically.
+	 */
+	@Parameter
+	private boolean semanticSort = true;
+
+	/**
+	 * The prefixes that should be treated as packages for
+	 * <code>semanticSort</code>. Useful for upper case package names.
+	 */
+	@Parameter
+	private Set<String> treatAsPackage = new HashSet<>();
+
+	/**
+	 * The prefixes that should be treated as classes for
+	 * <code>semanticSort</code>. Useful for lower case class names.
+	 */
+	@Parameter
+	private Set<String> treatAsClass = new HashSet<>();
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		if (file != null ^ order != null) {
 			if (file != null) {
 				File importsFile = config.getFileLocator().locateFile(file);
-				return ImportOrderStep.forJava().createFrom(wildcardsLast, importsFile);
+				return ImportOrderStep.forJava().createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass,
+						importsFile);
 			} else {
-				return ImportOrderStep.forJava().createFrom(wildcardsLast, order.split(",", -1));
+				return ImportOrderStep.forJava().createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass,
+						order.split(",", -1));
 			}
 		} else if (file == null && order == null) {
-			return ImportOrderStep.forJava().createFrom(wildcardsLast);
+			return ImportOrderStep.forJava().createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass);
 		} else {
 			throw new IllegalArgumentException("Must specify exactly one of 'file' or 'order'.");
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ImportOrder.java
@@ -44,7 +44,7 @@ public class ImportOrder implements FormatterStepFactory {
 	 * lexicographically.
 	 */
 	@Parameter
-	private boolean semanticSort = true;
+	private boolean semanticSort = false;
 
 	/**
 	 * The prefixes that should be treated as packages for

--- a/testlib/src/main/resources/java/importsorter/JavaCodeSortedLexicographic.test
+++ b/testlib/src/main/resources/java/importsorter/JavaCodeSortedLexicographic.test
@@ -1,0 +1,13 @@
+import static com.example.Test.*;
+import static com.example.Test.A_CONST;
+import static com.example.Test.Nested.B_CONST;
+import static com.example.Test.Z_CONST;
+
+import com.example.Test;
+import com.example.Test.*;
+import com.example.Test.Nested;
+import com.example.a.A;
+import com.example.b;
+import com.example.c.C;
+import com.sun.jna.platform.win32.COM.Unknown;
+import com.sun.jna.platform.win32.Guid.CLSID;

--- a/testlib/src/main/resources/java/importsorter/JavaCodeSortedSemanticSort.test
+++ b/testlib/src/main/resources/java/importsorter/JavaCodeSortedSemanticSort.test
@@ -1,0 +1,13 @@
+import static com.example.Test.*;
+import static com.example.Test.A_CONST;
+import static com.example.Test.Nested.B_CONST;
+import static com.example.Test.Z_CONST;
+
+import com.example.Test;
+import com.example.Test.*;
+import com.example.Test.Nested;
+import com.example.b;
+import com.example.a.A;
+import com.example.c.C;
+import com.sun.jna.platform.win32.Guid.CLSID;
+import com.sun.jna.platform.win32.COM.Unknown;

--- a/testlib/src/main/resources/java/importsorter/JavaCodeUnsortedSemanticSort.test
+++ b/testlib/src/main/resources/java/importsorter/JavaCodeUnsortedSemanticSort.test
@@ -1,0 +1,15 @@
+import static com.example.Test.*;
+import static com.example.Test.A_CONST;
+import static com.example.Test.Z_CONST;
+import static com.example.Test.Nested.B_CONST;
+
+import com.example.Test.Nested;
+import com.example.Test;
+import com.example.Test.*;
+
+import com.sun.jna.platform.win32.COM.Unknown;
+import com.sun.jna.platform.win32.Guid.CLSID;
+
+import com.example.a.A;
+import com.example.b;
+import com.example.c.C;

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -21,6 +21,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
+import java.util.Set;
 
 class ImportOrderStepTest extends ResourceHarness {
 	@Test
@@ -61,7 +62,7 @@ class ImportOrderStepTest extends ResourceHarness {
 
 	@Test
 	void sortImportsWildcardsLast() {
-		FormatterStep step = ImportOrderStep.forJava().createFrom(true);
+		FormatterStep step = ImportOrderStep.forJava().createFrom(true, true, null, null);
 		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedImports.test", "java/importsorter/JavaCodeSortedImportsWildcardsLast.test");
 	}
 
@@ -87,6 +88,19 @@ class ImportOrderStepTest extends ResourceHarness {
 	void empty() {
 		FormatterStep step = ImportOrderStep.forJava().createFrom(createTestFile("java/importsorter/import.properties"));
 		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeEmptyFile.test", "java/importsorter/JavaCodeEmptyFile.test");
+	}
+
+	@Test
+	void lexicographicSort() {
+		FormatterStep step = ImportOrderStep.forJava().createFrom(false, false, null, null, createTestFile("java/importsorter/import.properties"));
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedSemanticSort.test", "java/importsorter/JavaCodeSortedLexicographic.test");
+	}
+
+	@Test
+	void semanticSort() {
+		FormatterStep step = ImportOrderStep.forJava().createFrom(false, true, Set.of("com.sun.jna.platform.win32.COM"),
+				Set.of("com.example.b"), createTestFile("java/importsorter/import.properties"));
+		StepHarness.forStep(step).testResource("java/importsorter/JavaCodeUnsortedSemanticSort.test", "java/importsorter/JavaCodeSortedSemanticSort.test");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.spotless.java;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
-import java.util.Set;
 
 class ImportOrderStepTest extends ResourceHarness {
 	@Test


### PR DESCRIPTION
This PR is for issue #522.

It introduces semantics-aware sorting of Java imports, i.e. imports are sorted by package, classes and static members, instead of just lexicographically. This is the new default behavior, but the old one can be restored (in Maven e.g. via `<semanticSort>false</semanticSort>`). The imports are split based on conventions: package names start with lower case, class names with upper case. For exceptions, the `<treatAsPackage>` and `<treatAsClass>` configurations can be used.