### PR TITLE
Add header links in changelogs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -935,3 +935,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [1.0.0] - 2017-01-09
 * Initial release!
+
+
+
+[Unreleased]: https://github.com/diffplug/spotless/compare/lib/3.0.0.BETA2...HEAD
+[3.0.0.BETA2]: https://github.com/diffplug/spotless/releases/tag/lib/3.0.0.BETA2

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -1236,3 +1236,8 @@ Below is the algorithm used by git and spotless to determine the proper line end
 
 ## [0.1] - 2015-04-28
 * First release, to test out that we can release to jcenter and whatnot.
+
+
+
+[Unreleased]: https://github.com/diffplug/spotless/compare/gradle/7.0.0.BETA2...HEAD
+[7.0.0.BETA2]: https://github.com/diffplug/spotless/releases/tag/gradle/7.0.0.BETA2

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -860,3 +860,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Maven plugin written by [Konstantin Lutovich](https://github.com/lutovich).
 * Full support for the Java and Scala formatters.
 * Initial release, after user feedback we will ship `1.x`.
+
+
+
+[Unreleased]: https://github.com/diffplug/spotless/compare/maven/2.44.0.BETA2...HEAD
+[7.0.0.BETA2]: https://github.com/diffplug/spotless/releases/tag/maven/2.44.0.BETA2


### PR DESCRIPTION
Follow up #2196.

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/0e0a6467-d7fa-494e-ae8a-f0a6eb5928f9">
