### PR TITLE
Use palantir-java-format 2.57.0 on Java 21

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
 * Use palantir-java-format 2.57.0 on Java 21. ([#2447](https://github.com/diffplug/spotless/pull/2447))
 
 ## [3.1.0] - 2025-02-20

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Use palantir-java-format 2.57.0 on Java 21. ([#2447](https://github.com/diffplug/spotless/pull/2447))
 
 ## [3.1.0] - 2025-02-20
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -29,7 +29,7 @@ public class PalantirJavaFormatStep implements Serializable {
 	private static final String DEFAULT_STYLE = "PALANTIR";
 	private static final String NAME = "palantir-java-format";
 	public static final String MAVEN_COORDINATE = "com.palantir.javaformat:palantir-java-format:";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.39.0");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(8, "1.1.0").add(11, "2.28.0").add(21, "2.57.0");
 
 	/** The jar that contains the formatter. */
 	private final JarState.Promised jarState;

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Use palantir-java-format 2.57.0 on Java 21. ([#2447](https://github.com/diffplug/spotless/pull/2447))
 
 ## [7.0.2] - 2025-01-14
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changed
 * Use palantir-java-format 2.57.0 on Java 21. ([#2447](https://github.com/diffplug/spotless/pull/2447))
 
 ## [7.0.2] - 2025-01-14

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changed
 * Use palantir-java-format 2.57.0 on Java 21. ([#2447](https://github.com/diffplug/spotless/pull/2447))
 
 ## [2.44.3] - 2025-02-20

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Use palantir-java-format 2.57.0 on Java 21. ([#2447](https://github.com/diffplug/spotless/pull/2447))
 
 ## [2.44.3] - 2025-02-20
 * Support for `clang-format` ([#2406](https://github.com/diffplug/spotless/pull/2406))

--- a/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
@@ -56,7 +56,7 @@ class PalantirJavaFormatStepTest extends ResourceHarness {
 
 	@Test
 	void formatJavadoc() throws Exception {
-		FormatterStep step = PalantirJavaFormatStep.create("2.39.0", "PALANTIR", true, TestProvisioner.mavenCentral());
+		FormatterStep step = PalantirJavaFormatStep.create("2.57.0", "PALANTIR", true, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("java/palantirjavaformat/JavaCodeWithJavaDocUnformatted.test", "java/palantirjavaformat/JavaCodeWithJavaDocFormatted.test")
 				.testResource("java/palantirjavaformat/JavaCodeWithPackageUnformatted.test", "java/palantirjavaformat/JavaCodeWithPackageFormatted.test");


### PR DESCRIPTION
Updates the Palantir Java formatter to version `2.57.0` for improved code formatting for Java 21

ref: https://github.com/palantir/palantir-java-format/issues/952 and https://github.com/palantir/palantir-java-format/pull/1211