### PR TITLE
Fix Config Cache External Process Issue

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -8,6 +8,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 * Add support for `prettier` version `3.0.0` and newer. ([#1760]https://github.com/diffplug/spotless/pull/1760), [#1751](https://github.com/diffplug/spotless/issues/1751))
 * Fix npm install calls when npm cache is not up-to-date. ([#1760]https://github.com/diffplug/spotless/pull/1760), [#1750](https://github.com/diffplug/spotless/issues/1750))
+* Fix configuration cache failure when using LineEnding.GIT_ATTRIBUTES ([#1644](https://github.com/diffplug/spotless/issues/1644))
 ### Changes
 * Bump default `eslint` version to latest `8.31.0` -> `8.45.0` ([#1761](https://github.com/diffplug/spotless/pull/1761))
 * Bump default `prettier` version to latest (v2) `2.8.1` -> `2.8.8`. ([#1760](https://github.com/diffplug/spotless/pull/1760))

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -40,6 +40,7 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.tasks.TaskProvider;
@@ -925,7 +926,8 @@ public class FormatExtension {
 			steps.replaceAll(formatterStep -> formatterStep.filterByContent(OnMatch.EXCLUDE, targetExcludeContentPattern));
 		}
 		task.setSteps(steps);
-		task.setLineEndingsPolicy(getLineEndings().createPolicy(getProject().getProjectDir(), () -> totalTarget));
+		Directory projectDir = getProject().getLayout().getProjectDirectory();
+		task.setLineEndingsPolicy(getProject().provider(() -> getLineEndings().createPolicy(projectDir.getAsFile(), () -> totalTarget)));
 		spotless.getRegisterDependenciesTask().hookSubprojectTask(task);
 		task.setupRatchet(getRatchetFrom() != null ? getRatchetFrom() : "");
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -64,14 +65,14 @@ public abstract class SpotlessTask extends DefaultTask {
 		this.encoding = Objects.requireNonNull(encoding);
 	}
 
-	protected final LiveCache<LineEnding.Policy> lineEndingsPolicy = createLive("lineEndingsPolicy");
+	protected final LiveCache<Provider<LineEnding.Policy>> lineEndingsPolicy = createLive("lineEndingsPolicy");
 
 	@Input
-	public LineEnding.Policy getLineEndingsPolicy() {
+	public Provider<LineEnding.Policy> getLineEndingsPolicy() {
 		return lineEndingsPolicy.get();
 	}
 
-	public void setLineEndingsPolicy(LineEnding.Policy lineEndingsPolicy) {
+	public void setLineEndingsPolicy(Provider<LineEnding.Policy> lineEndingsPolicy) {
 		this.lineEndingsPolicy.set(lineEndingsPolicy);
 	}
 
@@ -185,7 +186,7 @@ public abstract class SpotlessTask extends DefaultTask {
 	Formatter buildFormatter() {
 		return Formatter.builder()
 				.name(formatName())
-				.lineEndingsPolicy(lineEndingsPolicy.get())
+				.lineEndingsPolicy(lineEndingsPolicy.get().get())
 				.encoding(Charset.forName(encoding))
 				.rootDir(getProjectDir().get().getAsFile().toPath())
 				.steps(steps.get())

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -62,7 +62,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 		private SpotlessTaskImpl createFormatTask(String name) {
 			SpotlessTaskImpl task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name), SpotlessTaskImpl.class);
 			task.init(taskService);
-			task.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
+			task.setLineEndingsPolicy(project.provider(LineEnding.UNIX::createPolicy));
 			task.setTarget(Collections.singletonList(file));
 			return task;
 		}
@@ -100,7 +100,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 
 	private Bundle create(List<File> files) throws IOException {
 		Bundle bundle = new Bundle("underTest");
-		bundle.task.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
+		bundle.task.setLineEndingsPolicy(bundle.project.provider(LineEnding.UNIX::createPolicy));
 		bundle.task.setTarget(files);
 		return bundle;
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FormatTaskTest.java
@@ -35,7 +35,7 @@ class FormatTaskTest extends ResourceHarness {
 	void createTask() {
 		Project project = TestProvisioner.gradleProject(rootFolder());
 		spotlessTask = project.getTasks().create("spotlessTaskUnderTest", SpotlessTaskImpl.class);
-		spotlessTask.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
+		spotlessTask.setLineEndingsPolicy(project.provider(LineEnding.UNIX::createPolicy));
 		spotlessTask.init(GradleIntegrationHarness.providerOf(new SpotlessTaskService() {
 			@Override
 			public BuildServiceParameters.None getParameters() {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -66,7 +66,7 @@ class PaddedCellTaskTest extends ResourceHarness {
 			SpotlessTaskImpl task = project.getTasks().create("spotless" + SpotlessPlugin.capitalize(name), SpotlessTaskImpl.class);
 			task.init(taskService);
 			task.addStep(step);
-			task.setLineEndingsPolicy(LineEnding.UNIX.createPolicy());
+			task.setLineEndingsPolicy(project.provider(LineEnding.UNIX::createPolicy));
 			task.setTarget(Collections.singletonList(file));
 			return task;
 		}


### PR DESCRIPTION
Fixes a [configuration cache failure](https://ge.solutions-team.gradle.com/s/hotcmm4fvwcri/failure#1) when applying Spotless Gradle Plugin.

The failure is caused by executing external processes during configuration time, which the configuration cache does not support. Specifically, the external processes are launched to determine the line ending policy when `LineEnding.GIT_ATTRIBUTES` is used.

This PR uses `Provider`s to supply the line ending policy, which because they are lazily evaluated, move the external processes involved in creating the line ending policy from configuration to execution time.

Using [spotless-plugin-gradle:6.21.0-SNAPSHOT published to mavenLocal](https://ge.solutions-team.gradle.com/s/j7tcsfqvmfzpa/build-dependencies?focusedDependency=WzEsMCw0LFsxLDAsWzRdXV0&toggled=W1sxXSxbMSwwXV0) containing these changes results in a [successful configuration cache write](https://ge.solutions-team.gradle.com/s/j7tcsfqvmfzpa/console-log?page=1#L20).