### PR TITLE
feat: supply eclipse formatter settings as XML content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Changed
+* TODO ([#](https://github.com/diffplug/spotless/pull/X))
 * Allow setting Eclipse config from a string, not only from files ([#2337](https://github.com/diffplug/spotless/pull/2337))
 * Bump default `ktlint` version to latest `1.3.0` -> `1.4.0`. ([#2314](https://github.com/diffplug/spotless/pull/2314))
 * Add _Sort Members_ feature based on [Eclipse JDT](plugin-gradle/README.md#eclipse-jdt) implementation. ([#2312](https://github.com/diffplug/spotless/pull/2312))

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
@@ -56,6 +56,7 @@ public abstract class EquoBasedStepBuilder {
 	private String formatterVersion;
 	private Iterable<File> settingsFiles = new ArrayList<>();
 	private List<String> settingProperties = new ArrayList<>();
+	private List<String> settingXml = new ArrayList<>();
 	private Map<String, String> p2Mirrors = Map.of();
 	private File cacheDirectory;
 
@@ -84,6 +85,10 @@ public abstract class EquoBasedStepBuilder {
 
 	public void setPropertyPreferences(List<String> propertyPreferences) {
 		this.settingProperties = propertyPreferences;
+	}
+
+	public void setXmlPreferences(List<String> settingXml) {
+		this.settingXml = settingXml;
 	}
 
 	public void setP2Mirrors(Map<String, String> p2Mirrors) {
@@ -119,7 +124,7 @@ public abstract class EquoBasedStepBuilder {
 
 	/** Returns the FormatterStep (whose state will be calculated lazily). */
 	public FormatterStep build() {
-		var roundtrippableState = new EquoStep(formatterVersion, settingProperties, FileSignature.promise(settingsFiles), JarState.promise(() -> {
+		var roundtrippableState = new EquoStep(formatterVersion, settingProperties, settingXml, FileSignature.promise(settingsFiles), JarState.promise(() -> {
 			P2QueryResult query;
 			try {
 				if (null != cacheDirectory) {
@@ -174,23 +179,26 @@ public abstract class EquoBasedStepBuilder {
 		private final JarState.Promised jarPromise;
 		private final ImmutableMap<String, String> stepProperties;
 		private List<String> settingProperties;
+		private List<String> settingXml;
 
 		EquoStep(
 				String semanticVersion,
 				List<String> settingProperties,
+				List<String> settingXml,
 				FileSignature.Promised settingsPromise,
 				JarState.Promised jarPromise,
 				ImmutableMap<String, String> stepProperties) {
 
 			this.semanticVersion = semanticVersion;
 			this.settingProperties = Optional.ofNullable(settingProperties).orElse(new ArrayList<>());
+			this.settingXml = Optional.ofNullable(settingXml).orElse(new ArrayList<>());
 			this.settingsPromise = settingsPromise;
 			this.jarPromise = jarPromise;
 			this.stepProperties = stepProperties;
 		}
 
 		private State state() {
-			return new State(semanticVersion, jarPromise.get(), settingProperties, settingsPromise.get(), stepProperties);
+			return new State(semanticVersion, jarPromise.get(), settingProperties, settingXml, settingsPromise.get(), stepProperties);
 		}
 	}
 
@@ -205,11 +213,13 @@ public abstract class EquoBasedStepBuilder {
 		final FileSignature settingsFiles;
 		final ImmutableMap<String, String> stepProperties;
 		private List<String> settingProperties;
+		private List<String> settingXml;
 
-		public State(String semanticVersion, JarState jarState, List<String> settingProperties, FileSignature settingsFiles, ImmutableMap<String, String> stepProperties) {
+		public State(String semanticVersion, JarState jarState, List<String> settingProperties, List<String> settingXml, FileSignature settingsFiles, ImmutableMap<String, String> stepProperties) {
 			this.semanticVersion = semanticVersion;
 			this.jarState = jarState;
 			this.settingProperties = Optional.ofNullable(settingProperties).orElse(new ArrayList<>());
+			this.settingXml = Optional.ofNullable(settingXml).orElse(new ArrayList<>());
 			this.settingsFiles = settingsFiles;
 			this.stepProperties = stepProperties;
 		}
@@ -225,7 +235,8 @@ public abstract class EquoBasedStepBuilder {
 		public Properties getPreferences() {
 			FormatterProperties fromFiles = FormatterProperties.from(settingsFiles.files());
 			FormatterProperties fromPropertiesContent = FormatterProperties.fromPropertiesContent(settingProperties);
-			return FormatterProperties.merge(fromFiles.getProperties(), fromPropertiesContent.getProperties()).getProperties();
+			FormatterProperties fromXmlContent = FormatterProperties.fromXmlContent(settingXml);
+			return FormatterProperties.merge(fromFiles.getProperties(), fromPropertiesContent.getProperties(), fromXmlContent.getProperties()).getProperties();
 		}
 
 		public ImmutableMap<String, String> getStepProperties() {

--- a/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
@@ -20,6 +20,7 @@ import static com.diffplug.spotless.MoreIterables.toNullHostileList;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -90,6 +92,25 @@ public final class FormatterProperties {
 		return properties;
 	}
 
+	public static FormatterProperties fromXmlContent(final Iterable<String> content) throws IllegalArgumentException {
+		final List<String> nonNullElements = toNullHostileList(content);
+		final FormatterProperties properties = new FormatterProperties();
+		nonNullElements.forEach(contentElement -> {
+			try {
+				final Properties newSettings = FileParser.XML.executeXmlContent(contentElement);
+				properties.properties.putAll(newSettings);
+			} catch (IOException | IllegalArgumentException exception) {
+				String message = String.format("Failed to add preferences from XML:%n%s%n", contentElement);
+				final String detailedMessage = exception.getMessage();
+				if (null != detailedMessage) {
+					message += String.format(" %s", detailedMessage);
+				}
+				throw new IllegalArgumentException(message, exception);
+			}
+		});
+		return properties;
+	}
+
 	public static FormatterProperties merge(Properties... properties) {
 		FormatterProperties merged = new FormatterProperties();
 		List.of(properties).stream().forEach((source) -> merged.properties.putAll(source));
@@ -139,20 +160,40 @@ public final class FormatterProperties {
 				}
 				return properties;
 			}
+
+			@Override
+			protected Properties executeXmlContent(String content) throws IOException, IllegalArgumentException {
+				throw new RuntimeException("Not implemented");
+			}
 		},
 
 		XML("xml") {
 			@Override
 			protected Properties execute(final File file) throws IOException, IllegalArgumentException {
-				Node rootNode = getRootNode(file);
+				return executeWithSupplier(() -> {
+					try {
+						return new FileInputStream(file);
+					} catch (FileNotFoundException e) {
+						throw new RuntimeException("File not found: " + file, e);
+					}
+				});
+			}
+
+			@Override
+			protected Properties executeXmlContent(String content) throws IOException, IllegalArgumentException {
+				return executeWithSupplier(() -> new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+			}
+
+			private Properties executeWithSupplier(Supplier<InputStream> isSupplier) throws IOException, IllegalArgumentException {
+				Node rootNode = getRootNode(isSupplier.get());
 				String nodeName = rootNode.getNodeName();
 				if (null == nodeName) {
 					throw new IllegalArgumentException("XML document does not contain a root node.");
 				}
-				return XmlParser.parse(file, rootNode);
+				return XmlParser.parse(isSupplier.get(), rootNode);
 			}
 
-			private Node getRootNode(final File file) throws IOException, IllegalArgumentException {
+			private Node getRootNode(final InputStream is) throws IOException, IllegalArgumentException {
 				try {
 					DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 					/*
@@ -166,7 +207,7 @@ public final class FormatterProperties {
 					 */
 					dbf.setFeature(LOAD_EXTERNAL_DTD_PROP, false);
 					DocumentBuilder db = dbf.newDocumentBuilder();
-					return db.parse(file).getDocumentElement();
+					return db.parse(is).getDocumentElement();
 				} catch (SAXException | ParserConfigurationException e) {
 					throw new IllegalArgumentException("File has no valid XML syntax.", e);
 				}
@@ -185,6 +226,8 @@ public final class FormatterProperties {
 		}
 
 		protected abstract Properties execute(File file) throws IOException, IllegalArgumentException;
+
+		protected abstract Properties executeXmlContent(String content) throws IOException, IllegalArgumentException;
 
 		public static Properties parse(final File file) throws IOException, IllegalArgumentException {
 			String fileNameExtension = getFileNameExtension(file);
@@ -211,19 +254,17 @@ public final class FormatterProperties {
 	private enum XmlParser {
 		PROPERTIES("properties") {
 			@Override
-			protected Properties execute(final File xmlFile, final Node rootNode)
+			protected Properties execute(final InputStream xmlFile, final Node rootNode)
 					throws IOException, IllegalArgumentException {
 				final Properties properties = new Properties();
-				try (InputStream xmlInput = new FileInputStream(xmlFile)) {
-					properties.loadFromXML(xmlInput);
-				}
+				properties.loadFromXML(xmlFile);
 				return properties;
 			}
 		},
 
 		PROFILES("profiles") {
 			@Override
-			protected Properties execute(File file, Node rootNode) throws IOException, IllegalArgumentException {
+			protected Properties execute(InputStream file, Node rootNode) throws IOException, IllegalArgumentException {
 				final Properties properties = new Properties();
 				Node firstProfile = getSingleProfile(rootNode);
 				for (Object settingObj : getChildren(firstProfile, "setting")) {
@@ -285,14 +326,14 @@ public final class FormatterProperties {
 			return this.rootNodeName;
 		}
 
-		protected abstract Properties execute(File file, Node rootNode) throws IOException, IllegalArgumentException;
+		protected abstract Properties execute(InputStream is, Node rootNode) throws IOException, IllegalArgumentException;
 
-		public static Properties parse(final File file, final Node rootNode)
+		public static Properties parse(final InputStream is, final Node rootNode)
 				throws IOException, IllegalArgumentException {
 			String rootNodeName = rootNode.getNodeName();
 			for (XmlParser parser : XmlParser.values()) {
 				if (parser.rootNodeName.equals(rootNodeName)) {
-					return parser.execute(file, rootNode);
+					return parser.execute(is, rootNode);
 				}
 			}
 			String msg = String.format("The XML root node '%1$s' is not part of the supported root nodes [%2$s].",

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -262,8 +262,12 @@ spotless {
     eclipse()
     // optional: you can specify a specific version and/or config file
     eclipse('4.26').configFile('eclipse-prefs.xml')
-    // Or supply the configuration as a string
+    // Or supply the configuration properties as a string
     eclipse('4.26').configProperties("""
+    ...
+    """)
+    // Or supply the configuration XML as a string
+    eclipse('4.26').configXml("""
     ...
     """)
     // if the access to the p2 repositories is restricted, mirrors can be
@@ -422,8 +426,12 @@ spotless {
     greclipse()
     // optional: you can specify a specific version or config file(s), version matches the Eclipse Platform
     greclipse('4.26').configFile('spotless.eclipseformat.xml', 'org.codehaus.groovy.eclipse.ui.prefs')
-    // Or supply the configuration as a string
+    // Or supply the configuration properties as a string
     greclipse('4.26').configProperties("""
+    ...
+    """)
+    // Or supply the configuration XML as a string
+    greclipse('4.26').configXml("""
     ...
     """)
 ```
@@ -580,8 +588,12 @@ spotles {
   cpp {
     // version and configFile are both optional
     eclipseCdt('4.13.0').configFile('eclipse-cdt.xml')
-    // Or supply the configuration as a string
+    // Or supply the configuration properties as a string
     eclipseCdt('4.13.0').configProperties("""
+    ...
+    """)
+    // Or supply the configuration XML as a string
+    eclipseCdt('4.13.0').configXml("""
     ...
     """)
   }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
@@ -80,6 +80,13 @@ public abstract class BaseGroovyExtension extends FormatExtension {
 			return this;
 		}
 
+		public GrEclipseConfig configXml(String... configs) {
+			requireElementsNonNull(configs);
+			builder.setXmlPreferences(List.of(configs));
+			extension.replaceStep(builder.build());
+			return this;
+		}
+
 		public GrEclipseConfig withP2Mirrors(Map<String, String> mirrors) {
 			builder.setP2Mirrors(mirrors);
 			extension.replaceStep(builder.build());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CppExtension.java
@@ -69,6 +69,13 @@ public class CppExtension extends FormatExtension implements HasBuiltinDelimiter
 			return this;
 		}
 
+		public EclipseConfig configXml(String... configs) {
+			requireElementsNonNull(configs);
+			builder.setXmlPreferences(List.of(configs));
+			replaceStep(builder.build());
+			return this;
+		}
+
 		public EclipseConfig withP2Mirrors(Map<String, String> mirrors) {
 			builder.setP2Mirrors(mirrors);
 			replaceStep(builder.build());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -312,6 +312,13 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 			return this;
 		}
 
+		public EclipseConfig configXml(String... configs) {
+			requireElementsNonNull(configs);
+			builder.setXmlPreferences(List.of(configs));
+			replaceStep(builder.build());
+			return this;
+		}
+
 		public EclipseConfig sortMembersDoNotSortFields(boolean doNotSortFields) {
 			builder.sortMembersDoNotSortFields(doNotSortFields);
 			replaceStep(builder.build());

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaEclipseTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaEclipseTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 
 class JavaEclipseTest extends GradleIntegrationHarness {
 	@Test
-	void settingsWithContentWithoutFile() throws IOException {
+	void settingsWithProprtiesContent() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
 				"  id 'com.diffplug.spotless'",
@@ -32,6 +32,29 @@ class JavaEclipseTest extends GradleIntegrationHarness {
 				"spotless {",
 				"  java {  eclipse().configProperties(\"\"\"",
 				"valid_line_oriented.prefs.string=string",
+				"\"\"\")  }",
+				"}");
+
+		gradleRunner().withArguments("spotlessApply").build();
+	}
+
+	@Test
+	void settingsWithXmlContent() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"  id 'com.diffplug.spotless'",
+				"  id 'java'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"  java {  eclipse().configProperties(\"\"\"",
+				"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>",
+				"<profiles version=\"12\">",
+				"  <profile kind=\"CodeFormatterProfile\" name=\"Spotless\" version=\"12\">",
+				"    <setting id=\"valid_line_oriented.prefs.string\" value=\"string\" />",
+				"  </profile>",
+				"</profiles>",
 				"\"\"\")  }",
 				"}");
 


### PR DESCRIPTION
Continuation of #2343. This PR enables a user to add Eclipse preferences in XML format, as content, without having it in a file.
