### PR TITLE
Updated SortPom from 3.2.1 to 3.4.0 with support for endWithNewline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 ### Changes
 * Bump default `ktfmt` version to latest `0.46` -> `0.47`. ([#2045](https://github.com/diffplug/spotless/pull/2045))
+* Bump default `sortpom` version to latest `3.2.1` -> `3.4.0`. ([#2049](https://github.com/diffplug/spotless/pull/2049))
 ### Removed
 * **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * **BREAKING** Replace `PipeStepPair` with `FenceStep`. ([#1954](https://github.com/diffplug/spotless/pull/1954))

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -128,8 +128,8 @@ dependencies {
 	// scalafmt
 	scalafmtCompileOnly "org.scalameta:scalafmt-core_2.13:3.7.3"
 	// sortPom
-	sortPomCompileOnly 'com.github.ekryd.sortpom:sortpom-sorter:3.2.1'
-	sortPomCompileOnly 'org.slf4j:slf4j-api:2.0.0'
+	sortPomCompileOnly 'com.github.ekryd.sortpom:sortpom-sorter:3.4.0'
+	sortPomCompileOnly 'org.slf4j:slf4j-api:2.0.12'
 	// zjsonPatch
 	zjsonPatchCompileOnly 'com.flipkart.zjsonpatch:zjsonpatch:0.4.14'
 }

--- a/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
+++ b/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.io.Serializable;
 public class SortPomCfg implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-	public String version = "3.2.1";
+	public String version = "3.4.0";
 
 	public String encoding = "UTF-8";
 
@@ -32,6 +32,8 @@ public class SortPomCfg implements Serializable {
 	public boolean spaceBeforeCloseEmptyElement = false;
 
 	public boolean keepBlankLines = true;
+
+	public boolean endWithNewline = true;
 
 	public int nrOfIndentSpace = 2;
 

--- a/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
+++ b/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class SortPomFormatterFunc implements FormatterFunc {
 				.setPomFile(pom)
 				.setFileOutput(false, null, null, false)
 				.setEncoding(cfg.encoding)
-				.setFormatting(cfg.lineSeparator, cfg.expandEmptyElements, cfg.spaceBeforeCloseEmptyElement, cfg.keepBlankLines)
+				.setFormatting(cfg.lineSeparator, cfg.expandEmptyElements, cfg.spaceBeforeCloseEmptyElement, cfg.keepBlankLines, cfg.endWithNewline)
 				.setIndent(cfg.nrOfIndentSpace, cfg.indentBlankLines, cfg.indentSchemaLocation)
 				.setSortOrder(cfg.sortOrderFile, cfg.predefinedSortOrder)
 				.setSortEntities(cfg.sortDependencies, cfg.sortDependencyExclusions, cfg.sortDependencyManagement,

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Ignore system git config when running tests ([#1990](https://github.com/diffplug/spotless/issues/1990))
 ### Changes
 * Bump default `ktfmt` version to latest `0.46` -> `0.47`. ([#2045](https://github.com/diffplug/spotless/pull/2045))
+* Bump default `sortpom` version to latest `3.2.1` -> `3.4.0`. ([#2049](https://github.com/diffplug/spotless/pull/2049))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Ignore system git config when running tests ([#1990](https://github.com/diffplug/spotless/issues/1990))
 ### Changes
 * Bump default `ktfmt` version to latest `0.46` -> `0.47`. ([#2045](https://github.com/diffplug/spotless/pull/2045))
+* Bump default `sortpom` version to latest `3.2.1` -> `3.4.0`. ([#2049](https://github.com/diffplug/spotless/pull/2049))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -659,6 +659,8 @@ All configuration settings are optional, they are described in detail [here](htt
 
   <keepBlankLines>true</keepBlankLines> <!-- Keep empty lines -->
 
+  <endWithNewline>true</endWithNewline> <!-- Whether sorted pom ends with a newline -->
+
   <nrOfIndentSpace>2</nrOfIndentSpace> <!-- Indentation -->
 
   <indentBlankLines>false</indentBlankLines> <!-- Should empty lines be indented -->

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/pom/SortPom.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/pom/SortPom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ public class SortPom implements FormatterStepFactory {
 
 	@Parameter
 	boolean keepBlankLines = defaultValues.keepBlankLines;
+
+	@Parameter
+	boolean endWithNewline = defaultValues.endWithNewline;
 
 	@Parameter
 	int nrOfIndentSpace = defaultValues.nrOfIndentSpace;
@@ -89,6 +92,7 @@ public class SortPom implements FormatterStepFactory {
 		cfg.expandEmptyElements = expandEmptyElements;
 		cfg.spaceBeforeCloseEmptyElement = spaceBeforeCloseEmptyElement;
 		cfg.keepBlankLines = keepBlankLines;
+		cfg.endWithNewline = endWithNewline;
 		cfg.nrOfIndentSpace = nrOfIndentSpace;
 		cfg.indentBlankLines = indentBlankLines;
 		cfg.indentSchemaLocation = indentSchemaLocation;

--- a/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +21,16 @@ import com.diffplug.spotless.*;
 
 public class SortPomTest extends ResourceHarness {
 	@Test
-	public void testSortPomWithDefaultConfig() throws Exception {
+	public void testSortPomWithDefaultConfig() {
 		SortPomCfg cfg = new SortPomCfg();
 		FormatterStep step = SortPomStep.create(cfg, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step).testResource("pom/pom_dirty.xml", "pom/pom_clean_default.xml");
 	}
 
 	@Test
-	public void testSortPomWithVersion() throws Exception {
+	public void testSortPomWithVersion() {
 		SortPomCfg cfg = new SortPomCfg();
-		cfg.version = "3.2.1";
+		cfg.version = "3.4.0";
 		FormatterStep step = SortPomStep.create(cfg, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step).testResource("pom/pom_dirty.xml", "pom/pom_clean_default.xml");
 	}


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
