### PR TITLE
Apply Gradle's strict plugin types validation to the Spotless plugin in preparation for Gradle 9.0

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Changed
 * Use palantir-java-format 2.57.0 on Java 21. ([#2447](https://github.com/diffplug/spotless/pull/2447))
 * Re-try `npm install` with `--prefer-online` after `ERESOLVE` error. ([#2448](https://github.com/diffplug/spotless/pull/2448))
+* Apply Gradle's strict plugin types validation to the Spotless plugin. ([#2454](https://github.com/diffplug/spotless/pull/2454))
 
 ## [7.0.2] - 2025-01-14
 ### Fixed

--- a/plugin-gradle/build.gradle
+++ b/plugin-gradle/build.gradle
@@ -33,6 +33,9 @@ apply from: rootProject.file('gradle/special-tests.gradle')
 tasks.withType(Test).configureEach {
 	testLogging.showStandardStreams = true
 }
+tasks.validatePlugins {
+	enableStricterValidation = true
+}
 
 //////////////////////////
 // GRADLE PLUGIN PORTAL //

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessApply.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,9 @@ import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 
+@DisableCachingByDefault(because = "not worth caching")
 public abstract class SpotlessApply extends SpotlessTaskService.ClientTask {
 	@TaskAction
 	public void performAction() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,14 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import org.jetbrains.annotations.NotNull;
 
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.ThrowingEx;
 import com.diffplug.spotless.extra.integration.DiffMessageFormatter;
 
+@DisableCachingByDefault(because = "not worth caching")
 public abstract class SpotlessCheck extends SpotlessTaskService.ClientTask {
 	@Internal
 	public abstract Property<String> getEncoding();

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessDiagnoseTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,14 @@ import java.util.Locale;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.UntrackedTask;
 
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.PaddedCell;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@UntrackedTask(because = "undeclared inputs/outputs")
 public class SpotlessDiagnoseTask extends DefaultTask {
 	SpotlessTask source;
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.work.DisableCachingByDefault;
 import org.gradle.work.Incremental;
 
 import com.diffplug.spotless.ConfigurationCacheHackList;
@@ -43,6 +44,7 @@ import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.LintSuppression;
 import com.diffplug.spotless.extra.GitRatchet;
 
+@DisableCachingByDefault(because = "abstract definition")
 public abstract class SpotlessTask extends DefaultTask {
 	@Internal
 	abstract Property<SpotlessTaskService> getTaskService();


### PR DESCRIPTION
Enable Gradle Plugin types strict validation by the :gradle-plugin:validatePlugins task. `ValidatePlugins` checks property annotations on work items like tasks and artifact transforms. Stricter validation adds forward-moving rules that will be promoted to regular validation. Most often in the next Gradle major version. With Gradle 9.0 coming soon, it's time to move forward. Having a release of the stopless plugin with these fixes before Gradle 9.0 will ensure a smooth transition for users.

This commit adds the missing mandatory cacheability annotations reported by the stricter rules on SpotlessTask, SpotlessApply, SpotlessCheck and SpotlessDiagnoseTask.
