### PR TITLE
support configuring jackson JsonParser. Feature

### DIFF
--- a/lib/src/jackson/java/com/diffplug/spotless/glue/json/JacksonJsonFormatterFunc.java
+++ b/lib/src/jackson/java/com/diffplug/spotless/glue/json/JacksonJsonFormatterFunc.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.Separators;
@@ -64,7 +65,12 @@ public class JacksonJsonFormatterFunc extends AJacksonFormatterFunc {
 
 			jsonFactory.configure(feature, toggle);
 		});
+		jacksonConfig.getJsonParserFeatureToToggle().forEach((rawFeature, toggle) -> {
+			// https://stackoverflow.com/questions/3735927/java-instantiating-an-enum-using-reflection
+			JsonParser.Feature feature = JsonParser.Feature.valueOf(rawFeature);
 
+			jsonFactory.configure(feature, toggle);
+		});
 		return jsonFactory;
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonConfig.java
@@ -27,12 +27,18 @@ public class JacksonJsonConfig extends JacksonConfig {
 
 	protected Map<String, Boolean> jsonFeatureToToggle = new LinkedHashMap<>();
 
+	protected Map<String, Boolean> jsonParserFeatureToToggle = new LinkedHashMap<>();
+
 	// https://github.com/revelc/formatter-maven-plugin/pull/280
 	// By default, Jackson adds a ' ' before separator, which is not standard with most IDE/JSON libraries
 	protected boolean spaceBeforeSeparator = false;
 
 	public Map<String, Boolean> getJsonFeatureToToggle() {
 		return Collections.unmodifiableMap(jsonFeatureToToggle);
+	}
+
+	public Map<String, Boolean> getJsonParserFeatureToToggle() {
+		return Collections.unmodifiableMap(jsonParserFeatureToToggle);
 	}
 
 	/**
@@ -47,6 +53,13 @@ public class JacksonJsonConfig extends JacksonConfig {
 	 */
 	public void appendJsonFeatureToToggle(Map<String, Boolean> features) {
 		this.jsonFeatureToToggle.putAll(features);
+	}
+
+	/**
+	 * Refers to com.fasterxml.jackson.core.JsonParser.Feature
+	 */
+	public void appendJsonParserFeatureToToggle(Map<String, Boolean> features) {
+		this.jsonParserFeatureToToggle.putAll(features);
 	}
 
 	public boolean isSpaceBeforeSeparator() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JsonExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JsonExtension.java
@@ -169,6 +169,15 @@ public class JsonExtension extends FormatExtension {
 			return this;
 		}
 
+		/**
+		 * Refers to com.fasterxml.jackson.core.JsonParser.Feature
+		 */
+		public JacksonJsonGradleConfig jsonParserFeature(String feature, boolean toggle) {
+			this.jacksonConfig.appendJsonParserFeatureToToggle(Collections.singletonMap(feature, toggle));
+			formatExtension.replaceStep(createStep());
+			return this;
+		}
+
 		@Override
 		public JacksonJsonGradleConfig self() {
 			return this;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/JacksonJson.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/JacksonJson.java
@@ -44,12 +44,16 @@ public class JacksonJson implements FormatterStepFactory {
 	@Parameter
 	private Map<String, Boolean> jsonFeatures = Collections.emptyMap();
 
+	@Parameter
+	private Map<String, Boolean> jsonParserFeatures = Collections.emptyMap();
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
 		JacksonJsonConfig jacksonConfig = new JacksonJsonConfig();
 
 		jacksonConfig.appendFeatureToToggle(features);
 		jacksonConfig.appendJsonFeatureToToggle(jsonFeatures);
+		jacksonConfig.appendJsonParserFeatureToToggle(jsonParserFeatures);
 		jacksonConfig.setSpaceBeforeSeparator(spaceBeforeSeparator);
 
 		return JacksonJsonStep


### PR DESCRIPTION
Fix #2271 

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
