### PR TITLE
Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           - kind: shfmt
             jre: 11
             os: ubuntu-latest
-            shfmt-version: 3.7.0
+            shfmt-version: v3.8.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -83,11 +83,15 @@ jobs:
       - name: test npm
         if: matrix.kind == 'npm'
         run: ./gradlew testNpm
+      - name: Setup go
+        if: matrix.kind == 'shfmt'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
       - name: Install shfmt
         if: matrix.kind == 'shfmt'
         run: |
-          curl -sSfL "https://github.com/mvdan/sh/releases/download/v${{ matrix.shfmt-version }}/shfmt_v${{ matrix.shfmt-version }}_linux_amd64" -o /usr/local/bin/shfmt
-          chmod +x /usr/local/bin/shfmt
+          go install mvdan.cc/sh/v3/cmd/shfmt@${{ matrix.shfmt-version }}
       - name: Test shfmt
         if: matrix.kind == 'shfmt'
         run: ./gradlew testShfmt

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 ### Changes
 * Bump default `ktfmt` version to latest `0.46` -> `0.47`. ([#2045](https://github.com/diffplug/spotless/pull/2045))
+* Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#TODO](https://github.com/diffplug/spotless/pull/TODO))
 ### Removed
 * **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * **BREAKING** Replace `PipeStepPair` with `FenceStep`. ([#1954](https://github.com/diffplug/spotless/pull/1954))

--- a/lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java
@@ -40,7 +40,7 @@ public class ShfmtStep {
 	}
 
 	public static String defaultVersion() {
-		return "3.7.0";
+		return "3.8.0";
 	}
 
 	private final String version;

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Ignore system git config when running tests ([#1990](https://github.com/diffplug/spotless/issues/1990))
 ### Changes
 * Bump default `ktfmt` version to latest `0.46` -> `0.47`. ([#2045](https://github.com/diffplug/spotless/pull/2045))
+* Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#TODO](https://github.com/diffplug/spotless/pull/TODO))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1011,7 +1011,7 @@ When formatting shell scripts via `shfmt`, configure `shfmt` settings via `.edit
 Refer to the `shfmt` [man page](https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd) for `.editorconfig` settings. 
 
 ```gradle
-shfmt('3.7.0') // version is optional
+shfmt('3.8.0') // version is optional
 
 // if shfmt is not on your path, you must specify its location manually
 shfmt().pathToExe('/opt/homebrew/bin/shfmt')

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Ignore system git config when running tests ([#1990](https://github.com/diffplug/spotless/issues/1990))
 ### Changes
 * Bump default `ktfmt` version to latest `0.46` -> `0.47`. ([#2045](https://github.com/diffplug/spotless/pull/2045))
+* Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#TODO](https://github.com/diffplug/spotless/pull/TODO))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1045,7 +1045,7 @@ When formatting shell scripts via `shfmt`, configure `shfmt` settings via `.edit
 
 ```xml
 <shfmt>
-  <version>3.7.0</version>                         <!-- optional: Custom version of 'mvdan/sh' -->
+  <version>3.8.0</version>                         <!-- optional: Custom version of 'mvdan/sh' -->
   <pathToExe>/opt/homebrew/bin/shfmt</pathToExe>   <!-- optional: if shfmt is not on your path, you must specify its location manually -->
 </shfmt>
 ```


### PR DESCRIPTION
Closes https://github.com/diffplug/spotless/issues/2035


