### PR TITLE
Simplify EditorConfigDefaults loading in KtLintCompat1Dot0Dot0Adapter

### DIFF
--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -93,12 +92,7 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 				.flatMap(loader -> loader.get().getRuleProviders().stream())
 				.collect(Collectors.toUnmodifiableSet());
 
-		EditorConfigDefaults editorConfig;
-		if (editorConfigPath == null || !Files.exists(editorConfigPath)) {
-			editorConfig = EditorConfigDefaults.Companion.getEMPTY_EDITOR_CONFIG_DEFAULTS();
-		} else {
-			editorConfig = EditorConfigDefaults.Companion.load(editorConfigPath, RuleProviderKt.propertyTypes(allRuleProviders));
-		}
+		EditorConfigDefaults editorConfig = EditorConfigDefaults.Companion.load(editorConfigPath, RuleProviderKt.propertyTypes(allRuleProviders));
 		EditorConfigOverride editorConfigOverride;
 		if (editorConfigOverrideMap.isEmpty()) {
 			editorConfigOverride = EditorConfigOverride.Companion.getEMPTY_EDITOR_CONFIG_OVERRIDE();


### PR DESCRIPTION
The nullability and file content have been checked in EditorConfigDefaultsLoader, seems we have no more need to inspect again.

See https://github.com/pinterest/ktlint/blob/a510eedc69f7431bcd3af2162db8e53a588f4435/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/EditorConfigDefaultsLoader.kt#L34-L42