### PR TITLE
Fix stdin pipe is being closed exception on Windows for large .proto files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,13 +11,14 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* `FileSignature.Promised` and `JarState.Promised` to facilitate round-trip serialization for the Gradle configuration cache. ([#1945](https://github.com/diffplug/spotless/pull/1945)) 
+* `FileSignature.Promised` and `JarState.Promised` to facilitate round-trip serialization for the Gradle configuration cache. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 ### Fixed
 * Ignore system git config when running tests ([#1990](https://github.com/diffplug/spotless/issues/1990))
 * Correctly provide EditorConfig property types for Ktlint ([#2052](https://github.com/diffplug/spotless/issues/2052))
 * Made ShadowCopy (`npmInstallCache`) more robust by re-creating the cache dir if it goes missing ([#1984](https://github.com/diffplug/spotless/issues/1984),[2096](https://github.com/diffplug/spotless/pull/2096))
 * scalafmt.conf fileOverride section now works correctly ([#1854](https://github.com/diffplug/spotless/pull/1854))
+* Fix stdin pipe is being closed exception on Windows for large .proto files ([#2147](https://github.com/diffplug/spotless/issues/2147))
 ### Changes
 * Bump default `cleanthat` version to latest `2.16` -> `2.20`. ([#1725](https://github.com/diffplug/spotless/pull/1725))
 * Bump default `gherkin-utils` version to latest `8.0.2` -> `9.0.0`. ([#1703](https://github.com/diffplug/spotless/pull/1703))

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 DiffPlug
+ * Copyright 2020-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -163,7 +163,6 @@ public class ProcessRunner implements AutoCloseable {
 		}
 		// write stdin
 		process.getOutputStream().write(stdin);
-		process.getOutputStream().close();
 		return new LongRunningProcess(process, args, outputFut, errorFut);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -164,6 +164,7 @@ public class ProcessRunner implements AutoCloseable {
 		// write stdin
 		process.getOutputStream().write(stdin);
 		process.getOutputStream().flush();
+		process.getOutputStream().close();
 		return new LongRunningProcess(process, args, outputFut, errorFut);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -163,6 +163,7 @@ public class ProcessRunner implements AutoCloseable {
 		}
 		// write stdin
 		process.getOutputStream().write(stdin);
+		process.getOutputStream().flush();
 		return new LongRunningProcess(process, args, outputFut, errorFut);
 	}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Full, no-asterisk support of Gradle configuration cache. ([#1274](https://github.com/diffplug/spotless/issues/1274), giving up on [#987](https://github.com/diffplug/spotless/issues/987))
-  * In order to use `custom`, you must now use Gradle 8.0+. 
+  * In order to use `custom`, you must now use Gradle 8.0+.
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Add support for formatting and sorting Maven POMs ([#2082](https://github.com/diffplug/spotless/issues/2082))
 ### Fixed
@@ -15,6 +15,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Fixed memory leak introduced in 6.21.0 ([#2067](https://github.com/diffplug/spotless/issues/2067))
 * Made ShadowCopy (`npmInstallCache`) more robust by re-creating the cache dir if it goes missing ([#1984](https://github.com/diffplug/spotless/issues/1984),[2096](https://github.com/diffplug/spotless/pull/2096))
 * scalafmt.conf fileOverride section now works correctly ([#1854](https://github.com/diffplug/spotless/pull/1854))
+* Fix stdin pipe is being closed exception on Windows for large .proto files ([#2147](https://github.com/diffplug/spotless/issues/2147))
 ### Changes
 * Bump default `cleanthat` version to latest `2.16` -> `2.20`. ([#1725](https://github.com/diffplug/spotless/pull/1725))
 * Bump default `gherkin-utils` version to latest `8.0.2` -> `9.0.0`. ([#1703](https://github.com/diffplug/spotless/pull/1703))

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BufIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BufIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,22 @@ import com.diffplug.spotless.tag.BufTest;
 
 @BufTest
 class BufIntegrationTest extends GradleIntegrationHarness {
+	@Test
+	void bufLarge() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"  id 'com.diffplug.spotless'",
+				"}",
+				"spotless {",
+				"  protobuf {",
+				"    buf()",
+				"  }",
+				"}");
+		setFile("buf.proto").toResource("protobuf/buf/buf_large.proto");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("buf.proto").sameAsResource("protobuf/buf/buf_large.proto.clean");
+	}
+
 	@Test
 	void buf() throws IOException {
 		setFile("build.gradle").toLines(

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Correctly provide EditorConfig property types for Ktlint ([#2052](https://github.com/diffplug/spotless/issues/2052))
 * Made ShadowCopy (`npmInstallCache`) more robust by re-creating the cache dir if it goes missing ([#1984](https://github.com/diffplug/spotless/issues/1984),[2096](https://github.com/diffplug/spotless/pull/2096))
 * scalafmt.conf fileOverride section now works correctly ([#1854](https://github.com/diffplug/spotless/pull/1854))
+* Fix stdin pipe is being closed exception on Windows for large .proto files ([#2147](https://github.com/diffplug/spotless/issues/2147))
 ### Changes
 * Bump default `cleanthat` version to latest `2.16` -> `2.20`. ([#1725](https://github.com/diffplug/spotless/pull/1725))
 * Bump default `gherkin-utils` version to latest `8.0.2` -> `9.0.0`. ([#1703](https://github.com/diffplug/spotless/pull/1703))

--- a/testlib/src/main/resources/protobuf/buf/buf_large.proto
+++ b/testlib/src/main/resources/protobuf/buf/buf_large.proto
@@ -1,0 +1,229 @@
+syntax = "proto3";
+
+package com.diffplug.gradle.spotless.buf.proto;
+
+option java_multiple_files = true;
+
+message Message {
+  string message = 1;
+}
+
+service Services {
+rpc Echo(Message) returns (Message);
+}
+
+message Message01 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message02 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message03 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message04 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message05 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message06 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message07 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message08 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message09 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message10 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message11 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message12 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message13 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message14 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message15 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message16 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message17 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message18 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+string message9 = 9;
+}

--- a/testlib/src/main/resources/protobuf/buf/buf_large.proto.clean
+++ b/testlib/src/main/resources/protobuf/buf/buf_large.proto.clean
@@ -1,0 +1,229 @@
+syntax = "proto3";
+
+package com.diffplug.gradle.spotless.buf.proto;
+
+option java_multiple_files = true;
+
+message Message {
+  string message = 1;
+}
+
+service Services {
+  rpc Echo(Message) returns (Message);
+}
+
+message Message01 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message02 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message03 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message04 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message05 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message06 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message07 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message08 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message09 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message10 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message11 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message12 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message13 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message14 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message15 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message16 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message17 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}
+
+message Message18 {
+  string message1 = 1;
+  string message2 = 2;
+  string message3 = 3;
+  string message4 = 4;
+  string message5 = 5;
+  string message6 = 6;
+  string message7 = 7;
+  string message8 = 8;
+  string message9 = 9;
+}


### PR DESCRIPTION
## Summary

This fixes #2147.

`ProcessRunner` closes the stdin stream on execution which throws an `IOException` with `Pipe is being closed` message on Windows for protobuf files slightly larger than 4100 bytes. This fix removes the `OutputStream#close()` call on `ProcessRunner`, but this should not affect current behavior, since the file descriptor and stream for stdin will be closed when the process is destroyed ([unix](https://github.com/openjdk/jdk/blob/a7864af08acbe63d09f770ca66780738260faac4/src/java.base/unix/classes/java/lang/ProcessImpl.java#L478),[windows](https://github.com/openjdk/jdk/blob/a7864af08acbe63d09f770ca66780738260faac4/src/java.base/windows/classes/java/lang/ProcessImpl.java#L516)).

Also added a test with a dirty `.proto` file that is slightly over 4100 bytes.

----
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [x] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
