### PR TITLE
Add maven shell script formatting support via shfmt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,13 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Maven - Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). TODO ([#9999](https://github.com/diffplug/spotless/pull/9999))
 
 ## [2.44.0] - 2024-01-15
 ### Added
 * New static method to `DiffMessageFormatter` which allows to retrieve diffs with their line numbers ([#1960](https://github.com/diffplug/spotless/issues/1960))
-* Format shell via [shfmt](https://github.com/mvdan/sh). ([#1994](https://github.com/diffplug/spotless/pull/1994))
+* Gradle - Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). ([#1994](https://github.com/diffplug/spotless/pull/1994))
 ### Fixed
 * Fix empty files with biome >= 1.5.0 when formatting files that are in the ignore list of the biome configuration file. ([#1989](https://github.com/diffplug/spotless/pull/1989) fixes [#1987](https://github.com/diffplug/spotless/issues/1987))
 * Fix a regression in BufStep where the same arguments were being provided to every `buf` invocation. ([#1976](https://github.com/diffplug/spotless/issues/1976))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Maven - Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). TODO ([#9999](https://github.com/diffplug/spotless/pull/9999))
+* Maven - Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). ([#1998](https://github.com/diffplug/spotless/pull/1998))
 
 ## [2.44.0] - 2024-01-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ lib('yaml.JacksonYamlStep')                      +'{{yes}}       | {{yes}}      
 | [`protobuf.BufStep`](lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java) | :+1:       | :white_large_square:       | :white_large_square:       | :white_large_square:  |
 | [`python.BlackStep`](lib/src/main/java/com/diffplug/spotless/python/BlackStep.java) | :+1:       | :white_large_square:       | :white_large_square:       | :white_large_square:  |
 | [`scala.ScalaFmtStep`](lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java) | :+1:       | :+1:      | :+1:      | :white_large_square:  |
-| [`shell.ShfmtStep`](lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java) | :+1:       | :white_large_square:       | :white_large_square:       | :white_large_square:  |
+| [`shell.ShfmtStep`](lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`sql.DBeaverSQLFormatterStep`](lib/src/main/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStep.java) | :+1:       | :+1:      | :+1:      | :white_large_square:  |
 | [`wtp.EclipseWtpFormatterStep`](lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |
 | [`yaml.JacksonYamlStep`](lib/src/main/java/com/diffplug/spotless/yaml/JacksonYamlStep.java) | :+1:       | :+1:      | :white_large_square:       | :white_large_square:  |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ lib('pom.SortPomStepStep')                       +'{{no}}        | {{yes}}      
 lib('protobuf.BufStep')                          +'{{yes}}       | {{no}}       | {{no}}       | {{no}}  |',
 lib('python.BlackStep')                          +'{{yes}}       | {{no}}       | {{no}}       | {{no}}  |',
 lib('scala.ScalaFmtStep')                        +'{{yes}}       | {{yes}}      | {{yes}}      | {{no}}  |',
-lib('shell.ShfmtStep')                           +'{{yes}}       | {{no}}       | {{no}}       | {{no}}  |',
+lib('shell.ShfmtStep')                           +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
 lib('sql.DBeaverSQLFormatterStep')               +'{{yes}}       | {{yes}}      | {{yes}}      | {{no}}  |',
 extra('wtp.EclipseWtpFormatterStep')             +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',
 lib('yaml.JacksonYamlStep')                      +'{{yes}}       | {{yes}}      | {{no}}       | {{no}}  |',

--- a/gradle/special-tests.gradle
+++ b/gradle/special-tests.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.adarshr.test-logger'
+
+// See com.diffplug.spotless.tag package for available JUnit 5 @Tag annotations
 def special = [
 	'Black',
 	'Buf',
@@ -9,10 +11,6 @@ def special = [
 
 boolean isCiServer = System.getenv().containsKey("CI")
 tasks.withType(Test).configureEach {
-	// See com.diffplug.spotless.tag package for available JUnit 5 @Tag annotations
-	useJUnitPlatform {
-		excludeTags special as String[]
-	}
 	if (isCiServer) {
 		retry {
 			maxRetries = 2
@@ -26,7 +24,11 @@ tasks.withType(Test).configureEach {
 		maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 	}
 }
-
+tasks.named('test').configure {
+	useJUnitPlatform {
+		excludeTags special as String[]
+	}
+}
 special.forEach { tag ->
 	tasks.register("test${tag}", Test) {
 		useJUnitPlatform { includeTags tag }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,7 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [6.24.0] - 2024-01-15
 ### Added
-* Support for shell via [shfmt](https://github.com/mvdan/sh).
+* Support for shell formatting via [shfmt](https://github.com/mvdan/sh). ([#1994](https://github.com/diffplug/spotless/pull/1994))
 ### Fixed
 * Fix empty files with biome >= 1.5.0 when formatting files that are in the ignore list of the biome configuration file. ([#1989](https://github.com/diffplug/spotless/pull/1989) fixes [#1987](https://github.com/diffplug/spotless/issues/1987))=======
 * Fix a regression in BufStep where the same arguments were being provided to every `buf` invocation. ([#1976](https://github.com/diffplug/spotless/issues/1976))

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ShellExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ShellExtensionTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.tag.ShfmtTest;
 
 @ShfmtTest
-public class ShfmtIntegrationTest extends GradleIntegrationHarness {
+public class ShellExtensionTest extends GradleIntegrationHarness {
 	@Test
 	void shfmt() throws IOException {
 		setFile("build.gradle").toLines(

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). [#1998](https://github.com/diffplug/spotless/issues/1998)
+* Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). ([#1998](https://github.com/diffplug/spotless/issues/1998))
 
 ## [2.42.0] - 2024-01-15
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). TODO [#9999](https://github.com/diffplug/spotless/issues/9999)
 
 ## [2.42.0] - 2024-01-15
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). TODO [#9999](https://github.com/diffplug/spotless/issues/9999)
+* Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). [#1998](https://github.com/diffplug/spotless/issues/1998)
 
 ## [2.42.0] - 2024-01-15
 ### Added

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,7 @@ import com.diffplug.spotless.maven.markdown.Markdown;
 import com.diffplug.spotless.maven.pom.Pom;
 import com.diffplug.spotless.maven.python.Python;
 import com.diffplug.spotless.maven.scala.Scala;
+import com.diffplug.spotless.maven.shell.Shell;
 import com.diffplug.spotless.maven.sql.Sql;
 import com.diffplug.spotless.maven.typescript.Typescript;
 import com.diffplug.spotless.maven.yaml.Yaml;
@@ -177,6 +178,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	@Parameter
 	private Json json;
+
+	@Parameter
+	private Shell shell;
 
 	@Parameter
 	private Yaml yaml;
@@ -358,7 +362,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private List<FormatterFactory> getFormatterFactories() {
-		return Stream.concat(formats.stream(), Stream.of(groovy, java, scala, kotlin, cpp, typescript, javascript, antlr4, pom, sql, python, markdown, json, yaml, gherkin))
+		return Stream.concat(formats.stream(), Stream.of(groovy, java, scala, kotlin, cpp, typescript, javascript, antlr4, pom, sql, python, markdown, json, shell, yaml, gherkin))
 				.filter(Objects::nonNull)
 				.collect(toList());
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/shell/Shell.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/shell/Shell.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.shell;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.maven.project.MavenProject;
+
+import com.diffplug.spotless.maven.FormatterFactory;
+import com.diffplug.spotless.maven.generic.LicenseHeader;
+
+/**
+ * A {@link FormatterFactory} implementation that corresponds to {@code <shell>...</shell>} configuration element.
+ * <p>
+ * It defines a formatter for shell source files that can execute both language agnostic (e.g. {@link LicenseHeader})
+ * and shell-specific (e.g. {@link Shfmt}) steps.
+ */
+public class Shell extends FormatterFactory {
+	@Override
+	public Set<String> defaultIncludes(MavenProject project) {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public String licenseHeaderDelimiter() {
+		return null;
+	}
+
+	public void addShfmt(Shfmt shfmt) {
+		addStepFactory(shfmt);
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/shell/Shfmt.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/shell/Shfmt.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.shell;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+import com.diffplug.spotless.shell.ShfmtStep;
+
+public class Shfmt implements FormatterStepFactory {
+
+	@Parameter
+	private String version;
+
+	@Parameter
+	private String pathToExe;
+
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig config) {
+		ShfmtStep shfmt = ShfmtStep.withVersion(version == null ? ShfmtStep.defaultVersion() : version);
+		if (pathToExe != null) {
+			shfmt = shfmt.withPathToExe(pathToExe);
+		}
+		return shfmt.create();
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,6 +177,10 @@ public class MavenIntegrationHarness extends ResourceHarness {
 
 	protected void writePomWithJsonSteps(String... steps) throws IOException {
 		writePom(groupWithSteps("json", including("**/*.json"), steps));
+	}
+
+	protected void writePomWithShellSteps(String... steps) throws IOException {
+		writePom(groupWithSteps("shell", including("**/*.sh"), steps));
 	}
 
 	protected void writePomWithYamlSteps(String... steps) throws IOException {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/shell/ShellTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/shell/ShellTest.java
@@ -15,14 +15,14 @@
  */
 package com.diffplug.spotless.maven.shell;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
+import com.diffplug.spotless.tag.ShfmtTest;
 
-@Disabled // Disabled due to GHA not having shfmt
+@ShfmtTest
 public class ShellTest extends MavenIntegrationHarness {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ShellTest.class);
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/shell/ShellTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/shell/ShellTest.java
@@ -15,12 +15,14 @@
  */
 package com.diffplug.spotless.maven.shell;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
 
+@Disabled // Disabled due to GHA not having shfmt
 public class ShellTest extends MavenIntegrationHarness {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ShellTest.class);
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/shell/ShellTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/shell/ShellTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.shell;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+public class ShellTest extends MavenIntegrationHarness {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ShellTest.class);
+
+	@Test
+	public void testFormatShell() throws Exception {
+		writePomWithShellSteps("<shfmt/>");
+		setFile("shfmt.sh").toResource("shell/shfmt/shfmt.sh");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile("shfmt.sh").sameAsResource("shell/shfmt/shfmt.clean");
+	}
+}


### PR DESCRIPTION
This adds Maven support for shfmt and addresses https://github.com/diffplug/spotless/issues/1567. This is a follow up to https://github.com/diffplug/spotless/pull/1994. Closes https://github.com/diffplug/spotless/issues/1567 https://github.com/diffplug/spotless/issues/1776