### PR TITLE
Fix configuration cache issue with BufStep

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -65,9 +65,9 @@ public class BufStep {
 	private State createState() {
 		String instructions = "https://docs.buf.build/installation";
 		ForeignExe exeAbsPath = ForeignExe.nameAndVersion("buf", version)
-			.pathToExe(pathToExe)
-			.versionRegex(Pattern.compile("(\\S*)"))
-			.fixCantFind("Try following the instructions at " + instructions + ", or else tell Spotless where it is with {@code buf().pathToExe('path/to/executable')}");
+				.pathToExe(pathToExe)
+				.versionRegex(Pattern.compile("(\\S*)"))
+				.fixCantFind("Try following the instructions at " + instructions + ", or else tell Spotless where it is with {@code buf().pathToExe('path/to/executable')}");
 		return new State(this, exeAbsPath);
 	}
 
@@ -88,9 +88,9 @@ public class BufStep {
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
 			if (args == null) {
 				args = Arrays.asList(
-					exe.confirmVersionAndGetAbsolutePath(),
-					"format",
-					file.getAbsolutePath());
+						exe.confirmVersionAndGetAbsolutePath(),
+						"format",
+						file.getAbsolutePath());
 			}
 			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -61,13 +62,12 @@ public class BufStep {
 		return FormatterStep.createLazy(name(), this::createState, State::toFunc);
 	}
 
-	private State createState() throws IOException, InterruptedException {
+	private State createState() {
 		String instructions = "https://docs.buf.build/installation";
-		String exeAbsPath = ForeignExe.nameAndVersion("buf", version)
-				.pathToExe(pathToExe)
-				.versionRegex(Pattern.compile("(\\S*)"))
-				.fixCantFind("Try following the instructions at " + instructions + ", or else tell Spotless where it is with {@code buf().pathToExe('path/to/executable')}")
-				.confirmVersionAndGetAbsolutePath();
+		ForeignExe exeAbsPath = ForeignExe.nameAndVersion("buf", version)
+			.pathToExe(pathToExe)
+			.versionRegex(Pattern.compile("(\\S*)"))
+			.fixCantFind("Try following the instructions at " + instructions + ", or else tell Spotless where it is with {@code buf().pathToExe('path/to/executable')}");
 		return new State(this, exeAbsPath);
 	}
 
@@ -76,19 +76,23 @@ public class BufStep {
 		private static final long serialVersionUID = -1825662356883926318L;
 		// used for up-to-date checks and caching
 		final String version;
+		final transient ForeignExe exe;
 		// used for executing
-		final transient List<String> args;
+		private transient @Nullable List<String> args;
 
-		State(BufStep step, String exeAbsPath) {
+		State(BufStep step, ForeignExe exeAbsPath) {
 			this.version = step.version;
-			this.args = Arrays.asList(exeAbsPath, "format");
+			this.exe = Objects.requireNonNull(exeAbsPath);
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
-			String[] processArgs = args.toArray(new String[args.size() + 1]);
-			// add an argument to the end
-			processArgs[args.size()] = file.getAbsolutePath();
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), processArgs).assertExitZero(StandardCharsets.UTF_8);
+			if (args == null) {
+				args = Arrays.asList(
+					exe.confirmVersionAndGetAbsolutePath(),
+					"format",
+					file.getAbsolutePath());
+			}
+			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Add support for `prettier` version `3.0.0` and newer. ([#1760]https://github.com/diffplug/spotless/pull/1760), [#1751](https://github.com/diffplug/spotless/issues/1751))
 * Fix npm install calls when npm cache is not up-to-date. ([#1760]https://github.com/diffplug/spotless/pull/1760), [#1750](https://github.com/diffplug/spotless/issues/1750))
 * Fix configuration cache failure when using LineEnding.GIT_ATTRIBUTES ([#1644](https://github.com/diffplug/spotless/issues/1644))
+* Fix configuration cache failure when formatting proto files with Buf. ([#1779]https://github.com/diffplug/spotless/pull/1779))
 ### Changes
 * Bump default `eslint` version to latest `8.31.0` -> `8.45.0` ([#1761](https://github.com/diffplug/spotless/pull/1761))
 * Bump default `prettier` version to latest (v2) `2.8.1` -> `2.8.8`. ([#1760](https://github.com/diffplug/spotless/pull/1760))


### PR DESCRIPTION
Fixes a [configuration cache issue](https://github.com/diffplug/spotless/issues/1762#issuecomment-1656354997) when using Buf to format proto files.

The failure was caused by calling `confirmVersionAndGetAbsolutePath` when creating the step state, which the configuration cache does not support. The version checking is deferred until a file is actually being formatted.