### PR TITLE
Fix misleading sentence in Maven plugin README

### DIFF
--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -73,7 +73,7 @@ user@machine repo % mvn spotless:check
 
 ## Quickstart
 
-To use it in your pom, just [add the Spotless dependency](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-maven-plugin%22), and configure it like so:
+To use it in your pom, just [add the Spotless plugin](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.diffplug.spotless%22%20AND%20a%3A%22spotless-maven-plugin%22), and configure it like so:
 
 ```xml
 <plugin>


### PR DESCRIPTION
The previous "add the Spotless dependency" could be misunderstood as having to add a regular Maven dependency entry for the Spotless plugin.

---

I assume this does not require an entry in `CHANGES.md`.