### PR TITLE
Don't reuse BufStep args across invocations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * New static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
+### Fixed
+* Fix a regression in BufStep where the same arguments were being provided to every `buf` invocation. ([#1976](https://github.com/diffplug/spotless/issues/1976))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 

--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -75,7 +75,10 @@ public class BufStep {
 		private static final long serialVersionUID = -1825662356883926318L;
 		// used for up-to-date checks and caching
 		final String version;
-		final transient ForeignExe exe;
+
+		// used for executing
+		private final transient ForeignExe exe;
+		private transient String exeAbsPath;
 
 		State(BufStep step, ForeignExe exe) {
 			this.version = step.version;
@@ -83,7 +86,10 @@ public class BufStep {
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
-			List<String> args = List.of(exe.confirmVersionAndGetAbsolutePath(), "format", file.getAbsolutePath());
+			if (exeAbsPath == null) {
+				exeAbsPath = exe.confirmVersionAndGetAbsolutePath();
+			}
+			List<String> args = List.of(exeAbsPath, "format", file.getAbsolutePath());
 			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -78,20 +77,14 @@ public class BufStep {
 		final String version;
 		final transient ForeignExe exe;
 
-        State(BufStep step, ForeignExe exe) {
+		State(BufStep step, ForeignExe exe) {
 			this.version = step.version;
 			this.exe = Objects.requireNonNull(exe);
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
-			return runner.exec(
-				input.getBytes(StandardCharsets.UTF_8),
-				List.of(
-					exe.confirmVersionAndGetAbsolutePath(),
-					"format",
-					file.getAbsolutePath()
-				)
-			).assertExitZero(StandardCharsets.UTF_8);
+			List<String> args = List.of(exe.confirmVersionAndGetAbsolutePath(), "format", file.getAbsolutePath());
+			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -64,11 +64,11 @@ public class BufStep {
 
 	private State createState() {
 		String instructions = "https://docs.buf.build/installation";
-		ForeignExe exeAbsPath = ForeignExe.nameAndVersion("buf", version)
+		ForeignExe exe = ForeignExe.nameAndVersion("buf", version)
 				.pathToExe(pathToExe)
 				.versionRegex(Pattern.compile("(\\S*)"))
 				.fixCantFind("Try following the instructions at " + instructions + ", or else tell Spotless where it is with {@code buf().pathToExe('path/to/executable')}");
-		return new State(this, exeAbsPath);
+		return new State(this, exe);
 	}
 
 	@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
@@ -77,22 +77,21 @@ public class BufStep {
 		// used for up-to-date checks and caching
 		final String version;
 		final transient ForeignExe exe;
-		// used for executing
-		private transient @Nullable List<String> args;
 
-		State(BufStep step, ForeignExe exeAbsPath) {
+        State(BufStep step, ForeignExe exe) {
 			this.version = step.version;
-			this.exe = Objects.requireNonNull(exeAbsPath);
+			this.exe = Objects.requireNonNull(exe);
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
-			if (args == null) {
-				args = Arrays.asList(
-						exe.confirmVersionAndGetAbsolutePath(),
-						"format",
-						file.getAbsolutePath());
-			}
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
+			return runner.exec(
+				input.getBytes(StandardCharsets.UTF_8),
+				List.of(
+					exe.confirmVersionAndGetAbsolutePath(),
+					"format",
+					file.getAbsolutePath()
+				)
+			).assertExitZero(StandardCharsets.UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix a regression in BufStep where the same arguments were being provided to every `buf` invocation. ([#1976](https://github.com/diffplug/spotless/issues/1976))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 * Bump default `ktlint` version to latest `1.0.1` -> `1.1.1`. ([#1973](https://github.com/diffplug/spotless/pull/1973))


### PR DESCRIPTION
https://github.com/diffplug/spotless/pull/1779 introduced a regression where the same args will be reused across all invocations to Buf, resulting in Spotless returning garbage for every file except the first during a lint run.

I'm actually not sure what the best way to test this is. Is there a test harness or template that can check multiple files in one plugin run? I should be able to add a failing test that this PR fixes that way.

---

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [x] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
