### PR TITLE
Leverage Maven local repository for p2 cache directory in Eclipse step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* Support configuring the Equo P2 cache. ([#2238](https://github.com/diffplug/spotless/pull/2238))
 
 ## [3.0.0.BETA2] - 2024-08-25
 ### Changed

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
@@ -37,6 +37,7 @@ import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.SerializedFunction;
 
 import dev.equo.solstice.NestedJars;
+import dev.equo.solstice.p2.CacheLocations;
 import dev.equo.solstice.p2.P2ClientCache;
 import dev.equo.solstice.p2.P2Model;
 import dev.equo.solstice.p2.P2QueryCache;
@@ -52,6 +53,7 @@ public abstract class EquoBasedStepBuilder {
 	private String formatterVersion;
 	private Iterable<File> settingsFiles = new ArrayList<>();
 	private Map<String, String> p2Mirrors = Map.of();
+	private File cacheDirectory;
 
 	/** Initialize valid default configuration, taking latest version */
 	public EquoBasedStepBuilder(String formatterName, Provisioner mavenProvisioner, @Nullable String defaultVersion, SerializedFunction<State, FormatterFunc> stateToFormatter) {
@@ -75,6 +77,10 @@ public abstract class EquoBasedStepBuilder {
 
 	public void setP2Mirrors(Collection<P2Mirror> p2Mirrors) {
 		this.p2Mirrors = p2Mirrors.stream().collect(toMap(P2Mirror::getPrefix, P2Mirror::getUrl));
+	}
+
+	public void setCacheDirectory(File cacheDirectory) {
+		this.cacheDirectory = cacheDirectory;
 	}
 
 	protected abstract P2Model model(String version);
@@ -101,6 +107,9 @@ public abstract class EquoBasedStepBuilder {
 		var roundtrippableState = new EquoStep(formatterVersion, FileSignature.promise(settingsFiles), JarState.promise(() -> {
 			P2QueryResult query;
 			try {
+				if (null != cacheDirectory) {
+					CacheLocations.override_p2data = cacheDirectory.toPath().resolve("dev/equo/p2-data").toFile();
+				}
 				query = createModelWithMirrors().query(P2ClientCache.PREFER_OFFLINE, P2QueryCache.ALLOW);
 			} catch (Exception x) {
 				throw new IOException("Failed to load " + formatterName + ": " + x, x);

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
+* Leverage local repository for Equo P2 cache. ([#2238](https://github.com/diffplug/spotless/pull/2238))
 
 ## [2.44.0.BETA2] - 2024-08-25
 ### Changed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -379,6 +379,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	private List<FormatterFactory> getFormatterFactories() {
 		return Stream.concat(formats.stream(), Stream.of(groovy, java, scala, kotlin, cpp, typescript, javascript, antlr4, pom, sql, python, markdown, json, shell, yaml, gherkin, go))
 				.filter(Objects::nonNull)
+				.map(factory -> factory.init(repositorySystemSession))
 				.collect(toList());
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystemSession;
 
 import com.diffplug.common.collect.Sets;
 import com.diffplug.spotless.FormatExceptionPolicyStrict;
@@ -196,5 +197,10 @@ public abstract class FormatterFactory {
 	private static boolean formatterStepOverriden(FormatterStepFactory global, List<FormatterStepFactory> allConfigured) {
 		return allConfigured.stream()
 				.anyMatch(configured -> configured.getClass() == global.getClass());
+	}
+
+	public FormatterFactory init(RepositorySystemSession repositorySystemSession) {
+		stepFactories.forEach(factory -> factory.init(repositorySystemSession));
+		return this;
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepFactory.java
@@ -15,9 +15,15 @@
  */
 package com.diffplug.spotless.maven;
 
+import org.eclipse.aether.RepositorySystemSession;
+
 import com.diffplug.spotless.FormatterStep;
 
 public interface FormatterStepFactory {
 
 	FormatterStep newFormatterStep(FormatterStepConfig config);
+
+	default void init(RepositorySystemSession repositorySystemSession) {
+		// nothing
+	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.RepositorySystemSession;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.extra.EquoBasedStepBuilder;
@@ -40,6 +41,8 @@ public class Eclipse implements FormatterStepFactory {
 	@Parameter
 	private List<P2Mirror> p2Mirrors = new ArrayList<>();
 
+	private File cacheDirectory;
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
 		EquoBasedStepBuilder eclipseConfig = EclipseJdtFormatterStep.createBuilder(stepConfig.getProvisioner());
@@ -49,6 +52,13 @@ public class Eclipse implements FormatterStepFactory {
 			eclipseConfig.setPreferences(Arrays.asList(settingsFile));
 		}
 		eclipseConfig.setP2Mirrors(p2Mirrors);
+		if (null != cacheDirectory) {
+			eclipseConfig.setCacheDirectory(cacheDirectory);
+		}
 		return eclipseConfig.build();
+	}
+
+	public void init(RepositorySystemSession repositorySystemSession) {
+		this.cacheDirectory = repositorySystemSession.getLocalRepository().getBasedir();
 	}
 }


### PR DESCRIPTION
This PR brings support of the Maven local repository configuration to store the Equo P2 cache.

This tackles what was mentioned in this comment https://github.com/diffplug/spotless/issues/1687#issuecomment-1862244636. And more precisely the use case described in https://github.com/diffplug/spotless/issues/1797.

I didn't bring such support for Gradle as I lack of knowledge of it.