### PR TITLE
Fixes #1987, no empty files with biome when formatting ignored files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 * New static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
 ### Fixed
-* Fix empty files with biome >= 1.5.0 when formatting files that are in the ignore list of the biome configuration file. (fixes [#1987](https://github.com/diffplug/spotless/issues/1987))
+* Fix empty files with biome >= 1.5.0 when formatting files that are in the ignore list of the biome configuration file. ([#1989](https://github.com/diffplug/spotless/pull/1989) fixes [#1987](https://github.com/diffplug/spotless/issues/1987))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * New static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
+### Fixed
+* Fix empty files with biome >= 1.5.0 when formatting files that are in the ignore list of the biome configuration file. (fixes [#1987](https://github.com/diffplug/spotless/issues/1987))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,26 @@ The gist of it is that you will have to:
 
 If you get something running, we'd love to host your plugin within this repo as a peer to `plugin-gradle` and `plugin-maven`.
 
+## Run tests
+
+To run all tests, simply do
+
+> gradlew test
+
+Since that takes some time, you might only want to run the tests
+concerning what you are working on:
+
+```shell
+# Run only from test from the "lib" project
+gradlew :testlib:test --tests com.diffplug.spotless.generic.IndentStepTest
+
+# Run only one test from the "plugin-maven" project
+gradlew :plugin-maven:test --tests com.diffplug.spotless.maven.pom.SortPomMavenTest
+
+# Run only one test from the "plugin-gradle" project
+gradlew :plugin-gradle:test --tests com.diffplug.gradle.spotless.FreshMarkExtensionTest
+```
+
 ## Integration testing
 
 ### Gradle - locally

--- a/lib/src/main/java/com/diffplug/spotless/rome/RomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/rome/RomeStep.java
@@ -427,9 +427,23 @@ public class RomeStep {
 			var stdin = input.getBytes(StandardCharsets.UTF_8);
 			var args = buildBiomeCommand(file);
 			if (logger.isDebugEnabled()) {
-				logger.debug("Running Biome comand to format code: '{}'", String.join(", ", args));
+				logger.debug("Running Biome command to format code: '{}'", String.join(", ", args));
 			}
-			return runner.exec(stdin, args).assertExitZero(StandardCharsets.UTF_8);
+			var runnerResult = runner.exec(stdin, args);
+			var stdErr = runnerResult.stdErrUtf8();
+			if (stdErr != null && !stdErr.isEmpty()) {
+				logger.warn("Biome stderr ouptut for file '{}'\n{}", file, stdErr.trim());
+			}
+			var formatted = runnerResult.assertExitZero(StandardCharsets.UTF_8);
+			// When biome encounters an ignored file, it does not output any formatted code
+			// Ignored files come from (a) the biome.json configuration file and (b) from
+			// a list of hard-coded file names, such as package.json or tsconfig.json.
+			if (formatted == null || formatted.isEmpty()) {
+				return input;
+			}
+			else {
+				return formatted;
+			}
 		}
 
 		/**

--- a/lib/src/main/java/com/diffplug/spotless/rome/RomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/rome/RomeStep.java
@@ -431,14 +431,14 @@ public class RomeStep {
 			}
 			var runnerResult = runner.exec(stdin, args);
 			var stdErr = runnerResult.stdErrUtf8();
-			if (stdErr != null && !stdErr.isEmpty()) {
+			if (!stdErr.isEmpty()) {
 				logger.warn("Biome stderr ouptut for file '{}'\n{}", file, stdErr.trim());
 			}
 			var formatted = runnerResult.assertExitZero(StandardCharsets.UTF_8);
 			// When biome encounters an ignored file, it does not output any formatted code
 			// Ignored files come from (a) the biome.json configuration file and (b) from
 			// a list of hard-coded file names, such as package.json or tsconfig.json.
-			if (formatted == null || formatted.isEmpty()) {
+			if (formatted.isEmpty()) {
 				return input;
 			} else {
 				return formatted;

--- a/lib/src/main/java/com/diffplug/spotless/rome/RomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/rome/RomeStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -440,8 +440,7 @@ public class RomeStep {
 			// a list of hard-coded file names, such as package.json or tsconfig.json.
 			if (formatted == null || formatted.isEmpty()) {
 				return input;
-			}
-			else {
+			} else {
 				return formatted;
 			}
 		}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix empty files with biome >= 1.5.0 when formatting files that are in the ignore list of the biome configuration file. ([#1989](https://github.com/diffplug/spotless/pull/1989) fixes [#1987](https://github.com/diffplug/spotless/issues/1987))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1218,11 +1218,6 @@ spotless {
 }
 ```
 
-**Limitations:**
-
-- The auto-discovery of config files (up the file tree) will not work when using
-  Biome within spotless.
-
 To apply Biome to more kinds of files with a different configuration, just add
 more formats:
 
@@ -1242,6 +1237,24 @@ spotless {
   }
 }
 ```
+
+**Limitations:**
+
+- The auto-discovery of config files (up the file tree) will not work when using
+  Biome within spotless.
+- The `ignore` option of the `biome.json` configuration file will not be applied.
+  Include and exclude patterns are configured in the spotless configuration in the
+  Gradle settings file instead.
+
+Note: Due to a limitation of biome, if the name of a file matches a pattern in
+the `ignore` option of the specified `biome.json` configuration file, it will not be
+formatted, even if included in the biome configuration section of the Gradle settings
+file.
+You could specify a different `biome.json` configuration file without an `ignore`
+pattern to circumvent this.
+
+Note 2: Biome is hard-coded to ignore certain special files, such as `package.json`
+or `tsconfig.json`. These files will never be formatted.
 
 ### Biome binary
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BiomeIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BiomeIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -352,16 +352,16 @@ class BiomeIntegrationTest extends GradleIntegrationHarness {
 	@Test
 	void preservesIgnoredFiles() throws Exception {
 		setFile("build.gradle").toLines(
-			"plugins {",
-			"    id 'com.diffplug.spotless'",
-			"}",
-			"repositories { mavenCentral() }",
-			"spotless {",
-			"    json {",
-			"        target '**/*.json'",
-			"        biome('1.5.0')",
-			"    }",
-			"}");
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    json {",
+				"        target '**/*.json'",
+				"        biome('1.5.0')",
+				"    }",
+				"}");
 		setFile("package.json").toResource("biome/json/packageBefore.json");
 
 		var spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * M2E support: Emit file specific errors during incremental build. ([#1960](https://github.com/diffplug/spotless/issues/1960))
+### Fixed
+* Fix empty files with biome >= 1.5.0 when formatting files that are in the ignore list of the biome configuration file. ([#1989](https://github.com/diffplug/spotless/pull/1989) fixes [#1987](https://github.com/diffplug/spotless/issues/1987))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1300,10 +1300,6 @@ usually you will be creating a generic format.
 </configuration>
 ```
 
-**Limitations:**
-- The auto-discovery of config files (up the file tree) will not work when using
-  Biome within spotless.
-
 To apply Biome to more kinds of files with a different configuration, just add
 more formats:
 
@@ -1314,6 +1310,22 @@ more formats:
     <format><includes>src/**/*.js</includes><biome/></format>
 </configuration>
 ```
+
+**Limitations:**
+- The auto-discovery of config files (up the file tree) will not work when using
+  Biome within spotless.
+- The `ignore` option of the `biome.json` configuration file will not be applied.
+  Include and exclude patterns are configured in the spotless configuration in the
+  Maven pom instead.
+
+Note: Due to a limitation of biome, if the name of a file matches a pattern in
+the `ignore` option of the specified `biome.json` configuration file, it will not be
+formatted, even if included in the biome configuration section of the Maven pom.
+You could specify a different `biome.json` configuration file without an `ignore`
+pattern to circumvent this.
+
+Note 2: Biome is hard-coded to ignore certain special files, such as `package.json`
+or `tsconfig.json`. These files will never be formatted.
 
 ### Biome binary
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/biome/BiomeMavenTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/biome/BiomeMavenTest.java
@@ -199,4 +199,20 @@ class BiomeMavenTest extends MavenIntegrationHarness {
 		assertThat(result.stdOutUtf8()).contains("Unable to format file");
 		assertThat(result.stdOutUtf8()).contains("Step 'biome' found problem in 'biome_test.js'");
 	}
+
+	/**
+	 * Biome is hard-coded to ignore certain files, such as package.json. Since version 1.5.0,
+	 * the biome CLI does not output any formatted code anymore, whereas previously it printed
+	 * the input as-is. This tests checks that when the biome formatter outputs an empty string,
+	 * the contents of the file to format are used instead.
+	 *
+	 * @throws Exception When a test failure occurs.
+	 */
+	@Test
+	void preservesIgnoredFiles() throws Exception {
+		writePomWithJsonSteps("**/*.json", "<biome><version>1.5.0</version></biome>");
+		setFile("package.json").toResource("biome/json/packageBefore.json");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile("package.json").sameAsResource("biome/json/packageAfter.json");
+	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/biome/BiomeMavenTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/biome/BiomeMavenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/main/resources/biome/json/package.json
+++ b/testlib/src/main/resources/biome/json/package.json
@@ -1,0 +1,3 @@
+{
+"name": "test-package","version": "0.0.1"
+  }

--- a/testlib/src/main/resources/biome/json/packageAfter.json
+++ b/testlib/src/main/resources/biome/json/packageAfter.json
@@ -1,0 +1,3 @@
+{
+"name": "test-package","version": "0.0.1"
+  }

--- a/testlib/src/main/resources/biome/json/packageBefore.json
+++ b/testlib/src/main/resources/biome/json/packageBefore.json
@@ -1,0 +1,3 @@
+{
+"name": "test-package","version": "0.0.1"
+  }

--- a/testlib/src/test/java/com/diffplug/spotless/rome/RomeStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/rome/RomeStepTest.java
@@ -392,6 +392,19 @@ class RomeStepTest extends ResourceHarness {
 				var stepHarness = StepHarnessWithFile.forStep(RomeStepTest.this, step);
 				stepHarness.testResource("biome/ts/fileBefore.tsx", "biome/ts/fileAfter.tsx");
 			}
+
+			/**
+			 * Biome is hard-coded to ignore certain files, such as package.json. Since version 1.5.0,
+			 * the biome CLI does not output any formatted code anymore, whereas previously it printed
+			 * the input as-is. This tests checks that when the biome formatter outputs an empty string,
+			 * the contents of the file to format are used instead.
+			 */
+			@Test
+			void preservesIgnoredFiles() {
+				var step = RomeStep.withExeDownload(BiomeFlavor.BIOME, "1.5.0", downloadDir.toString()).create();
+				var stepHarness = StepHarnessWithFile.forStep(RomeStepTest.this, step);
+				stepHarness.testResource("biome/json/package.json", "biome/json/packageAfter.json");
+			}
 		}
 
 		@Nested

--- a/testlib/src/test/java/com/diffplug/spotless/rome/RomeStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/rome/RomeStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #1987, no empty files with biome when formatting ignored files

The issue happens only with the latest release 1.5.0.

* When the biome output is empty, the contents of the input file to format are used unchanged instead.
* When biome outputs warnings / errors to stderr, these are now logged. This includes warnings such as when biome ignores files. Otherwise people would be left wondering why certain files are not formatted.
* Added a test for this scenario and update the readme.

On another note, I mostly use Maven, so I always need to look up how to run tests via Gradle. I added a short section to CONTRIBUTING.md that gives some example commands how to run tests for this project, especially how to run only a single test.

---

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- [x] a link to the issue you are resolving (for small changes)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
