### PR TITLE
Polish GradleExtension tests

### DIFF
--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GroovyGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GroovyGradleExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +17,20 @@ package com.diffplug.gradle.spotless;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.diffplug.common.base.StringPrinter;
 
-class GroovyGradleExtensionTest extends GradleIntegrationHarness {
+/**
+ * We test GroovyGradleExtension only behaviors here.
+ */
+class GroovyGradleExtensionTest extends GroovyExtensionTest {
 	private static final String HEADER = "//My tests header";
 
-	@Test
-	void defaultTarget() throws IOException {
-		testTarget(true);
-	}
-
-	@Test
-	void customTarget() throws IOException {
-		testTarget(false);
-	}
-
-	private void testTarget(boolean useDefaultTarget) throws IOException {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void testTarget(boolean useDefaultTarget) throws IOException {
 		String target = useDefaultTarget ? "" : "target 'other.gradle'";
 		String buildContent = StringPrinter.buildStringFromLines(
 				"plugins {",

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -30,7 +30,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	void integrationDiktat() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -48,7 +48,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	void integrationKtfmt_dropboxStyle_0_19() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -66,7 +66,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	void withExperimentalEditorConfigOverride() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -90,7 +90,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -110,7 +110,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 		setFile(".editorconfig").toResource("kotlin/ktlint/ktlint_official/.editorconfig");
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -127,7 +127,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 		setFile(".editorconfig").toResource("kotlin/ktlint/intellij_idea/.editorconfig");
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -145,7 +145,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	void withCustomRuleSetApply() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -169,7 +169,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	void testWithHeader() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",
@@ -188,7 +188,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	void testWithCustomMaxWidthDefaultStyleKtfmt() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -30,7 +30,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	void integrationDiktat() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.4.30'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -30,7 +30,7 @@ class KotlinGradleExtensionTest extends KotlinExtensionTest {
 	void testTarget(boolean useDefaultTarget) throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.5.31'",
+				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
 				"    id 'com.diffplug.spotless'",
 				"}",
 				"repositories { mavenCentral() }",


### PR DESCRIPTION
Changed:
- Remove redundant tests in `GroovyGradleExtensionTest`, and let it extend `GroovyExtensionTest`.
- Remove redundant tests in `KotlinGradleExtensionTest`, and let it extend `KotlinExtensionTest`.
- Bump Kotlin plugins for Java 21 tests in the future.

Follow up:
- #1890
- #1892