### PR TITLE
plugin-gradle: Build shadow jar and relocate jgit

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
-* Bundle dependencies in the Gradle plugin and relocate most dependencies. ([#1991](https://github.com/diffplug/spotless/pull/1991))
+* Bundle some dependencies in the Gradle plugin and relocate JGit. ([#1991](https://github.com/diffplug/spotless/pull/1991))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Bundle dependencies in the Gradle plugin and relocate most dependencies. ([#1991](https://github.com/diffplug/spotless/pull/1991))
 ### Changes
 * Use palantir-java-format 2.39.0 on Java 21. ([#1948](https://github.com/diffplug/spotless/pull/1948))
 

--- a/plugin-gradle/build.gradle
+++ b/plugin-gradle/build.gradle
@@ -37,24 +37,8 @@ tasks.withType(Test).configureEach {
 
 shadowJar {
 	archiveClassifier.set('')
+	enableRelocation = false
 	relocate 'org.eclipse.jgit', 'shadow.eclipse.jgit'
-	relocate 'org.eclipse.osgi', 'shadow.eclipse.osgi'
-	relocate 'org.eclipse.equinox', 'shadow.eclipse.equinox'
-	relocate 'org.eclipse.core', 'shadow.eclipse.core'
-	relocate 'org.osgi', 'shadow.org.osgi'
-	relocate 'com.googlecode.concurrenttrees', 'shadow.googlecode.concurrenttrees'
-	relocate 'com.googlecode.javaewah', 'shadow.googlecode.javaewah'
-	relocate 'com.googlecode.javaewah32', 'shadow.googlecode.javaewah32'
-	relocate 'dev.equo.solstice', 'shadow.equo.solstice'
-	relocate 'dev.equo.ide', 'shadow.equo.ide'
-	relocate 'org.apache.commons', 'shadow.apache.commons'
-	relocate 'org.apache.felix', 'shadow.apache.felix'
-	relocate 'org.tukaani.xz', 'shadow.tukaani.xz'
-	relocate 'okhttp3', 'shadow.okhttp3'
-	relocate 'okio', 'shadow.okio'
-	relocate 'org.intellij', 'shadow.intellij'
-	relocate 'org.jetbrains', 'shadow.jetbrains'
-	relocate 'org.slf4j', 'shadow.slf4j'
 }
 
 //////////////////////////

--- a/plugin-gradle/build.gradle
+++ b/plugin-gradle/build.gradle
@@ -1,6 +1,7 @@
 apply from: rootProject.file('gradle/changelog.gradle')
 ext.artifactId = project.artifactIdGradle
 version = spotlessChangelog.versionNext
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java-library'
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'java-gradle-plugin'
@@ -32,6 +33,28 @@ dependencies {
 apply from: rootProject.file('gradle/special-tests.gradle')
 tasks.withType(Test).configureEach {
 	testLogging.showStandardStreams = true
+}
+
+shadowJar {
+	archiveClassifier.set('')
+	relocate 'org.eclipse.jgit', 'shadow.eclipse.jgit'
+	relocate 'org.eclipse.osgi', 'shadow.eclipse.osgi'
+	relocate 'org.eclipse.equinox', 'shadow.eclipse.equinox'
+	relocate 'org.eclipse.core', 'shadow.eclipse.core'
+	relocate 'org.osgi', 'shadow.org.osgi'
+	relocate 'com.googlecode.concurrenttrees', 'shadow.googlecode.concurrenttrees'
+	relocate 'com.googlecode.javaewah', 'shadow.googlecode.javaewah'
+	relocate 'com.googlecode.javaewah32', 'shadow.googlecode.javaewah32'
+	relocate 'dev.equo.solstice', 'shadow.equo.solstice'
+	relocate 'dev.equo.ide', 'shadow.equo.ide'
+	relocate 'org.apache.commons', 'shadow.apache.commons'
+	relocate 'org.apache.felix', 'shadow.apache.felix'
+	relocate 'org.tukaani.xz', 'shadow.tukaani.xz'
+	relocate 'okhttp3', 'shadow.okhttp3'
+	relocate 'okio', 'shadow.okio'
+	relocate 'org.intellij', 'shadow.intellij'
+	relocate 'org.jetbrains', 'shadow.jetbrains'
+	relocate 'org.slf4j', 'shadow.slf4j'
 }
 
 //////////////////////////

--- a/plugin-gradle/build.gradle
+++ b/plugin-gradle/build.gradle
@@ -11,11 +11,11 @@ apply from: rootProject.file('gradle/spotless-freshmark.gradle')
 
 dependencies {
 	if (version.endsWith('-SNAPSHOT') || (rootProject.spotlessChangelog.versionNext == rootProject.spotlessChangelog.versionLast)) {
-		api projects.lib
-		api projects.libExtra
+		shadow projects.lib
+		shadow projects.libExtra
 	} else {
-		api "com.diffplug.spotless:spotless-lib:${rootProject.spotlessChangelog.versionLast}"
-		api "com.diffplug.spotless:spotless-lib-extra:${rootProject.spotlessChangelog.versionLast}"
+		shadow "com.diffplug.spotless:spotless-lib:${rootProject.spotlessChangelog.versionLast}"
+		shadow "com.diffplug.spotless:spotless-lib-extra:${rootProject.spotlessChangelog.versionLast}"
 	}
 	implementation "com.diffplug.durian:durian-core:${VER_DURIAN}"
 	implementation "com.diffplug.durian:durian-io:${VER_DURIAN}"
@@ -30,6 +30,12 @@ dependencies {
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
+configurations {
+	testImplementation.extendsFrom(shadow, implementation)
+}
+
+assemble.dependsOn shadowJar
+
 apply from: rootProject.file('gradle/special-tests.gradle')
 tasks.withType(Test).configureEach {
 	testLogging.showStandardStreams = true
@@ -38,7 +44,7 @@ tasks.withType(Test).configureEach {
 shadowJar {
 	archiveClassifier.set('')
 	enableRelocation = false
-	relocate 'org.eclipse.jgit', 'shadow.eclipse.jgit'
+	relocate 'org.eclipse.jgit', 'spotless.shadow.org.eclipse.jgit'
 }
 
 //////////////////////////

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,8 @@ plugins {
 	id 'com.gradle.enterprise' version '3.16'
 	// https://github.com/equodev/equo-ide/blob/main/plugin-gradle/CHANGELOG.md
 	id 'dev.equo.ide' version '1.7.5' apply false
+	// https://github.com/johnrengelman/shadow/tags
+	id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This builds a shadow jar with all dependencies bundled in the plugin and relocates ~~most dependencies~~ `jgit` under shadow. This will fix issues where other Gradle plugins uses incompatible versions of the same dependencies.

Fixes #587

