### PR TITLE
Provide Gradle projects as dependencies

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 
 import com.diffplug.common.base.Errors;
@@ -157,7 +156,7 @@ public class EclipseBasedStepBuilder {
 
 		/** State constructor expects that all passed items are not modified afterwards */
 		protected State(String formatterVersion, String formatterStepExt, Provisioner jarProvisioner, List<String> dependencies, Iterable<File> settingsFiles) throws IOException {
-			this.jarState = JarState.withoutTransitives(dependencies, jarProvisioner);
+			this.jarState = JarState.from(dependencies, jarProvisioner, false);
 			this.settingsFiles = FileSignature.signAsList(settingsFiles);
 			this.formatterStepExt = formatterStepExt;
 			semanticVersion = convertEclipseVersion(formatterVersion);
@@ -185,12 +184,6 @@ public class EclipseBasedStepBuilder {
 			//Keep the IllegalArgumentException since it contains detailed information
 			FormatterProperties preferences = FormatterProperties.from(settingsFiles.files());
 			return preferences.getProperties();
-		}
-
-		/** Returns first coordinate from sorted set that starts with a given prefix.*/
-		public Optional<String> getMavenCoordinate(String prefix) {
-			return jarState.getMavenCoordinates().stream()
-					.filter(coordinate -> coordinate.startsWith(prefix)).findFirst();
 		}
 
 		/**

--- a/lib/src/main/java/com/diffplug/spotless/Provisioner.java
+++ b/lib/src/main/java/com/diffplug/spotless/Provisioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.diffplug.spotless;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -25,17 +24,10 @@ import java.util.Set;
  * Spotless' dependencies minimal.
  */
 public interface Provisioner {
-	/**
-	 * Given a set of Maven coordinates, returns a set of jars which include all
-	 * of the specified coordinates and optionally their transitive dependencies.
-	 */
-	public default Set<File> provisionWithTransitives(boolean withTransitives, String... mavenCoordinates) {
-		return provisionWithTransitives(withTransitives, Arrays.asList(mavenCoordinates));
-	}
 
 	/**
 	 * Given a set of Maven coordinates, returns a set of jars which include all
-	 * of the specified coordinates and optionally their transitive dependencies.
+	 * the specified coordinates and optionally their transitive dependencies.
 	 */
-	public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates);
+	Set<File> provisionWithTransitives(boolean withTransitives, Collection<?> dependencies);
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleProvisionerTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleProvisionerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class GradleProvisionerTest extends GradleIntegrationHarness {
+	private static final String JUPITER_COORDINATE = "'" + "org.junit.jupiter:junit-jupiter:5.10.0" + "'";
+	private static final String JUPITER_TRANSITIVE = "junit-jupiter-params-5.10.0.jar, junit-jupiter-engine-5.10.0.jar, junit-jupiter-api-5.10.0.jar, junit-platform-engine-1.10.0.jar, junit-platform-commons-1.10.0.jar, junit-jupiter-5.10.0.jar, opentest4j-1.3.0.jar";
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void canResolveMavenCoordinates(boolean withTransitives) throws IOException {
+		String output = resolveDepsResult(withTransitives, JUPITER_COORDINATE);
+		assertThat(output).contains(withTransitives ? JUPITER_TRANSITIVE : "junit-jupiter-5.10.0.jar");
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void canResolveLocalProject(boolean withTransitives) throws IOException {
+		setFile("settings.gradle").toLines("include 'sub'");
+		setFile("sub/build.gradle").toLines(
+				"plugins {",
+				"    id 'java'",
+				"}",
+				"repositories { mavenCentral() }",
+				"dependencies {",
+				"    implementation " + JUPITER_COORDINATE,
+				"}");
+		String output = resolveDepsResult(withTransitives, "project(':sub')");
+		assertThat(output).contains(withTransitives ? JUPITER_TRANSITIVE : "sub.jar");
+	}
+
+	private String resolveDepsResult(boolean withTransitives, Object dep) throws IOException {
+		setFile("build.gradle").toLines(
+				"import com.diffplug.gradle.spotless.GradleProvisioner",
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"tasks.register('resolveDeps') {",
+				"    def files = GradleProvisioner.forProject(project)",
+				String.format(".provisionWithTransitives(%s, [%s])", withTransitives, dep),
+				"    println files.collect { it.getName() }.join(', ')",
+				"}");
+		return gradleRunner().withArguments("resolveDeps").build().getOutput();
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,13 +60,13 @@ public class ArtifactResolver {
 	 * Given a set of maven coordinates, returns a set of jars which include all
 	 * of the specified coordinates and optionally their transitive dependencies.
 	 */
-	public Set<File> resolve(boolean withTransitives, Collection<String> mavenCoordinates) {
+	public Set<File> resolve(boolean withTransitives, Collection<?> mavenCoordinates) {
 		Collection<Exclusion> excludeTransitive = new ArrayList<Exclusion>(1);
 		if (!withTransitives) {
 			excludeTransitive.add(EXCLUDE_ALL_TRANSITIVES);
 		}
 		List<Dependency> dependencies = mavenCoordinates.stream()
-				.map(coordinateString -> new DefaultArtifact(coordinateString))
+				.map(coordinate -> new DefaultArtifact(coordinate.toString()))
 				.map(artifact -> new Dependency(artifact, null, null, excludeTransitive))
 				.collect(toList());
 		CollectRequest collectRequest = new CollectRequest(dependencies, null, repositories);

--- a/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 package com.diffplug.spotless;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
@@ -25,12 +26,10 @@ import org.junit.jupiter.api.Test;
 class ProvisionerTest {
 	@Test
 	void testManipulation() {
-		Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(File::new).collect(Collectors.toSet());
-		Assertions.assertThat(provisioner.provisionWithTransitives(true, "a"))
+		Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(Object::toString).map(File::new).collect(Collectors.toSet());
+		Assertions.assertThat(provisioner.provisionWithTransitives(true, Collections.singleton("a")))
 				.containsExactlyInAnyOrder(new File("a"));
-		Assertions.assertThat(provisioner.provisionWithTransitives(true, "a", "a"))
-				.containsExactlyInAnyOrder(new File("a"));
-		Assertions.assertThat(provisioner.provisionWithTransitives(true, Arrays.asList("a", "a")))
+		Assertions.assertThat(provisioner.provisionWithTransitives(true, List.of("a", "a")))
 				.containsExactlyInAnyOrder(new File("a"));
 	}
 }


### PR DESCRIPTION
I just finished the support for Gradle projects, need more work to support Gradle's version catalogs, type-safe project accessors, or something else. May need to review this carefully, it would be better to merge this after `6.23.0` is out.



Closes #1901.