### PR TITLE
Make `ktlint` formatters read the string content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `ktlint` steps now read from the `string` instead of the `file` so they don't clobber earlier steps. (fixes [#1599](https://github.com/diffplug/spotless/issues/1599))
 
 ## [3.0.0.BETA3] - 2024-10-15
 ### Added

--- a/lib/src/compatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ public class KtLintCompat0Dot48Dot0Adapter implements KtLintCompatAdapter {
 
 	@Override
 	public String format(
+			String unix,
 			Path path,
 			Path editorConfigPath,
 			Map<String, Object> editorConfigOverrideMap) {
@@ -105,7 +106,7 @@ public class KtLintCompat0Dot48Dot0Adapter implements KtLintCompatAdapter {
 				editorConfig,
 				editorConfigOverride,
 				false)
-				.format(path, formatterCallback);
+				.format(unix, path, formatterCallback);
 	}
 
 	/**

--- a/lib/src/compatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0Adapter.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -125,7 +124,7 @@ public class KtLintCompat0Dot49Dot0Adapter implements KtLintCompatAdapter {
 			String unix,
 			Path path,
 			Path editorConfigPath,
-			Map<String, Object> editorConfigOverrideMap) throws NoSuchFieldException, IllegalAccessException {
+			Map<String, Object> editorConfigOverrideMap) {
 		final FormatterCallback formatterCallback = new FormatterCallback();
 
 		Set<RuleProvider> allRuleProviders = ServiceLoader.load(RuleSetProviderV3.class, RuleSetProviderV3.class.getClassLoader())
@@ -150,10 +149,7 @@ public class KtLintCompat0Dot49Dot0Adapter implements KtLintCompatAdapter {
 
 		// create Code and then set the content to match previous steps in the Spotless pipeline
 		Code code = Code.Companion.fromPath(path);
-		Field contentField = code.getClass().getDeclaredField("content");
-		contentField.setAccessible(true);
-		contentField.set(code, unix);
-
+		KtLintCompatAdapter.setCodeContent(code, unix);
 		return new KtLintRuleEngine(
 				allRuleProviders,
 				editorConfig,

--- a/lib/src/compatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0Adapter.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -87,7 +86,7 @@ public class KtLintCompat0Dot50Dot0Adapter implements KtLintCompatAdapter {
 			String unix,
 			Path path,
 			Path editorConfigPath,
-			Map<String, Object> editorConfigOverrideMap) throws NoSuchFieldException, IllegalAccessException {
+			Map<String, Object> editorConfigOverrideMap) {
 		final FormatterCallback formatterCallback = new FormatterCallback();
 
 		Set<RuleProvider> allRuleProviders = ServiceLoader.load(RuleSetProviderV3.class, RuleSetProviderV3.class.getClassLoader())
@@ -112,10 +111,7 @@ public class KtLintCompat0Dot50Dot0Adapter implements KtLintCompatAdapter {
 
 		// create Code and then set the content to match previous steps in the Spotless pipeline
 		Code code = Code.Companion.fromPath(path);
-		Field contentField = code.getClass().getDeclaredField("content");
-		contentField.setAccessible(true);
-		contentField.set(code, unix);
-
+		KtLintCompatAdapter.setCodeContent(code, unix);
 		return new KtLintRuleEngine(
 				allRuleProviders,
 				editorConfig,

--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
-import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +85,7 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 			String unix,
 			Path path,
 			Path editorConfigPath,
-			Map<String, Object> editorConfigOverrideMap) throws NoSuchFieldException, IllegalAccessException {
+			Map<String, Object> editorConfigOverrideMap) {
 		final FormatterCallback formatterCallback = new FormatterCallback();
 
 		Set<RuleProvider> allRuleProviders = ServiceLoader.load(RuleSetProviderV3.class, RuleSetProviderV3.class.getClassLoader())
@@ -107,10 +106,7 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 
 		// create Code and then set the content to match previous steps in the Spotless pipeline
 		Code code = Code.Companion.fromPath(path);
-		Field contentField = code.getClass().getDeclaredField("content");
-		contentField.setAccessible(true);
-		contentField.set(code, unix);
-
+		KtLintCompatAdapter.setCodeContent(code, unix);
 		return new KtLintRuleEngine(
 				allRuleProviders,
 				editorConfig,

--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -82,9 +83,10 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 
 	@Override
 	public String format(
+			String unix,
 			Path path,
 			Path editorConfigPath,
-			Map<String, Object> editorConfigOverrideMap) {
+			Map<String, Object> editorConfigOverrideMap) throws NoSuchFieldException, IllegalAccessException {
 		final FormatterCallback formatterCallback = new FormatterCallback();
 
 		Set<RuleProvider> allRuleProviders = ServiceLoader.load(RuleSetProviderV3.class, RuleSetProviderV3.class.getClassLoader())
@@ -103,13 +105,19 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 					editorConfigOverrideMap);
 		}
 
+		// create Code and then set the content to match previous steps in the Spotless pipeline
+		Code code = Code.Companion.fromPath(path);
+		Field contentField = code.getClass().getDeclaredField("content");
+		contentField.setAccessible(true);
+		contentField.set(code, unix);
+
 		return new KtLintRuleEngine(
 				allRuleProviders,
 				editorConfig,
 				editorConfigOverride,
 				false,
 				path.getFileSystem())
-				.format(Code.Companion.fromPath(path), formatterCallback);
+				.format(code, formatterCallback);
 	}
 
 	/**

--- a/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatAdapter.java
+++ b/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import java.util.Map;
 public interface KtLintCompatAdapter {
 
 	String format(
+			String content,
 			Path path,
 			Path editorConfigPath,
-			Map<String, Object> editorConfigOverrideMap);
+			Map<String, Object> editorConfigOverrideMap) throws NoSuchFieldException, IllegalAccessException;
 }

--- a/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatAdapter.java
+++ b/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatAdapter.java
@@ -15,7 +15,10 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
+import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 
 public interface KtLintCompatAdapter {
@@ -25,4 +28,18 @@ public interface KtLintCompatAdapter {
 			Path path,
 			Path editorConfigPath,
 			Map<String, Object> editorConfigOverrideMap) throws NoSuchFieldException, IllegalAccessException;
+
+	static void setCodeContent(Object code, String content) {
+		AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+			try {
+				Field contentField = code.getClass().getDeclaredField("content");
+				contentField.setAccessible(true);
+				contentField.set(code, content);
+			} catch (NoSuchFieldException | IllegalAccessException e) {
+				// Handle exceptions as needed
+				throw new RuntimeException("Failed to set content field", e);
+			}
+			return null;
+		});
+	}
 }

--- a/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
+++ b/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,12 +60,13 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 	}
 
 	@Override
-	public String applyWithFile(String unix, File file) {
+	public String applyWithFile(String unix, File file) throws NoSuchFieldException, IllegalAccessException {
 		Path absoluteEditorConfigPath = null;
 		if (editorConfigPath != null) {
 			absoluteEditorConfigPath = editorConfigPath.getOnlyFile().toPath();
 		}
 		return adapter.format(
+				unix,
 				file.toPath(),
 				absoluteEditorConfigPath,
 				editorConfigOverrideMap);

--- a/lib/src/testCompatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0AdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,19 +33,19 @@ public class KtLintCompat0Dot48Dot0AdapterTest {
 	@Test
 	public void testDefaults(@TempDir Path path) throws IOException {
 		KtLintCompat0Dot48Dot0Adapter ktLintCompat0Dot48Dot0Adapter = new KtLintCompat0Dot48Dot0Adapter();
-		loadAndWriteText(path, "empty_class_body.kt");
+		var content = loadAndWriteText(path, "empty_class_body.kt");
 		final Path filePath = Paths.get(path.toString(), "empty_class_body.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
 
-		String formatted = ktLintCompat0Dot48Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = ktLintCompat0Dot48Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class empty_class_body\n", formatted);
 	}
 
 	@Test
 	public void testEditorConfigCanDisable(@TempDir Path path) throws IOException {
 		KtLintCompat0Dot48Dot0Adapter ktLintCompat0Dot48Dot0Adapter = new KtLintCompat0Dot48Dot0Adapter();
-		loadAndWriteText(path, "fails_no_semicolons.kt");
+		var content = loadAndWriteText(path, "fails_no_semicolons.kt");
 		final Path filePath = Paths.get(path.toString(), "fails_no_semicolons.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
@@ -54,7 +54,7 @@ public class KtLintCompat0Dot48Dot0AdapterTest {
 		// ktlint_filename is an invalid rule in ktlint 0.48.0
 		editorConfigOverrideMap.put("ktlint_filename", "disabled");
 
-		String formatted = ktLintCompat0Dot48Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = ktLintCompat0Dot48Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class fails_no_semicolons {\n\tval i = 0;\n}\n", formatted);
 	}
 

--- a/lib/src/testCompatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0AdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,26 +33,26 @@ public class KtLintCompat0Dot49Dot0AdapterTest {
 	@Test
 	public void testDefaults(@TempDir Path path) throws IOException {
 		KtLintCompat0Dot49Dot0Adapter ktLintCompat0Dot49Dot0Adapter = new KtLintCompat0Dot49Dot0Adapter();
-		loadAndWriteText(path, "EmptyClassBody.kt");
+		var content = loadAndWriteText(path, "EmptyClassBody.kt");
 		final Path filePath = Paths.get(path.toString(), "EmptyClassBody.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
 
-		String formatted = ktLintCompat0Dot49Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = ktLintCompat0Dot49Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class EmptyClassBody\n", formatted);
 	}
 
 	@Test
 	public void testEditorConfigCanDisable(@TempDir Path path) throws IOException {
 		KtLintCompat0Dot49Dot0Adapter ktLintCompat0Dot49Dot0Adapter = new KtLintCompat0Dot49Dot0Adapter();
-		loadAndWriteText(path, "FailsNoSemicolons.kt");
+		var content = loadAndWriteText(path, "FailsNoSemicolons.kt");
 		final Path filePath = Paths.get(path.toString(), "FailsNoSemicolons.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
 		editorConfigOverrideMap.put("indent_style", "tab");
 		editorConfigOverrideMap.put("ktlint_standard_no-semi", "disabled");
 
-		String formatted = ktLintCompat0Dot49Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = ktLintCompat0Dot49Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class FailsNoSemicolons {\n\tval i = 0;\n}\n", formatted);
 	}
 

--- a/lib/src/testCompatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0AdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,26 +33,26 @@ public class KtLintCompat0Dot50Dot0AdapterTest {
 	@Test
 	public void testDefaults(@TempDir Path path) throws IOException {
 		KtLintCompat0Dot50Dot0Adapter KtLintCompat0Dot50Dot0Adapter = new KtLintCompat0Dot50Dot0Adapter();
-		loadAndWriteText(path, "EmptyClassBody.kt");
+		var content = loadAndWriteText(path, "EmptyClassBody.kt");
 		final Path filePath = Paths.get(path.toString(), "EmptyClassBody.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
 
-		String formatted = KtLintCompat0Dot50Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = KtLintCompat0Dot50Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class EmptyClassBody\n", formatted);
 	}
 
 	@Test
 	public void testEditorConfigCanDisable(@TempDir Path path) throws IOException {
 		KtLintCompat0Dot50Dot0Adapter KtLintCompat0Dot50Dot0Adapter = new KtLintCompat0Dot50Dot0Adapter();
-		loadAndWriteText(path, "FailsNoSemicolons.kt");
+		var content = loadAndWriteText(path, "FailsNoSemicolons.kt");
 		final Path filePath = Paths.get(path.toString(), "FailsNoSemicolons.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
 		editorConfigOverrideMap.put("indent_style", "tab");
 		editorConfigOverrideMap.put("ktlint_standard_no-semi", "disabled");
 
-		String formatted = KtLintCompat0Dot50Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = KtLintCompat0Dot50Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class FailsNoSemicolons {\n\tval i = 0;\n}\n", formatted);
 	}
 

--- a/lib/src/testCompatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0AdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,26 +33,26 @@ public class KtLintCompat1Dot0Dot0AdapterTest {
 	@Test
 	public void testDefaults(@TempDir Path path) throws IOException {
 		KtLintCompat1Dot0Dot0Adapter KtLintCompat1Dot0Dot0Adapter = new KtLintCompat1Dot0Dot0Adapter();
-		loadAndWriteText(path, "EmptyClassBody.kt");
+		var content = loadAndWriteText(path, "EmptyClassBody.kt");
 		final Path filePath = Paths.get(path.toString(), "EmptyClassBody.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
 
-		String formatted = KtLintCompat1Dot0Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = KtLintCompat1Dot0Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class EmptyClassBody\n", formatted);
 	}
 
 	@Test
 	public void testEditorConfigCanDisable(@TempDir Path path) throws IOException {
 		KtLintCompat1Dot0Dot0Adapter KtLintCompat1Dot0Dot0Adapter = new KtLintCompat1Dot0Dot0Adapter();
-		loadAndWriteText(path, "FailsNoSemicolons.kt");
+		var content = loadAndWriteText(path, "FailsNoSemicolons.kt");
 		final Path filePath = Paths.get(path.toString(), "FailsNoSemicolons.kt");
 
 		Map<String, Object> editorConfigOverrideMap = new HashMap<>();
 		editorConfigOverrideMap.put("indent_style", "tab");
 		editorConfigOverrideMap.put("ktlint_standard_no-semi", "disabled");
 
-		String formatted = KtLintCompat1Dot0Dot0Adapter.format(filePath, null, editorConfigOverrideMap);
+		String formatted = KtLintCompat1Dot0Dot0Adapter.format(content, filePath, null, editorConfigOverrideMap);
 		assertEquals("class FailsNoSemicolons {\n\tval i = 0;\n}\n", formatted);
 	}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `ktlint` steps now read from the `string` instead of the `file` so they don't clobber earlier steps. (fixes [#1599](https://github.com/diffplug/spotless/issues/1599))
 
 ## [7.0.0.BETA3] - 2024-10-15
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `ktlint` steps now read from the `string` instead of the `file` so they don't clobber earlier steps. (fixes [#1599](https://github.com/diffplug/spotless/issues/1599))
 
 ## [2.44.0.BETA3] - 2024-10-15
 ### Added


### PR DESCRIPTION
If they don't, it clobbers the results of earlier steps and breaks all our idempotence fixing stuff.

- Fixes #1599