### PR TITLE
Speedup GIT_ATTRIBUTES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
   the version accordingly. ([#1804](https://github.com/diffplug/spotless/issues/1804)).
 * Support for `google-java-format`'s `skip-javadoc-formatting` option. ([#1793](https://github.com/diffplug/spotless/pull/1793))
 * Support configuration of mirrors for P2 repositories in maven DSL ([#1697](https://github.com/diffplug/spotless/issues/1697)).
+* New line endings mode `GIT_ATTRIBUTES_FAST_ALLSAME`. ([#1838](https://github.com/diffplug/spotless/pull/1838))
 ### Fixed
 * Fix support for plugins when using Prettier version `3.0.0` and newer. ([#1802](https://github.com/diffplug/spotless/pull/1802))
 * Fix configuration cache issue around `external process started '/usr/bin/git --version'`. ([#1806](https://github.com/diffplug/spotless/issues/1806))

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -78,6 +78,7 @@ public final class GitAttributesLineEndings {
 	}
 
 	static class LazyAllTheSame extends LazyForwardingEquality<String> implements LineEnding.Policy {
+		private static final long serialVersionUID = 727912266173243664L;
 		transient File projectDir;
 		transient Supplier<Iterable<File>> toFormat;
 

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -19,10 +19,7 @@ import java.io.File;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
 
 /**
  * Represents the line endings which should be written by the tool.
@@ -76,8 +73,6 @@ public enum LineEnding {
 		}
 	}
 
-	private static volatile @Nullable BiFunction<File, Supplier<Iterable<File>>, Policy> gitAttributesPolicyCreator;
-
 	// @formatter:off
 	/** Should use {@link #createPolicy(File, Supplier)} instead, but this will work iff its a path-independent LineEnding policy. */
 	public Policy createPolicy() {
@@ -85,7 +80,7 @@ public enum LineEnding {
 		case PLATFORM_NATIVE:	return _platformNativePolicy;
 		case WINDOWS:			return WINDOWS_POLICY;
 		case UNIX:				return UNIX_POLICY;
-        case MAC_CLASSIC:       return MAC_CLASSIC_POLICY;
+		case MAC_CLASSIC:		return MAC_CLASSIC_POLICY;
 		default:	throw new UnsupportedOperationException(this + " is a path-specific line ending.");
 		}
 	}
@@ -129,7 +124,7 @@ public enum LineEnding {
 		case PLATFORM_NATIVE:	return _platformNative;
 		case WINDOWS:			return "\r\n";
 		case UNIX:				return "\n";
-		case MAC_CLASSIC:       return "\r";
+		case MAC_CLASSIC:		return "\r";
 		default:	throw new UnsupportedOperationException(this + " is a path-specific line ending.");
 		}
 	}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -13,6 +13,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Fixed support for plugins when using Prettier version `3.0.0` and newer. ([#1802](https://github.com/diffplug/spotless/pull/1802))
 ### Changes
 * Bump default `ktlint` version to latest `0.50.0` -> `1.0.0`. ([#1808](https://github.com/diffplug/spotless/pull/1808))
+* **POSSIBLY BREAKING** the default line endings are now `GIT_ATTRIBUTES_FAST_ALLSAME` instead of `GIT_ATTRIBUTES`. ([#1838](https://github.com/diffplug/spotless/pull/1838))
+  * If all the files within a format have the same line endings, then there is no change in behavior.
+  * Fixes large performance regression. ([#1527](https://github.com/diffplug/spotless/issues/1527))
 
 ## [6.21.0] - 2023-08-29
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1425,12 +1425,12 @@ spotless {
     encoding 'Cp1252' // except java, which will be Cp1252
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, and `GIT_ATTRIBUTES`.  The default value is `GIT_ATTRIBUTES`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time.
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, and `GIT_ATTRIBUTES_FAST_ALLSAME`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
 
 You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
 
 <a name="custom"></a>
-<a name="custom-rulwa"></a>
+<a name="custom-steps"></a>
 
 ## Custom steps
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -57,7 +57,7 @@ public abstract class SpotlessExtension {
 	}
 
 	/** Line endings (if any). */
-	LineEnding lineEndings = LineEnding.GIT_ATTRIBUTES;
+	LineEnding lineEndings = LineEnding.GIT_ATTRIBUTES_FAST_ALLSAME;
 
 	public LineEnding getLineEndings() {
 		return lineEndings;

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -28,6 +28,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changes
 * Bump default `flexmark` version to latest `0.64.0` -> `0.64.8`. ([#1801](https://github.com/diffplug/spotless/pull/1801))
 * Bump default `ktlint` version to latest `0.50.0` -> `1.0.0`. ([#1808](https://github.com/diffplug/spotless/pull/1808))
+* **POSSIBLY BREAKING** the default line endings are now `GIT_ATTRIBUTES_FAST_ALLSAME` instead of `GIT_ATTRIBUTES`. ([#1838](https://github.com/diffplug/spotless/pull/1838))
+  * If all the files within a format have the same line endings, then there is no change in behavior.
+  * Fixes large performance regression. ([#1527](https://github.com/diffplug/spotless/issues/1527))
 
 ## [2.39.0] - 2023-08-29
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1586,7 +1586,7 @@ Spotless uses UTF-8 by default, but you can use [any encoding which Java support
 </configuration>
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, and `GIT_ATTRIBUTES`.  The default value is `GIT_ATTRIBUTES`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time.
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, and `GIT_ATTRIBUTES_FAST_ALLSAME`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
 
 You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -80,7 +80,7 @@ import com.diffplug.spotless.maven.yaml.Yaml;
 public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	private static final String DEFAULT_INDEX_FILE_NAME = "spotless-index";
 	private static final String DEFAULT_ENCODING = "UTF-8";
-	private static final String DEFAULT_LINE_ENDINGS = "GIT_ATTRIBUTES";
+	private static final String DEFAULT_LINE_ENDINGS = "GIT_ATTRIBUTES_FAST_ALLSAME";
 
 	/** Value to allow unsetting the ratchet inherited from parent pom configuration. */
 	static final String RATCHETFROM_NONE = "NONE";


### PR DESCRIPTION
Git has strong opinions about line endings, so it's really nice to let it be the source-of-truth for them. We used to support `.gitattributes` **exactly** and **lazily**. But with configuration-cache and its serialization requirement (#987), we are now forced to be **eager** instead of **lazy**, which ended up being crazy slow

- #1527

In this PR, we introduce a new mode `GIT_ATTRIBUTES_FAST_ALLSAME`, and it is now the default for both Gradle and Maven. You can still use `GIT_ATTRIBUTES` if you prefer.

If all of the files within a given format have the same line endings (probably true for 99.99% of cases), then the behavior will be exactly the same. But it's much much faster.