### PR TITLE
Use steps name as task input instead of steps to generate a consistent cache key

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * to not introduce any windows-style newlines as well.
  */
 public interface FormatterStep extends Serializable, AutoCloseable {
-	/** The name of the step, for debugging purposes. */
+    /** The name of the step, for debugging purposes and to uniquely identify a step when computing the Gradle Build Cache key. */
 	String getName();
 
 	/**

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Gradle build cache miss due to volatility of SpotlessTask.steps input ([#2168](https://github.com/diffplug/spotless/issues/2168))
 
 ## [7.0.0.BETA1] - 2024-06-04
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.gradle.api.DefaultTask;
@@ -152,12 +153,18 @@ public abstract class SpotlessTask extends DefaultTask {
 
 	protected final List<FormatterStep> steps = new ArrayList<>();
 
-	@Input
+	@Internal
 	public List<FormatterStep> getSteps() {
-		return Collections.unmodifiableList(steps);
+        return Collections.unmodifiableList(steps);
 	}
 
-	public void setSteps(List<FormatterStep> steps) {
+    /** Steps name are exposed as task input instead of steps to generate a consistent Gradle build cache key **/
+    @Input
+    public List<String> getStepsName() {
+        return steps.stream().map(FormatterStep::getName).collect(Collectors.toList());
+    }
+
+    public void setSteps(List<FormatterStep> steps) {
 		PluginGradlePreconditions.requireElementsNonNull(steps);
 		this.steps.clear();
 		this.steps.addAll(steps);


### PR DESCRIPTION
Fixes https://github.com/diffplug/spotless/issues/2168
