### PR TITLE
Make IDE hook work with configuration cache, take 2

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/TestingOnly.java
+++ b/lib/src/main/java/com/diffplug/spotless/TestingOnly.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.util.Locale;
+
+/** These FormatterStep are meant to be used for testing only. */
+public class TestingOnly {
+	public static FormatterStep lowercase() {
+		return FormatterStep.create("lowercase", "lowercaseStateUnused", unused -> TestingOnly::lowercase);
+	}
+
+	private static String lowercase(String raw) {
+		return raw.toLowerCase(Locale.ROOT);
+	}
+
+	public static FormatterStep diverge() {
+		return FormatterStep.create("diverge", "divergeStateUnused", unused -> TestingOnly::diverge);
+	}
+
+	private static String diverge(String raw) {
+		return raw + " ";
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
@@ -19,12 +19,34 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
+import javax.annotation.Nullable;
+
+import org.gradle.api.Project;
+
 import com.diffplug.common.base.Errors;
 import com.diffplug.common.io.ByteStreams;
 import com.diffplug.spotless.DirtyState;
 import com.diffplug.spotless.Formatter;
+import com.diffplug.spotless.NoLambda;
 
 class IdeHook {
+	static class State extends NoLambda.EqualityBasedOnSerialization {
+		final @Nullable String path;
+		final boolean useStdIn;
+		final boolean useStdOut;
+
+		State(Project project) {
+			path = (String) project.findProperty(PROPERTY);
+			if (path != null) {
+				useStdIn = project.hasProperty(USE_STD_IN);
+				useStdOut = project.hasProperty(USE_STD_OUT);
+			} else {
+				useStdIn = false;
+				useStdOut = false;
+			}
+		}
+	}
+
 	final static String PROPERTY = "spotlessIdeHook";
 	final static String USE_STD_IN = "spotlessIdeHookUseStdIn";
 	final static String USE_STD_OUT = "spotlessIdeHookUseStdOut";
@@ -33,9 +55,8 @@ class IdeHook {
 		System.err.println("IS CLEAN");
 	}
 
-	static void performHook(SpotlessTaskImpl spotlessTask) {
-		String path = (String) spotlessTask.getProject().property(PROPERTY);
-		File file = new File(path);
+	static void performHook(SpotlessTaskImpl spotlessTask, IdeHook.State state) {
+		File file = new File(state.path);
 		if (!file.isAbsolute()) {
 			System.err.println("Argument passed to " + PROPERTY + " must be an absolute path");
 			return;
@@ -50,7 +71,7 @@ class IdeHook {
 					}
 				}
 				byte[] bytes;
-				if (spotlessTask.getProject().hasProperty(USE_STD_IN)) {
+				if (state.useStdIn) {
 					bytes = ByteStreams.toByteArray(System.in);
 				} else {
 					bytes = Files.readAllBytes(file.toPath());
@@ -63,7 +84,7 @@ class IdeHook {
 					System.err.println("Run 'spotlessDiagnose' for details https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md");
 				} else {
 					System.err.println("IS DIRTY");
-					if (spotlessTask.getProject().hasProperty(USE_STD_OUT)) {
+					if (state.useStdOut) {
 						dirty.writeCanonicalTo(System.out);
 					} else {
 						dirty.writeCanonicalTo(file);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -34,6 +34,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.ChangeType;
 import org.gradle.work.FileChange;
@@ -49,6 +50,7 @@ import com.diffplug.spotless.extra.GitRatchet;
 @CacheableTask
 public abstract class SpotlessTaskImpl extends SpotlessTask {
 	@Input
+	@Optional
 	abstract Property<IdeHook.State> getIdeHookState();
 
 	@Internal

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,11 +40,11 @@ class IdeHookTest extends GradleIntegrationHarness {
 				"spotless {",
 				"  format 'misc', {",
 				"    target 'DIRTY.md', 'CLEAN.md'",
-				"    custom 'lowercase', { str -> str.toLowerCase(Locale.ROOT) }",
+				"    addStep com.diffplug.spotless.TestingOnly.lowercase()",
 				"  }",
 				"  format 'diverge', {",
 				"    target 'DIVERGE.md'",
-				"    custom 'diverge', { str -> str + ' ' }",
+				"    addStep com.diffplug.spotless.TestingOnly.diverge()",
 				"  }",
 				"}");
 		dirty = new File(rootFolder(), "DIRTY.md");


### PR DESCRIPTION
- A fix for #1082
- Key idea copied from #2278, thanks to @lehmanju for figuring out the idea
- Refactored compared to the PR to preserve stdin/stdout features