### PR TITLE
Add <p> tags to Javadoc comments

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -246,7 +246,7 @@ public final class GitAttributesLineEndings {
 
 		/**
 		 * Default line ending, determined in this order (paths are a teensy different platform to platform).
-		 *
+		 * <p>
 		 * - .git/config (per-repo)
 		 * - ~/.gitconfig (per-user)
 		 * - /etc/gitconfig (system-wide)

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitWorkarounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public final class GitWorkarounds {
 
 	/**
 	 * Finds the .git directory for the given project directory.
-	 *
+	 * <p>
 	 * Ordinarily one would just use JGit for this, but it doesn't support worktrees properly.
 	 * So this applies an additional workaround for that.
 	 *
@@ -55,7 +55,7 @@ public final class GitWorkarounds {
 
 	/**
 	 * Creates a {@link RepositorySpecificResolver} for the given project directory.
-	 *
+	 * <p>
 	 * This applies a workaround for JGit not supporting worktrees properly.
 	 *
 	 * @param projectDir the project directory.
@@ -67,7 +67,7 @@ public final class GitWorkarounds {
 
 	/**
 	 * Creates a {@link RepositorySpecificResolver} for the given project directory.
-	 *
+	 * <p>
 	 * This applies a workaround for JGit not supporting worktrees properly.
 	 *
 	 * @param projectDir the project directory.
@@ -86,7 +86,7 @@ public final class GitWorkarounds {
 
 	/**
 	 * Piggyback on the {@link FileRepositoryBuilder} mechanics for finding the git directory.
-	 *
+	 * <p>
 	 * Here we take into account that git repositories can share a common directory. This directory
 	 * will contain ./config ./objects/, ./info/, and ./refs/.
 	 */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -27,7 +27,7 @@ import dev.equo.solstice.p2.P2Model;
 
 /**
  * Formatter step which calls out to the Eclipse CDT formatter.
- *
+ * <p>
  * Eclipse-CDT <code>org.eclipse.core.contenttype.contentTypes</code>
  * extension <code>cSource</code>, <code>cHeader</code>, <code>cxxSource</code> and <code>cxxHeader</code>.
  * can handle: "c", "h", "C", "cpp", "cxx", "cc", "c++", "h", "hpp", "hh", "hxx", "inc"

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -249,9 +249,9 @@ public final class DiffMessageFormatter {
 
 	/**
 	 * Returns a git-style diff between the two unix strings.
-	 *
+	 * <p>
 	 * Output has no trailing newlines.
-	 *
+	 * <p>
 	 * Boolean args determine whether whitespace or line endings will be visible.
 	 */
 	private static String diffWhitespaceLineEndings(String dirty, String clean, boolean whitespace, boolean lineEndings) throws IOException {
@@ -278,7 +278,7 @@ public final class DiffMessageFormatter {
 
 	/**
 	 * Makes the whitespace and/or the lineEndings visible.
-	 *
+	 * <p>
 	 * MyersDiff wants inputs with only unix line endings.  So this ensures that that is the case.
 	 */
 	private static String visibleWhitespaceLineEndings(String input, boolean whitespace, boolean lineEndings) {

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepSpecialCaseTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepSpecialCaseTest.java
@@ -24,7 +24,7 @@ import com.diffplug.spotless.TestProvisioner;
 public class GrEclipseFormatterStepSpecialCaseTest {
 	/**
 	 * https://github.com/diffplug/spotless/issues/1657
-	 *
+	 * <p>
 	 * broken: ${parm == null ? "" : "<tag>$parm</tag>"}
 	 *  works: ${parm == null ? "" : "<tag>parm</tag>"}
 	 */

--- a/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
+++ b/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  * but linked against the `Url[]`. This allows us to ship classfiles which function as glue
  * code but delay linking/definition to runtime after the user has specified which version
  * of the formatter they want.
- *
+ * <p>
  *  For `"org.slf4j.` and (`com.diffplug.spotless.` but not `com.diffplug.spotless.extra.`)
  * 	the classes are loaded from the buildToolClassLoader.
  */

--- a/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
+++ b/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
  * Finds a foreign executable and checks its version.
  * If either part of that fails, it shows you why
  * and helps you fix it.
- *
+ * <p>
  * Usage: {@code ForeignExe.nameAndVersion("grep", "2.5.7").confirmVersionAndGetAbsolutePath()}
  * will find grep, confirm that it is version 2.5.7, and then return.
  */

--- a/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatExceptionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ public interface FormatExceptionPolicy extends Serializable, NoLambda {
 
 	/**
 	 * Returns a byte array representation of everything inside this {@code FormatExceptionPolicy}.
-	 *
+	 * <p>
 	 * The main purpose of this method is to ensure one can't instantiate this class with lambda
 	 * expressions, which are notoriously difficult to serialize and deserialize properly.
 	 */

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -193,7 +193,7 @@ public final class Formatter implements Serializable, AutoCloseable {
 
 	/**
 	 * Applies formatting to the given file.
-	 *
+	 * <p>
 	 * Returns null if the file was already clean, or the
 	 * formatted result with unix newlines if it was not.
 	 */

--- a/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
@@ -42,11 +42,11 @@ public interface FormatterFunc {
 
 		/**
 		 * Dangerous way to create a {@link Closeable} from an AutoCloseable and a function.
-		 *
+		 * <p>
 		 * It's important for FormatterStep's to allocate their resources as lazily as possible.
 		 * It's easy to create a resource inside the state, and not realize that it may not be
 		 * released.  It's far better to use one of the non-deprecated {@code of()} methods below.
-		 *
+		 * <p>
 		 * The bug (and its fix) which is easy to write using this method: https://github.com/diffplug/spotless/commit/7f16ecca031810b5e6e6f647e1f10a6d2152d9f4
 		 * How the {@code of()} methods below make the correct thing easier to write and safer: https://github.com/diffplug/spotless/commit/18c10f9c93d6f18f753233d0b5f028d5f0961916
 		 */

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 
 /**
  * An implementation of this class specifies a single step in a formatting process.
- *
+ * <p>
  * The input is guaranteed to have unix-style newlines, and the output is required
  * to not introduce any windows-style newlines as well.
  */
@@ -75,7 +75,7 @@ public interface FormatterStep extends Serializable {
 	/**
 	 * Returns a new FormatterStep which will only apply its changes
 	 * to files which pass the given filter.
-	 *
+	 * <p>
 	 * The provided filter must be serializable.
 	 */
 	public default FormatterStep filterByFile(SerializableFileFilter filter) {

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepImpl.java
@@ -27,7 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * Standard implementation of FormatExtension which cleanly enforces
  * separation of serializable configuration and a pure format function.
- *
+ * <p>
  * Not an inner-class of FormatterStep so that it can stay entirely private
  * from the API.
  */

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  * Grabs a jar and its dependencies from maven,
  * and makes it easy to access the collection in
  * a classloader.
- *
+ * <p>
  * Serializes the full state of the jar, so it can
  * catch changes in a SNAPSHOT version.
  */

--- a/lib/src/main/java/com/diffplug/spotless/LazyForwardingEquality.java
+++ b/lib/src/main/java/com/diffplug/spotless/LazyForwardingEquality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public abstract class LazyForwardingEquality<T extends Serializable> implements 
 	/**
 	 * This function is guaranteed to be called at most once.
 	 * If the state is never required, then it will never be called at all.
-	 *
+	 * <p>
 	 * Throws exception because it's likely that there will be some IO going on.
 	 */
 	protected abstract T calculateState() throws Exception;

--- a/lib/src/main/java/com/diffplug/spotless/NoLambda.java
+++ b/lib/src/main/java/com/diffplug/spotless/NoLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ import java.util.Arrays;
 /**
  * Marker interface to prevent lambda implementations of
  * single-method interfaces that require serializability.
- *
+ * <p>
  * In order for Spotless to support up-to-date checks, all
  * of its parameters must be {@link Serializable} so that
  * entries can be written to file, and they must implement
  * equals and hashCode correctly.
- *
+ * <p>
  * This interface and its standard implementation,
  * {@link EqualityBasedOnSerialization}, are a quick way
  * to accomplish these goals.
@@ -34,7 +34,7 @@ import java.util.Arrays;
 public interface NoLambda extends Serializable {
 	/**
 	 * Returns a byte array representation of everything inside this {@code SerializableFileFilter}.
-	 *
+	 * <p>
 	 * The main purpose of this method is to ensure one can't instantiate this class with lambda
 	 * expressions, which are notoriously difficult to serialize and deserialize properly. (See
 	 * {@code SerializableFileFilterImpl.SkipFilesNamed} for an example of how to make a serializable

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 /**
  * Models the result of applying a {@link Formatter} on a given {@link File}
  * while characterizing various failure modes (slow convergence, cycles, and divergence).
- *
+ * <p>
  * See {@link #check(Formatter, File)} as the entry point to this class.
  */
 public final class PaddedCell {
@@ -78,9 +78,9 @@ public final class PaddedCell {
 	/**
 	 * Applies the given formatter to the given file, checking that
 	 * F(F(input)) == F(input).
-	 *
+	 * <p>
 	 * If it meets this test, {@link #misbehaved()} will return false.
-	 *
+	 * <p>
 	 * If it fails the test, {@link #misbehaved()} will return true, and you can find
 	 * out more about the misbehavior based on its {@link Type}.
 	 *

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -43,7 +43,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * Shelling out to a process is harder than it ought to be in Java.
  * If you don't read stdout and stderr on their own threads, you risk
  * deadlock on a clogged buffer.
- *
+ * <p>
  * ProcessRunner allocates two threads specifically for the purpose of
  * flushing stdout and stderr to buffers.  These threads will remain alive until
  * the ProcessRunner is closed, so it is especially useful for repeated
@@ -239,7 +239,7 @@ public class ProcessRunner implements AutoCloseable {
 		/**
 		 * Asserts that the exit code was zero, and if so, returns
 		 * the content of stdout encoded with the given charset.
-		 *
+		 * <p>
 		 * If the exit code was not zero, throws an exception
 		 * with useful debugging information.
 		 */

--- a/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
+++ b/lib/src/main/java/com/diffplug/spotless/ThrowingEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.diffplug.spotless;
 /**
  * Basic functional interfaces which throw exception, along with
  * static helper methods for calling them.
- *
+ * <p>
  * Contains most of the functionality of Durian's Throwing and Errors
  * classes, but stripped down and renamed to avoid any confusion.
  */
@@ -80,7 +80,7 @@ public final class ThrowingEx {
 
 	/**
 	 * Casts or wraps the given exception to be a RuntimeException.
-	 *
+	 * <p>
 	 * If the input exception is a RuntimeException, it is simply
 	 * cast and returned.  Otherwise, it wrapped in a
 	 * {@link WrappedAsRuntimeException} and returned.

--- a/lib/src/main/java/com/diffplug/spotless/annotations/Internal.java
+++ b/lib/src/main/java/com/diffplug/spotless/annotations/Internal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 /**
  * Signifies that a {@code public} API is actually an implementation detail, and should be treated as if it
  * were {@code private}.
- *
+ * <p>
  * The user of the API should be warned that it may unexpectedly disappear in future versions of
  * Spotless. Usually the best place to put this warning is in the API's class JavaDoc.
  */

--- a/lib/src/main/java/com/diffplug/spotless/npm/JsonEscaper.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/JsonEscaper.java
@@ -60,7 +60,7 @@ final class JsonEscaper {
 	private static String jsonEscape(String unescaped) {
 		/**
 		 * the following characters are reserved in JSON and must be properly escaped to be used in strings:
-		 *
+		 * <p>
 		 * Backspace is replaced with \b
 		 * Form feed is replaced with \f
 		 * Newline is replaced with \n
@@ -68,7 +68,7 @@ final class JsonEscaper {
 		 * Tab is replaced with \t
 		 * Double quote is replaced with \"
 		 * Backslash is replaced with \\
-		 *
+		 * <p>
 		 * additionally we handle xhtml '</bla>' string
 		 * and non-ascii chars
 		 */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBPKeywordType.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBPKeywordType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.diffplug.spotless.sql.dbeaver;
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on DBPKeywordType from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/DBeaverSQLFormatterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ import com.diffplug.spotless.annotations.Internal;
 /**
  * **Warning:** Use this class at your own risk. It is an implementation detail and is not
  * guaranteed to exist in future versions.
- *
+ * <p>
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on SQLFormatterConfiguration from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/Pair.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.diffplug.spotless.sql.dbeaver;
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on Pair from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLConstants.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.diffplug.spotless.sql.dbeaver;
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on SQLConstants from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLDialect.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLDialect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.util.TreeSet;
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on SQLDialect from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,11 @@ import com.diffplug.spotless.annotations.Internal;
 /**
  * **Warning:** Use this class at your own risk. It is an implementation detail and is not
  * guaranteed to exist in future versions.
- *
+ * <p>
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on SQLTokenizedFormatter from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.Set;
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on SQLTokensParser from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/TokenType.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/TokenType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.diffplug.spotless.sql.dbeaver;
  * Forked from
  * DBeaver - Universal Database Manager
  * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
- *
+ * <p>
  * Based on TokenType from https://github.com/serge-rider/dbeaver,
  * which itself is licensed under the Apache 2.0 license.
  */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -204,14 +204,14 @@ public class FormatExtension {
 	/**
 	 * Sets which files should be formatted. Files to be formatted = (target -
 	 * targetExclude).
-	 *
+	 * <p>
 	 * When this method is called multiple times, only the last call has any effect.
-	 *
+	 * <p>
 	 * FileCollections pass through raw. Strings are treated as the 'include' arg to
 	 * fileTree, with project.rootDir as the dir. List<String> are treated as the
 	 * 'includes' arg to fileTree, with project.rootDir as the dir. Anything else
 	 * gets passed to getProject().files().
-	 *
+	 * <p>
 	 * If you pass any strings that start with "**\/*", this method will
 	 * automatically filter out "build", ".gradle", and ".git" folders.
 	 */
@@ -222,9 +222,9 @@ public class FormatExtension {
 	/**
 	 * Sets which files will be excluded from formatting. Files to be formatted =
 	 * (target - targetExclude).
-	 *
+	 * <p>
 	 * When this method is called multiple times, only the last call has any effect.
-	 *
+	 * <p>
 	 * FileCollections pass through raw. Strings are treated as the 'include' arg to
 	 * fileTree, with project.rootDir as the dir. List<String> are treated as the
 	 * 'includes' arg to fileTree, with project.rootDir as the dir. Anything else
@@ -236,7 +236,7 @@ public class FormatExtension {
 
 	/**
 	 * Excludes all files whose content contains {@code string}.
-	 *
+	 * <p>
 	 * When this method is called multiple times, only the last call has any effect.
 	 */
 	public void targetExcludeIfContentContains(String string) {
@@ -245,7 +245,7 @@ public class FormatExtension {
 
 	/**
 	 * Excludes all files whose content contains the given regex.
-	 *
+	 * <p>
 	 * When this method is called multiple times, only the last call has any effect.
 	 */
 	public void targetExcludeIfContentContainsRegex(String regex) {
@@ -392,13 +392,13 @@ public class FormatExtension {
 	 * An optional performance optimization if you are using any of the
 	 * {@code custom} methods. If you aren't explicitly calling {@code custom}, then
 	 * this method has no effect.
-	 *
+	 * <p>
 	 * Spotless tracks what files have changed from run to run, so that it can run
 	 * faster by only checking files which have changed, or whose formatting steps
 	 * have changed. If you use the {@code custom} methods, then gradle can never
 	 * mark your files as {@code up-to-date}, because it can't know if perhaps the
 	 * behavior of your custom function has changed.
-	 *
+	 * <p>
 	 * If you set {@code bumpThisNumberIfACustomStepChanges( <some number> )}, then
 	 * spotless will assume that the custom rules have not changed if the number has
 	 * not changed. If a custom rule does change, then you must bump the number so
@@ -1090,16 +1090,16 @@ public class FormatExtension {
 	/**
 	 * Creates an independent {@link SpotlessApply} for (very) unusual
 	 * circumstances.
-	 *
+	 * <p>
 	 * Most users will not want this method. In the rare case that you want to
 	 * create a {@code SpotlessApply} which is independent of the normal Spotless
 	 * machinery, this will let you do that.
-	 *
+	 * <p>
 	 * The returned task will not be hooked up to the global {@code spotlessApply},
 	 * and there will be no corresponding {@code check} task.
-	 *
+	 * <p>
 	 * The task name must not end with `Apply`.
-	 *
+	 * <p>
 	 * NOTE: does not respect the rarely-used <a href=
 	 * "https://github.com/diffplug/spotless/blob/b7f8c551a97dcb92cc4b0ee665448da5013b30a3/plugin-gradle/README.md#can-i-apply-spotless-to-specific-files">{@code spotlessFiles}
 	 * property</a>.

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -159,7 +159,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 	/**
 	 * Uses the given version of <a href="https://github.com/google/google-java-format">google-java-format</a> to format source code.
-	 *
+	 * <p>
 	 * Limited to published versions.  See <a href="https://github.com/diffplug/spotless/issues/33#issuecomment-252315095">issue #33</a>
 	 * for a workaround for using snapshot versions.
 	 */
@@ -243,7 +243,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 	/**
 	 * Uses the given version of <a href="https://github.com/palantir/palantir-java-format">palantir-java-format</a> to format source code.
-	 *
+	 * <p>
 	 * Limited to published versions.  See <a href="https://github.com/diffplug/spotless/issues/33#issuecomment-252315095">issue #33</a>
 	 * for a workaround for using snapshot versions.
 	 */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -39,7 +39,7 @@ import com.diffplug.spotless.FormatterStep;
 
 /**
  * NOT AN END-USER TASK, DO NOT USE FOR ANYTHING!
- *
+ * <p>
  * - When a user asks for a formatter, we need to download the jars for that formatter
  * - Gradle wants us to resolve all our dependencies in the root project - no new dependencies in subprojects
  * - So, whenever a SpotlessTask in a subproject gets configured, we call {@link #hookSubprojectTask(SpotlessTask)},

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -234,7 +234,7 @@ public abstract class SpotlessExtension {
 	/**
 	 * Configures Gradle's {@code check} task to run {@code spotlessCheck} if {@code true},
 	 * but to not do so if {@code false}.
-	 *
+	 * <p>
 	 * {@code true} by default.
 	 */
 	public void setEnforceCheck(boolean enforceCheck) {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -94,12 +94,12 @@ public class GradleIntegrationHarness extends ResourceHarness {
 	/**
 	 * Each test gets its own temp folder, and we create a gradle
 	 * build there and run it.
-	 *
+	 * <p>
 	 * Because those test folders don't have a .gitattributes file,
 	 * git (on windows) will default to \r\n. So now if you read a
 	 * test file from the spotless test resources, and compare it
 	 * to a build result, the line endings won't match.
-	 *
+	 * <p>
 	 * By sticking this .gitattributes file into the test directory,
 	 * we ensure that the default Spotless line endings policy of
 	 * GIT_ATTRIBUTES will use \n, so that tests match the test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -70,12 +70,12 @@ public class MavenIntegrationHarness extends ResourceHarness {
 	/**
 	 * Each test gets its own temp folder, and we create a maven
 	 * build there and run it.
-	 *
+	 * <p>
 	 * Because those test folders don't have a .gitattributes file,
 	 * git on windows will default to \r\n. So now if you read a
 	 * test file from the spotless test resources, and compare it
 	 * to a build result, the line endings won't match.
-	 *
+	 * <p>
 	 * By sticking this .gitattributes file into the test directory,
 	 * we ensure that the default Spotless line endings policy of
 	 * GIT_ATTRIBUTES will use \n, so that tests match the test

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -52,10 +52,10 @@ public class TestProvisioner {
 
 	/**
 	 * Creates a Provisioner for the given repositories.
-	 *
+	 * <p>
 	 * The first time a project is created, there are ~7 seconds of configuration
 	 * which will go away for all subsequent runs.
-	 *
+	 * <p>
 	 * Every call to resolve will take about 1 second, even when all artifacts are resolved.
 	 */
 	private static Provisioner createWithRepositories(Consumer<RepositoryHandler> repoConfig) {


### PR DESCRIPTION
A blank line in Javadoc will not break a paragraph.  This leads to IDE tooltip annotations (as well as any generate Javadoc) being displayed as a single paragraph.  This PR adds <p> tags to all the blank lines where a new paragraph seems to be implied.

This change was authored by letting my IDE do all the work, if it's not a change that's helpful then please accept my apologies and close the PR.

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
