### PR TITLE
fix the crash repored in #1858

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,7 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-
+### Fixed
+* Fix crash when build dir is a softlink to another directory. ([#1859](https://github.com/diffplug/spotless/pull/1859))
 ### Added
 * CompileSourceRoots and TestCompileSourceRoots are now respected as default includes. These properties are commonly set when adding extra source directories. ([#1846](https://github.com/diffplug/spotless/issues/1846))
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/FileIndex.java
@@ -144,7 +144,14 @@ class FileIndex {
 			throw new IllegalStateException("Index file does not have a parent dir: " + indexFile);
 		}
 		try {
-			Files.createDirectories(parentDir);
+			if (Files.exists(parentDir, LinkOption.NOFOLLOW_LINKS)) {
+				Path realPath = parentDir.toRealPath();
+				if (!Files.exists(realPath)) {
+					Files.createDirectories(realPath);
+				}
+			} else {
+				Files.createDirectories(parentDir);
+			}
 		} catch (IOException e) {
 			throw new UncheckedIOException("Unable to create parent directory for the index file: " + indexFile, e);
 		}


### PR DESCRIPTION
 The crash happens when the maven build dir is a softlink to another directory.

- #1858