### PR TITLE
Add LineEnding.PRESERVE policy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for line ending policy `PRESERVE` which just takes the first line ending of every given file as setting (no matter if `\n`, `\r\n` or `\r`) ([#2304](https://github.com/diffplug/spotless/pull/2304))
+
 
 ## [3.0.0.BETA3] - 2024-10-15
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public enum LineEnding {
 	/** {@code \r\n} */
 	WINDOWS,
     /** {@code \n} */
-    UNIX,   
+    UNIX,
     /** {@code \r} */
     MAC_CLASSIC,
     /** preserve the line ending of the first line (no matter which format) */

--- a/lib/src/test/java/com/diffplug/spotless/LineEndingTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/LineEndingTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2024 DiffPlug
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,27 +24,27 @@ import org.junit.jupiter.api.Test;
 
 class LineEndingTest {
 
-    @Test
-    void testGetEndingFor() throws IOException {
-        assertLineEnding("\r", "\r");
-        assertLineEnding("\r", "Test\r");
-        assertLineEnding("\r", "Test\rTest2\n");
-        
-        assertLineEnding("\n", "Test");
-        
-        assertLineEnding("\r\n", "\r\n");
-        assertLineEnding("\r\n", "Test\r\n");
-        assertLineEnding("\r\n", "Test\r\nTest2\n");
+	@Test
+	void testGetEndingFor() throws IOException {
+		assertLineEnding("\r", "\r");
+		assertLineEnding("\r", "Test\r");
+		assertLineEnding("\r", "Test\rTest2\n");
 
-        assertLineEnding("\n", "\n");
-        assertLineEnding("\n", "Test\n");
-        assertLineEnding("\n", "Test\nTest2\r");
-        assertLineEnding("\n", "\n\t");
-    }
-    
-    static void assertLineEnding(String ending, String input) throws IOException {
-        try (Reader reader = new StringReader(input)) {
-            Assertions.assertEquals(ending, LineEnding.PreserveLineEndingPolicy.getEndingFor(reader));
-        }
-    }
+		assertLineEnding("\n", "Test");
+
+		assertLineEnding("\r\n", "\r\n");
+		assertLineEnding("\r\n", "Test\r\n");
+		assertLineEnding("\r\n", "Test\r\nTest2\n");
+
+		assertLineEnding("\n", "\n");
+		assertLineEnding("\n", "Test\n");
+		assertLineEnding("\n", "Test\nTest2\r");
+		assertLineEnding("\n", "\n\t");
+	}
+
+	static void assertLineEnding(String ending, String input) throws IOException {
+		try (Reader reader = new StringReader(input)) {
+			Assertions.assertEquals(ending, LineEnding.PreserveLineEndingPolicy.getEndingFor(reader));
+		}
+	}
 }

--- a/lib/src/test/java/com/diffplug/spotless/LineEndingTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/LineEndingTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class LineEndingTest {
+
+    @Test
+    void testGetEndingFor() throws IOException {
+        assertLineEnding("\r", "\r");
+        assertLineEnding("\r", "Test\r");
+        assertLineEnding("\r", "Test\rTest2\n");
+        
+        assertLineEnding("\n", "Test");
+        
+        assertLineEnding("\r\n", "\r\n");
+        assertLineEnding("\r\n", "Test\r\n");
+        assertLineEnding("\r\n", "Test\r\nTest2\n");
+
+        assertLineEnding("\n", "\n");
+        assertLineEnding("\n", "Test\n");
+        assertLineEnding("\n", "Test\nTest2\r");
+        assertLineEnding("\n", "\n\t");
+    }
+    
+    static void assertLineEnding(String ending, String input) throws IOException {
+        try (Reader reader = new StringReader(input)) {
+            Assertions.assertEquals(ending, LineEnding.PreserveLineEndingPolicy.getEndingFor(reader));
+        }
+    }
+}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for line ending policy `PRESERVE` which just takes the first line ending of every given file as setting (no matter if `\n`, `\r\n` or `\r`) ([#2304](https://github.com/diffplug/spotless/pull/2304))
 
 ## [7.0.0.BETA3] - 2024-10-15
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1577,9 +1577,11 @@ spotless {
     encoding 'Cp1252' // except java, which will be Cp1252
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, and `GIT_ATTRIBUTES_FAST_ALLSAME`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, `GIT_ATTRIBUTES_FAST_ALLSAME` and `PRESERVE`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
 
 You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
+
+Use `PRESERVE` in order to keep the existing line endings of a file. This policy enforces that all line endings equal the first one of the according file (no matter which line delimiter it is).
 
 <a name="custom"></a>
 <a name="custom-steps"></a>

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1577,11 +1577,15 @@ spotless {
     encoding 'Cp1252' // except java, which will be Cp1252
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, `GIT_ATTRIBUTES_FAST_ALLSAME` and `PRESERVE`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports
+
+- constant modes (`UNIX`, `WINDOWS`, `MAC_CLASSIC`)
+- simple modes (`PLATFORM_NATIVE`, `PRESERVE`)
+- and git-aware modes (`GIT_ATTRIBUTES`, `GIT_ATTRIBUTES_FAST_ALLSAME`)
+
+The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
 
 You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
-
-Use `PRESERVE` in order to keep the existing line endings of a file. This policy enforces that all line endings equal the first one of the according file (no matter which line delimiter it is).
 
 <a name="custom"></a>
 <a name="custom-steps"></a>

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Support for line ending policy `PRESERVE` which just takes the first line ending of every given file as setting (no matter if `\n`, `\r\n` or `\r`) ([#2304](https://github.com/diffplug/spotless/pull/2304))
 
 ## [2.44.0.BETA3] - 2024-10-15
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1784,11 +1784,15 @@ Spotless uses UTF-8 by default, but you can use [any encoding which Java support
 </configuration>
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, `GIT_ATTRIBUTES_FAST_ALLSAME` and `PRESERVE`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports
 
-You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
+- constant modes (`UNIX`, `WINDOWS`, `MAC_CLASSIC`)
+- simple modes (`PLATFORM_NATIVE`, `PRESERVE`)
+- and git-aware modes (`GIT_ATTRIBUTES`, `GIT_ATTRIBUTES_FAST_ALLSAME`)
 
-Use `PRESERVE` in order to keep the existing line endings of a file. This policy enforces that all line endings equal the first one of the according file (no matter which line delimiter it is).
+The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
+
+You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/). Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
 
 <a name="enforceCheck"></a>
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1784,9 +1784,11 @@ Spotless uses UTF-8 by default, but you can use [any encoding which Java support
 </configuration>
 ```
 
-Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, and `GIT_ATTRIBUTES_FAST_ALLSAME`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
+Line endings can also be set globally or per-format using the `lineEndings` property.  Spotless supports four line ending modes: `UNIX`, `WINDOWS`, `MAC_CLASSIC`, `PLATFORM_NATIVE`, `GIT_ATTRIBUTES`, `GIT_ATTRIBUTES_FAST_ALLSAME` and `PRESERVE`.  The default value is `GIT_ATTRIBUTES_FAST_ALLSAME`, and *we highly recommend that you* ***do not change*** *this value*.  Git has opinions about line endings, and if Spotless and git disagree, then you're going to have a bad time. `FAST_ALLSAME` just means that Spotless can assume that every file being formatted has the same line endings ([more info](https://github.com/diffplug/spotless/pull/1838)).
 
 You can easily set the line endings of different files using [a `.gitattributes` file](https://help.github.com/articles/dealing-with-line-endings/).  Here's an example `.gitattributes` which sets all files to unix newlines: `* text eol=lf`.
+
+Use `PRESERVE` in order to keep the existing line endings of a file. This policy enforces that all line endings equal the first one of the according file (no matter which line delimiter it is).
 
 <a name="enforceCheck"></a>
 


### PR DESCRIPTION
This closes #2277.
It is not properly formatted though due to #2290

WIP

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
