### PR TITLE
Start making each `FormatterStep` roundtrip serializable.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* `FileSignature.Promised` and `JarState.Promised` to facilitate round-trip serialization for the Gradle configuration cache. ([#1945](https://github.com/diffplug/spotless/pull/1945)) 
+### Removed
+* **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 
 ## [2.45.0] - 2024-01-23
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,13 +96,13 @@ Here's a checklist for creating a new step for Spotless:
 - [ ] Class name ends in Step, `SomeNewStep`.
 - [ ] Class has a public static method named `create` that returns a `FormatterStep`.
 - [ ] Has a test class named `SomeNewStepTest` that uses `StepHarness` or `StepHarnessWithFile` to test the step.
-  - [ ] Start with `StepHarness.forStep(myStep).supportsRoundTrip(false)`, and then add round trip support as decribed in the next section. 
+  - [ ] Start with `StepHarness.forStep(myStep).supportsRoundTrip(false)`, and then add round trip support as described in the next section. 
 - [ ] Test class has test methods to verify behavior.
 - [ ] Test class has a test method `equality()` which tests equality using `StepEqualityTester` (see existing methods for examples).
 
 ### Serialization roundtrip
 
-In order to support Gradle's configuration cache, all `FormatterStep` must be round-trip serializable. This is a bit tricky because step equality is based on the serialied form of the state, and `transient` is used to take absolute paths out of the equality check. To make this work, roundtrip compatible steps actually have *two* states
+In order to support Gradle's configuration cache, all `FormatterStep` must be round-trip serializable. This is a bit tricky because step equality is based on the serialized form of the state, and `transient` is used to take absolute paths out of the equality check. To make this work, roundtrip compatible steps actually have *two* states:
 
 - `RoundtripState` which must be roundtrip serializable but has no equality constraints
   - `FileSignature.Promised` for settings files and `JarState.Promised` for the classpath 

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 
 import com.diffplug.common.base.Errors;
@@ -185,12 +184,6 @@ public class EclipseBasedStepBuilder {
 			//Keep the IllegalArgumentException since it contains detailed information
 			FormatterProperties preferences = FormatterProperties.from(settingsFiles.files());
 			return preferences.getProperties();
-		}
-
-		/** Returns first coordinate from sorted set that starts with a given prefix.*/
-		public Optional<String> getMavenCoordinate(String prefix) {
-			return jarState.getMavenCoordinates().stream()
-					.filter(coordinate -> coordinate.startsWith(prefix)).findFirst();
 		}
 
 		/**

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -103,7 +103,7 @@ public final class FileSignature implements Serializable {
 		@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 		private transient @Nullable FileSignature cached;
 
-		private Promised(List<File> files, FileSignature cached) {
+		private Promised(List<File> files, @Nullable FileSignature cached) {
 			this.files = files;
 			this.cached = cached;
 		}

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -108,10 +108,10 @@ public final class FileSignature implements Serializable {
 			this.cached = cached;
 		}
 
-		public FileSignature stripAbsolutePaths() throws IOException {
+		public FileSignature get() {
 			if (cached == null) {
 				// null when restored via serialization
-				cached = new FileSignature(files);
+				cached = ThrowingEx.get(() -> new FileSignature(files));
 			}
 			return cached;
 		}
@@ -135,7 +135,7 @@ public final class FileSignature implements Serializable {
 
 	public static @Nullable FileSignature stripAbsolutePathsNullable(@Nullable Promised roundTrippable) throws IOException {
 		if (roundTrippable != null) {
-			return roundTrippable.stripAbsolutePaths();
+			return roundTrippable.get();
 		} else {
 			return null;
 		}

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -97,13 +97,13 @@ public final class FileSignature implements Serializable {
 	}
 
 	/** A view of `FileSignature` which can be safely roundtripped. */
-	public static class RoundTrippable implements Serializable {
+	public static class Promised implements Serializable {
 		private static final long serialVersionUID = 1L;
 		private final List<File> files;
 		@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 		private transient @Nullable FileSignature cached;
 
-		private RoundTrippable(List<File> files, FileSignature cached) {
+		private Promised(List<File> files, FileSignature cached) {
 			this.files = files;
 			this.cached = cached;
 		}
@@ -117,11 +117,15 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	public RoundTrippable roundTrippable() {
-		return new RoundTrippable(files, this);
+	public static Promised promise(Iterable<File> files) {
+		return new Promised(MoreIterables.toNullHostileList(files), null);
 	}
 
-	public static @Nullable RoundTrippable roundTrippableNullable(@Nullable FileSignature signature) {
+	public Promised roundTrippable() {
+		return new Promised(files, this);
+	}
+
+	public static @Nullable Promised roundTrippableNullable(@Nullable FileSignature signature) {
 		if (signature != null) {
 			return signature.roundTrippable();
 		} else {
@@ -129,7 +133,7 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	public static @Nullable FileSignature stripAbsolutePathsNullable(@Nullable RoundTrippable roundTrippable) throws IOException {
+	public static @Nullable FileSignature stripAbsolutePathsNullable(@Nullable Promised roundTrippable) throws IOException {
 		if (roundTrippable != null) {
 			return roundTrippable.stripAbsolutePaths();
 		} else {

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -121,24 +121,8 @@ public final class FileSignature implements Serializable {
 		return new Promised(MoreIterables.toNullHostileList(files), null);
 	}
 
-	public Promised roundTrippable() {
+	public Promised asPromise() {
 		return new Promised(files, this);
-	}
-
-	public static @Nullable Promised roundTrippableNullable(@Nullable FileSignature signature) {
-		if (signature != null) {
-			return signature.roundTrippable();
-		} else {
-			return null;
-		}
-	}
-
-	public static @Nullable FileSignature stripAbsolutePathsNullable(@Nullable Promised roundTrippable) throws IOException {
-		if (roundTrippable != null) {
-			return roundTrippable.get();
-		} else {
-			return null;
-		}
 	}
 
 	/** Returns all of the files in this signature, throwing an exception if there are more or less than 1 file. */

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -98,7 +98,9 @@ public final class FileSignature implements Serializable {
 
 	/** A view of `FileSignature` which can be safely roundtripped. */
 	public static class RoundTrippable implements Serializable {
+		private static final long serialVersionUID = 1L;
 		private final List<File> files;
+		@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 		private transient @Nullable FileSignature cached;
 
 		private RoundTrippable(List<File> files, FileSignature cached) {

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -117,10 +117,6 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	public static Promised promise(Iterable<File> files) {
-		return new Promised(MoreIterables.toNullHostileList(files), null);
-	}
-
 	public Promised asPromise() {
 		return new Promised(files, this);
 	}

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -304,6 +304,8 @@ public final class Formatter implements Serializable, AutoCloseable {
 		for (FormatterStep step : steps) {
 			if (step instanceof FormatterStepImpl.Standard) {
 				((FormatterStepImpl.Standard) step).cleanupFormatterFunc();
+			} else if (step instanceof FormatterStepEqualityOnStateSerialization) {
+				((FormatterStepEqualityOnStateSerialization) step).cleanupFormatterFunc();
 			}
 		}
 	}

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -129,6 +129,28 @@ public interface FormatterStep extends Serializable {
 
 	/**
 	 * @param name
+	 *             The name of the formatter step.
+	 * @param roundTrip
+	 *             The roundtrip serializable state of the step.
+	 * @param equalityFunc
+	 * 		       A pure serializable function (method reference recommended) which takes the result of `roundTrip`,
+	 * 		       and returns a serializable object whose serialized representation will be used for `.equals` and
+	 * 		       `.hashCode` of the FormatterStep.
+	 * @param formatterFunc
+	 * 		       A pure serializable function (method reference recommended) which takes the result of `equalityFunc`,
+	 * 		       and returns a `FormatterFunc` which will be used for the actual formatting.
+	 * @return A FormatterStep which can be losslessly roundtripped through the java serialization machinery.
+	 */
+	static <RoundtripState extends Serializable, EqualityState extends Serializable> FormatterStep create(
+			String name,
+			RoundtripState roundTrip,
+			SerializedFunction<RoundtripState, EqualityState> equalityFunc,
+			SerializedFunction<EqualityState, FormatterFunc> formatterFunc) {
+		return createLazy(name, () -> roundTrip, equalityFunc, formatterFunc);
+	}
+
+	/**
+	 * @param name
 	 *             The name of the formatter step
 	 * @param stateSupplier
 	 *             If the rule has any state, this supplier will calculate it lazily, and the result

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  */
 public interface FormatterStep extends Serializable {
 	/** The name of the step, for debugging purposes. */
-	public String getName();
+	String getName();
 
 	/**
 	 * Returns a formatted version of the given content.
@@ -43,7 +43,8 @@ public interface FormatterStep extends Serializable {
 	 *         if the formatter step doesn't have any changes to make
 	 * @throws Exception if the formatter step experiences a problem
 	 */
-	public @Nullable String format(String rawUnix, File file) throws Exception;
+	@Nullable
+	String format(String rawUnix, File file) throws Exception;
 
 	/**
 	 * Returns a new FormatterStep which will only apply its changes
@@ -54,7 +55,7 @@ public interface FormatterStep extends Serializable {
 	 * @return FormatterStep
 	 */
 	@Deprecated
-	public default FormatterStep filterByContentPattern(String contentPattern) {
+	default FormatterStep filterByContentPattern(String contentPattern) {
 		return filterByContent(OnMatch.INCLUDE, contentPattern);
 	}
 
@@ -68,7 +69,7 @@ public interface FormatterStep extends Serializable {
 	 *            java regular expression used to filter in or out files which content contain pattern
 	 * @return FormatterStep
 	 */
-	public default FormatterStep filterByContent(OnMatch onMatch, String contentPattern) {
+	default FormatterStep filterByContent(OnMatch onMatch, String contentPattern) {
 		return new FilterByContentPatternFormatterStep(this, onMatch, contentPattern);
 	}
 
@@ -78,7 +79,7 @@ public interface FormatterStep extends Serializable {
 	 * <p>
 	 * The provided filter must be serializable.
 	 */
-	public default FormatterStep filterByFile(SerializableFileFilter filter) {
+	default FormatterStep filterByFile(SerializableFileFilter filter) {
 		return new FilterByFileFormatterStep(this, filter);
 	}
 
@@ -124,7 +125,7 @@ public interface FormatterStep extends Serializable {
 			ThrowingEx.Supplier<RoundtripState> roundtripInit,
 			SerializedFunction<RoundtripState, EqualityState> equalityFunc,
 			SerializedFunction<EqualityState, FormatterFunc> formatterFunc) {
-		return new FormatterStepSerializationRoundtrip(name, roundtripInit, equalityFunc, formatterFunc);
+		return new FormatterStepSerializationRoundtrip<>(name, roundtripInit, equalityFunc, formatterFunc);
 	}
 
 	/**
@@ -160,7 +161,7 @@ public interface FormatterStep extends Serializable {
 	 *             only the state supplied by state and nowhere else.
 	 * @return A FormatterStep
 	 */
-	public static <State extends Serializable> FormatterStep createLazy(
+	static <State extends Serializable> FormatterStep createLazy(
 			String name,
 			ThrowingEx.Supplier<State> stateSupplier,
 			ThrowingEx.Function<State, FormatterFunc> stateToFormatter) {
@@ -177,7 +178,7 @@ public interface FormatterStep extends Serializable {
 	 *             only the state supplied by state and nowhere else.
 	 * @return A FormatterStep
 	 */
-	public static <State extends Serializable> FormatterStep create(
+	static <State extends Serializable> FormatterStep create(
 			String name,
 			State state,
 			ThrowingEx.Function<State, FormatterFunc> stateToFormatter) {
@@ -194,7 +195,7 @@ public interface FormatterStep extends Serializable {
 	 * @return A FormatterStep which will never report that it is up-to-date, because
 	 *         it is not equal to the serialized representation of itself.
 	 */
-	public static FormatterStep createNeverUpToDateLazy(
+	static FormatterStep createNeverUpToDateLazy(
 			String name,
 			ThrowingEx.Supplier<FormatterFunc> functionSupplier) {
 		return new FormatterStepImpl.NeverUpToDate(name, functionSupplier);
@@ -208,7 +209,7 @@ public interface FormatterStep extends Serializable {
 	 * @return A FormatterStep which will never report that it is up-to-date, because
 	 *         it is not equal to the serialized representation of itself.
 	 */
-	public static FormatterStep createNeverUpToDate(
+	static FormatterStep createNeverUpToDate(
 			String name,
 			FormatterFunc function) {
 		Objects.requireNonNull(function, "function");

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -106,6 +106,29 @@ public interface FormatterStep extends Serializable {
 
 	/**
 	 * @param name
+	 *             The name of the formatter step.
+	 * @param roundtripInit
+	 *             If the step has any state, this supplier will calculate it lazily. The supplier doesn't
+	 *             have to be serializable, but the result it calculates needs to be serializable.
+	 * @param equalityFunc
+	 * 		       A pure serializable function (method reference recommended) which takes the result of `roundtripInit`,
+	 * 		       and returns a serializable object whose serialized representation will be used for `.equals` and
+	 * 		       `.hashCode` of the FormatterStep.
+	 * @param formatterFunc
+	 * 		       A pure serializable function (method reference recommended) which takes the result of `equalityFunc`,
+	 * 		       and returns a `FormatterFunc` which will be used for the actual formatting.
+	 * @return A FormatterStep which can be losslessly roundtripped through the java serialization machinery.
+	 */
+	static <RoundtripState extends Serializable, EqualityState extends Serializable> FormatterStep createLazy(
+			String name,
+			ThrowingEx.Supplier<RoundtripState> roundtripInit,
+			SerializedFunction<RoundtripState, EqualityState> equalityFunc,
+			SerializedFunction<EqualityState, FormatterFunc> formatterFunc) {
+		return new FormatterStepSerializationRoundtrip(name, roundtripInit, equalityFunc, formatterFunc);
+	}
+
+	/**
+	 * @param name
 	 *             The name of the formatter step
 	 * @param stateSupplier
 	 *             If the rule has any state, this supplier will calculate it lazily, and the result

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepEqualityOnStateSerialization.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepEqualityOnStateSerialization.java
@@ -29,7 +29,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * and such without interfering with buildcache keys.
  */
 @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-public abstract class FormatterStepEqualityOnStateSerialization<State extends Serializable> implements FormatterStep, Serializable {
+abstract class FormatterStepEqualityOnStateSerialization<State extends Serializable> implements FormatterStep, Serializable {
 	private static final long serialVersionUID = 1L;
 
 	protected abstract State stateSupplier() throws Exception;
@@ -80,11 +80,7 @@ public abstract class FormatterStepEqualityOnStateSerialization<State extends Se
 
 	private byte[] serializedState() {
 		if (serializedStateInternal == null) {
-			try {
-				serializedStateInternal = LazyForwardingEquality.toBytes(state());
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
+			serializedStateInternal = ThrowingEx.get(() -> LazyForwardingEquality.toBytes(state()));
 		}
 		return serializedStateInternal;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepEqualityOnStateSerialization.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepEqualityOnStateSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepEqualityOnStateSerialization.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepEqualityOnStateSerialization.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016-2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.Arrays;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Standard implementation of FormatterStep which cleanly enforces
+ * separation of a lazily computed "state" object whose serialized form
+ * is used as the basis for equality and hashCode, which is separate
+ * from the serialized form of the step itself, which can include absolute paths
+ * and such without interfering with buildcache keys.
+ */
+@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+public abstract class FormatterStepEqualityOnStateSerialization<State extends Serializable> implements FormatterStep, Serializable {
+	private static final long serialVersionUID = 1L;
+
+	protected abstract State stateSupplier() throws Exception;
+
+	protected abstract FormatterFunc stateToFormatter(State state) throws Exception;
+
+	private transient FormatterFunc formatter;
+	private transient State stateInternal;
+	private transient byte[] serializedStateInternal;
+
+	@Override
+	public String format(String rawUnix, File file) throws Exception {
+		if (formatter == null) {
+			formatter = stateToFormatter(state());
+		}
+		return formatter.apply(rawUnix, file);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null) {
+			return false;
+		} else if (getClass() != o.getClass()) {
+			return false;
+		} else {
+			return Arrays.equals(serializedState(), ((FormatterStepEqualityOnStateSerialization<?>) o).serializedState());
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Arrays.hashCode(serializedState());
+	}
+
+	void cleanupFormatterFunc() {
+		if (formatter instanceof FormatterFunc.Closeable) {
+			((FormatterFunc.Closeable) formatter).close();
+			formatter = null;
+		}
+	}
+
+	private State state() throws Exception {
+		if (stateInternal == null) {
+			stateInternal = stateSupplier();
+		}
+		return stateInternal;
+	}
+
+	private byte[] serializedState() {
+		if (serializedStateInternal == null) {
+			try {
+				serializedStateInternal = LazyForwardingEquality.toBytes(state());
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return serializedStateInternal;
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+class FormatterStepSerializationRoundtrip<RoundtripState extends Serializable, EqualityState extends Serializable> extends FormatterStepEqualityOnStateSerialization<EqualityState> {
+	private final String name;
+	private final transient ThrowingEx.Supplier<RoundtripState> initializer;
+	private @Nullable RoundtripState roundtripStateInternal;
+	private final SerializedFunction<RoundtripState, EqualityState> equalityStateExtractor;
+	private final SerializedFunction<EqualityState, FormatterFunc> equalityStateToFormatter;
+
+	public FormatterStepSerializationRoundtrip(String name, ThrowingEx.Supplier<RoundtripState> initializer, SerializedFunction<RoundtripState, EqualityState> equalityStateExtractor, SerializedFunction<EqualityState, FormatterFunc> equalityStateToFormatter) {
+		this.name = name;
+		this.initializer = initializer;
+		this.equalityStateExtractor = equalityStateExtractor;
+		this.equalityStateToFormatter = equalityStateToFormatter;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	protected EqualityState stateSupplier() throws Exception {
+		if (roundtripStateInternal != null) {
+			roundtripStateInternal = initializer.get();
+		}
+		return equalityStateExtractor.apply(roundtripStateInternal);
+	}
+
+	@Override
+	protected FormatterFunc stateToFormatter(EqualityState equalityState) throws Exception {
+		return equalityStateToFormatter.apply(equalityState);
+	}
+
+	// override serialize output
+	private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+		if (roundtripStateInternal == null) {
+			roundtripStateInternal = ThrowingEx.get(initializer::get);
+		}
+		out.defaultWriteObject();
+	}
+
+	private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+	}
+
+	private void readObjectNoData() throws ObjectStreamException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 class FormatterStepSerializationRoundtrip<RoundtripState extends Serializable, EqualityState extends Serializable> extends FormatterStepEqualityOnStateSerialization<EqualityState> {
+	private static final long serialVersionUID = 1L;
 	private final String name;
 	private final transient ThrowingEx.Supplier<RoundtripState> initializer;
 	private @Nullable RoundtripState roundtripStateInternal;

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
@@ -42,7 +42,7 @@ class FormatterStepSerializationRoundtrip<RoundtripState extends Serializable, E
 
 	@Override
 	protected EqualityState stateSupplier() throws Exception {
-		if (roundtripStateInternal != null) {
+		if (roundtripStateInternal == null) {
 			roundtripStateInternal = initializer.get();
 		}
 		return equalityStateExtractor.apply(roundtripStateInternal);

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 public final class JarState implements Serializable {
 	/** A lazily evaluated JarState, which becomes a set of files when serialized. */
 	public static class Promised implements Serializable {
+		private static final long serialVersionUID = 1L;
 		private final transient ThrowingEx.Supplier<JarState> supplier;
 		private FileSignature.RoundTrippable cached;
 

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -51,7 +51,7 @@ public final class JarState implements Serializable {
 			try {
 				if (cached == null) {
 					JarState result = supplier.get();
-					cached = result.fileSignature.roundTrippable();
+					cached = result.fileSignature.asPromise();
 					return result;
 				}
 				return new JarState(cached.get());

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -54,7 +54,7 @@ public final class JarState implements Serializable {
 					cached = result.fileSignature.roundTrippable();
 					return result;
 				}
-				return new JarState(cached.stripAbsolutePaths());
+				return new JarState(cached.get());
 			} catch (Exception e) {
 				throw ThrowingEx.asRuntime(e);
 			}

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -41,7 +41,7 @@ public final class JarState implements Serializable {
 	public static class Promised implements Serializable {
 		private static final long serialVersionUID = 1L;
 		private final transient ThrowingEx.Supplier<JarState> supplier;
-		private FileSignature.RoundTrippable cached;
+		private FileSignature.Promised cached;
 
 		public Promised(ThrowingEx.Supplier<JarState> supplier) {
 			this.supplier = supplier;

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -39,12 +38,9 @@ import java.util.stream.Collectors;
 public final class JarState implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-	@Deprecated
-	private final Set<String> mavenCoordinates;
 	private final FileSignature fileSignature;
 
-	private JarState(Collection<String> mavenCoordinates, FileSignature fileSignature) {
-		this.mavenCoordinates = new TreeSet<>(mavenCoordinates);
+	private JarState(FileSignature fileSignature) {
 		this.fileSignature = fileSignature;
 	}
 
@@ -71,13 +67,13 @@ public final class JarState implements Serializable {
 			throw new NoSuchElementException("Resolved to an empty result: " + mavenCoordinates.stream().collect(Collectors.joining(", ")));
 		}
 		FileSignature fileSignature = FileSignature.signAsSet(jars);
-		return new JarState(mavenCoordinates, fileSignature);
+		return new JarState(fileSignature);
 	}
 
 	/** Wraps the given collection of a files as a JarState, maintaining the order in the Collection. */
 	public static JarState preserveOrder(Collection<File> jars) throws IOException {
 		FileSignature fileSignature = FileSignature.signAsList(jars);
-		return new JarState(Collections.emptySet(), fileSignature);
+		return new JarState(fileSignature);
 	}
 
 	URL[] jarUrls() {
@@ -106,11 +102,5 @@ public final class JarState implements Serializable {
 	 */
 	public ClassLoader getClassLoader(Serializable key) {
 		return SpotlessCache.instance().classloader(key, this);
-	}
-
-	/** Returns unmodifiable view on sorted Maven coordinates */
-	@Deprecated
-	public Set<String> getMavenCoordinates() {
-		return Collections.unmodifiableSet(mavenCoordinates);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/SerializedFunction.java
+++ b/lib/src/main/java/com/diffplug/spotless/SerializedFunction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.Serializable;
+
+@FunctionalInterface
+interface SerializedFunction<T, R> extends Serializable, ThrowingEx.Function<T, R> {}

--- a/lib/src/main/java/com/diffplug/spotless/SerializedFunction.java
+++ b/lib/src/main/java/com/diffplug/spotless/SerializedFunction.java
@@ -18,4 +18,8 @@ package com.diffplug.spotless;
 import java.io.Serializable;
 
 @FunctionalInterface
-interface SerializedFunction<T, R> extends Serializable, ThrowingEx.Function<T, R> {}
+public interface SerializedFunction<T, R> extends Serializable, ThrowingEx.Function<T, R> {
+	static <T> SerializedFunction<T, T> identity() {
+		return t -> t;
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/SerializedFunction.java
+++ b/lib/src/main/java/com/diffplug/spotless/SerializedFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/generic/IndentStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/IndentStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -26,6 +26,7 @@ import com.diffplug.spotless.*;
 
 /** Wraps up <a href="https://github.com/cqfn/diKTat">diktat</a> as a FormatterStep. */
 public class DiktatStep extends FormatterStepEqualityOnStateSerialization<DiktatStep.State> {
+	private static final long serialVersionUID = 1L;
 	private final JarState.Promised jarState;
 	private final boolean isScript;
 	private final @Nullable FileSignature.RoundTrippable config;

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -34,7 +34,7 @@ public class DiktatStep implements Serializable {
 	private DiktatStep(JarState.Promised jarState, boolean isScript, @Nullable FileSignature config) {
 		this.jarState = jarState;
 		this.isScript = isScript;
-		this.config = FileSignature.roundTrippableNullable(config);
+		this.config = config != null ? config.asPromise() : null;
 	}
 
 	private static final String MIN_SUPPORTED_VERSION = "1.2.1";
@@ -72,7 +72,7 @@ public class DiktatStep implements Serializable {
 	}
 
 	private State equalityState() throws Exception {
-		return new State(jarState.get(), isScript, FileSignature.stripAbsolutePathsNullable(config));
+		return new State(jarState.get(), isScript, config != null ? config.get() : null);
 	}
 
 	static final class State implements Serializable {

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import com.diffplug.spotless.*;
 
 /** Wraps up <a href="https://github.com/cqfn/diKTat">diktat</a> as a FormatterStep. */
-public class DiktatStep extends FormatterStepEqualityOnStateSerialization<DiktatStep.State> {
+public class DiktatStep implements Serializable {
 	private static final long serialVersionUID = 1L;
 	private final JarState.Promised jarState;
 	private final boolean isScript;
@@ -66,26 +66,16 @@ public class DiktatStep extends FormatterStepEqualityOnStateSerialization<Diktat
 		}
 		Objects.requireNonNull(versionDiktat, "versionDiktat");
 		Objects.requireNonNull(provisioner, "provisioner");
-		return new DiktatStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + versionDiktat, provisioner)), isScript, config);
+		return FormatterStep.create(NAME,
+				new DiktatStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + versionDiktat, provisioner)), isScript, config),
+				DiktatStep::equalityState, State::createFormat);
 	}
 
-	@Override
-	public String getName() {
-		return NAME;
-	}
-
-	@Override
-	protected State stateSupplier() throws Exception {
+	private State equalityState() throws Exception {
 		return new State(jarState.get(), isScript, FileSignature.stripAbsolutePathsNullable(config));
 	}
 
-	@Override
-	protected FormatterFunc stateToFormatter(State state) throws Exception {
-		return state.createFormat();
-	}
-
 	static final class State implements Serializable {
-
 		private static final long serialVersionUID = 1L;
 
 		final JarState jar;

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -71,8 +71,14 @@ public class DiktatStep implements Serializable {
 		}
 		Objects.requireNonNull(versionDiktat, "versionDiktat");
 		Objects.requireNonNull(provisioner, "provisioner");
+		final String diktatCoordinate;
+		if (BadSemver.version(versionDiktat) >= BadSemver.version(PACKAGE_RELOCATED_VERSION)) {
+			diktatCoordinate = MAVEN_COORDINATE + versionDiktat;
+		} else {
+			diktatCoordinate = MAVEN_COORDINATE_PRE_2_0_0 + versionDiktat;
+		}
 		return FormatterStep.create(NAME,
-				new DiktatStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + versionDiktat, provisioner)), versionDiktat, isScript, config),
+				new DiktatStep(JarState.promise(() -> JarState.from(diktatCoordinate, provisioner)), versionDiktat, isScript, config),
 				DiktatStep::equalityState, State::createFormat);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -29,7 +29,7 @@ public class DiktatStep extends FormatterStepEqualityOnStateSerialization<Diktat
 	private static final long serialVersionUID = 1L;
 	private final JarState.Promised jarState;
 	private final boolean isScript;
-	private final @Nullable FileSignature.RoundTrippable config;
+	private final @Nullable FileSignature.Promised config;
 
 	private DiktatStep(JarState.Promised jarState, boolean isScript, @Nullable FileSignature config) {
 		this.jarState = jarState;

--- a/testlib/src/main/java/com/diffplug/spotless/SerializableEqualityTester.java
+++ b/testlib/src/main/java/com/diffplug/spotless/SerializableEqualityTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public abstract class SerializableEqualityTester {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <T extends Serializable> T reserialize(T input) {
+	static <T extends Serializable> T reserialize(T input) {
 		byte[] asBytes = LazyForwardingEquality.toBytes(input);
 		ByteArrayInputStream byteInput = new ByteArrayInputStream(asBytes);
 		try (ObjectInputStream objectInput = new ObjectInputStream(byteInput)) {

--- a/testlib/src/main/java/com/diffplug/spotless/SerializableEqualityTester.java
+++ b/testlib/src/main/java/com/diffplug/spotless/SerializableEqualityTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -21,17 +21,14 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 
 /** An api for testing a {@code FormatterStep} that doesn't depend on the File path. DO NOT ADD FILE SUPPORT TO THIS, use {@link StepHarnessWithFile} if you need that. */
-public class StepHarness implements AutoCloseable {
-	private final Formatter formatter;
-
+public class StepHarness extends StepHarnessBase<StepHarness> {
 	private StepHarness(Formatter formatter) {
-		this.formatter = Objects.requireNonNull(formatter);
+		super(formatter);
 	}
 
 	/** Creates a harness for testing steps which don't depend on the file. */
@@ -57,14 +54,14 @@ public class StepHarness implements AutoCloseable {
 
 	/** Asserts that the given element is transformed as expected, and that the result is idempotent. */
 	public StepHarness test(String before, String after) {
-		String actual = formatter.compute(LineEnding.toUnix(before), new File(""));
+		String actual = formatter().compute(LineEnding.toUnix(before), new File(""));
 		assertEquals(after, actual, "Step application failed");
 		return testUnaffected(after);
 	}
 
 	/** Asserts that the given element is idempotent w.r.t the step under test. */
 	public StepHarness testUnaffected(String idempotentElement) {
-		String actual = formatter.compute(LineEnding.toUnix(idempotentElement), new File(""));
+		String actual = formatter().compute(LineEnding.toUnix(idempotentElement), new File(""));
 		assertEquals(idempotentElement, actual, "Step is not idempotent");
 		return this;
 	}
@@ -88,7 +85,7 @@ public class StepHarness implements AutoCloseable {
 
 	public AbstractStringAssert<?> testExceptionMsg(String before) {
 		try {
-			formatter.compute(LineEnding.toUnix(before), Formatter.NO_FILE_SENTINEL);
+			formatter().compute(LineEnding.toUnix(before), Formatter.NO_FILE_SENTINEL);
 			throw new SecurityException("Expected exception");
 		} catch (Throwable e) {
 			if (e instanceof SecurityException) {
@@ -104,10 +101,5 @@ public class StepHarness implements AutoCloseable {
 				return Assertions.assertThat(rootCause.getMessage());
 			}
 		}
-	}
-
-	@Override
-	public void close() {
-		formatter.close();
 	}
 }

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
@@ -41,6 +41,8 @@ class StepHarnessBase<T extends StepHarnessBase<?>> implements AutoCloseable {
 			String onlyStepName = formatter.getSteps().get(0).getName();
 			if (onlyStepName.startsWith("indentWith")) {
 				supportsRoundTrip = true;
+			} else if (onlyStepName.equals("diktat")) {
+				supportsRoundTrip = true;
 			}
 		}
 	}

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
@@ -26,11 +26,23 @@ class StepHarnessBase<T extends StepHarnessBase<?>> implements AutoCloseable {
 
 	protected StepHarnessBase(Formatter formatter) {
 		this.formatter = Objects.requireNonNull(formatter);
-	}
-
-	public T supportsRoundTrip(boolean supportsRoundTrip) {
-		this.supportsRoundTrip = supportsRoundTrip;
-		return (T) this;
+		if (formatter.getSteps().size() == 1) {
+			// our goal is for everything to be roundtrip serializable
+			// the steps to get there are
+			// - make every individual step round-trippable
+			// - make the other machinery (Formatter, LineEnding, etc) round-trippable
+			// - done!
+			//
+			// Right now, we're still trying to get each and every single step to be round-trippable.
+			// You can help by add a test below, make sure that the test for that step fails, and then
+			// make the test pass. `FormatterStepEqualityOnStateSerialization` is a good base class for
+			// easily converting a step to round-trip serialization while maintaining easy and concise
+			// equality code.
+			String onlyStepName = formatter.getSteps().get(0).getName();
+			if (onlyStepName.startsWith("indentWith")) {
+				supportsRoundTrip = true;
+			}
+		}
 	}
 
 	protected Formatter formatter() {

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.util.Objects;
+
+import org.assertj.core.api.Assertions;
+
+class StepHarnessBase<T extends StepHarnessBase<?>> implements AutoCloseable {
+	private final Formatter formatter;
+	private Formatter roundTripped;
+	private boolean supportsRoundTrip = false;
+
+	protected StepHarnessBase(Formatter formatter) {
+		this.formatter = Objects.requireNonNull(formatter);
+	}
+
+	public T supportsRoundTrip(boolean supportsRoundTrip) {
+		this.supportsRoundTrip = supportsRoundTrip;
+		return (T) this;
+	}
+
+	protected Formatter formatter() {
+		if (!supportsRoundTrip) {
+			return formatter;
+		} else {
+			if (roundTripped == null) {
+				roundTripped = SerializableEqualityTester.reserialize(formatter);
+				Assertions.assertThat(roundTripped).isEqualTo(formatter);
+			}
+			return roundTripped;
+		}
+	}
+
+	@Override
+	public void close() {
+		formatter.close();
+		if (roundTripped != null) {
+			roundTripped.close();
+		}
+	}
+}

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -52,7 +52,8 @@ public class StepHarnessWithFile extends StepHarnessBase<StepHarnessWithFile> {
 	}
 
 	/** Asserts that the given element is transformed as expected, and that the result is idempotent. */
-	public StepHarnessWithFile test(File file, String before, String after) {
+	public StepHarnessWithFile test(String filename, String before, String after) {
+		File file = harness.setFile(filename).toContent(before);
 		String actual = formatter().compute(LineEnding.toUnix(before), file);
 		assertEquals(after, actual, "Step application failed");
 		return testUnaffected(file, after);
@@ -65,6 +66,11 @@ public class StepHarnessWithFile extends StepHarnessBase<StepHarnessWithFile> {
 		return this;
 	}
 
+	/** Asserts that the given element is idempotent w.r.t the step under test. */
+	public StepHarnessWithFile testUnaffected(String file, String idempotentElement) {
+		return testUnaffected(harness.setFile(file).toContent(idempotentElement), idempotentElement);
+	}
+
 	/** Asserts that the given elements in  the resources directory are transformed as expected. */
 	public StepHarnessWithFile testResource(String resourceBefore, String resourceAfter) {
 		return testResource(resourceBefore, resourceBefore, resourceAfter);
@@ -72,8 +78,7 @@ public class StepHarnessWithFile extends StepHarnessBase<StepHarnessWithFile> {
 
 	public StepHarnessWithFile testResource(String filename, String resourceBefore, String resourceAfter) {
 		String contentBefore = ResourceHarness.getTestResource(resourceBefore);
-		File file = harness.setFile(filename).toContent(contentBefore);
-		return test(file, contentBefore, ResourceHarness.getTestResource(resourceAfter));
+		return test(filename, contentBefore, ResourceHarness.getTestResource(resourceAfter));
 	}
 
 	/** Asserts that the given elements in the resources directory are transformed as expected. */

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -26,13 +26,12 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 
 /** An api for testing a {@code FormatterStep} that depends on the File path. */
-public class StepHarnessWithFile implements AutoCloseable {
-	private final Formatter formatter;
+public class StepHarnessWithFile extends StepHarnessBase<StepHarnessWithFile> {
 	private final ResourceHarness harness;
 
 	private StepHarnessWithFile(ResourceHarness harness, Formatter formatter) {
+		super(formatter);
 		this.harness = Objects.requireNonNull(harness);
-		this.formatter = Objects.requireNonNull(formatter);
 	}
 
 	/** Creates a harness for testing steps which do depend on the file. */
@@ -54,14 +53,14 @@ public class StepHarnessWithFile implements AutoCloseable {
 
 	/** Asserts that the given element is transformed as expected, and that the result is idempotent. */
 	public StepHarnessWithFile test(File file, String before, String after) {
-		String actual = formatter.compute(LineEnding.toUnix(before), file);
+		String actual = formatter().compute(LineEnding.toUnix(before), file);
 		assertEquals(after, actual, "Step application failed");
 		return testUnaffected(file, after);
 	}
 
 	/** Asserts that the given element is idempotent w.r.t the step under test. */
 	public StepHarnessWithFile testUnaffected(File file, String idempotentElement) {
-		String actual = formatter.compute(LineEnding.toUnix(idempotentElement), file);
+		String actual = formatter().compute(LineEnding.toUnix(idempotentElement), file);
 		assertEquals(idempotentElement, actual, "Step is not idempotent");
 		return this;
 	}
@@ -96,7 +95,7 @@ public class StepHarnessWithFile implements AutoCloseable {
 
 	public AbstractStringAssert<?> testExceptionMsg(File file, String before) {
 		try {
-			formatter.compute(LineEnding.toUnix(before), file);
+			formatter().compute(LineEnding.toUnix(before), file);
 			throw new SecurityException("Expected exception");
 		} catch (Throwable e) {
 			if (e instanceof SecurityException) {
@@ -109,10 +108,5 @@ public class StepHarnessWithFile implements AutoCloseable {
 				return Assertions.assertThat(rootCause.getMessage());
 			}
 		}
-	}
-
-	@Override
-	public void close() {
-		formatter.close();
 	}
 }

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -268,7 +268,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 	void should_apply_license_containing_filename_token() throws Exception {
 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$FILE), package_).build();
 		StepHarnessWithFile.forStep(this, step)
-				.test(new File("Test.java"), getTestResource(FILE_NO_LICENSE), hasHeaderFileName(HEADER_WITH_$FILE, "Test.java"))
+				.test("Test.java", getTestResource(FILE_NO_LICENSE), hasHeaderFileName(HEADER_WITH_$FILE, "Test.java"))
 				.testUnaffected(new File("Test.java"), hasHeaderFileName(HEADER_WITH_$FILE, "Test.java"));
 	}
 
@@ -276,8 +276,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 	void should_update_license_containing_filename_token() throws Exception {
 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$FILE), package_).build();
 		StepHarnessWithFile.forStep(this, step)
-				.test(
-						new File("After.java"),
+				.test("After.java",
 						hasHeaderFileName(HEADER_WITH_$FILE, "Before.java"),
 						hasHeaderFileName(HEADER_WITH_$FILE, "After.java"));
 	}
@@ -286,12 +285,10 @@ class LicenseHeaderStepTest extends ResourceHarness {
 	void should_apply_license_containing_YEAR_filename_token() throws Exception {
 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR_$FILE), package_).build();
 		StepHarnessWithFile.forStep(this, step)
-				.test(
-						new File("Test.java"),
+				.test("Test.java",
 						getTestResource(FILE_NO_LICENSE),
 						hasHeaderYearFileName(HEADER_WITH_$YEAR_$FILE, currentYear(), "Test.java"))
-				.testUnaffected(
-						new File("Test.java"),
+				.testUnaffected("Test.java",
 						hasHeaderYearFileName(HEADER_WITH_$YEAR_$FILE, currentYear(), "Test.java"));
 	}
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/test/java/com/diffplug/spotless/npm/EslintFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/EslintFormatterStepTest.java
@@ -56,7 +56,6 @@ class EslintFormatterStepTest {
 			//			final File eslintRc = setFile(buildDir().getPath() + "/.eslintrc.js").toResource(filedir + ".eslintrc.js");
 
 			final String dirtyFile = filedir + "javascript-es6.dirty";
-			File dirtyFileFile = setFile(testDir + "test.js").toResource(dirtyFile);
 			final String cleanFile = filedir + "javascript-es6.clean";
 
 			final FormatterStep formatterStep = EslintFormatterStep.create(
@@ -69,7 +68,7 @@ class EslintFormatterStepTest {
 					new EslintConfig(eslintRc, null));
 
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
-				stepHarness.test(dirtyFileFile, ResourceHarness.getTestResource(dirtyFile), ResourceHarness.getTestResource(cleanFile));
+				stepHarness.test("test.js", ResourceHarness.getTestResource(dirtyFile), ResourceHarness.getTestResource(cleanFile));
 			}
 		}
 	}
@@ -100,7 +99,6 @@ class EslintFormatterStepTest {
 				tsconfigFile = setFile(testDir + "tsconfig.json").toResource(filedir + "tsconfig.json");
 			}
 			final String dirtyFile = filedir + "typescript.dirty";
-			File dirtyFileFile = setFile(testDir + "test.ts").toResource(dirtyFile);
 			final String cleanFile = filedir + "typescript.clean";
 
 			final FormatterStep formatterStep = EslintFormatterStep.create(
@@ -113,7 +111,7 @@ class EslintFormatterStepTest {
 					new EslintTypescriptConfig(eslintRc, null, tsconfigFile));
 
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
-				stepHarness.test(dirtyFileFile, ResourceHarness.getTestResource(dirtyFile), ResourceHarness.getTestResource(cleanFile));
+				stepHarness.test(testDir + "test.ts", ResourceHarness.getTestResource(dirtyFile), ResourceHarness.getTestResource(cleanFile));
 			}
 		}
 	}
@@ -158,7 +156,6 @@ class EslintFormatterStepTest {
 
 			File tsconfigFile = setFile(testDir + "tsconfig.json").toResource(filedir + "tsconfig.json");
 			final String dirtyFile = filedir + "typescript.dirty";
-			File dirtyFileFile = setFile(testDir + "test.ts").toResource(dirtyFile);
 			final String cleanFile = filedir + "typescript.clean";
 
 			final FormatterStep formatterStep = EslintFormatterStep.create(
@@ -171,7 +168,7 @@ class EslintFormatterStepTest {
 					new EslintTypescriptConfig(null, esLintConfig, tsconfigFile));
 
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
-				stepHarness.test(dirtyFileFile, ResourceHarness.getTestResource(dirtyFile), ResourceHarness.getTestResource(cleanFile));
+				stepHarness.test(testDir + "test.ts", ResourceHarness.getTestResource(dirtyFile), ResourceHarness.getTestResource(cleanFile));
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/npm/EslintFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/EslintFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I don't like the design of the Gradle configuration cache. It puts too much burden on plugin developers, and it's too slow for end users (#987). But our workaround is a bit of a hassle, and we've had a really active contributor pool lately so maybe we have the brainpower to do the big rewrite that it would take to remove the `JvmLocalCache` workaround and fully support roundtrip serialization.

This PR introduces `StepHarnessBase`, which is a mechanism for enforcing that every individual formatter step must support roundtrip serialization. It will take a while for every step to support it, so we can adjust this `StepHarnessBase` as more and more steps add support. Once every step supports it, we will enforce this requirement for all new steps.

This PR also introduces `FormatterStepEqualityOnStateSerialization`. This allows us to keep the exact same equality semantics we have used so far, but it gives us more flexibility to implement serialization. Especially serialization of absolute paths without screwing up buildcache keys.