### PR TITLE
Gradle 8 migrations

### DIFF
--- a/_ext/gradle/java-setup.gradle
+++ b/_ext/gradle/java-setup.gradle
@@ -20,6 +20,7 @@ dependencies {
 	testImplementation "org.junit.jupiter:junit-jupiter:${VER_JUNIT}"
 	testImplementation "org.assertj:assertj-core:${VER_ASSERTJ}"
 	testImplementation projects.testlib
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 tasks.withType(Test).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true
 
 name=spotless
 description=Spotless - keep your code spotless with Gradle

--- a/lib-extra/build.gradle
+++ b/lib-extra/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	testImplementation "org.junit.jupiter:junit-jupiter:${VER_JUNIT}"
 	testImplementation "org.assertj:assertj-core:${VER_ASSERTJ}"
 	testImplementation "com.diffplug.durian:durian-testlib:${VER_DURIAN}"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 spotless {
 	java {

--- a/plugin-gradle/build.gradle
+++ b/plugin-gradle/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	testImplementation "org.assertj:assertj-core:${VER_ASSERTJ}"
 	testImplementation "com.diffplug.durian:durian-testlib:${VER_DURIAN}"
 	testImplementation 'org.owasp.encoder:encoder:1.2.3'
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 apply from: rootProject.file('gradle/special-tests.gradle')

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 	testImplementation "org.eclipse.aether:aether-api:${VER_ECLIPSE_AETHER}"
 	testImplementation "org.codehaus.plexus:plexus-resources:${VER_PLEXUS_RESOURCES}"
 	testImplementation "org.apache.maven:maven-core:${VER_MAVEN_API}"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 apply from: rootProject.file('gradle/special-tests.gradle')

--- a/testlib/build.gradle
+++ b/testlib/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	api "org.junit.jupiter:junit-jupiter:${VER_JUNIT}"
 	api "org.assertj:assertj-core:${VER_ASSERTJ}"
 	api "org.mockito:mockito-core:$VER_MOCKITO"
+	runtimeOnly "org.junit.platform:junit-platform-launcher"
 
 	implementation "com.diffplug.durian:durian-io:${VER_DURIAN}"
 	implementation "com.diffplug.durian:durian-collect:${VER_DURIAN}"


### PR DESCRIPTION
Follow up #1570.

https://docs.gradle.org/8.4-rc-3/userguide/upgrading_version_8.html?#test_framework_implementation_dependencies