### PR TITLE
Manually declaring `junit-platform-launcher` for `testCommon`

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 	testCommonImplementation "org.junit.jupiter:junit-jupiter:$VER_JUNIT"
 	testCommonImplementation "org.assertj:assertj-core:$VER_ASSERTJ"
 	testCommonImplementation "com.diffplug.durian:durian-testlib:$VER_DURIAN"
+	testCommonRuntimeOnly "org.junit.platform:junit-platform-launcher"
 
 	// GLUE CODE (alphabetic order please)
 	// cleanthat


### PR DESCRIPTION
Follow up #1842, fix deprecations in https://scans.gradle.com/s/bm6qlixjgqohw/deprecations#32.