### PR TITLE
Remove support for Eclipse CDT 10.7, new minimum is 11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,9 +17,11 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `jackson` version to latest `2.18.0` -> `2.18.1`. ([#2319](https://github.com/diffplug/spotless/pull/2319))
 * Bump default `ktfmt` version to latest `0.52` -> `0.53`. ([#2320](https://github.com/diffplug/spotless/pull/2320))
 * Bump default `ktlint` version to latest `1.4.0` -> `1.5.0`. ([#2354](https://github.com/diffplug/spotless/pull/2354))
+* Bump minimum `eclipse-cdt` version to `11.0` (removed support for `10.7`). ([#2373](https://github.com/diffplug/spotless/pull/2373))
 ### Fixed
 * You can now use `removeUnusedImports` and `googleJavaFormat` at the same time again. (fixes [#2159](https://github.com/diffplug/spotless/issues/2159))
 * The default list of type annotations used by `formatAnnotations` now includes Jakarta Validation's `Valid` and constraints validations (fixes [#2334](https://github.com/diffplug/spotless/issues/2334))
+
 
 ## [3.0.0.BETA4] - 2024-10-24
 ### Added

--- a/lib-extra/build.gradle
+++ b/lib-extra/build.gradle
@@ -50,6 +50,9 @@ def NEEDS_P2_DEPS = [
 	'groovy',
 	'jdt'
 ]
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+	NEEDS_P2_DEPS.remove('cdt')
+}
 for (needsP2 in NEEDS_P2_DEPS) {
 	sourceSets.register(needsP2) {
 		compileClasspath += sourceSets.main.output
@@ -74,11 +77,12 @@ tasks.withType(Test).configureEach {
 
 apply plugin: 'dev.equo.p2deps'
 p2deps {
-	// (alphabetic order please)
-	into 'cdtCompileOnly', {
-		p2repo 'https://download.eclipse.org/eclipse/updates/4.26/'
-		p2repo 'https://download.eclipse.org/tools/cdt/releases/11.0/'
-		install 'org.eclipse.cdt.core'
+	if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+		into 'cdtCompileOnly', {
+			p2repo 'https://download.eclipse.org/eclipse/updates/4.26/'
+			p2repo 'https://download.eclipse.org/tools/cdt/releases/11.0/'
+			install 'org.eclipse.cdt.core'
+		}
 	}
 	into 'groovyCompileOnly', {
 		p2repo 'https://download.eclipse.org/eclipse/updates/4.26/'

--- a/lib-extra/build.gradle
+++ b/lib-extra/build.gradle
@@ -77,7 +77,7 @@ p2deps {
 	// (alphabetic order please)
 	into 'cdtCompileOnly', {
 		p2repo 'https://download.eclipse.org/eclipse/updates/4.26/'
-		p2repo 'https://download.eclipse.org/tools/cdt/releases/10.7/'
+		p2repo 'https://download.eclipse.org/tools/cdt/releases/11.0/'
 		install 'org.eclipse.cdt.core'
 	}
 	into 'groovyCompileOnly', {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -38,7 +38,7 @@ public final class EclipseCdtFormatterStep {
 	private EclipseCdtFormatterStep() {}
 
 	private static final String NAME = "eclipse cdt formatter";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "11.0").add(17, "11.6");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(17, "11.6");
 
 	public static String defaultVersion() {
 		return JVM_SUPPORT.getRecommendedFormatterVersion();

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public final class EclipseCdtFormatterStep {
 	private EclipseCdtFormatterStep() {}
 
 	private static final String NAME = "eclipse cdt formatter";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "10.7").add(17, "11.6");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(11, "11.0").add(17, "11.6");
 
 	public static String defaultVersion() {
 		return JVM_SUPPORT.getRecommendedFormatterVersion();

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,11 @@
  */
 package com.diffplug.spotless.extra.cpp;
 
+import static org.junit.jupiter.api.condition.JRE.JAVA_17;
+
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -30,6 +33,7 @@ class EclipseCdtFormatterStepTest extends EquoResourceHarness {
 
 	@ParameterizedTest
 	@MethodSource
+	@EnabledForJreRange(min = JAVA_17)
 	void formatWithVersion(String version) throws Exception {
 		harnessFor(version).test("main.c",
 				"#include <a.h>;\nint main(int argc,   \nchar *argv[]) {}",
@@ -37,6 +41,6 @@ class EclipseCdtFormatterStepTest extends EquoResourceHarness {
 	}
 
 	private static Stream<String> formatWithVersion() {
-		return Stream.of("10.6", "10.7", EclipseCdtFormatterStep.defaultVersion());
+		return Stream.of("11.0", "11.6", EclipseCdtFormatterStep.defaultVersion());
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `jackson` version to latest `2.18.0` -> `2.18.1`. ([#2319](https://github.com/diffplug/spotless/pull/2319))
 * Bump default `ktfmt` version to latest `0.52` -> `0.53`. ([#2320](https://github.com/diffplug/spotless/pull/2320))
 * Bump default `ktlint` version to latest `1.4.0` -> `1.5.0`. ([#2354](https://github.com/diffplug/spotless/pull/2354))
+* Bump minimum `eclipse-cdt` version to `11.0` (removed support for `10.7`). ([#2373](https://github.com/diffplug/spotless/pull/2373))
 ### Fixed
 * You can now use `removeUnusedImports` and `googleJavaFormat` at the same time again. (fixes [#2159](https://github.com/diffplug/spotless/issues/2159))
 * The default list of type annotations used by `formatAnnotations` now includes Jakarta Validation's `Valid` and constraints validations (fixes [#2334](https://github.com/diffplug/spotless/issues/2334))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -8,6 +8,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `jackson` version to latest `2.18.0` -> `2.18.1`. ([#2319](https://github.com/diffplug/spotless/pull/2319))
 * Bump default `ktfmt` version to latest `0.52` -> `0.53`. ([#2320](https://github.com/diffplug/spotless/pull/2320))
 * Bump default `ktlint` version to latest `1.4.0` -> `1.5.0`. ([#2354](https://github.com/diffplug/spotless/pull/2354))
+* Bump minimum `eclipse-cdt` version to `11.0` (removed support for `10.7`). ([#2373](https://github.com/diffplug/spotless/pull/2373))
 ### Fixed
 * You can now use `removeUnusedImports` and `googleJavaFormat` at the same time again. (fixes [#2159](https://github.com/diffplug/spotless/issues/2159))
 * The default list of type annotations used by `formatAnnotations` now includes Jakarta Validation's `Valid` and constraints validations (fixes [#2334](https://github.com/diffplug/spotless/issues/2334))


### PR DESCRIPTION
CDT 10.7 has been archived by Eclipse.org, so it is now hard to download. Bumping min to 11.0