### PR TITLE
Update documented default semanticSort to false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Update documented default `semanticSort` to `false`. ([#1728](https://github.com/diffplug/spotless/pull/1728))
 
 ## [2.39.0] - 2023-05-24
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Update documented default `semanticSort` to `false`. ([#1728](https://github.com/diffplug/spotless/pull/1728))
 
 ## [2.37.0] - 2023-05-24
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -196,7 +196,7 @@ any other maven phase (i.e. compile) then it can be configured as below;
       <wildcardsLast>false</wildcardsLast> <!-- Optional, default false. Sort wildcard import after specific imports -->
       <order>java|javax,org,com,com.diffplug,,\#com.diffplug,\#</order>  <!-- or use <file>${project.basedir}/eclipse.importorder</file> -->
       <!-- you can use an empty string for all the imports you didn't specify explicitly, '|' to join group without blank line, and '\#` prefix for static imports. -->
-      <semanticSort>false</semanticSort> <!-- Optional, default true. Sort by package, then class, then member (for static imports). Splitting is based on common conventions (packages are lower case, classes start with upper case). Use <treatAsPackage> and <treatAsClass> for exceptions. -->
+      <semanticSort>false</semanticSort> <!-- Optional, default false. Sort by package, then class, then member (for static imports). Splitting is based on common conventions (packages are lower case, classes start with upper case). Use <treatAsPackage> and <treatAsClass> for exceptions. -->
       <treatAsPackage> <!-- Packages starting with upper case letters. -->
         <package>com.example.MyPackage</package>
       </treatAsPackage>


### PR DESCRIPTION
The default value was updated to false [1] per suggestion [2].

[1] https://github.com/diffplug/spotless/pull/1709/commits/10610f8a8d12bfdc8303645daafc4d68c17c9165
[2] https://github.com/diffplug/spotless/pull/1709#pullrequestreview-1437212887

<!-- Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that. -->
<!--  -->
<!-- Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it. -->
<!--  -->
<!-- ![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png) -->
<!--  -->
<!-- After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes: -->
<!--  -->
<!-- - [ ] a summary of the change -->
<!-- - either -->
<!--     - [ ] a link to the issue you are resolving (for small changes) -->
<!--     - [ ] a link to the PR you just created (for big changes likely to have discussion) -->
<!--  -->
<!-- If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin. -->
<!--  -->
<!-- If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them. -->
<!--  -->
<!-- This makes it easier for the maintainers to quickly release your changes :) -->
