### PR TITLE
Make `BaseGroovyExtension` and `BaseKotlinExtension` public

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -10,13 +10,15 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * Support custom rule sets for Ktlint. ([#1896](https://github.com/diffplug/spotless/pull/1896))
 ### Fixed
+* Fix `GoogleJavaFormatConfig.reorderImports` not working. ([#1872](https://github.com/diffplug/spotless/issues/1872))
 * Fix Eclipse JDT on some settings files. ([#1864](https://github.com/diffplug/spotless/pull/1864) fixes [#1638](https://github.com/diffplug/spotless/issues/1638))
 * Check if EditorConfig file exist for Ktlint in KotlinGradleExtension. ([#1889](https://github.com/diffplug/spotless/pull/1889))
 ### Changes
 * Bump default `ktlint` version to latest `1.0.0` -> `1.0.1`. ([#1855](https://github.com/diffplug/spotless/pull/1855))
 * Add a Step to remove semicolons from Groovy files. ([#1881](https://github.com/diffplug/spotless/pull/1881))
-### Fixed
-* Fix `GoogleJavaFormatConfig.reorderImports` not working. ([#1872](https://github.com/diffplug/spotless/issues/1872))
+* **POSSIBLY BREAKING** `userData` method has been removed from Ktlint step in ([#1891](https://github.com/diffplug/spotless/pull/1891)), you may use `editorConfigOverride` instead.
+* **POSSIBLY BREAKING** Reuse configs for `KotlinExtension` and `KotlinGradleExtension` in ([#1890](https://github.com/diffplug/spotless/pull/1890)), this may break your integrations in Gradle Kotlin DSL, wait for Spotless 6.23.1 to fix this.
+* **POSSIBLY BREAKING** Reuse configs for `GroovyExtension` and `GroovyGradleExtension` in ([#1890](https://github.com/diffplug/spotless/pull/1890)), this may break your integrations in Gradle Kotlin DSL, wait for Spotless 6.23.1 to fix this.
 
 ## [6.22.0] - 2023-09-28
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -8,7 +8,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [6.23.0] - 2023-11-27
 ### Added
-* Support custom rule sets for Ktlint. ([#1896](https://github.com/diffplug/spotless/pull/1896)
+* Support custom rule sets for Ktlint. ([#1896](https://github.com/diffplug/spotless/pull/1896))
 ### Fixed
 * Fix Eclipse JDT on some settings files. ([#1864](https://github.com/diffplug/spotless/pull/1864) fixes [#1638](https://github.com/diffplug/spotless/issues/1638))
 * Check if EditorConfig file exist for Ktlint in KotlinGradleExtension. ([#1889](https://github.com/diffplug/spotless/pull/1889))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Make `BaseGroovyExtension` and `BaseKotlinExtension` public. ([#1912](https://github.com/diffplug/spotless/pull/1912))
 
 ## [6.23.0] - 2023-11-27
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
@@ -27,7 +27,7 @@ import com.diffplug.spotless.extra.groovy.GrEclipseFormatterStep;
 import com.diffplug.spotless.groovy.RemoveSemicolonsStep;
 import com.diffplug.spotless.java.ImportOrderStep;
 
-abstract class BaseGroovyExtension extends FormatExtension {
+public abstract class BaseGroovyExtension extends FormatExtension {
 	protected BaseGroovyExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseKotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseKotlinExtension.java
@@ -33,7 +33,7 @@ import com.diffplug.spotless.kotlin.DiktatStep;
 import com.diffplug.spotless.kotlin.KtLintStep;
 import com.diffplug.spotless.kotlin.KtfmtStep;
 
-abstract class BaseKotlinExtension extends FormatExtension {
+public abstract class BaseKotlinExtension extends FormatExtension {
 	protected BaseKotlinExtension(SpotlessExtension spotless) {
 		super(spotless);
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -143,21 +143,21 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 
 	@Test
 	void withCustomRuleSetApply() throws IOException {
-		setFile("build.gradle").toLines(
+		setFile("build.gradle.kts").toLines(
 				"plugins {",
-				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
-				"    id 'com.diffplug.spotless'",
+				"    id(\"org.jetbrains.kotlin.jvm\") version \"1.6.21\"",
+				"    id(\"com.diffplug.spotless\")",
 				"}",
 				"repositories { mavenCentral() }",
 				"spotless {",
 				"    kotlin {",
 				"        ktlint(\"1.0.1\")",
-				"        .customRuleSets([",
+				"        .customRuleSets(listOf(",
 				"            \"io.nlopez.compose.rules:ktlint:0.3.3\"",
-				"        ])",
-				"        .editorConfigOverride([",
-				"            ktlint_function_naming_ignore_when_annotated_with: \"Composable\",",
-				"        ])",
+				"        ))",
+				"        .editorConfigOverride(mapOf(",
+				"            \"ktlint_function_naming_ignore_when_annotated_with\" to \"Composable\"",
+				"        ))",
 				"    }",
 				"}");
 		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/listScreen.dirty");

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,7 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [2.41.0] - 2023-11-27
 ### Added
 * CompileSourceRoots and TestCompileSourceRoots are now respected as default includes. These properties are commonly set when adding extra source directories. ([#1846](https://github.com/diffplug/spotless/issues/1846))
-* Support custom rule sets for Ktlint. ([#1896](https://github.com/diffplug/spotless/pull/1896)
+* Support custom rule sets for Ktlint. ([#1896](https://github.com/diffplug/spotless/pull/1896))
 ### Fixed
 * Fix crash when build dir is a softlink to another directory. ([#1859](https://github.com/diffplug/spotless/pull/1859))
 * Fix Eclipse JDT on some settings files. ([#1864](https://github.com/diffplug/spotless/pull/1864) fixes [#1638](https://github.com/diffplug/spotless/issues/1638))


### PR DESCRIPTION
- Follow up https://github.com/diffplug/spotless/pull/1890#issuecomment-1827263031.
- Closes #1911.