### PR TITLE
Resolves #1995, flag to format JavaDoc for Palantir formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Maven - Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). ([#1998](https://github.com/diffplug/spotless/pull/1998))
-* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#1995](https://github.com/diffplug/spotless/issues/1995))
+* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#2009](https://github.com/diffplug/spotless/pull/2009))
 
 ## [2.44.0] - 2024-01-15
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Maven - Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). ([#1998](https://github.com/diffplug/spotless/pull/1998))
+* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#1995](https://github.com/diffplug/spotless/issues/1995))
 
 ## [2.44.0] - 2024-01-15
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,17 @@ gradlew :plugin-maven:test --tests com.diffplug.spotless.maven.pom.SortPomMavenT
 gradlew :plugin-gradle:test --tests com.diffplug.gradle.spotless.FreshMarkExtensionTest
 ```
 
+## Check and format code
+
+Before creating a pull request, you might want to format (yes, spotless is  formatted by spotless)
+the code and check for possible bugs
+
+* `./gradlew spotlessApply`
+* `./gradlew spotbugsMain`
+
+These checks are also run by the automated pipeline when you submit a pull request, if
+the pipeline fails, first check if the code is formatted and no bugs were found.
+
 ## Integration testing
 
 ### Gradle - locally

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -27,6 +27,7 @@ public class PalantirJavaFormatStep {
 	// prevent direct instantiation
 	private PalantirJavaFormatStep() {}
 
+	private static final boolean DEFAULT_FORMAT_JAVADOC = false;
 	private static final String DEFAULT_STYLE = "PALANTIR";
 	private static final String NAME = "palantir-java-format";
 	public static final String MAVEN_COORDINATE = "com.palantir.javaformat:palantir-java-format:";
@@ -42,14 +43,25 @@ public class PalantirJavaFormatStep {
 		return create(version, defaultStyle(), provisioner);
 	}
 
-	/** Creates a step which formats everything - code, import order, and unused imports. And with the style input. */
+	/**
+	 * Creates a step which formats code, import order, and unused imports, but not Java docs. And with the given format
+	 * style.
+	 */
 	public static FormatterStep create(String version, String style, Provisioner provisioner) {
+		return create(version, style, defaultFormatJavadoc(), provisioner);
+	}
+
+	/**
+	 * Creates a step which formats everything - code, import order, unused imports, and Java docs. And with the given
+	 * format style.
+	 */
+	public static FormatterStep create(String version, String style, boolean formatJavadoc, Provisioner provisioner) {
 		Objects.requireNonNull(version, "version");
 		Objects.requireNonNull(style, "style");
 		Objects.requireNonNull(provisioner, "provisioner");
 
 		return FormatterStep.createLazy(NAME,
-				() -> new State(JarState.from(MAVEN_COORDINATE + version, provisioner), version, style),
+				() -> new State(JarState.from(MAVEN_COORDINATE + version, provisioner), version, style, formatJavadoc),
 				State::createFormat);
 	}
 
@@ -63,6 +75,11 @@ public class PalantirJavaFormatStep {
 		return DEFAULT_STYLE;
 	}
 
+	/** Get default for whether Java docs should be formatted */
+	public static boolean defaultFormatJavadoc() {
+		return DEFAULT_FORMAT_JAVADOC;
+	}
+
 	private static final class State implements Serializable {
 		private static final long serialVersionUID = 1L;
 
@@ -71,23 +88,23 @@ public class PalantirJavaFormatStep {
 		/** Version of the formatter jar. */
 		private final String formatterVersion;
 		private final String style;
+		/** Whether to format Java docs. */
+		private final boolean formatJavadoc;
 
-		State(JarState jarState, String formatterVersion) {
-			this(jarState, formatterVersion, DEFAULT_STYLE);
-		}
-
-		State(JarState jarState, String formatterVersion, String style) {
+		State(JarState jarState, String formatterVersion, String style, boolean formatJavadoc) {
 			ModuleHelper.doOpenInternalPackagesIfRequired();
 			this.jarState = jarState;
 			this.formatterVersion = formatterVersion;
 			this.style = style;
+			this.formatJavadoc = formatJavadoc;
 		}
 
 		FormatterFunc createFormat() throws Exception {
 			final ClassLoader classLoader = jarState.getClassLoader();
 			final Class<?> formatterFunc = classLoader.loadClass("com.diffplug.spotless.glue.pjf.PalantirJavaFormatFormatterFunc");
-			final Constructor<?> constructor = formatterFunc.getConstructor(String.class); // style
-			return JVM_SUPPORT.suggestLaterVersionOnError(formatterVersion, (FormatterFunc) constructor.newInstance(style));
+			// 1st arg is "style", 2nd arg is "formatJavadoc"
+			final Constructor<?> constructor = formatterFunc.getConstructor(String.class, boolean.class);
+			return JVM_SUPPORT.suggestLaterVersionOnError(formatterVersion, (FormatterFunc) constructor.newInstance(style, formatJavadoc));
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -48,7 +48,7 @@ public class PalantirJavaFormatStep {
 	 * style.
 	 */
 	public static FormatterStep create(String version, String style, Provisioner provisioner) {
-		return create(version, style, defaultFormatJavadoc(), provisioner);
+		return create(version, style, DEFAULT_FORMAT_JAVADOC, provisioner);
 	}
 
 	/**

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Added
+* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#1995](https://github.com/diffplug/spotless/issues/1995))
+
 ## [6.24.0] - 2024-01-15
 ### Added
 * Support for shell formatting via [shfmt](https://github.com/mvdan/sh). ([#1994](https://github.com/diffplug/spotless/pull/1994))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Added
-* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#1995](https://github.com/diffplug/spotless/issues/1995))
+* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#2009](https://github.com/diffplug/spotless/pull/2009))
 
 ## [6.24.0] - 2024-01-15
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -220,6 +220,8 @@ spotless {
     palantirJavaFormat()
     // optional: you can specify a specific version and/or switch to AOSP/GOOGLE style
     palantirJavaFormat('2.9.0').style("GOOGLE")
+    // optional: you can also format Javadocs, requires at least Palantir 2.39.0
+    palantirJavaFormat('2.39.0').formatJavadoc(true)
 ```
 
 ### eclipse jdt

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -256,6 +256,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	public class PalantirJavaFormatConfig {
 		final String version;
 		String style;
+		boolean formatJavadoc;
 
 		PalantirJavaFormatConfig(String version) {
 			this.version = Objects.requireNonNull(version);
@@ -269,8 +270,14 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			return this;
 		}
 
+		public PalantirJavaFormatConfig formatJavadoc(boolean formatJavadoc) {
+			this.formatJavadoc = formatJavadoc;
+			replaceStep(createStep());
+			return this;
+		}
+
 		private FormatterStep createStep() {
-			return PalantirJavaFormatStep.create(version, style, provisioner());
+			return PalantirJavaFormatStep.create(version, style, formatJavadoc, provisioner());
 		}
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PalantirJavaFormatIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PalantirJavaFormatIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,28 @@ class PalantirJavaFormatIntegrationTest extends GradleIntegrationHarness {
 		replace("build.gradle",
 				"palantirJavaFormat('1.1.0')",
 				"palantirJavaFormat('1.0.1')");
+		checkRunsThenUpToDate();
+	}
+
+	@Test
+	void formatJavaDoc() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"    java {",
+				"        target file('test.java')",
+				"        palantirJavaFormat('2.39.0').formatJavadoc(true)",
+				"    }",
+				"}");
+
+		setFile("test.java").toResource("java/palantirjavaformat/JavaCodeWithJavaDocUnformatted.test");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("test.java").sameAsResource("java/palantirjavaformat/JavaCodeWithJavaDocFormatted.test");
+
 		checkRunsThenUpToDate();
 	}
 }

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). ([#1998](https://github.com/diffplug/spotless/issues/1998))
-* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#1995](https://github.com/diffplug/spotless/issues/1995))
+* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#2009](https://github.com/diffplug/spotless/pull/2009))
 
 ## [2.42.0] - 2024-01-15
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Support for formatting shell scripts via [shfmt](https://github.com/mvdan/sh). ([#1998](https://github.com/diffplug/spotless/issues/1998))
+* Maven / Gradle - Support for formatting Java Docs for the Palantir formatter ([#1995](https://github.com/diffplug/spotless/issues/1995))
 
 ## [2.42.0] - 2024-01-15
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -246,8 +246,9 @@ any other maven phase (i.e. compile) then it can be configured as below;
 
 ```xml
 <palantirJavaFormat>
-  <version>2.10.0</version>                     <!-- optional -->
+  <version>2.39.0</version>                     <!-- optional -->
   <style>PALANTIR</style>                       <!-- or AOSP/GOOGLE (optional) -->
+  <formatJavadoc>false</formatJavadoc>          <!-- defaults to false (optional, requires at least Palantir 2.39.0) -->
 </palantirJavaFormat>
 ```
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/PalantirJavaFormat.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/PalantirJavaFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,14 @@ public class PalantirJavaFormat implements FormatterStepFactory {
 	@Parameter
 	private String style;
 
+	@Parameter
+	private Boolean formatJavadoc;
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		String version = this.version != null ? this.version : PalantirJavaFormatStep.defaultVersion();
 		String style = this.style != null ? this.style : PalantirJavaFormatStep.defaultStyle();
-		return PalantirJavaFormatStep.create(version, style, config.getProvisioner());
+		boolean formatJavadoc = this.formatJavadoc != null ? this.formatJavadoc : PalantirJavaFormatStep.defaultFormatJavadoc();
+		return PalantirJavaFormatStep.create(version, style, formatJavadoc, config.getProvisioner());
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/PalantirJavaFormatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/PalantirJavaFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ class PalantirJavaFormatTest extends MavenIntegrationHarness {
 				"  <version>1.1.0</version>",
 				"</palantirJavaFormat>");
 
-		runTest("java/palantirjavaformat/JavaCodeFormatted.test");
+		runTest("java/palantirjavaformat/JavaCodeFormatted.test", "java/palantirjavaformat/JavaCodeUnformatted.test");
 	}
 
 	@Test
@@ -37,12 +37,23 @@ class PalantirJavaFormatTest extends MavenIntegrationHarness {
 				"  <version>2.39.0</version>",
 				"</palantirJavaFormat>");
 
-		runTest("java/palantirjavaformat/JavaCodeFormatted.test");
+		runTest("java/palantirjavaformat/JavaCodeFormatted.test", "java/palantirjavaformat/JavaCodeUnformatted.test");
 	}
 
-	private void runTest(String targetResource) throws Exception {
+	@Test
+	void formatJavaDoc() throws Exception {
+		writePomWithJavaSteps(
+				"<palantirJavaFormat>",
+				"  <version>2.39.0</version>",
+				"  <formatJavadoc>true</formatJavadoc>",
+				"</palantirJavaFormat>");
+
+		runTest("java/palantirjavaformat/JavaCodeWithJavaDocFormatted.test", "java/palantirjavaformat/JavaCodeWithJavaDocUnformatted.test");
+	}
+
+	private void runTest(String targetResource, String sourceResource) throws Exception {
 		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/palantirjavaformat/JavaCodeUnformatted.test");
+		setFile(path).toResource(sourceResource);
 		mavenRunner().withArguments("spotless:apply").runNoError();
 		assertFile(path).sameAsResource(targetResource);
 	}

--- a/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithJavaDocFormatted.test
+++ b/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithJavaDocFormatted.test
@@ -1,0 +1,39 @@
+import mylib.Unused;
+import mylib.UsedA;
+import mylib.UsedB;
+
+/**
+ * This is a test class with a long unformatted JavaDoc description. Lorem ipsum dolor sit amet, consectetur adipiscing
+ * elit. Vestibulum pulvinar condimentum elit, eget mollis magna sollicitudin in. Aenean pharetra nunc nec luctus
+ * consequat. Donec nec tincidunt quam, in auctor ipsum. Nam in sem orci. Maecenas interdum posuere orci a semper. Cras
+ * vulputate blandit metus, nec semper urna porttitor at. Praesent velit turpis, consequat in cursus eget, posuere eget
+ * magna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Pellentesque ante eros, sagittis sed tempus nec,
+ * rutrum ac arcu. Sed porttitor quam at enim commodo dictum. Sed fringilla tincidunt ex in aliquet.
+ *
+ * @author https://www.lipsum.com/
+ * @since 0.0.2
+ */
+public class Java {
+    /**
+     * A very simple method that I really like a lot?
+     *
+     * <p>Care for more details?
+     *
+     * <ul>
+     *   <li>Too
+     *   <li>bad
+     *   <li>I
+     *   <li>don't
+     *   <li>have
+     *   <li>any
+     * </ul>
+     *
+     * @param args Useless args, but see {@link Unused}, perhaps even {@link UsedA} or even {@link UsedB b }?
+     */
+    public static void main(String[] args) {
+        System.out.println(
+                "A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+        UsedB.someMethod();
+        UsedA.someMethod();
+    }
+}

--- a/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithJavaDocUnformatted.test
+++ b/testlib/src/main/resources/java/palantirjavaformat/JavaCodeWithJavaDocUnformatted.test
@@ -1,0 +1,30 @@
+
+import mylib.Unused;
+import mylib.UsedB;
+import mylib.UsedA;
+
+/** This is a test class with a long unformatted JavaDoc description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum pulvinar condimentum elit, eget mollis magna sollicitudin in. Aenean pharetra nunc nec luctus consequat. Donec nec tincidunt quam, in auctor ipsum. Nam in sem orci. Maecenas interdum posuere orci a semper. Cras vulputate blandit metus, nec semper urna porttitor at. Praesent velit turpis, consequat in cursus eget, posuere eget magna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Pellentesque ante eros, sagittis sed tempus nec, rutrum ac arcu. Sed porttitor quam at enim commodo dictum. Sed fringilla tincidunt ex in aliquet.
+ *             @author              https://www.lipsum.com/
+ *    @since  0.0.2
+ */
+public class Java {
+   /**
+    * A very simple method that I
+    * really
+    * like
+    * a lot?
+    *
+    * Care for more details? <ul><li>Too</li><li>bad</li>
+    * <li>I</li><li>don't</li><li>have</li>
+    *    <li>any</li>
+    * </ul>
+    *
+    *    @param args Useless args, but
+    * see   {@link Unused}, perhaps even {@link UsedA} or even {@link UsedB   b }?
+    */
+public static void main(String[] args) {
+System.out.println("A very very very very very very very very very very very very very very very very very very very very very long string that goes beyond the 100-character line length.");
+UsedB.someMethod();
+UsedA.someMethod();
+}
+}

--- a/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,14 @@ class PalantirJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
+	void formatJavadoc() throws Exception {
+		FormatterStep step = PalantirJavaFormatStep.create("2.39.0", "PALANTIR", true, TestProvisioner.mavenCentral());
+		StepHarness.forStep(step)
+				.testResource("java/palantirjavaformat/JavaCodeWithJavaDocUnformatted.test", "java/palantirjavaformat/JavaCodeWithJavaDocFormatted.test")
+				.testResource("java/palantirjavaformat/JavaCodeWithPackageUnformatted.test", "java/palantirjavaformat/JavaCodeWithPackageFormatted.test");
+	}
+
+	@Test
 	void behaviorWithGoogleStyle() throws Exception {
 		FormatterStep step = PalantirJavaFormatStep.create("1.1.0", "GOOGLE", TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
@@ -68,23 +76,33 @@ class PalantirJavaFormatStepTest extends ResourceHarness {
 		new SerializableEqualityTester() {
 			String version = "1.1.0";
 			String style = "";
+			boolean formatJavadoc = false;
 
 			@Override
 			protected void setupTest(API api) {
 				// same version == same
 				api.areDifferentThan();
+
 				// change the version, and it's different
 				version = "1.0.0";
 				api.areDifferentThan();
+				version = "1.1.0";
+
 				// change the style, and it's different
 				style = "AOSP";
 				api.areDifferentThan();
+				style = "";
+
+				// change the format Java doc flag, and it's different
+				formatJavadoc = true;
+				api.areDifferentThan();
+				formatJavadoc = false;
 			}
 
 			@Override
 			protected FormatterStep create() {
 				String finalVersion = this.version;
-				return PalantirJavaFormatStep.create(finalVersion, style, TestProvisioner.mavenCentral());
+				return PalantirJavaFormatStep.create(finalVersion, style, formatJavadoc, TestProvisioner.mavenCentral());
 			}
 		}.testEquals();
 	}


### PR DESCRIPTION
Adds a `formatJavadoc` flag to the Palantir formatter (Maven + Gradle) to enable Java Doc to be formatted, resolves #1995

This requires at least Palantir version 2.36.0, although there seem to be some issues with dependency resolution (see palantir/palantir-java-format#976), which seem to be fixed in Palantir version 2.39.0, so I used that version in the README.

To support older versions, the `builder.formatJavadoc(true)` method is called via reflection only if required.

---

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [x] a link to the issue you are resolving (for small changes)