### PR TITLE
Skip execution in incremental (m2e) builds by default

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
+* Skip execution in M2E (incremental) builds by default ([#1814](https://github.com/diffplug/spotless/issues/1814), [#2037](https://github.com/diffplug/spotless/issues/2037)) 
 
 ## [2.43.0] - 2024-01-23
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1696,7 +1696,7 @@ cmd> mvn spotless:apply -DspotlessFiles=my/file/pattern.java,more/generic/.*-pat
 
 The patterns are matched using `String#matches(String)` against the absolute file path.
 
-## Does Spotless support incremental builds in Eclipse
+## Does Spotless support incremental builds in Eclipse?
 
 Spotless comes with [m2e](https://eclipse.dev/m2e/) support. However by default its execution is skipped by default in incremental builds. To enable it use the following parameter
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1707,7 +1707,7 @@ To enable it use the following parameter
 </configuration>
 ```
 
-In addition Eclipse problem markers are being emitted. By default they have the severity `WARNING`.
+In addition Eclipse problem markers are being emitted for goal `check`. By default they have the severity `WARNING`.
 You can adjust this with 
 
 ```

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1698,7 +1698,7 @@ The patterns are matched using `String#matches(String)` against the absolute fil
 
 ## Does Spotless support incremental builds in Eclipse
 
-Spotless comes with [m2e](https://eclipse.dev/m2e/) support. However by default its execution is skipped by default in incremental builds. To enable it use the following parameter.
+Spotless comes with [m2e](https://eclipse.dev/m2e/) support. However by default its execution is skipped by default in incremental builds. To enable it use the following parameter
 
 ```
 <configuration>
@@ -1714,6 +1714,7 @@ You can adjust this with
     <incrementalBuildMessageSeverity>ERROR</incrementalBuildMessageSeverity><!-- WARNING or ERROR -->
 </configuration>
 ```
+
 Note that for Incremental build support the goals have to be bound to a phase prior to `test`.
 
 <a name="examples"></a>

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1703,7 +1703,7 @@ To enable it use the following parameter
 
 ```
 <configuration>
-    <enableForIncrementalBuild>true</enableForIncrementalBuild><!-- this is false by default -->
+    <m2eEnableForIncrementalBuild>true</m2eEnableForIncrementalBuild><!-- this is false by default -->
 </configuration>
 ```
 
@@ -1712,7 +1712,7 @@ You can adjust this with
 
 ```
 <configuration>
-    <incrementalBuildMessageSeverity>ERROR</incrementalBuildMessageSeverity><!-- WARNING or ERROR -->
+    <m2eIncrementalBuildMessageSeverity>ERROR</m2eIncrementalBuildMessageSeverity><!-- WARNING or ERROR -->
 </configuration>
 ```
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1696,6 +1696,26 @@ cmd> mvn spotless:apply -DspotlessFiles=my/file/pattern.java,more/generic/.*-pat
 
 The patterns are matched using `String#matches(String)` against the absolute file path.
 
+## Does Spotless support incremental builds in Eclipse
+
+Spotless comes with [m2e](https://eclipse.dev/m2e/) support. However by default its execution is skipped by default in incremental builds. To enable it use the following parameter.
+
+```
+<configuration>
+    <enableForIncrementalBuild>true</enableForIncrementalBuild><!-- this is false by default -->
+</configuration>
+```
+
+In addition Eclipse problem markers are being emitted. By default they have the severity `WARNING`.
+You can adjust this with 
+
+```
+<configuration>
+    <incrementalBuildMessageSeverity>ERROR</incrementalBuildMessageSeverity><!-- WARNING or ERROR -->
+</configuration>
+```
+Note that for Incremental build support the goals have to be bound to a phase prior to `test`.
+
 <a name="examples"></a>
 
 ## Example configurations (from real-world projects)

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1698,7 +1698,8 @@ The patterns are matched using `String#matches(String)` against the absolute fil
 
 ## Does Spotless support incremental builds in Eclipse?
 
-Spotless comes with [m2e](https://eclipse.dev/m2e/) support. However by default its execution is skipped by default in incremental builds. To enable it use the following parameter
+Spotless comes with [m2e](https://eclipse.dev/m2e/) support. However, by default its execution is skipped in incremental builds as most developers want to fix all issues in one go via explicit `mvn spotless:apply` prior to raising a PR and don't want to be bothered with Spotless issues during working on the source code in the IDE.
+To enable it use the following parameter
 
 ```
 <configuration>

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -201,6 +201,13 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter
 	private UpToDateChecking upToDateChecking = UpToDateChecking.enabled();
 
+	/**
+	 * If set to {@code true} will also run on incremental builds (i.e. within Eclipse with m2e).
+	 * Otherwise this goal is skipped in incremental builds and only runs on full builds.
+	 */
+	@Parameter(defaultValue = "false")
+	protected boolean enableForIncrementalBuild;
+
 	protected abstract void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException;
 
 	private static final int MINIMUM_JRE = 11;
@@ -243,6 +250,10 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	private boolean shouldSkip() {
 		if (skip) {
+			return true;
+		}
+		if (buildContext.isIncremental() && !enableForIncrementalBuild) {
+			getLog().debug("Skipping for incremental builds as parameter 'enableForIncrementalBuilds' is set to 'false'");
 			return true;
 		}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -206,7 +206,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	 * Otherwise this goal is skipped in incremental builds and only runs on full builds.
 	 */
 	@Parameter(defaultValue = "false")
-	protected boolean enableForIncrementalBuild;
+	protected boolean m2eEnableForIncrementalBuild;
 
 	protected abstract void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException;
 
@@ -252,7 +252,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		if (skip) {
 			return true;
 		}
-		if (buildContext.isIncremental() && !enableForIncrementalBuild) {
+		if (buildContext.isIncremental() && !m2eEnableForIncrementalBuild) {
 			getLog().debug("Skipping for incremental builds as parameter 'enableForIncrementalBuilds' is set to 'false'");
 			return true;
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 import com.diffplug.spotless.Formatter;
@@ -38,6 +39,30 @@ import com.diffplug.spotless.maven.incremental.UpToDateChecker;
 @Mojo(name = AbstractSpotlessMojo.GOAL_CHECK, defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 
+	private static final String INCREMENTAL_MESSAGE_PREFIX = "Spotless Violation: ";
+
+	public enum MessageSeverity {
+		WARNING(BuildContext.SEVERITY_WARNING), ERROR(BuildContext.SEVERITY_ERROR);
+
+		private final int severity;
+
+		MessageSeverity(int severity) {
+			this.severity = severity;
+		}
+
+		public int getSeverity() {
+			return severity;
+		}
+	}
+
+	/**
+	 * The severity used to emit messages during incremental builds.
+	 * Either {@code WARNING} or {@code ERROR}.
+	 * @see AbstractSpotlessMojo#enableForIncrementalBuild
+	 */
+	@Parameter(defaultValue = "WARNING")
+	private MessageSeverity incrementalBuildMessageSeverity;
+
 	@Override
 	protected void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
 		ImpactedFilesTracker counter = new ImpactedFilesTracker();
@@ -51,14 +76,14 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 				}
 				continue;
 			}
-
+			buildContext.removeMessages(file);
 			try {
 				PaddedCell.DirtyState dirtyState = PaddedCell.calculateDirtyState(formatter, file);
 				if (!dirtyState.isClean() && !dirtyState.didNotConverge()) {
 					problemFiles.add(file);
 					if (buildContext.isIncremental()) {
 						Map.Entry<Integer, String> diffEntry = DiffMessageFormatter.diff(formatter, file);
-						buildContext.addMessage(file, diffEntry.getKey() + 1, 0, diffEntry.getValue(), BuildContext.SEVERITY_ERROR, null);
+						buildContext.addMessage(file, diffEntry.getKey() + 1, 0, INCREMENTAL_MESSAGE_PREFIX + diffEntry.getValue(), incrementalBuildMessageSeverity.getSeverity(), null);
 					}
 					counter.cleaned();
 				} else {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -58,10 +58,10 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 	/**
 	 * The severity used to emit messages during incremental builds.
 	 * Either {@code WARNING} or {@code ERROR}.
-	 * @see AbstractSpotlessMojo#enableForIncrementalBuild
+	 * @see AbstractSpotlessMojo#m2eEnableForIncrementalBuild
 	 */
 	@Parameter(defaultValue = "WARNING")
-	private MessageSeverity incrementalBuildMessageSeverity;
+	private MessageSeverity m2eIncrementalBuildMessageSeverity;
 
 	@Override
 	protected void process(Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
@@ -83,7 +83,7 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 					problemFiles.add(file);
 					if (buildContext.isIncremental()) {
 						Map.Entry<Integer, String> diffEntry = DiffMessageFormatter.diff(formatter, file);
-						buildContext.addMessage(file, diffEntry.getKey() + 1, 0, INCREMENTAL_MESSAGE_PREFIX + diffEntry.getValue(), incrementalBuildMessageSeverity.getSeverity(), null);
+						buildContext.addMessage(file, diffEntry.getKey() + 1, 0, INCREMENTAL_MESSAGE_PREFIX + diffEntry.getValue(), m2eIncrementalBuildMessageSeverity.getSeverity(), null);
 					}
 					counter.cleaned();
 				} else {


### PR DESCRIPTION
Clear stale messages during "check" mojo
Allow to parameterize message severity
Add Spotless prefix to messages

This closes #1814
This closes #2037

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
