### PR TITLE
Improve github release notes

### DIFF
--- a/gradle/changelog.gradle
+++ b/gradle/changelog.gradle
@@ -22,7 +22,7 @@ spotlessChangelog {
 	branch        'release'
 	tagPrefix     "${kind}/"
 	commitMessage "Published ${kind}/{{version}}" // {{version}} will be replaced
-	tagMessage "${kind} v{{version}}\n\n{{changes}}"
+	tagMessage "{{changes}}"
 	runAfterPush "gh release create ${kind}/{{version}} --title '${releaseTitle} v{{version}}' --notes-from-tag"
 
 	if (kind == 'gradle') {


### PR DESCRIPTION
- As discussed https://github.com/diffplug/spotless/pull/2196#issuecomment-2315836050
- Removed the workaround for https://github.com/cli/cli/issues/9299
- I manually edited our published notes to remove the little scrap of noise