### PR TITLE
Tweak maxParallelForks

### DIFF
--- a/gradle/special-tests.gradle
+++ b/gradle/special-tests.gradle
@@ -17,13 +17,10 @@ tasks.withType(Test).configureEach {
 			maxRetries = 2
 			maxFailures = 10
 		}
-
-		// There are only 2 cores in each GitHub Action Runner, we use all of them here.
-		maxParallelForks = Runtime.getRuntime().availableProcessors()
-	} else {
-		// https://docs.gradle.org/8.4/userguide/performance.html#execute_tests_in_parallel
-		maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 	}
+
+	// https://docs.gradle.org/8.8/userguide/performance.html#execute_tests_in_parallel
+	maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 tasks.named('test').configure {
 	useJUnitPlatform {


### PR DESCRIPTION
Now GHA upgrades to 4-core runners, we can tweak this option a bit.

Follow up #1874.

