### PR TITLE
Bump google-java-format to 1.19.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * New static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
+* Bump default `googleJavaFormat` version to latest `1.18.1` -> `1.19.2`. ([#1971](https://github.com/diffplug/spotless/pull/1971))
 
 ## [2.43.1] - 2023-12-04
 ### Fixed

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 	gherkinCompileOnly 'io.cucumber:gherkin-utils:8.0.2'
 	gherkinCompileOnly 'org.slf4j:slf4j-api:2.0.0'
 	// googleJavaFormat
-	googleJavaFormatCompileOnly 'com.google.googlejavaformat:google-java-format:1.18.1'
+	googleJavaFormatCompileOnly 'com.google.googlejavaformat:google-java-format:1.19.2'
 	// gson
 	gsonCompileOnly 'com.google.code.gson:gson:2.10.1'
 	// jackson

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class GoogleJavaFormatStep {
 			.addMin(11, "1.8") // we only support google-java-format >= 1.8 due to api changes
 			.addMin(16, "1.10.0") // java 16 requires at least 1.10.0 due to jdk api changes in JavaTokenizer
 			.addMin(21, "1.17.0") // java 21 requires at least 1.17.0 due to https://github.com/google/google-java-format/issues/898
-			.add(11, "1.18.1"); // default version
+			.add(11, "1.19.2"); // default version
 
 	public static String defaultGroupArtifact() {
 		return MAVEN_COORDINATE;

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -35,7 +35,7 @@ public class GoogleJavaFormatStep {
 	private static final boolean DEFAULT_REORDER_IMPORTS = false;
 	private static final boolean DEFAULT_FORMAT_JAVADOC = true;
 	static final String NAME = "google-java-format";
-	static final String MAVEN_COORDINATE = "com.google.googlejavaformat:google-java-format";
+	public static final String MAVEN_COORDINATE = "com.google.googlejavaformat:google-java-format";
 
 	/** Creates a step which formats everything - code, import order, and unused imports. */
 	public static FormatterStep create(Provisioner provisioner) {

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -35,7 +35,7 @@ public class GoogleJavaFormatStep {
 	private static final boolean DEFAULT_REORDER_IMPORTS = false;
 	private static final boolean DEFAULT_FORMAT_JAVADOC = true;
 	static final String NAME = "google-java-format";
-	public static final String MAVEN_COORDINATE = "com.google.googlejavaformat:google-java-format";
+	static final String MAVEN_COORDINATE = "com.google.googlejavaformat:google-java-format";
 
 	/** Creates a step which formats everything - code, import order, and unused imports. */
 	public static FormatterStep create(Provisioner provisioner) {

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -29,7 +29,7 @@ public class PalantirJavaFormatStep {
 
 	private static final String DEFAULT_STYLE = "PALANTIR";
 	private static final String NAME = "palantir-java-format";
-	private static final String MAVEN_COORDINATE = "com.palantir.javaformat:palantir-java-format:";
+	public static final String MAVEN_COORDINATE = "com.palantir.javaformat:palantir-java-format:";
 	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.39.0");
 
 	/** Creates a step which formats everything - code, import order, and unused imports. */

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public class PalantirJavaFormatStep {
 
 	private static final String DEFAULT_STYLE = "PALANTIR";
 	private static final String NAME = "palantir-java-format";
-	public static final String MAVEN_COORDINATE = "com.palantir.javaformat:palantir-java-format:";
+	private static final String MAVEN_COORDINATE = "com.palantir.javaformat:palantir-java-format:";
 	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.39.0");
 
 	/** Creates a step which formats everything - code, import order, and unused imports. */

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
+* Bump default `googleJavaFormat` version to latest `1.18.1` -> `1.19.2`. ([#1971](https://github.com/diffplug/spotless/pull/1971))
 
 ## [6.23.3] - 2023-12-04
 **BREAKING CHANGE** `6.23.0` made breaking changes to the ABI of the `KotlinExtension` and `GroovyExtension`. Those are reflected retroactively now.

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory;
 import com.diffplug.common.base.Unhandled;
 import com.diffplug.common.collect.ImmutableList;
 import com.diffplug.spotless.Provisioner;
-import com.diffplug.spotless.java.GoogleJavaFormatStep;
-import com.diffplug.spotless.java.PalantirJavaFormatStep;
 
 /** Should be package-private. */
 class GradleProvisioner {
@@ -119,16 +117,7 @@ class GradleProvisioner {
 						+ new Request(withTransitives, mavenCoords).hashCode());
 				mavenCoords.stream()
 						.map(dependencies::create)
-						.forEach(dependency -> {
-							config.getDependencies().add(dependency);
-							String coordinate = dependency.getGroup() + ":" + dependency.getName();
-							if (coordinate.startsWith(GoogleJavaFormatStep.MAVEN_COORDINATE) ||
-									coordinate.startsWith(PalantirJavaFormatStep.MAVEN_COORDINATE)) {
-								// Use Guava 32.1.3, see https://github.com/google/guava/issues/6657.
-								// TODO: May remove this after https://github.com/google/google-java-format/pull/996 and https://github.com/palantir/palantir-java-format/issues/957 are released.
-								config.getDependencies().add(dependencies.create("com.google.guava:guava:32.1.3-jre"));
-							}
-						});
+						.forEach(config.getDependencies()::add);
 				config.setDescription(mavenCoords.toString());
 				config.setTransitive(withTransitives);
 				config.setCanBeConsumed(false);

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * M2E support: Emit file specific errors during incremental build. ([#1960](https://github.com/diffplug/spotless/issues/1960))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
+* Bump default `googleJavaFormat` version to latest `1.18.1` -> `1.19.2`. ([#1971](https://github.com/diffplug/spotless/pull/1971))
 
 ## [2.41.1] - 2023-12-04
 ### Fixed

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -42,8 +41,6 @@ import com.diffplug.common.base.StandardSystemProperty;
 import com.diffplug.common.base.Suppliers;
 import com.diffplug.common.collect.ImmutableSet;
 import com.diffplug.common.io.Files;
-import com.diffplug.spotless.java.GoogleJavaFormatStep;
-import com.diffplug.spotless.java.PalantirJavaFormatStep;
 
 public class TestProvisioner {
 	public static Project gradleProject(File dir) {
@@ -68,15 +65,7 @@ public class TestProvisioner {
 		Project project = TestProvisioner.gradleProject(tempDir);
 		repoConfig.accept(project.getRepositories());
 		return (withTransitives, mavenCoords) -> {
-			boolean forceGuava = mavenCoords.stream().anyMatch(coordinate -> coordinate.startsWith(GoogleJavaFormatStep.MAVEN_COORDINATE) ||
-					coordinate.startsWith(PalantirJavaFormatStep.MAVEN_COORDINATE));
-			Stream<String> coordinateStream = mavenCoords.stream();
-			if (forceGuava) {
-				// Use Guava 32.1.3, see https://github.com/google/guava/issues/6657.
-				// TODO: May remove this after https://github.com/google/google-java-format/pull/996 and https://github.com/palantir/palantir-java-format/issues/957 are released.
-				coordinateStream = Stream.concat(coordinateStream, Stream.of("com.google.guava:guava:32.1.3-jre"));
-			}
-			Dependency[] deps = coordinateStream
+			Dependency[] deps = mavenCoords.stream()
 					.map(project.getDependencies()::create)
 					.toArray(Dependency[]::new);
 			Configuration config = project.getConfigurations().detachedConfiguration(deps);


### PR DESCRIPTION
Closes #1965.

https://github.com/google/google-java-format/releases/tag/v1.19.0
https://github.com/google/google-java-format/releases/tag/v1.19.1
https://github.com/google/google-java-format/releases/tag/v1.19.2

