### PR TITLE
Fix incorrect target usage with `kotlinGradle` in docs

### DIFF
--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -380,7 +380,7 @@ spotless { // if you are using build.gradle.kts, instead of 'spotless {' use:
     licenseHeader '/* (C)$YEAR */' // or licenseHeaderFile
   }
   kotlinGradle {
-    target '*.gradle.kts' // default target for kotlinGradle
+    target('*.gradle.kts') // default target for kotlinGradle
     ktlint() // or ktfmt() or prettier()
   }
 }


### PR DESCRIPTION
As `kotlinGradle` will only be used in `build.gradle.kts`, the Kotlin syntax must be used.

As I just changed the documentation, I assume I don't have to add a bullet point in any of the `CHANGES.md` files, otherwise let me know and I'll happily add it!