### PR TITLE
Wildcards are sorted only for the same package path depth

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -253,6 +253,10 @@ final class ImportSorterImpl {
 		if (!samePrefix) {
 			return string1.compareTo(string2);
 		}
+		boolean diffPathDepth = string1IsWildcard ? string2.substring(prefixLength).contains(".") : string1.substring(prefixLength).contains(".");
+		if (diffPathDepth) {
+			return string1IsWildcard ? -1 : 1;
+		}
 		return (string1IsWildcard == wildcardsLast) ? 1 : -1;
 	}
 


### PR DESCRIPTION
Wildcard imports should come first in all subpackages.

like IDEA:
```java
import java.nio.file.Paths;
import java.util.*;
import java.util.concurrent.atomic.AtomicInteger;
import java.util.regex.Matcher;
```
but, spotless:check:
```
[ERROR]         @@ -10,12 +10,12 @@
[ERROR]          import·java.nio.file.Files;
[ERROR]          import·java.nio.file.Path;
[ERROR]          import·java.nio.file.Paths;
[ERROR]         -import·java.util.*;
[ERROR]          import·java.util.concurrent.atomic.AtomicInteger;
[ERROR]          import·java.util.regex.Matcher;
[ERROR]          import·java.util.regex.Pattern;
[ERROR]          import·java.util.stream.Collectors;
[ERROR]          import·java.util.stream.Stream;
[ERROR]         +import·java.util.*;
```