### PR TITLE
feat: allow overriding classloader (to enable cli)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,9 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
 * Support for`clang-format` on maven-plugin ([#2406](https://github.com/diffplug/spotless/pull/2406))
+* Allow overriding classLoader for all `JarState`s to enable spotless-cli ([#xxx](https://github.com/diffplug/spotless/pull/XXX))
 
 ## [3.0.2] - 2025-01-14
 ### Fixed

--- a/lib/src/test/java/com/diffplug/spotless/JarStateTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/JarStateTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JarStateTest {
+
+	@TempDir
+	java.nio.file.Path tempDir;
+
+	File a;
+
+	File b;
+
+	Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(name -> name.equals("a") ? a : b).collect(Collectors.toSet());
+
+	@BeforeEach
+	void setUp() throws IOException {
+		a = Files.createTempFile(tempDir, "a", ".class").toFile();
+		Files.writeString(a.toPath(), "a");
+		b = Files.createTempFile(tempDir, "b", ".class").toFile();
+		Files.writeString(b.toPath(), "b");
+	}
+
+	@AfterEach
+	void tearDown() {
+		JarState.setForcedClassLoader(null);
+	}
+
+	@Test
+	void itCreatesClassloaderWhenForcedClassLoaderNotSet() throws IOException {
+		JarState state1 = JarState.from(a.getName(), provisioner);
+		JarState state2 = JarState.from(b.getName(), provisioner);
+
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(state1.getClassLoader()).isNotNull();
+			softly.assertThat(state2.getClassLoader()).isNotNull();
+		});
+	}
+
+	@Test
+	void itReturnsForcedClassloaderIfSetNoMatterIfSetBeforeOrAfterCreation() throws IOException {
+		JarState stateA = JarState.from(a.getName(), provisioner);
+		ClassLoader forcedClassLoader = new URLClassLoader(new java.net.URL[0]);
+		JarState.setForcedClassLoader(forcedClassLoader);
+		JarState stateB = JarState.from(b.getName(), provisioner);
+
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stateA.getClassLoader()).isSameAs(forcedClassLoader);
+			softly.assertThat(stateB.getClassLoader()).isSameAs(forcedClassLoader);
+		});
+	}
+
+	@Test
+	void itReturnsForcedClassloaderEvenWhenRountripSerialized() throws IOException, ClassNotFoundException {
+		JarState stateA = JarState.from(a.getName(), provisioner);
+		ClassLoader forcedClassLoader = new URLClassLoader(new java.net.URL[0]);
+		JarState.setForcedClassLoader(forcedClassLoader);
+		JarState stateB = JarState.from(b.getName(), provisioner);
+
+		JarState stateARoundtripSerialized = roundtripSerialize(stateA);
+		JarState stateBRoundtripSerialized = roundtripSerialize(stateB);
+
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(stateARoundtripSerialized.getClassLoader()).isSameAs(forcedClassLoader);
+			softly.assertThat(stateBRoundtripSerialized.getClassLoader()).isSameAs(forcedClassLoader);
+		});
+	}
+
+	private JarState roundtripSerialize(JarState state) throws IOException, ClassNotFoundException {
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		try (ObjectOutputStream oOut = new ObjectOutputStream(outputStream)) {
+			oOut.writeObject(state);
+		}
+		try (ObjectInputStream oIn = new ObjectInputStream(new java.io.ByteArrayInputStream(outputStream.toByteArray()))) {
+			return (JarState) oIn.readObject();
+		}
+	}
+
+}


### PR DESCRIPTION
Extracted from #2419: Allow to override classloader in JarState to enable native-compiled `spotless-cli` to use dynamically loaded formatters like GJF.
