### PR TITLE
Make the Gradle testing methods public, to allow easier parameterized testing.

### DIFF
--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BumpThisNumberIfACustomStepChangesTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BumpThisNumberIfACustomStepChangesTest.java
@@ -39,7 +39,7 @@ class BumpThisNumberIfACustomStepChangesTest extends GradleIntegrationHarness {
 	}
 
 	@Override
-	protected void applyIsUpToDate(boolean upToDate) throws IOException {
+	public void applyIsUpToDate(boolean upToDate) throws IOException {
 		super.applyIsUpToDate(upToDate);
 		assertFile("README.md").hasContent("abc");
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigurationCacheTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 public class ConfigurationCacheTest extends GradleIntegrationHarness {
 	@Override
-	protected GradleRunner gradleRunner() throws IOException {
+	public GradleRunner gradleRunner() throws IOException {
 		setFile("gradle.properties").toContent("org.gradle.unsafe.configuration-cache=true");
 		setFile("settings.gradle").toContent("enableFeaturePreview(\"STABLE_CONFIGURATION_CACHE\")");
 		return super.gradleRunner().withGradleVersion(GradleVersionSupport.STABLE_CONFIGURATION_CACHE.version);

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GitRatchetGradleTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GitRatchetGradleTest.java
@@ -52,7 +52,7 @@ class GitRatchetGradleTest extends GradleIntegrationHarness {
 	}
 
 	@Override
-	protected GradleRunner gradleRunner() throws IOException {
+	public GradleRunner gradleRunner() throws IOException {
 		return super.gradleRunner().withGradleVersion(GradleVersionSupport.CUSTOM_STEPS.version);
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -121,7 +121,7 @@ public class GradleIntegrationHarness extends ResourceHarness {
 		setFile(".gitattributes").toContent("* text eol=lf");
 	}
 
-	protected GradleRunner gradleRunner() throws IOException {
+	public GradleRunner gradleRunner() throws IOException {
 		GradleVersionSupport version;
 		if (newFile("build.gradle").exists() && read("build.gradle").contains("custom")) {
 			version = GradleVersionSupport.CUSTOM_STEPS;
@@ -136,11 +136,11 @@ public class GradleIntegrationHarness extends ResourceHarness {
 	}
 
 	/** Dumps the complete file contents of the folder to the console. */
-	protected String getContents() {
+	public String getContents() {
 		return getContents(subPath -> !subPath.startsWith(".gradle"));
 	}
 
-	protected String getContents(Predicate<String> subpathsToInclude) {
+	public String getContents(Predicate<String> subpathsToInclude) {
 		return StringPrinter.buildString(printer -> Errors.rethrow().run(() -> iterateFiles(subpathsToInclude, (subpath, file) -> {
 			printer.println("### " + subpath + " ###");
 			try {
@@ -152,18 +152,18 @@ public class GradleIntegrationHarness extends ResourceHarness {
 	}
 
 	/** Dumps the filtered file listing of the folder to the console. */
-	protected String listFiles(Predicate<String> subpathsToInclude) {
+	public String listFiles(Predicate<String> subpathsToInclude) {
 		return StringPrinter.buildString(printer -> iterateFiles(subpathsToInclude, (subPath, file) -> {
 			printer.println(subPath + " [" + getFileAttributes(file) + "]");
 		}));
 	}
 
 	/** Dumps the file listing of the folder to the console. */
-	protected String listFiles() {
+	public String listFiles() {
 		return listFiles(subPath -> !subPath.startsWith(".gradle"));
 	}
 
-	protected void iterateFiles(Predicate<String> subpathsToInclude, BiConsumer<String, File> consumer) {
+	public void iterateFiles(Predicate<String> subpathsToInclude, BiConsumer<String, File> consumer) {
 		TreeDef<File> treeDef = TreeDef.forFile(Errors.rethrow());
 		List<File> files = TreeStream.depthFirst(treeDef, rootFolder())
 				.filter(File::isFile)
@@ -180,20 +180,20 @@ public class GradleIntegrationHarness extends ResourceHarness {
 		}
 	}
 
-	protected String getFileAttributes(File file) {
+	public String getFileAttributes(File file) {
 		return (file.canRead() ? "r" : "-") + (file.canWrite() ? "w" : "-") + (file.canExecute() ? "x" : "-");
 	}
 
-	protected void checkRunsThenUpToDate() throws IOException {
+	public void checkRunsThenUpToDate() throws IOException {
 		checkIsUpToDate(false);
 		checkIsUpToDate(true);
 	}
 
-	protected void applyIsUpToDate(boolean upToDate) throws IOException {
+	public void applyIsUpToDate(boolean upToDate) throws IOException {
 		taskIsUpToDate("spotlessApply", upToDate);
 	}
 
-	protected void checkIsUpToDate(boolean upToDate) throws IOException {
+	public void checkIsUpToDate(boolean upToDate) throws IOException {
 		taskIsUpToDate("spotlessCheck", upToDate);
 	}
 
@@ -215,13 +215,13 @@ public class GradleIntegrationHarness extends ResourceHarness {
 		}
 	}
 
-	protected static List<String> outcomes(BuildResult build, TaskOutcome outcome) {
+	public static List<String> outcomes(BuildResult build, TaskOutcome outcome) {
 		return build.taskPaths(outcome).stream()
 				.filter(s -> !s.equals(":spotlessInternalRegisterDependencies"))
 				.collect(Collectors.toList());
 	}
 
-	protected static List<BuildTask> outcomes(BuildResult build) {
+	public static List<BuildTask> outcomes(BuildResult build) {
 		return build.getTasks().stream()
 				.filter(t -> !t.getPath().equals(":spotlessInternalRegisterDependencies"))
 				.collect(Collectors.toList());

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2024 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@ package com.diffplug.gradle.spotless;
 
 import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.Predicates;
 
+@Disabled("https://status.npmjs.org/ shows npm services down on 12/8/2024, should undisable this later")
 class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 
 	@Test

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -53,17 +53,17 @@ public class ResourceHarness {
 	File folderDontUseDirectly;
 
 	/** Returns the root folder (canonicalized to fix OS X issue) */
-	protected File rootFolder() {
+	public File rootFolder() {
 		return Errors.rethrow().get(() -> folderDontUseDirectly.getCanonicalFile());
 	}
 
 	/** Returns a new child of the root folder. */
-	protected File newFile(String subpath) {
+	public File newFile(String subpath) {
 		return new File(rootFolder(), subpath);
 	}
 
 	/** Creates and returns a new child-folder of the root folder. */
-	protected File newFolder(String subpath) throws IOException {
+	public File newFolder(String subpath) throws IOException {
 		File targetDir = newFile(subpath);
 		if (!targetDir.mkdir()) {
 			throw new IOException("Failed to create " + targetDir);
@@ -77,7 +77,7 @@ public class ResourceHarness {
 	 * @return the list of resources in that directory on the classpath, unix-style file separators
 	 * @throws IOException
 	 */
-	protected List<String> listTestResources(String path) throws IOException {
+	public List<String> listTestResources(String path) throws IOException {
 		// add leading slash if required, otherwise resources won't be found
 		if (!path.startsWith("/")) {
 			path = path + "/";
@@ -102,19 +102,19 @@ public class ResourceHarness {
 		return filenames;
 	}
 
-	protected String relativeToRoot(String path) {
+	public String relativeToRoot(String path) {
 		return new File(path).toPath().relativize(rootFolder().toPath()).toString();
 	}
 
-	protected String read(String path) throws IOException {
+	public String read(String path) throws IOException {
 		return read(newFile(path).toPath(), StandardCharsets.UTF_8);
 	}
 
-	protected String read(Path path, Charset encoding) throws IOException {
+	public String read(Path path, Charset encoding) throws IOException {
 		return new String(Files.readAllBytes(path), encoding);
 	}
 
-	protected void replace(String path, String toReplace, String replaceWith) throws IOException {
+	public void replace(String path, String toReplace, String replaceWith) throws IOException {
 		String before = read(path);
 		String after = before.replace(toReplace, replaceWith);
 		if (before.equals(after)) {
@@ -124,7 +124,7 @@ public class ResourceHarness {
 	}
 
 	/** Returns the contents of the given file from the src/test/resources directory. */
-	protected static String getTestResource(String filename) {
+	public static String getTestResource(String filename) {
 		Optional<URL> resourceUrl = getTestResourceUrl(filename);
 		if (resourceUrl.isPresent()) {
 			return ThrowingEx.get(() -> LineEnding.toUnix(Resources.toString(resourceUrl.get(), StandardCharsets.UTF_8)));
@@ -132,7 +132,7 @@ public class ResourceHarness {
 		throw new IllegalArgumentException("No such resource " + filename);
 	}
 
-	protected static boolean existsTestResource(String filename) {
+	public static boolean existsTestResource(String filename) {
 		return getTestResourceUrl(filename).isPresent();
 	}
 
@@ -142,7 +142,7 @@ public class ResourceHarness {
 	}
 
 	/** Returns Files (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
-	protected List<File> createTestFiles(String... filenames) {
+	public List<File> createTestFiles(String... filenames) {
 		List<File> files = new ArrayList<>(filenames.length);
 		for (String filename : filenames) {
 			files.add(createTestFile(filename));
@@ -151,7 +151,7 @@ public class ResourceHarness {
 	}
 
 	/** Returns a File (in a temporary folder) which has the contents of the given file from the src/test/resources directory. */
-	protected File createTestFile(String filename) {
+	public File createTestFile(String filename) {
 		return createTestFile(filename, UnaryOperator.identity());
 	}
 
@@ -159,7 +159,7 @@ public class ResourceHarness {
 	 * Returns a File (in a temporary folder) which has the contents, possibly processed, of the given file from the
 	 * src/test/resources directory.
 	 */
-	protected File createTestFile(String filename, UnaryOperator<String> fileContentsProcessor) {
+	public File createTestFile(String filename, UnaryOperator<String> fileContentsProcessor) {
 		int lastSlash = filename.lastIndexOf('/');
 		String name = lastSlash >= 0 ? filename.substring(lastSlash) : filename;
 		File file = newFile(name);
@@ -169,12 +169,12 @@ public class ResourceHarness {
 	}
 
 	@CheckReturnValue
-	protected ReadAsserter assertFile(String path) {
+	public ReadAsserter assertFile(String path) {
 		return new ReadAsserter(newFile(path));
 	}
 
 	@CheckReturnValue
-	protected ReadAsserter assertFile(File file) {
+	public ReadAsserter assertFile(File file) {
 		return new ReadAsserter(file);
 	}
 
@@ -207,7 +207,7 @@ public class ResourceHarness {
 		}
 	}
 
-	protected WriteAsserter setFile(String path) {
+	public WriteAsserter setFile(String path) {
 		return new WriteAsserter(newFile(path));
 	}
 


### PR DESCRIPTION
We need a lot of tests where we have configuration cache on and then off, and that will be easier if the test methods are public instead of protected.