### PR TITLE
Emit contextual error message during incremental m2e builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,9 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* New static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
 ### Changes
-* Add new static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 
 ## [2.43.1] - 2023-12-04

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
+* Add new static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 
 ## [2.43.1] - 2023-12-04

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -55,10 +55,10 @@ public final class DiffMessageFormatter {
 		String getFormatted(File file, String rawUnix);
 	}
 
-	private static class CleanProviderFormatter implements CleanProvider {
+	public static class CleanProviderFormatter implements CleanProvider {
 		private final Formatter formatter;
 
-		CleanProviderFormatter(Formatter formatter) {
+		public CleanProviderFormatter(Formatter formatter) {
 			this.formatter = Objects.requireNonNull(formatter);
 		}
 
@@ -234,6 +234,10 @@ public final class DiffMessageFormatter {
 	 * sequence (\n, \r, \r\n).
 	 */
 	private String diff(File file) throws IOException {
+		return diff(formatter, file);
+	}
+
+	public static String diff(CleanProvider formatter, File file) throws IOException {
 		String raw = new String(Files.readAllBytes(file.toPath()), formatter.getEncoding());
 		String rawUnix = LineEnding.toUnix(raw);
 		String formatted = formatter.getFormatted(file, rawUnix);

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -22,7 +22,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.AbstractMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -237,19 +236,19 @@ public final class DiffMessageFormatter {
 	 * sequence (\n, \r, \r\n).
 	 */
 	private String diff(File file) throws IOException {
-		return diff(formatter, file).getKey();
+		return diff(formatter, file).getValue();
 	}
 
 	/**
-	 * Returns a map entry with key being a git-style diff between the contents of the given file and what those contents would
+	 * Returns a map entry with value being a git-style diff between the contents of the given file and what those contents would
 	 * look like if formatted using the given formatter. Does not end with any newline
-	 * sequence (\n, \r, \r\n). The value of the map entry is the line where the first difference occurred.
+	 * sequence (\n, \r, \r\n). The key of the map entry is the 0-based line where the first difference occurred.
 	 */
-	public static Map.Entry<String, Integer> diff(Formatter formatter, File file) throws IOException {
+	public static Map.Entry<Integer, String> diff(Formatter formatter, File file) throws IOException {
 		return diff(new CleanProviderFormatter(formatter), file);
 	}
 
-	private static Map.Entry<String, Integer> diff(CleanProvider formatter, File file) throws IOException {
+	private static Map.Entry<Integer, String> diff(CleanProvider formatter, File file) throws IOException {
 		String raw = new String(Files.readAllBytes(file.toPath()), formatter.getEncoding());
 		String rawUnix = LineEnding.toUnix(raw);
 		String formatted = formatter.getFormatted(file, rawUnix);
@@ -264,13 +263,13 @@ public final class DiffMessageFormatter {
 	}
 
 	/**
-	 * Returns a map entry with key being a git-style diff between the two unix strings and value being the line of the first difference (in the dirty string)
+	 * Returns a map entry with value being a git-style diff between the two unix strings and key being the 0-based line of the first difference (in the dirty string)
 	 * <p>
 	 * Output has no trailing newlines.
 	 * <p>
 	 * Boolean args determine whether whitespace or line endings will be visible.
 	 */
-	private static Map.Entry<String, Integer> diffWhitespaceLineEndings(String dirty, String clean, boolean whitespace, boolean lineEndings) throws IOException {
+	private static Map.Entry<Integer, String> diffWhitespaceLineEndings(String dirty, String clean, boolean whitespace, boolean lineEndings) throws IOException {
 		dirty = visibleWhitespaceLineEndings(dirty, whitespace, lineEndings);
 		clean = visibleWhitespaceLineEndings(clean, whitespace, lineEndings);
 
@@ -287,7 +286,7 @@ public final class DiffMessageFormatter {
 
 		// we don't need the diff to show this, since we display newlines ourselves
 		formatted = formatted.replace("\\ No newline at end of file\n", "");
-		return new AbstractMap.SimpleEntry<>(NEWLINE_MATCHER.trimTrailingFrom(formatted), getLineOfFirstDifference(edits));
+		return Map.entry(getLineOfFirstDifference(edits), NEWLINE_MATCHER.trimTrailingFrom(formatted));
 	}
 
 	private static int getLineOfFirstDifference(EditList edits) {

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,8 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
-### Changes
+### Added
 * M2E support: Emit file specific errors during incremental build. ([#1960](https://github.com/diffplug/spotless/issues/1960))
+### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 
 ## [2.41.1] - 2023-12-04

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changes
+* M2E support: Emit file specific errors during incremental build. ([#1960](https://github.com/diffplug/spotless/issues/1960))
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 
 ## [2.41.1] - 2023-12-04

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -58,7 +58,7 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 					problemFiles.add(file);
 					if (buildContext.isIncremental()) {
 						Map.Entry<String, Integer> diffEntry = DiffMessageFormatter.diff(formatter, file);
-						buildContext.addMessage(file, diffEntry.getValue(), 0, diffEntry.getKey(), BuildContext.SEVERITY_ERROR, null);
+						buildContext.addMessage(file, diffEntry.getValue() + 1, 0, diffEntry.getKey(), BuildContext.SEVERITY_ERROR, null);
 					}
 					counter.cleaned();
 				} else {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -23,10 +23,12 @@ import java.util.List;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.sonatype.plexus.build.incremental.BuildContext;
 
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.PaddedCell;
 import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
+import com.diffplug.spotless.extra.integration.DiffMessageFormatter.CleanProviderFormatter;
 import com.diffplug.spotless.maven.incremental.UpToDateChecker;
 
 /**
@@ -54,6 +56,9 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					problemFiles.add(file);
+					if (buildContext.isIncremental()) {
+						buildContext.addMessage(file, 0, 0, DiffMessageFormatter.diff(new CleanProviderFormatter(formatter), file), BuildContext.SEVERITY_ERROR, null);
+					}
 					counter.cleaned();
 				} else {
 					counter.checkedButAlreadyClean();

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -57,8 +57,8 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					problemFiles.add(file);
 					if (buildContext.isIncremental()) {
-						Map.Entry<String, Integer> diffEntry = DiffMessageFormatter.diff(formatter, file);
-						buildContext.addMessage(file, diffEntry.getValue() + 1, 0, diffEntry.getKey(), BuildContext.SEVERITY_ERROR, null);
+						Map.Entry<Integer, String> diffEntry = DiffMessageFormatter.diff(formatter, file);
+						buildContext.addMessage(file, diffEntry.getKey() + 1, 0, diffEntry.getValue(), BuildContext.SEVERITY_ERROR, null);
 					}
 					counter.cleaned();
 				} else {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -28,7 +29,6 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.PaddedCell;
 import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
-import com.diffplug.spotless.extra.integration.DiffMessageFormatter.CleanProviderFormatter;
 import com.diffplug.spotless.maven.incremental.UpToDateChecker;
 
 /**
@@ -57,7 +57,8 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					problemFiles.add(file);
 					if (buildContext.isIncremental()) {
-						buildContext.addMessage(file, 0, 0, DiffMessageFormatter.diff(new CleanProviderFormatter(formatter), file), BuildContext.SEVERITY_ERROR, null);
+						Map.Entry<String, Integer> diffEntry = DiffMessageFormatter.diff(formatter, file);
+						buildContext.addMessage(file, diffEntry.getValue(), 0, diffEntry.getKey(), BuildContext.SEVERITY_ERROR, null);
 					}
 					counter.cleaned();
 				} else {
@@ -65,7 +66,7 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 					upToDateChecker.setUpToDate(file.toPath());
 				}
 			} catch (IOException | RuntimeException e) {
-				throw new MojoExecutionException("Unable to format file " + file, e);
+				throw new MojoExecutionException("Unable to check file " + file, e);
 			}
 		}
 


### PR DESCRIPTION
This closes #1960

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
