### PR TITLE
feat: supply Eclipse config from string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changed
+* Allow setting Eclipse config from a string, not only from files ([#2337](https://github.com/diffplug/spotless/pull/2337))
 * Bump default `ktlint` version to latest `1.3.0` -> `1.4.0`. ([#2314](https://github.com/diffplug/spotless/pull/2314))
 * Add _Sort Members_ feature based on [Eclipse JDT](plugin-gradle/README.md#eclipse-jdt) implementation. ([#2312](https://github.com/diffplug/spotless/pull/2312))
 * Bump default `jackson` version to latest `2.18.0` -> `2.18.1`. ([#2319](https://github.com/diffplug/spotless/pull/2319))

--- a/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@ package com.diffplug.spotless;
 
 import static com.diffplug.spotless.MoreIterables.toNullHostileList;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -73,6 +75,25 @@ public final class FormatterProperties {
 		FormatterProperties properties = new FormatterProperties();
 		nonNullFiles.forEach(properties::add);
 		return properties;
+	}
+
+	public static FormatterProperties fromContent(Iterable<String> content) throws IllegalArgumentException {
+		List<String> nonNullElements = toNullHostileList(content);
+		FormatterProperties properties = new FormatterProperties();
+		nonNullElements.forEach(contentElement -> {
+			try (InputStream is = new ByteArrayInputStream(contentElement.getBytes(StandardCharsets.UTF_8))) {
+				properties.properties.load(is);
+			} catch (IOException e) {
+				throw new IllegalArgumentException("Unable to load properties: " + contentElement);
+			}
+		});
+		return properties;
+	}
+
+	public static FormatterProperties merge(Properties... properties) {
+		FormatterProperties merged = new FormatterProperties();
+		List.of(properties).stream().forEach((source) -> merged.properties.putAll(source));
+		return merged;
 	}
 
 	/**

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changed
+* Allow setting Eclipse config from a string, not only from files ([#2337](https://github.com/diffplug/spotless/pull/2337))
 * Bump default `ktlint` version to latest `1.3.0` -> `1.4.0`. ([#2314](https://github.com/diffplug/spotless/pull/2314))
 * Bump default `jackson` version to latest `2.18.0` -> `2.18.1`. ([#2319](https://github.com/diffplug/spotless/pull/2319))
 * Bump default `ktfmt` version to latest `0.52` -> `0.53`. ([#2320](https://github.com/diffplug/spotless/pull/2320)

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -262,6 +262,10 @@ spotless {
     eclipse()
     // optional: you can specify a specific version and/or config file
     eclipse('4.26').configFile('eclipse-prefs.xml')
+    // Or supply the configuration as a string
+    eclipse('4.26').config("""
+    ...
+    """)
     // if the access to the p2 repositories is restricted, mirrors can be
     // specified using a URI prefix map as follows:
     eclipse().withP2Mirrors(['https://download.eclipse.org/eclipse/updates/4.29/':'https://some.internal.mirror/4-29-updates-p2/']) 
@@ -418,6 +422,10 @@ spotless {
     greclipse()
     // optional: you can specify a specific version or config file(s), version matches the Eclipse Platform
     greclipse('4.26').configFile('spotless.eclipseformat.xml', 'org.codehaus.groovy.eclipse.ui.prefs')
+    // Or supply the configuration as a string
+    greclipse('4.26').config("""
+    ...
+    """)
 ```
 
 Groovy-Eclipse formatting errors/warnings lead per default to a build failure. This behavior can be changed by adding the property/key value `ignoreFormatterProblems=true` to a configuration file. In this scenario, files causing problems, will not be modified by this formatter step.
@@ -572,6 +580,10 @@ spotles {
   cpp {
     // version and configFile are both optional
     eclipseCdt('4.13.0').configFile('eclipse-cdt.xml')
+    // Or supply the configuration as a string
+    eclipseCdt('4.13.0').config("""
+    ...
+    """)
   }
 }
 ```

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
@@ -17,6 +17,7 @@ package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -68,6 +69,13 @@ public abstract class BaseGroovyExtension extends FormatExtension {
 			requireElementsNonNull(configFiles);
 			Project project = extension.getProject();
 			builder.setPreferences(project.files(configFiles).getFiles());
+			extension.replaceStep(builder.build());
+			return this;
+		}
+
+		public GrEclipseConfig config(String... configs) {
+			requireElementsNonNull(configs);
+			builder.setPreferences(List.of(configs));
 			extension.replaceStep(builder.build());
 			return this;
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
@@ -17,12 +17,14 @@ package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
 
 import org.gradle.api.Project;
 
+import com.diffplug.gradle.spotless.JavaExtension.EclipseConfig;
 import com.diffplug.spotless.cpp.CppDefaults;
 import com.diffplug.spotless.extra.EquoBasedStepBuilder;
 import com.diffplug.spotless.extra.cpp.EclipseCdtFormatterStep;
@@ -56,6 +58,13 @@ public class CppExtension extends FormatExtension implements HasBuiltinDelimiter
 			requireElementsNonNull(configFiles);
 			Project project = getProject();
 			builder.setPreferences(project.files(configFiles).getFiles());
+			replaceStep(builder.build());
+			return this;
+		}
+
+		public EclipseConfig config(String... configs) {
+			requireElementsNonNull(configs);
+			builder.setPreferences(List.of(configs));
 			replaceStep(builder.build());
 			return this;
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -305,6 +305,13 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			return this;
 		}
 
+		public EclipseConfig config(String... configs) {
+			requireElementsNonNull(configs);
+			builder.setPreferences(List.of(configs));
+			replaceStep(builder.build());
+			return this;
+		}
+
 		public EclipseConfig sortMembersDoNotSortFields(boolean doNotSortFields) {
 			builder.sortMembersDoNotSortFields(doNotSortFields);
 			replaceStep(builder.build());

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaEclipseTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaEclipseTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+class JavaEclipseTest extends GradleIntegrationHarness {
+	@Test
+	void settingsWithContentWithoutFile() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"  id 'com.diffplug.spotless'",
+				"  id 'java'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"  java {  eclipse().config(\"\"\"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>",
+				"<profiles version=\"12\">",
+				"  <profile kind=\"CodeFormatterProfile\" name=\"Spotless\" version=\"12\">",
+				"    <setting id=\"org.eclipse.jdt.core.formatter.tabulation.size\" value=\"4\" />",
+				"  </profile>",
+				"</profiles>",
+				"\"\"\")  }",
+				"}");
+
+		gradleRunner().withArguments("spotlessApply").build();
+	}
+}


### PR DESCRIPTION
This allows a user to supply the configuration, needed by Eclipse formatter, as a string.