### PR TITLE
Adjust existing steps to be lint-friendly

### DIFF
--- a/lib/src/compatDiktat1Dot2Dot5/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat1Dot2Dot5Adapter.java
+++ b/lib/src/compatDiktat1Dot2Dot5/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat1Dot2Dot5Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,9 +77,7 @@ public class DiktatCompat1Dot2Dot5Adapter implements DiktatCompatAdapter {
 				false,
 				new EditorConfigOverride(),
 				false));
-
-		DiktatReporting.reportIfRequired(errors, LintError::getLine, LintError::getCol, LintError::getDetail);
-
+		DiktatReporting.reportIfRequired(errors, LintError::getLine, LintError::getRuleId, LintError::getDetail);
 		return result;
 	}
 }

--- a/lib/src/compatDiktat2Dot0Dot0/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat2Dot0Dot0Adapter.java
+++ b/lib/src/compatDiktat2Dot0Dot0/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat2Dot0Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class DiktatCompat2Dot0Dot0Adapter implements DiktatCompatAdapter {
 	public String format(File file, String content, boolean isScript) {
 		errors.clear();
 		String result = processor.fix(content, file.toPath(), formatterCallback);
-		DiktatReporting.reportIfRequired(errors, DiktatError::getLine, DiktatError::getCol, DiktatError::getDetail);
+		DiktatReporting.reportIfRequired(errors, DiktatError::getLine, DiktatError::getRuleId, DiktatError::getDetail);
 		return result;
 	}
 

--- a/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
+++ b/lib/src/compatKtLintApi/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompatReporting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,25 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
-final class KtLintCompatReporting {
+public final class KtLintCompatReporting {
 
 	private KtLintCompatReporting() {}
 
 	static void report(int line, int column, String ruleId, String detail) {
-		throw new AssertionError("Error on line: " + line + ", column: " + column + "\nrule: " + ruleId + "\n" + detail);
+		throw new KtlintSpotlessException(line, ruleId, detail);
+	}
+
+	public static class KtlintSpotlessException extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+
+		public final int line;
+		public final String ruleId;
+		public final String detail;
+
+		KtlintSpotlessException(int line, String ruleId, String detail) {
+			this.line = line;
+			this.ruleId = ruleId;
+			this.detail = detail;
+		}
 	}
 }

--- a/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
+++ b/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 package com.diffplug.spotless.glue.diktat;
 
 import java.io.File;
+import java.util.stream.Collectors;
 
 import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.Lint;
 import com.diffplug.spotless.glue.diktat.compat.DiktatCompat1Dot2Dot5Adapter;
 import com.diffplug.spotless.glue.diktat.compat.DiktatCompat2Dot0Dot0Adapter;
 import com.diffplug.spotless.glue.diktat.compat.DiktatCompatAdapter;
+import com.diffplug.spotless.glue.diktat.compat.DiktatReporting;
 
 public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 	private final DiktatCompatAdapter adapter;
@@ -40,6 +43,10 @@ public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 
 	@Override
 	public String applyWithFile(String unix, File file) {
-		return adapter.format(file, unix, isScript);
+		try {
+			return adapter.format(file, unix, isScript);
+		} catch (DiktatReporting.LintException e) {
+			throw Lint.shortcut(e.lints.stream().map(lint -> Lint.atLine(lint.line, lint.ruleId, lint.detail)).collect(Collectors.toList()));
+		}
 	}
 }

--- a/lib/src/gson/java/com/diffplug/spotless/glue/gson/GsonFormatterFunc.java
+++ b/lib/src/gson/java/com/diffplug/spotless/glue/gson/GsonFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import com.diffplug.spotless.json.gson.GsonConfig;
 
 public class GsonFormatterFunc implements FormatterFunc {
 
-	private static final String FAILED_TO_PARSE_ERROR_MESSAGE = "Unable to format JSON";
+	private static final String FAILED_TO_PARSE_ERROR_MESSAGE = "Unable to parse JSON";
 
 	private final Gson gson;
 	private final GsonConfig gsonConfig;
@@ -56,7 +56,7 @@ public class GsonFormatterFunc implements FormatterFunc {
 		} else {
 			JsonElement jsonElement = gson.fromJson(inputString, JsonElement.class);
 			if (jsonElement == null) {
-				throw new AssertionError(FAILED_TO_PARSE_ERROR_MESSAGE);
+				throw new IllegalArgumentException(FAILED_TO_PARSE_ERROR_MESSAGE);
 			}
 			if (gsonConfig.isSortByKeys()) {
 				jsonElement = sortByKeys(jsonElement);

--- a/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
+++ b/lib/src/ktlint/java/com/diffplug/spotless/glue/ktlint/KtlintFormatterFunc.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.Lint;
 import com.diffplug.spotless.glue.ktlint.compat.*;
 
 public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
@@ -65,10 +66,14 @@ public class KtlintFormatterFunc implements FormatterFunc.NeedsFile {
 		if (editorConfigPath != null) {
 			absoluteEditorConfigPath = editorConfigPath.getOnlyFile().toPath();
 		}
-		return adapter.format(
-				unix,
-				file.toPath(),
-				absoluteEditorConfigPath,
-				editorConfigOverrideMap);
+		try {
+			return adapter.format(
+					unix,
+					file.toPath(),
+					absoluteEditorConfigPath,
+					editorConfigOverrideMap);
+		} catch (KtLintCompatReporting.KtlintSpotlessException e) {
+			throw Lint.atLine(e.line, e.ruleId, e.detail).shortcut();
+		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/Jvm.java
+++ b/lib/src/main/java/com/diffplug/spotless/Jvm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,8 @@ public final class Jvm {
 	 * @param <V> Version type of formatter
 	 */
 	public static class Support<V> {
+		static final String LINT_CODE = "jvm-version";
+
 		private final String fmtName;
 		private final Comparator<? super V> fmtVersionComparator;
 		private final NavigableMap<Integer, V> jvm2fmtMaxVersion;
@@ -139,7 +141,7 @@ public final class Jvm {
 			Objects.requireNonNull(formatterVersion);
 			String error = buildUnsupportedFormatterMessage(formatterVersion);
 			if (!error.isEmpty()) {
-				throw new IllegalArgumentException(error);
+				throw Lint.atUndefinedLine(LINT_CODE, error).shortcut();
 			}
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/LintState.java
+++ b/lib/src/main/java/com/diffplug/spotless/LintState.java
@@ -62,7 +62,15 @@ public class LintState {
 		return result;
 	}
 
-	public String asString(File file, Formatter formatter) {
+	public String asStringDetailed(File file, Formatter formatter) {
+		return asString(file, formatter, false);
+	}
+
+	public String asStringOneLine(File file, Formatter formatter) {
+		return asString(file, formatter, true);
+	}
+
+	private String asString(File file, Formatter formatter, boolean oneLine) {
 		if (!isHasLints()) {
 			return "(none)";
 		} else {
@@ -84,7 +92,16 @@ public class LintState {
 						}
 						result.append(" ");
 						result.append(step.getName()).append("(").append(lint.getRuleId()).append(") ");
-						result.append(lint.getDetail());
+
+						int firstNewline = lint.getDetail().indexOf('\n');
+						if (firstNewline == -1) {
+							result.append(lint.getDetail());
+						} else if (oneLine) {
+							result.append(lint.getDetail(), 0, firstNewline);
+							result.append(" (...)");
+						} else {
+							result.append(lint.getDetail());
+						}
 						result.append("\n");
 					}
 				}

--- a/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
@@ -210,9 +210,8 @@ public class FenceStep {
 				} else {
 					pattern = regex.pattern();
 				}
-				throw new Lint.ShortcutException(Lint.create("fenceRemoved",
-						"An intermediate step removed a match of " + pattern,
-						startLine, endLine));
+				throw Lint.atLineRange(startLine, endLine, "fenceRemoved",
+						"An intermediate step removed a match of " + pattern).shortcut();
 			}
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -16,7 +16,6 @@
 package com.diffplug.spotless.kotlin;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.util.*;
@@ -95,7 +94,7 @@ public class DiktatStep implements Serializable {
 		private final boolean isScript;
 		private final @Nullable FileSignature config;
 
-		State(JarState jar, String versionDiktat, boolean isScript, @Nullable FileSignature config) throws IOException {
+		State(JarState jar, String versionDiktat, boolean isScript, @Nullable FileSignature config) {
 			this.jar = jar;
 			this.versionDiktat = versionDiktat;
 			this.isScript = isScript;

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -15,8 +15,7 @@
  */
 package com.diffplug.spotless.maven.kotlin;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.ProcessRunner;
@@ -89,7 +88,7 @@ class KtlintTest extends MavenIntegrationHarness {
 				"</ktlint>");
 		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/listScreen.dirty");
 		ProcessRunner.Result result = mavenRunner().withArguments("spotless:check").runHasError();
-		assertTrue(result.toString().contains("Composable functions that return Unit should start with an uppercase letter."));
+		Assertions.assertThat(result.toString()).contains("Composable functions that return Unit should start with an uppercase letter.");
 	}
 
 	private void checkKtlintOfficialStyle() throws Exception {

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -98,7 +98,7 @@ public class StepHarness extends StepHarnessBase {
 	}
 
 	static StringSelfie expectLintsOf(LintState state, Formatter formatter) {
-		String assertAgainst = state.asString(Formatter.NO_FILE_SENTINEL, formatter);
+		String assertAgainst = state.asStringOneLine(Formatter.NO_FILE_SENTINEL, formatter);
 		String cleaned = assertAgainst.replace("NO_FILE_SENTINEL:", "");
 
 		int numLines = 1;

--- a/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,9 +94,9 @@ class JvmTest {
 		assertNull(testSupport.getRecommendedFormatterVersion(), "No formatter version is supported");
 
 		for (String fmtVersion : Arrays.asList("1.2", "1.2.3", "1.2-SNAPSHOT", "1.2.3-SNAPSHOT")) {
-			String proposal = assertThrows(Exception.class, () -> {
+			String proposal = assertThrows(Lint.ShortcutException.class, () -> {
 				testSupport.assertFormatterSupported(fmtVersion);
-			}).getMessage();
+			}).getLints().get(0).getDetail();
 			assertThat(proposal).contains(String.format("on JVM %d", Jvm.version()));
 			assertThat(proposal).contains(String.format("%s %s requires JVM %d+", TEST_NAME, fmtVersion, higherJvmVersion));
 			assertThat(proposal).contains(String.format("try %s alternatives", TEST_NAME));
@@ -112,9 +112,9 @@ class JvmTest {
 		}
 
 		for (String fmtVersion : Arrays.asList("1.2.4", "2", "1.2.5-SNAPSHOT")) {
-			String proposal = assertThrows(Exception.class, () -> {
+			String proposal = assertThrows(Lint.ShortcutException.class, () -> {
 				testSupport.assertFormatterSupported(fmtVersion);
-			}).getMessage();
+			}).getLints().get(0).getDetail();
 			assertThat(proposal).contains(String.format("%s %s requires JVM %d+", TEST_NAME, fmtVersion, higherJvmVersion + 1));
 
 			proposal = assertThrows(Exception.class, () -> {

--- a/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
@@ -89,7 +89,7 @@ class FenceStepTest extends ResourceHarness {
 				"spotless:off",
 				"D E F",
 				"spotless:on",
-				"G H I")).toBe("1-6 fence(fenceRemoved) An intermediate step removed a match of spotless:off spotless:on");
+				"G H I")).toBe("L1-6 fence(fenceRemoved) An intermediate step removed a match of spotless:off spotless:on");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -65,8 +65,9 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 	void versionBelowMinimumRequiredVersionIsNotAllowed() throws Exception {
 		FormatterStep step = GoogleJavaFormatStep.create("1.2", "AOSP", TestProvisioner.mavenCentral());
 		StepHarness.forStepNoRoundtrip(step)
-				.testResourceExceptionMsg("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test")
-				.contains("you are using 1.2");
+				.expectLintsOfResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test")
+				.toBe("LINE_UNDEFINED google-java-format(jvm-version) You are running Spotless on JVM 21. This requires google-java-format of at least 1.17.0 (you are using 1.2).",
+						"");
 	}
 
 	@Test
@@ -74,8 +75,9 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 	void versionBelowOneDotTenIsNotAllowed() throws Exception {
 		FormatterStep step = GoogleJavaFormatStep.create("1.9", "AOSP", TestProvisioner.mavenCentral());
 		StepHarness.forStepNoRoundtrip(step)
-				.testResourceExceptionMsg("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test")
-				.contains("you are using 1.9");
+				.expectLintsOfResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test")
+				.toBe("LINE_UNDEFINED google-java-format(jvm-version) You are running Spotless on JVM 21. This requires google-java-format of at least 1.17.0 (you are using 1.9).",
+						"");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -17,8 +17,8 @@ package com.diffplug.spotless.java;
 
 import static org.junit.jupiter.api.condition.JRE.JAVA_13;
 import static org.junit.jupiter.api.condition.JRE.JAVA_15;
-import static org.junit.jupiter.api.condition.JRE.JAVA_16;
 import static org.junit.jupiter.api.condition.JRE.JAVA_20;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -62,6 +62,7 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@EnabledForJreRange(min = JAVA_21, max = JAVA_21)
 	void versionBelowMinimumRequiredVersionIsNotAllowed() throws Exception {
 		FormatterStep step = GoogleJavaFormatStep.create("1.2", "AOSP", TestProvisioner.mavenCentral());
 		StepHarness.forStepNoRoundtrip(step)
@@ -70,7 +71,7 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 	}
 
 	@Test
-	@EnabledForJreRange(min = JAVA_16)
+	@EnabledForJreRange(min = JAVA_21, max = JAVA_21)
 	void versionBelowOneDotTenIsNotAllowed() throws Exception {
 		FormatterStep step = GoogleJavaFormatStep.create("1.9", "AOSP", TestProvisioner.mavenCentral());
 		StepHarness.forStepNoRoundtrip(step)

--- a/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/GoogleJavaFormatStepTest.java
@@ -66,8 +66,7 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 		FormatterStep step = GoogleJavaFormatStep.create("1.2", "AOSP", TestProvisioner.mavenCentral());
 		StepHarness.forStepNoRoundtrip(step)
 				.expectLintsOfResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test")
-				.toBe("LINE_UNDEFINED google-java-format(jvm-version) You are running Spotless on JVM 21. This requires google-java-format of at least 1.17.0 (you are using 1.2).",
-						"");
+				.toBe("LINE_UNDEFINED google-java-format(jvm-version) You are running Spotless on JVM 21. This requires google-java-format of at least 1.17.0 (you are using 1.2). (...)");
 	}
 
 	@Test
@@ -76,8 +75,7 @@ class GoogleJavaFormatStepTest extends ResourceHarness {
 		FormatterStep step = GoogleJavaFormatStep.create("1.9", "AOSP", TestProvisioner.mavenCentral());
 		StepHarness.forStepNoRoundtrip(step)
 				.expectLintsOfResource("java/googlejavaformat/JavaCodeWithLicenseUnformatted.test")
-				.toBe("LINE_UNDEFINED google-java-format(jvm-version) You are running Spotless on JVM 21. This requires google-java-format of at least 1.17.0 (you are using 1.9).",
-						"");
+				.toBe("LINE_UNDEFINED google-java-format(jvm-version) You are running Spotless on JVM 21. This requires google-java-format of at least 1.17.0 (you are using 1.9). (...)");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,14 +73,33 @@ class JsonSimpleStepTest {
 
 	@Test
 	void handlesInvalidJson() {
-		stepHarness.testResourceExceptionMsg("json/invalidJsonBefore.json")
-				.contains("Expected a ',' or '}' at 9 [character 0 line 3]");
+		stepHarness.expectLintsOfResource("json/invalidJsonBefore.json").toBe("L3 jsonSimple(java.lang.IllegalArgumentException) Unable to format JSON",
+				"\tat com.diffplug.spotless.json.JsonSimpleStep$State.format(JsonSimpleStep.java:109)",
+				"\tat com.diffplug.spotless.json.JsonSimpleStep$State.lambda$toFormatter$0(JsonSimpleStep.java:94)",
+				"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
+				"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
+				"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
+				"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
+				"\tat com.diffplug.spotless.StepHarness.expectLintsOfResource(StepHarness.java:92)",
+				"\tat com.diffplug.spotless.json.JsonSimpleStepTest.handlesInvalidJson(JsonSimpleStepTest.java:76)",
+				"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
+				"(... and more)");
 	}
 
 	@Test
 	void handlesNotJson() {
-		stepHarness.testResourceExceptionMsg("json/notJsonBefore.json")
-				.contains("Unable to determine JSON type, expected a '{' or '[' but found '#'");
+		stepHarness.expectLintsOfResource("json/notJsonBefore.json")
+				.toBe("LINE_UNDEFINED jsonSimple(java.lang.IllegalArgumentException) Unable to determine JSON type, expected a '{' or '[' but found '#'",
+						"\tat com.diffplug.spotless.json.JsonSimpleStep$State.lambda$toFormatter$0(JsonSimpleStep.java:100)",
+						"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
+						"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
+						"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
+						"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
+						"\tat com.diffplug.spotless.StepHarness.expectLintsOfResource(StepHarness.java:92)",
+						"\tat com.diffplug.spotless.json.JsonSimpleStepTest.handlesNotJson(JsonSimpleStepTest.java:91)",
+						"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
+						"\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)",
+						"(... and more)");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/JsonSimpleStepTest.java
@@ -73,33 +73,13 @@ class JsonSimpleStepTest {
 
 	@Test
 	void handlesInvalidJson() {
-		stepHarness.expectLintsOfResource("json/invalidJsonBefore.json").toBe("L3 jsonSimple(java.lang.IllegalArgumentException) Unable to format JSON",
-				"\tat com.diffplug.spotless.json.JsonSimpleStep$State.format(JsonSimpleStep.java:109)",
-				"\tat com.diffplug.spotless.json.JsonSimpleStep$State.lambda$toFormatter$0(JsonSimpleStep.java:94)",
-				"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
-				"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
-				"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
-				"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
-				"\tat com.diffplug.spotless.StepHarness.expectLintsOfResource(StepHarness.java:92)",
-				"\tat com.diffplug.spotless.json.JsonSimpleStepTest.handlesInvalidJson(JsonSimpleStepTest.java:76)",
-				"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
-				"(... and more)");
+		stepHarness.expectLintsOfResource("json/invalidJsonBefore.json").toBe("L3 jsonSimple(java.lang.IllegalArgumentException) Unable to format JSON (...)");
 	}
 
 	@Test
 	void handlesNotJson() {
 		stepHarness.expectLintsOfResource("json/notJsonBefore.json")
-				.toBe("LINE_UNDEFINED jsonSimple(java.lang.IllegalArgumentException) Unable to determine JSON type, expected a '{' or '[' but found '#'",
-						"\tat com.diffplug.spotless.json.JsonSimpleStep$State.lambda$toFormatter$0(JsonSimpleStep.java:100)",
-						"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
-						"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
-						"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
-						"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
-						"\tat com.diffplug.spotless.StepHarness.expectLintsOfResource(StepHarness.java:92)",
-						"\tat com.diffplug.spotless.json.JsonSimpleStepTest.handlesNotJson(JsonSimpleStepTest.java:91)",
-						"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
-						"\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)",
-						"(... and more)");
+				.toBe("LINE_UNDEFINED jsonSimple(java.lang.IllegalArgumentException) Unable to determine JSON type, expected a '{' or '[' but found '#' (...)");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
@@ -39,32 +39,12 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 
 	@Test
 	void handlesInvalidJson() {
-		getStepHarness().expectLintsOfResource("json/invalidJsonBefore.json").toBe("L3 gson(com.google.gson.JsonSyntaxException) java.io.EOFException: End of input at line 3 column 1 path $.a",
-				"\tat com.google.gson.Gson.fromJson(Gson.java:1370)",
-				"\tat com.google.gson.Gson.fromJson(Gson.java:1262)",
-				"\tat com.google.gson.Gson.fromJson(Gson.java:1171)",
-				"\tat com.google.gson.Gson.fromJson(Gson.java:1107)",
-				"\tat com.diffplug.spotless.glue.gson.GsonFormatterFunc.apply(GsonFormatterFunc.java:57)",
-				"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
-				"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
-				"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
-				"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
-				"(... and more)");
+		getStepHarness().expectLintsOfResource("json/invalidJsonBefore.json").toBe("L3 gson(com.google.gson.JsonSyntaxException) java.io.EOFException: End of input at line 3 column 1 path $.a (...)");
 	}
 
 	@Test
 	void handlesNotJson() {
-		getStepHarness().expectLintsOfResource("json/notJsonBefore.json").toBe("LINE_UNDEFINED gson(java.lang.IllegalArgumentException) Unable to parse JSON",
-				"\tat com.diffplug.spotless.glue.gson.GsonFormatterFunc.apply(GsonFormatterFunc.java:59)",
-				"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
-				"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
-				"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
-				"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
-				"\tat com.diffplug.spotless.StepHarness.expectLintsOfResource(StepHarness.java:92)",
-				"\tat com.diffplug.spotless.json.gson.GsonStepTest.handlesNotJson(GsonStepTest.java:57)",
-				"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
-				"\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)",
-				"(... and more)");
+		getStepHarness().expectLintsOfResource("json/notJsonBefore.json").toBe("LINE_UNDEFINED gson(java.lang.IllegalArgumentException) Unable to parse JSON (...)");
 	}
 
 	@Test
@@ -97,17 +77,7 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 	@Test
 	void handlesVersionIncompatibility() {
 		StepHarness.forStep(GsonStep.create(new GsonConfig(false, false, INDENT, "1.7"), TestProvisioner.mavenCentral()))
-				.expectLintsOf("").toBe("LINE_UNDEFINED gson(java.lang.IllegalStateException) There was a problem interacting with Gson; maybe you set an incompatible version?",
-						"\tat com.diffplug.spotless.json.gson.GsonStep$State.toFormatter(GsonStep.java:73)",
-						"\tat com.diffplug.spotless.FormatterStepSerializationRoundtrip.stateToFormatter(FormatterStepSerializationRoundtrip.java:64)",
-						"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:47)",
-						"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
-						"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
-						"\tat com.diffplug.spotless.json.gson.GsonStepTest.handlesVersionIncompatibility(GsonStepTest.java:100)",
-						"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
-						"\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)",
-						"\tat org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:766)",
-						"(... and more)");
+				.expectLintsOf("").toBe("LINE_UNDEFINED gson(java.lang.IllegalStateException) There was a problem interacting with Gson; maybe you set an incompatible version? (...)");
 	}
 
 	@Override

--- a/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/json/gson/GsonStepTest.java
@@ -17,9 +17,6 @@ package com.diffplug.spotless.json.gson;
 
 import static com.diffplug.spotless.json.gson.GsonStep.DEFAULT_VERSION;
 
-import java.io.File;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -42,12 +39,32 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 
 	@Test
 	void handlesInvalidJson() {
-		getStepHarness().testResourceExceptionMsg("json/invalidJsonBefore.json").isEqualTo("End of input at line 3 column 1 path $.a");
+		getStepHarness().expectLintsOfResource("json/invalidJsonBefore.json").toBe("L3 gson(com.google.gson.JsonSyntaxException) java.io.EOFException: End of input at line 3 column 1 path $.a",
+				"\tat com.google.gson.Gson.fromJson(Gson.java:1370)",
+				"\tat com.google.gson.Gson.fromJson(Gson.java:1262)",
+				"\tat com.google.gson.Gson.fromJson(Gson.java:1171)",
+				"\tat com.google.gson.Gson.fromJson(Gson.java:1107)",
+				"\tat com.diffplug.spotless.glue.gson.GsonFormatterFunc.apply(GsonFormatterFunc.java:57)",
+				"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
+				"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
+				"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
+				"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
+				"(... and more)");
 	}
 
 	@Test
 	void handlesNotJson() {
-		getStepHarness().testResourceExceptionMsg("json/notJsonBefore.json").isEqualTo("Unable to format JSON");
+		getStepHarness().expectLintsOfResource("json/notJsonBefore.json").toBe("LINE_UNDEFINED gson(java.lang.IllegalArgumentException) Unable to parse JSON",
+				"\tat com.diffplug.spotless.glue.gson.GsonFormatterFunc.apply(GsonFormatterFunc.java:59)",
+				"\tat com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)",
+				"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
+				"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
+				"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
+				"\tat com.diffplug.spotless.StepHarness.expectLintsOfResource(StepHarness.java:92)",
+				"\tat com.diffplug.spotless.json.gson.GsonStepTest.handlesNotJson(GsonStepTest.java:57)",
+				"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
+				"\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)",
+				"(... and more)");
 	}
 
 	@Test
@@ -79,10 +96,18 @@ public class GsonStepTest extends JsonFormatterStepCommonTests {
 
 	@Test
 	void handlesVersionIncompatibility() {
-		FormatterStep step = GsonStep.create(new GsonConfig(false, false, INDENT, "1.7"), TestProvisioner.mavenCentral());
-		Assertions.assertThatThrownBy(() -> step.format("", new File("")))
-				.isInstanceOf(IllegalStateException.class)
-				.hasMessage("There was a problem interacting with Gson; maybe you set an incompatible version?");
+		StepHarness.forStep(GsonStep.create(new GsonConfig(false, false, INDENT, "1.7"), TestProvisioner.mavenCentral()))
+				.expectLintsOf("").toBe("LINE_UNDEFINED gson(java.lang.IllegalStateException) There was a problem interacting with Gson; maybe you set an incompatible version?",
+						"\tat com.diffplug.spotless.json.gson.GsonStep$State.toFormatter(GsonStep.java:73)",
+						"\tat com.diffplug.spotless.FormatterStepSerializationRoundtrip.stateToFormatter(FormatterStepSerializationRoundtrip.java:64)",
+						"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:47)",
+						"\tat com.diffplug.spotless.LintState.of(LintState.java:141)",
+						"\tat com.diffplug.spotless.StepHarness.expectLintsOf(StepHarness.java:96)",
+						"\tat com.diffplug.spotless.json.gson.GsonStepTest.handlesVersionIncompatibility(GsonStepTest.java:100)",
+						"\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)",
+						"\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)",
+						"\tat org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:766)",
+						"(... and more)");
 	}
 
 	@Override

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,15 +29,11 @@ import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 
 class DiktatStepTest extends ResourceHarness {
-
 	@Test
 	void behavior() {
 		FormatterStep step = DiktatStep.create(TestProvisioner.mavenCentral());
-		StepHarnessWithFile.forStep(this, step).testResourceExceptionMsg("kotlin/diktat/Unsolvable.kt").isEqualTo("There are 2 unfixed errors:" +
-				System.lineSeparator() + "Error on line: 12, column: 9 cannot be fixed automatically" +
-				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
-				System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
-				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
+		StepHarnessWithFile.forStep(this, step).expectLintsOfResource("kotlin/diktat/Unsolvable.kt").toBe("L12 diktat(diktat-ruleset:debug-print) [DEBUG_PRINT] use a dedicated logging library: found println()",
+				"L13 diktat(diktat-ruleset:debug-print) [DEBUG_PRINT] use a dedicated logging library: found println()");
 	}
 
 	@Test
@@ -47,11 +43,8 @@ class DiktatStepTest extends ResourceHarness {
 		FileSignature config = signAsList(conf);
 
 		FormatterStep step = DiktatStep.create("1.2.1", TestProvisioner.mavenCentral(), config);
-		StepHarnessWithFile.forStep(this, step).testResourceExceptionMsg("kotlin/diktat/Unsolvable.kt").isEqualTo("There are 2 unfixed errors:" +
-				System.lineSeparator() + "Error on line: 1, column: 1 cannot be fixed automatically" +
-				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()" +
-				System.lineSeparator() + "Error on line: 13, column: 9 cannot be fixed automatically" +
-				System.lineSeparator() + "[DEBUG_PRINT] use a dedicated logging library: found println()");
+		StepHarnessWithFile.forStep(this, step).expectLintsOfResource("kotlin/diktat/Unsolvable.kt").toBe("L1 diktat(diktat-ruleset:debug-print) [DEBUG_PRINT] use a dedicated logging library: found println()",
+				"L13 diktat(diktat-ruleset:debug-print) [DEBUG_PRINT] use a dedicated logging library: found println()");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,7 @@ class KtLintStepTest extends ResourceHarness {
 		FormatterStep step = KtLintStep.create("0.48.0", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic-old.clean")
-				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
-						"rule: no-wildcard-imports\n" +
-						"Wildcard import");
+				.expectLintsOfResource("kotlin/ktlint/unsolvable.dirty").toBe("L1 ktlint(no-wildcard-imports) Wildcard import");
 	}
 
 	@Test
@@ -39,9 +37,7 @@ class KtLintStepTest extends ResourceHarness {
 		FormatterStep step = KtLintStep.create("0.48.1", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic-old.clean")
-				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
-						"rule: no-wildcard-imports\n" +
-						"Wildcard import");
+				.expectLintsOfResource("kotlin/ktlint/unsolvable.dirty").toBe("L1 ktlint(no-wildcard-imports) Wildcard import");
 	}
 
 	@Test
@@ -49,9 +45,7 @@ class KtLintStepTest extends ResourceHarness {
 		FormatterStep step = KtLintStep.create("0.49.0", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic-old.clean")
-				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
-						"rule: standard:no-wildcard-imports\n" +
-						"Wildcard import");
+				.expectLintsOfResource("kotlin/ktlint/unsolvable.dirty").toBe("L1 ktlint(standard:no-wildcard-imports) Wildcard import");
 	}
 
 	@Test
@@ -59,9 +53,7 @@ class KtLintStepTest extends ResourceHarness {
 		FormatterStep step = KtLintStep.create("0.49.1", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic-old.clean")
-				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
-						"rule: standard:no-wildcard-imports\n" +
-						"Wildcard import");
+				.expectLintsOfResource("kotlin/ktlint/unsolvable.dirty").toBe("L1 ktlint(standard:no-wildcard-imports) Wildcard import");
 	}
 
 	@Test
@@ -69,9 +61,7 @@ class KtLintStepTest extends ResourceHarness {
 		FormatterStep step = KtLintStep.create("0.50.0", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
-						"rule: standard:no-wildcard-imports\n" +
-						"Wildcard import");
+				.expectLintsOfResource("kotlin/ktlint/unsolvable.dirty").toBe("L1 ktlint(standard:no-wildcard-imports) Wildcard import");
 	}
 
 	@Test
@@ -79,9 +69,7 @@ class KtLintStepTest extends ResourceHarness {
 		FormatterStep step = KtLintStep.create("1.0.0", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
-						"rule: standard:no-empty-file\n" +
-						"File 'unsolvable.dirty' should not be empty");
+				.expectLintsOfResource("kotlin/ktlint/unsolvable.dirty").toBe("L1 ktlint(standard:no-empty-file) File 'unsolvable.dirty' should not be empty");
 	}
 
 	@Test
@@ -89,9 +77,7 @@ class KtLintStepTest extends ResourceHarness {
 		FormatterStep step = KtLintStep.create(TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
 				.testResource("kotlin/ktlint/basic.dirty", "kotlin/ktlint/basic.clean")
-				.testResourceExceptionMsg("kotlin/ktlint/unsolvable.dirty").isEqualTo("Error on line: 1, column: 1\n" +
-						"rule: standard:no-empty-file\n" +
-						"File 'unsolvable.dirty' should not be empty");
+				.expectLintsOfResource("kotlin/ktlint/unsolvable.dirty").toBe("L1 ktlint(standard:no-empty-file) File 'unsolvable.dirty' should not be empty");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
@@ -137,17 +137,7 @@ class PrettierFormatterStepTest extends NpmFormatterStepCommonTests {
 					new PrettierConfig(null, ImmutableMap.of("parser", "postcss")));
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
 				stepHarness.expectLintsOfResource("npm/prettier/filetypes/scss/scss.dirty")
-						.toBe("1-35 prettier-format(prettier-format) com.diffplug.spotless.npm.SimpleRestClient$SimpleRestResponseException: Unexpected response status code at /prettier/format [HTTP 500] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")",
-								"\tat com.diffplug.spotless.npm.SimpleRestClient.postJson(SimpleRestClient.java:72)",
-								"\tat com.diffplug.spotless.npm.SimpleRestClient.postJson(SimpleRestClient.java:46)",
-								"\tat com.diffplug.spotless.npm.PrettierRestService.format(PrettierRestService.java:46)",
-								"\tat com.diffplug.spotless.npm.PrettierFormatterStep$PrettierFilePathPassingFormatterFunc.applyWithFile(PrettierFormatterStep.java:125)",
-								"\tat com.diffplug.spotless.FormatterFunc$NeedsFile.apply(FormatterFunc.java:174)",
-								"\tat com.diffplug.spotless.FormatterFunc$Closeable$1.apply(FormatterFunc.java:73)",
-								"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
-								"\tat com.diffplug.spotless.LintState.of(LintState.java:135)",
-								"\tat com.diffplug.spotless.LintState.of(LintState.java:92)",
-								"(... and more)");
+						.toBe("LINE_UNDEFINED prettier-format(com.diffplug.spotless.npm.SimpleRestClient$SimpleRestResponseException) Unexpected response status code at /prettier/format [HTTP 500] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\") (...)");
 			}
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
@@ -136,8 +136,18 @@ class PrettierFormatterStepTest extends NpmFormatterStepCommonTests {
 					npmPathResolver(),
 					new PrettierConfig(null, ImmutableMap.of("parser", "postcss")));
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
-				stepHarness.testResourceExceptionMsg("npm/prettier/filetypes/scss/scss.dirty").isEqualTo(
-						"Unexpected response status code at /prettier/format [HTTP 500] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")");
+				stepHarness.expectLintsOfResource("npm/prettier/filetypes/scss/scss.dirty")
+						.toBe("1-35 prettier-format(prettier-format) com.diffplug.spotless.npm.SimpleRestClient$SimpleRestResponseException: Unexpected response status code at /prettier/format [HTTP 500] -- (Error while formatting: Error: Couldn't resolve parser \"postcss\")",
+								"\tat com.diffplug.spotless.npm.SimpleRestClient.postJson(SimpleRestClient.java:72)",
+								"\tat com.diffplug.spotless.npm.SimpleRestClient.postJson(SimpleRestClient.java:46)",
+								"\tat com.diffplug.spotless.npm.PrettierRestService.format(PrettierRestService.java:46)",
+								"\tat com.diffplug.spotless.npm.PrettierFormatterStep$PrettierFilePathPassingFormatterFunc.applyWithFile(PrettierFormatterStep.java:125)",
+								"\tat com.diffplug.spotless.FormatterFunc$NeedsFile.apply(FormatterFunc.java:174)",
+								"\tat com.diffplug.spotless.FormatterFunc$Closeable$1.apply(FormatterFunc.java:73)",
+								"\tat com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)",
+								"\tat com.diffplug.spotless.LintState.of(LintState.java:135)",
+								"\tat com.diffplug.spotless.LintState.of(LintState.java:92)",
+								"(... and more)");
 			}
 		}
 	}


### PR DESCRIPTION
Most of all, this PR is an example of how `Lint` can be incorporated into steps.

Now that we have a Lint API, all exceptions that get thrown by `FormatterStep` get turned into lints. If you throw a real "Spotless Lint" then it shows up nice, if it's any other kind of exception then the lint includes the full stacktrace (good for debugging, bad if it should be just a clean message).
