### PR TITLE
Update sortpom to 4.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
-* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
+* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0` and support versions back to `3.2.1`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
 ### Removed
 * **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * **BREAKING** Replace `PipeStepPair` with `FenceStep`. ([#1954](https://github.com/diffplug/spotless/pull/1954))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
+* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
 ### Removed
 * **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * **BREAKING** Replace `PipeStepPair` with `FenceStep`. ([#1954](https://github.com/diffplug/spotless/pull/1954))

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -128,7 +128,7 @@ dependencies {
 	// scalafmt
 	scalafmtCompileOnly "org.scalameta:scalafmt-core_2.13:3.7.3"
 	// sortPom
-	sortPomCompileOnly 'com.github.ekryd.sortpom:sortpom-sorter:3.4.1'
+	sortPomCompileOnly 'com.github.ekryd.sortpom:sortpom-sorter:4.0.0'
 	sortPomCompileOnly 'org.slf4j:slf4j-api:2.0.12'
 	// zjsonPatch
 	zjsonPatchCompileOnly 'com.flipkart.zjsonpatch:zjsonpatch:0.4.14'

--- a/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
+++ b/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 public class SortPomCfg implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-	public String version = "3.4.1";
+	public String version = "4.0.0";
 
 	public String encoding = "UTF-8";
 
@@ -40,6 +40,8 @@ public class SortPomCfg implements Serializable {
 	public boolean indentBlankLines = false;
 
 	public boolean indentSchemaLocation = false;
+
+	public String indentAttribute = null;
 
 	public String predefinedSortOrder = "recommended_2008_06";
 

--- a/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
+++ b/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
@@ -62,7 +62,7 @@ public class SortPomFormatterFunc implements FormatterFunc {
 				builder = (PluginParameters.Builder) method
 						.invoke(builder, cfg.lineSeparator, cfg.expandEmptyElements, cfg.spaceBeforeCloseEmptyElement,
 								cfg.keepBlankLines);
-			} catch (Exception ignore) {
+			} catch (ReflectiveOperationException | RuntimeException ignore) {
 				throw e;
 			}
 		}
@@ -76,7 +76,7 @@ public class SortPomFormatterFunc implements FormatterFunc {
 						.getMethod("setIndent", int.class, boolean.class, boolean.class);
 				builder = (PluginParameters.Builder) method
 						.invoke(builder, cfg.nrOfIndentSpace, cfg.indentBlankLines, cfg.indentSchemaLocation);
-			} catch (Exception ignore) {
+			} catch (ReflectiveOperationException | RuntimeException ignore) {
 				throw e;
 			}
 		}

--- a/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
+++ b/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.glue.pom;
 
 import java.io.*;
+import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 
@@ -46,17 +47,45 @@ public class SortPomFormatterFunc implements FormatterFunc {
 			writer.write(input);
 		}
 		SortPomImpl sortPom = new SortPomImpl();
-		sortPom.setup(new MySortPomLogger(), PluginParameters.builder()
+		PluginParameters.Builder builder = PluginParameters.builder()
 				.setPomFile(pom)
 				.setFileOutput(false, null, null, false)
-				.setEncoding(cfg.encoding)
-				.setFormatting(cfg.lineSeparator, cfg.expandEmptyElements, cfg.spaceBeforeCloseEmptyElement, cfg.keepBlankLines, cfg.endWithNewline)
-				.setIndent(cfg.nrOfIndentSpace, cfg.indentBlankLines, cfg.indentSchemaLocation, cfg.indentAttribute)
+				.setEncoding(cfg.encoding);
+		try {
+			builder = builder
+					.setFormatting(cfg.lineSeparator, cfg.expandEmptyElements, cfg.spaceBeforeCloseEmptyElement,
+							cfg.keepBlankLines, cfg.endWithNewline);
+		} catch (NoSuchMethodError e) {
+			try {
+				Method method = PluginParameters.Builder.class
+						.getMethod("setFormatting", String.class, boolean.class, boolean.class, boolean.class);
+				builder = (PluginParameters.Builder) method
+						.invoke(builder, cfg.lineSeparator, cfg.expandEmptyElements, cfg.spaceBeforeCloseEmptyElement,
+								cfg.keepBlankLines);
+			} catch (Exception ignore) {
+				throw e;
+			}
+		}
+		try {
+			builder = builder
+					.setIndent(cfg.nrOfIndentSpace, cfg.indentBlankLines, cfg.indentSchemaLocation,
+							cfg.indentAttribute);
+		} catch (NoSuchMethodError e) {
+			try {
+				Method method = PluginParameters.Builder.class
+						.getMethod("setIndent", int.class, boolean.class, boolean.class);
+				builder = (PluginParameters.Builder) method
+						.invoke(builder, cfg.nrOfIndentSpace, cfg.indentBlankLines, cfg.indentSchemaLocation);
+			} catch (Exception ignore) {
+				throw e;
+			}
+		}
+		builder = builder
 				.setSortOrder(cfg.sortOrderFile, cfg.predefinedSortOrder)
 				.setSortEntities(cfg.sortDependencies, cfg.sortDependencyExclusions, cfg.sortDependencyManagement,
 						cfg.sortPlugins, cfg.sortProperties, cfg.sortModules, cfg.sortExecutions)
-				.setIgnoreLineSeparators(false)
-				.build());
+				.setIgnoreLineSeparators(false);
+		sortPom.setup(new MySortPomLogger(), builder.build());
 		sortPom.sortPom();
 		return Files.readString(pom.toPath(), Charset.forName(cfg.encoding));
 	}

--- a/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
+++ b/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
@@ -51,7 +51,7 @@ public class SortPomFormatterFunc implements FormatterFunc {
 				.setFileOutput(false, null, null, false)
 				.setEncoding(cfg.encoding)
 				.setFormatting(cfg.lineSeparator, cfg.expandEmptyElements, cfg.spaceBeforeCloseEmptyElement, cfg.keepBlankLines, cfg.endWithNewline)
-				.setIndent(cfg.nrOfIndentSpace, cfg.indentBlankLines, cfg.indentSchemaLocation)
+				.setIndent(cfg.nrOfIndentSpace, cfg.indentBlankLines, cfg.indentSchemaLocation, cfg.indentAttribute)
 				.setSortOrder(cfg.sortOrderFile, cfg.predefinedSortOrder)
 				.setSortEntities(cfg.sortDependencies, cfg.sortDependencyExclusions, cfg.sortDependencyManagement,
 						cfg.sortPlugins, cfg.sortProperties, cfg.sortModules, cfg.sortExecutions)

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -14,6 +14,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
+* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Add support for formatting and sorting Maven POMs ([#2082](https://github.com/diffplug/spotless/issues/2082))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -14,7 +14,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
-* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
+* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0` and support versions back to `3.2.1`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Add support for formatting and sorting Maven POMs ([#2082](https://github.com/diffplug/spotless/issues/2082))

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -700,7 +700,7 @@ All configuration settings are optional, they are described in detail [here](htt
 ```gradle
 spotless {
   pom {
-    sortPom('3.4.0')
+    sortPom('4.0.0')
       .encoding('UTF-8') // The encoding of the pom files
       .lineSeparator(System.getProperty('line.separator')) // line separator to use
       .expandEmptyElements(true) // Should empty elements be expanded
@@ -710,6 +710,7 @@ spotless {
       .nrOfIndentSpace(2) // Indentation
       .indentBlankLines(false) // Should empty lines be indented
       .indentSchemaLocation(false) // Should schema locations be indented
+      .indentAttribute(null) // Should the xml attributes be indented
       .predefinedSortOrder('recommended_2008_06') // Sort order of elements: https://github.com/Ekryd/sortpom/wiki/PredefinedSortOrderProfiles
       .sortOrderFile(null) // Custom sort order of elements: https://raw.githubusercontent.com/Ekryd/sortpom/master/sorter/src/main/resources/custom_1.xml
       .sortDependencies(null) // Sort dependencies: https://github.com/Ekryd/sortpom/wiki/SortDependencies

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PomExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PomExtension.java
@@ -107,6 +107,11 @@ public class PomExtension extends FormatExtension {
 			return this;
 		}
 
+		public SortPomGradleConfig indentAttribute(String indentAttribute) {
+			cfg.indentAttribute = indentAttribute;
+			return this;
+		}
+
 		public SortPomGradleConfig predefinedSortOrder(String predefinedSortOrder) {
 			cfg.predefinedSortOrder = predefinedSortOrder;
 			return this;

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SortPomGradleTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SortPomGradleTest.java
@@ -16,6 +16,8 @@
 package com.diffplug.gradle.spotless;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class SortPomGradleTest extends GradleIntegrationHarness {
 	@Test
@@ -63,8 +65,9 @@ class SortPomGradleTest extends GradleIntegrationHarness {
 		assertFile("test.xml").sameAsResource("pom/pom_clean_default.xml");
 	}
 
-	@Test
-	void sortPomWithVersion() throws Exception {
+	@ParameterizedTest
+	@ValueSource(strings = {"3.2.1", "3.3.0", "3.4.1", "4.0.0"})
+	void sortPomWithVersion(String version) throws Exception {
 		// given
 		setFile("build.gradle").toLines(
 				"plugins {",
@@ -73,7 +76,7 @@ class SortPomGradleTest extends GradleIntegrationHarness {
 				"repositories { mavenCentral() }",
 				"spotless {",
 				"  pom {",
-				"    sortPom '4.0.0'",
+				"    sortPom '" + version + "'",
 				"  }",
 				"}");
 		setFile("pom.xml").toResource("pom/pom_dirty.xml");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SortPomGradleTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SortPomGradleTest.java
@@ -73,7 +73,7 @@ class SortPomGradleTest extends GradleIntegrationHarness {
 				"repositories { mavenCentral() }",
 				"spotless {",
 				"  pom {",
-				"    sortPom '3.4.0'",
+				"    sortPom '4.0.0'",
 				"  }",
 				"}");
 		setFile("pom.xml").toResource("pom/pom_dirty.xml");
@@ -105,6 +105,7 @@ class SortPomGradleTest extends GradleIntegrationHarness {
 				"      .nrOfIndentSpace(2)",
 				"      .indentBlankLines(false)",
 				"      .indentSchemaLocation(false)",
+				"      .indentAttribute(null)",
 				"      .predefinedSortOrder('recommended_2008_06')",
 				"      .sortOrderFile(null)",
 				"      .sortDependencies(null)",

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -12,7 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
-* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
+* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0` and support versions back to `3.2.1`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Skip execution in M2E (incremental) builds by default ([#1814](https://github.com/diffplug/spotless/issues/1814), [#2037](https://github.com/diffplug/spotless/issues/2037)) 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
+* Bump default `sortpom` version to latest `3.4.1` -> `4.0.0`. ([#2115](https://github.com/diffplug/spotless/pull/2115))
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Skip execution in M2E (incremental) builds by default ([#1814](https://github.com/diffplug/spotless/issues/1814), [#2037](https://github.com/diffplug/spotless/issues/2037)) 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -667,6 +667,8 @@ All configuration settings are optional, they are described in detail [here](htt
 
   <indentSchemaLocation>false</indentSchemaLocation> <!-- Should schema locations be indented -->
 
+  <indentAttribute></indentAttribute> <!-- Should the xml attributes be indented -->
+
   <predefinedSortOrder>recommended_2008_06</predefinedSortOrder> <!-- Sort order of elements: https://github.com/Ekryd/sortpom/wiki/PredefinedSortOrderProfiles-->
 
   <sortOrderFile></sortOrderFile> <!-- Custom sort order of elements: https://raw.githubusercontent.com/Ekryd/sortpom/master/sorter/src/main/resources/custom_1.xml -->

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/pom/SortPom.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/pom/SortPom.java
@@ -57,6 +57,9 @@ public class SortPom implements FormatterStepFactory {
 	boolean indentSchemaLocation = defaultValues.indentSchemaLocation;
 
 	@Parameter
+	String indentAttribute = defaultValues.indentAttribute;
+
+	@Parameter
 	String predefinedSortOrder = defaultValues.predefinedSortOrder;
 
 	@Parameter
@@ -96,6 +99,7 @@ public class SortPom implements FormatterStepFactory {
 		cfg.nrOfIndentSpace = nrOfIndentSpace;
 		cfg.indentBlankLines = indentBlankLines;
 		cfg.indentSchemaLocation = indentSchemaLocation;
+		cfg.indentAttribute = indentAttribute;
 		cfg.predefinedSortOrder = predefinedSortOrder;
 		cfg.sortOrderFile = sortOrderFile;
 		cfg.sortDependencies = sortDependencies;

--- a/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
@@ -30,7 +30,7 @@ public class SortPomTest extends ResourceHarness {
 	@Test
 	public void testSortPomWithVersion() {
 		SortPomCfg cfg = new SortPomCfg();
-		cfg.version = "3.4.1";
+		cfg.version = "4.0.0";
 		FormatterStep step = SortPomStep.create(cfg, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step).testResource("pom/pom_dirty.xml", "pom/pom_clean_default.xml");
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
@@ -16,6 +16,8 @@
 package com.diffplug.spotless.pom;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.diffplug.spotless.*;
 
@@ -27,10 +29,11 @@ public class SortPomTest extends ResourceHarness {
 		StepHarness.forStep(step).testResource("pom/pom_dirty.xml", "pom/pom_clean_default.xml");
 	}
 
-	@Test
-	public void testSortPomWithVersion() {
+	@ParameterizedTest
+	@ValueSource(strings = {"3.2.1", "3.3.0", "3.4.1", "4.0.0"})
+	public void testSortPomWithVersion(String version) {
 		SortPomCfg cfg = new SortPomCfg();
-		cfg.version = "4.0.0";
+		cfg.version = version;
 		FormatterStep step = SortPomStep.create(cfg, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step).testResource("pom/pom_dirty.xml", "pom/pom_clean_default.xml");
 	}


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
