### PR TITLE
Add information about using ratchetFrom on CI systems

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1326,14 +1326,12 @@ However, we strongly recommend that you use a non-local branch, such as a tag or
 
 This is especially helpful for injecting accurate copyright dates using the [license step](#license-header).
 
-### Using ratchetFrom on CI systems
+### Using `ratchetFrom` on CI systems
 
-If you are running Spotless on a CI system, make sure you do not have a shallow clone, or `ratchetFrom` will fail with `No such reference`. Many CI systems use a shallow clone by default for performance reasons. Here is how you turn off shallow clones for some common CI systems:
+Many popular CI systems (GitHub, GitLab, BitBucket, and Travis) use a "shallow clone". This means that `ratchetFrom 'origin/main'` will fail with `No such reference`. You can fix this by:
 
-* **GitHub Actions**: Ad `fetch-depth: 0` to `<action>.yml`
-* **GitLab CI**: Add `GIT_DEPTH: 0` under the `variables:` section of `.gitlab-ci.yml`
-* **BitBucket Pipelines**: Add `clone: depth: full` to the build step
-* **Travis**: Add `git: depth: false` in `travis.yml`
+- calling `git fetch origin main` before you call Spotless
+- disabling the shallow clone [like so](https://github.com/diffplug/spotless/issues/710)
 
 ## `spotless:off` and `spotless:on`
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1326,6 +1326,15 @@ However, we strongly recommend that you use a non-local branch, such as a tag or
 
 This is especially helpful for injecting accurate copyright dates using the [license step](#license-header).
 
+### Using ratchetFrom on CI systems
+
+If you are running Spotless on a CI system, make sure you do not have a shallow clone, or `ratchetFrom` will fail with `No such reference`. Many CI systems use a shallow clone by default for performance reasons. Here is how you turn off shallow clones for some common CI systems:
+
+* **GitHub Actions**: Ad `fetch-depth: 0` to `<action>.yml`
+* **GitLab CI**: Add `GIT_DEPTH: 0` under the `variables:` section of `.gitlab-ci.yml`
+* **BitBucket Pipelines**: Add `clone: depth: full` to the build step
+* **Travis**: Add `git: depth: false` in `travis.yml`
+
 ## `spotless:off` and `spotless:on`
 
 Sometimes there is a chunk of code  which you have carefully handcrafted, and you would like to exclude just this one little part from getting clobbered by the autoformat. Some formatters have a way to do this, many don't, but who cares.  If you setup your spotless like this:

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1526,6 +1526,13 @@ You can explicitly disable ratchet functionality by providing the value 'NONE':
 ```
 This is useful for disabling the ratchet functionality in child projects where the parent defines a ratchetFrom value.
 
+### Using `ratchetFrom` on CI systems
+
+Many popular CI systems (GitHub, GitLab, BitBucket, and Travis) use a "shallow clone". This means that `<ratchetFrom>origin/main</ratchetFrom>` will fail with `No such reference`. You can fix this by:
+
+- calling `git fetch origin main` before you call Spotless
+- disabling the shallow clone [like so](https://github.com/diffplug/spotless/issues/710)
+
 ## `spotless:off` and `spotless:on`
 
 Sometimes there is a chunk of code  which you have carefully handcrafted, and you would like to exclude just this one little part from getting clobbered by the autoformat. Some formatters have a way to do this, many don't, but who cares. If you setup your spotless like this:


### PR DESCRIPTION
Add the important TL;DR from #710 to the documentation where it is pertinent.

I got almost crazy trying to figure out what was wrong. I understand now why ratchetFrom does not work on shallow clones, but as long as #710 is not fixed, this is critical information for anyone trying to setup a way of running Spotless with ratchetFrom on a CI system.