### PR TITLE
feat: add execution ID parameter to SpotlessCheckMojo

### DIFF
--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -63,6 +63,12 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 	@Parameter(defaultValue = "WARNING")
 	private MessageSeverity m2eIncrementalBuildMessageSeverity;
 
+	/**
+	 * The execution ID from Maven's configuration.
+	 */
+	@Parameter(defaultValue = "${mojoExecution.executionId}")
+	private String executionId;
+
 	@Override
 	protected void process(String name, Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
 		ImpactedFilesTracker counter = new ImpactedFilesTracker();
@@ -104,8 +110,14 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 		}
 
 		if (!problemFiles.isEmpty()) {
+			final String runToFixMessage;
+			if (executionId != null && !executionId.isEmpty() && !executionId.equals("default-cli")) {
+				runToFixMessage = "Run 'mvn spotless:apply@" + executionId + "' to fix these violations.";
+			} else {
+				runToFixMessage = "Run 'mvn spotless:apply' to fix these violations.";
+			}
 			throw new MojoExecutionException(DiffMessageFormatter.builder()
-					.runToFix("Run 'mvn spotless:apply' to fix these violations.")
+					.runToFix(runToFixMessage)
 					.formatter(baseDir.toPath(), formatter)
 					.problemFiles(problemFiles)
 					.getMessage());

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
@@ -65,10 +65,18 @@ class SpotlessCheckMojoTest extends MavenIntegrationHarness {
 				null,
 				null);
 
-		testSpotlessCheck(UNFORMATTED_FILE, "verify", true);
+		testSpotlessCheck(UNFORMATTED_FILE, "verify", "check");
 	}
 
 	private void testSpotlessCheck(String fileName, String command, boolean expectError) throws Exception {
+		testSpotlessCheck(fileName, command, expectError, "");
+	}
+
+	private void testSpotlessCheck(String fileName, String command, String expectedFailingExecutionId) throws Exception {
+		testSpotlessCheck(fileName, command, true, "@" + expectedFailingExecutionId);
+	}
+
+	private void testSpotlessCheck(String fileName, String command, boolean expectError, String expectedExecutionId) throws Exception {
 		setFile("license.txt").toResource("license/TestLicense");
 		setFile("src/main/java/com.github.youribonnaffe.gradle.format/Java8Test.java").toResource(fileName);
 
@@ -76,7 +84,9 @@ class SpotlessCheckMojoTest extends MavenIntegrationHarness {
 
 		if (expectError) {
 			ProcessRunner.Result result = mavenRunner.runHasError();
-			assertThat(result.stdOutUtf8()).contains("The following files had format violations");
+			String stdOutUtf8 = result.stdOutUtf8();
+			assertThat(stdOutUtf8).contains("The following files had format violations");
+			assertThat(stdOutUtf8).contains("Run 'mvn spotless:apply" + expectedExecutionId + "' to fix these violations.");
 		} else {
 			mavenRunner.runNoError();
 		}


### PR DESCRIPTION
for improved error messaging, issue #1988

- Introduced a new parameter `executionId` to capture the execution ID from Maven's configuration.
- Updated error messages to include the execution ID when suggesting commands to fix format violations.
- Enhanced test cases to validate the new behavior of error messages based on the execution ID.

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
