### PR TITLE
Kotlin dsl for yaml formatter in can't use the syntax jackson().yamlFeature(String, boolean)

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,16 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Fixed
+* Correctly support the syntax
+  ```
+  spotless {
+    yaml {
+      jackson().yamlFeature("MINIMIZE_QUOTES", true)
+    }
+  }
+  ```
+
 ## [6.19.0] - 2023-05-24
 ### Added
 * Support Rome as a formatter for JavaScript and TypeScript code. Adds a new `rome` step to `javascript` and `typescript` formatter configurations. ([#1663](https://github.com/diffplug/spotless/pull/1663))

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AJacksonGradleConfig.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AJacksonGradleConfig.java
@@ -21,7 +21,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.json.JacksonConfig;
 import com.diffplug.spotless.json.JacksonJsonStep;
 
-public abstract class AJacksonGradleConfig {
+public abstract class AJacksonGradleConfig<T extends AJacksonGradleConfig> {
 	protected final FormatExtension formatExtension;
 
 	protected JacksonConfig jacksonConfig;
@@ -35,17 +35,19 @@ public abstract class AJacksonGradleConfig {
 		this.jacksonConfig = jacksonConfig;
 	}
 
-	public AJacksonGradleConfig feature(String feature, boolean toggle) {
+	public T feature(String feature, boolean toggle) {
 		this.jacksonConfig.appendFeatureToToggle(Collections.singletonMap(feature, toggle));
 		formatExtension.replaceStep(createStep());
-		return this;
+		return self();
 	}
 
-	public AJacksonGradleConfig version(String version) {
+	public T version(String version) {
 		this.version = version;
 		formatExtension.replaceStep(createStep());
-		return this;
+		return self();
 	}
+
+	public abstract T self();
 
 	protected abstract FormatterStep createStep();
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JsonExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JsonExtension.java
@@ -132,7 +132,7 @@ public class JsonExtension extends FormatExtension {
 		}
 	}
 
-	public static class JacksonJsonGradleConfig extends AJacksonGradleConfig {
+	public static class JacksonJsonGradleConfig extends AJacksonGradleConfig<JacksonJsonGradleConfig> {
 		protected JacksonJsonConfig jacksonConfig;
 
 		public JacksonJsonGradleConfig(JacksonJsonConfig jacksonConfig, FormatExtension formatExtension) {
@@ -149,9 +149,14 @@ public class JsonExtension extends FormatExtension {
 		/**
 		 * Refers to com.fasterxml.jackson.core.JsonGenerator.Feature
 		 */
-		public AJacksonGradleConfig jsonFeature(String feature, boolean toggle) {
+		public JacksonJsonGradleConfig jsonFeature(String feature, boolean toggle) {
 			this.jacksonConfig.appendJsonFeatureToToggle(Collections.singletonMap(feature, toggle));
 			formatExtension.replaceStep(createStep());
+			return this;
+		}
+
+		@Override
+		public JacksonJsonGradleConfig self() {
 			return this;
 		}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/YamlExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/YamlExtension.java
@@ -39,11 +39,11 @@ public class YamlExtension extends FormatExtension {
 		super.setupTask(task);
 	}
 
-	public AJacksonGradleConfig jackson() {
+	public JacksonYamlGradleConfig jackson() {
 		return new JacksonYamlGradleConfig(this);
 	}
 
-	public class JacksonYamlGradleConfig extends AJacksonGradleConfig {
+	public class JacksonYamlGradleConfig extends AJacksonGradleConfig<JacksonYamlGradleConfig> {
 		protected JacksonYamlConfig jacksonConfig;
 
 		public JacksonYamlGradleConfig(JacksonYamlConfig jacksonConfig, FormatExtension formatExtension) {
@@ -61,9 +61,14 @@ public class YamlExtension extends FormatExtension {
 		/**
 		 * Refers to com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature
 		 */
-		public AJacksonGradleConfig yamlFeature(String feature, boolean toggle) {
+		public JacksonYamlGradleConfig yamlFeature(String feature, boolean toggle) {
 			this.jacksonConfig.appendYamlFeatureToToggle(Collections.singletonMap(feature, toggle));
 			formatExtension.replaceStep(createStep());
+			return this;
+		}
+
+		@Override
+		public JacksonYamlGradleConfig self() {
 			return this;
 		}
 


### PR DESCRIPTION
Motivation
In gradle, kotlin DSL is compiled. Since YamlExtension#jackson return a AJacksonGradleConfig class, we can't use the method #yamlFeature(String, boolean) without casting the object
