### PR TITLE
Tweak gradle/actions/setup-gradle usages

### DIFF
--- a/.github/workflows/changelog-print.yml
+++ b/.github/workflows/changelog-print.yml
@@ -18,5 +18,5 @@ jobs:
       - name: gradle caching
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-home-cache-cleanup: true
+          cache-read-only: true
       - run: ./gradlew changelogPrint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: gradle caching
         uses: gradle/actions/setup-gradle@v3
         with:
+          cache-encryption-key: Da25KUVSE5jbGds2zXmfXw==
           gradle-home-cache-cleanup: true
       - name: spotlessCheck
         run: ./gradlew spotlessCheck
@@ -73,6 +74,7 @@ jobs:
       - name: gradle caching
         uses: gradle/actions/setup-gradle@v3
         with:
+          cache-encryption-key: Da25KUVSE5jbGds2zXmfXw==
           gradle-home-cache-cleanup: true
       - name: build (maven-only)
         if: matrix.kind == 'maven'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: gradle caching
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-home-cache-cleanup: true
+          cache-read-only: true
       - name: git fetch origin main
         run: git fetch origin main
       - name: publish all


### PR DESCRIPTION
- Enable `cache-read-only` for deploy and print jobs.
- Enable `cache-encryption-key` for build jobs.

See the full doc at https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#general-usage.
