### PR TITLE
feat(#2395): adopt maven plugin development from gradle x

### DIFF
--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -107,17 +107,22 @@ model {
 				artifactId project.ext.artifactId
 				version project.version
 
+				def projectExtArtifactId = project.ext.artifactId
+				def projectDescription = project.description
+				def projectOrg = project.org
+				def rootProjectName = rootProject.name
+
 				pom.withXml {
 					// add MavenCentral requirements to the POM
 					asNode().children().last() + {
 						resolveStrategy = Closure.DELEGATE_FIRST
-						name project.ext.artifactId
-						description project.description
-						url "https://github.com/${project.org}/${rootProject.name}"
+						name projectExtArtifactId
+						description projectDescription
+						url "https://github.com/${projectOrg}/${rootProjectName}"
 						scm {
-							url "https://github.com/${project.org}/${rootProject.name}"
-							connection "scm:git:https://github.com/${project.org}/${rootProject.name}.git"
-							developerConnection "scm:git:ssh:git@github.com/${project.org}/${rootProject.name}.git"
+							url "https://github.com/${projectOrg}/${rootProjectName}"
+							connection "scm:git:https://github.com/${projectOrg}/${rootProjectName}.git"
+							developerConnection "scm:git:ssh:git@github.com/${projectOrg}/${rootProjectName}.git"
 						}
 						licenses {
 							if (isExt) {
@@ -188,13 +193,12 @@ if (System.env['JITPACK'] == 'true' || version.endsWith('-SNAPSHOT')) {
 		dependsOn changelogTasks.named('changelogCheck')
 	}
 	// ensures that changelog bump and push only happens if the publish was successful
-	def thisProj = project
 	changelogTasks.named('changelogBump').configure {
-		dependsOn ":${thisProj.path}:publishPluginMavenPublicationToSonatypeRepository"
+		dependsOn project.path + ":publishPluginMavenPublicationToSonatypeRepository"
 		dependsOn ":closeAndReleaseSonatypeStagingRepository"
 		// if we have a Gradle plugin, we need to push it up to the plugin portal too
-		if (thisProj.tasks.names.contains('publishPlugins')) {
-			dependsOn thisProj.tasks.named('publishPlugins')
+		if (project.tasks.names.contains('publishPlugins')) {
+			dependsOn project.tasks.named('publishPlugins')
 		}
 	}
 }

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -1,9 +1,9 @@
-import de.benediktritter.maven.plugin.development.task.GenerateHelpMojoSourcesTask
-import de.benediktritter.maven.plugin.development.task.GenerateMavenPluginDescriptorTask
+import org.gradlex.maven.plugin.development.task.GenerateHelpMojoSourcesTask
+import org.gradlex.maven.plugin.development.task.GenerateMavenPluginDescriptorTask
 
 plugins {
-	// https://www.benediktritter.de/maven-plugin-development/#release-history
-	id 'de.benediktritter.maven-plugin-development' version '0.4.3'
+	// https://github.com/gradlex-org/maven-plugin-development
+	id 'org.gradlex.maven-plugin-development' version '1.0.3'
 }
 
 apply from: rootProject.file('gradle/changelog.gradle')

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -19,13 +19,6 @@ mavenPlugin {
 	description = project.description
 }
 
-tasks.withType(GenerateMavenPluginDescriptorTask).configureEach {
-	notCompatibleWithConfigurationCache('https://github.com/britter/maven-plugin-development/issues/8')
-}
-tasks.withType(GenerateHelpMojoSourcesTask).configureEach {
-	notCompatibleWithConfigurationCache('https://github.com/britter/maven-plugin-development/issues/8')
-}
-
 String VER_MAVEN_API = '3.0'
 String VER_ECLIPSE_AETHER = '1.1.0'
 String VER_PLEXUS_RESOURCES = '1.3.0'


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
