### PR TITLE
Don't capture the FormatExtension in LiveCache

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 * Ignore system git config when running tests ([#1990](https://github.com/diffplug/spotless/issues/1990))
+* Fixed memory leak introduced in 6.21.0 ([#2067](https://github.com/diffplug/spotless/issues/2067))
 ### Changes
 * Bump default `ktfmt` version to latest `0.46` -> `0.47`. ([#2045](https://github.com/diffplug/spotless/pull/2045))
 * Bump default `sortpom` version to latest `3.2.1` -> `3.4.0`. ([#2049](https://github.com/diffplug/spotless/pull/2049))

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -1067,8 +1067,9 @@ public class FormatExtension {
 		}
 		task.setSteps(steps);
 		Directory projectDir = getProject().getLayout().getProjectDirectory();
+		LineEnding lineEndings = getLineEndings();
 		task.setLineEndingsPolicy(
-				getProject().provider(() -> getLineEndings().createPolicy(projectDir.getAsFile(), () -> totalTarget)));
+				getProject().provider(() -> lineEndings.createPolicy(projectDir.getAsFile(), () -> totalTarget)));
 		spotless.getRegisterDependenciesTask().hookSubprojectTask(task);
 		task.setupRatchet(getRatchetFrom() != null ? getRatchetFrom() : "");
 	}


### PR DESCRIPTION
Fixed memory leak caused by capturing the Gradle project model referenced by the LineEndings Provider stored in the JvmLocalCache.

Fixes #2067

Now only the file collection, the line endings enum and the directory are captured:
![image](https://github.com/diffplug/spotless/assets/208302/8689d24f-d91d-4e79-9a5e-7841671586ec)
