### PR TITLE
Enable Gradle users to create custom steps that require a provisioner

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Added
+
+* Add an overload for `FormatExtension.addStep` which provides access to the `FormatExtension`'s `Provisioner`, enabling custom steps to make use of third-party dependencies.
+
 ### Fixed
 * Correctly support the syntax
   ```

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -298,6 +299,13 @@ public class FormatExtension {
 			throw new GradleException("Multiple steps with name '" + newStep.getName() + "' for spotless format '" + formatName() + "'");
 		}
 		steps.add(newStep);
+	}
+
+	/** Adds a new step that requires a Provisioner. */
+	public void addStep(Function<Provisioner, FormatterStep> createStepFn) {
+		requireNonNull(createStepFn);
+		FormatterStep newStep = createStepFn.apply(provisioner());
+		addStep(newStep);
 	}
 
 	/** Returns the index of the existing step with the given name, or -1 if no such step exists. */


### PR DESCRIPTION
The guidance about [custom steps](https://github.com/diffplug/spotless/tree/main/plugin-gradle#custom-steps) advises users that they can create their own `FormatterStep`, and links to the guidance about [creating a new formatter step](https://github.com/diffplug/spotless/blob/main/CONTRIBUTING.md#how-to-add-a-new-formatterstep).

This guidance is helpful up to the point that you need to use a third-party dependency, at which point you need a `Provisioner`. Getting access to one of those within the Gradle plugin is pretty difficult, as all of the methods which provide one are protected. 

This makes it hard for folks to experiment with custom steps within their own projects.

This PR adds a new `addStep` overload which allows users to add steps, making use of the current `FormatExtension`'s provisioner.