### PR TITLE
fix(FormatExtension/Gradle): Fix step setup with `toggleFence` and `targetExcludeContentPattern`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix `UnsupportedOperationException` in the Gradle plugin when using `targetExcludeContent[Pattern]` ([#2487](https://github.com/diffplug/spotless/pull/2487))
 ### Changed
 * Bump default `eclipse` version to latest `4.34` -> `4.35`. ([#2458](https://github.com/diffplug/spotless/pull/2458))
 * Bump default `greclipse` version to latest `4.32` -> `4.35`. ([#2458](https://github.com/diffplug/spotless/pull/2458))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Fix `UnsupportedOperationException` in the Gradle plugin when using `targetExcludeContent[Pattern]` ([#2487](https://github.com/diffplug/spotless/pull/2487))
 ### Changed
 * Bump default `eclipse` version to latest `4.34` -> `4.35`. ([#2458](https://github.com/diffplug/spotless/pull/2458))
 * Bump default `greclipse` version to latest `4.32` -> `4.35`. ([#2458](https://github.com/diffplug/spotless/pull/2458))

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -1061,7 +1061,9 @@ public class FormatExtension {
 		task.setTarget(totalTarget);
 		List<FormatterStep> steps;
 		if (toggleFence != null) {
-			steps = List.of(toggleFence.preserveWithin(this.steps));
+			// need a mutable List, 'steps' is mutated by 'steps.replaceAll()' below
+			steps = new ArrayList<>();
+			steps.add(toggleFence.preserveWithin(this.steps));
 		} else {
 			steps = this.steps;
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
@@ -80,4 +80,56 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 		gradleRunner().withArguments("spotlessApply").build();
 		assertFile("src/main/java/test.java").sameAsResource("java/removeunusedimports/Jdk17TextBlockFormatted.test");
 	}
+
+	/**
+	 * Triggers the special case in {@link FormatExtension#setupTask(SpotlessTask)} with {@code toggleFence} and
+	 * {@code targetExcludeContentPattern} both being not {@code null}.
+	 */
+	@Test
+	void fenceWithTargetExcludeNoMatch() throws Exception {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"  id 'com.diffplug.spotless'",
+				"  id 'java'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"  java {" +
+				"    licenseHeader('// my-copyright')",
+				"    toggleOffOn()",
+				"    targetExcludeIfContentContains('excludeMe')",
+				"  }",
+				"}");
+
+		setFile("src/main/java/test.java").toResource("java/targetExclude/TargetExcludeNoMatchUnformatted.test");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/java/test.java").sameAsResource("java/targetExclude/TargetExcludeNoMatchFormatted.test");
+	}
+
+	/**
+	 * Triggers the special case in {@link FormatExtension#setupTask(SpotlessTask)} with {@code toggleFence} and
+	 * {@code targetExcludeContentPattern} both being not {@code null}.
+	 */
+	@Test
+	void fenceWithTargetExcludeMatch() throws Exception {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"  id 'com.diffplug.spotless'",
+				"  id 'java'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"  java {" +
+				"    licenseHeader('// my-copyright')",
+				"    toggleOffOn()",
+				"    targetExcludeIfContentContains('excludeMe')",
+				"  }",
+				"}");
+
+		setFile("src/main/java/test.java").toResource("java/targetExclude/TargetExcludeMatch.test");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/java/test.java").sameAsResource("java/targetExclude/TargetExcludeMatch.test");
+	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 				"repositories { mavenCentral() }",
 				"",
 				"spotless {",
-				"  java {" +
+				"  java {",
 				"    licenseHeader('// my-copyright')",
 				"    toggleOffOn()",
 				"    targetExcludeIfContentContains('excludeMe')",
@@ -121,7 +121,7 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 				"repositories { mavenCentral() }",
 				"",
 				"spotless {",
-				"  java {" +
+				"  java {",
 				"    licenseHeader('// my-copyright')",
 				"    toggleOffOn()",
 				"    targetExcludeIfContentContains('excludeMe')",

--- a/testlib/src/main/resources/java/targetExclude/TargetExcludeMatch.test
+++ b/testlib/src/main/resources/java/targetExclude/TargetExcludeMatch.test
@@ -1,0 +1,4 @@
+// excludeMe
+import foo.Bar;
+
+class Bar {}

--- a/testlib/src/main/resources/java/targetExclude/TargetExcludeNoMatchFormatted.test
+++ b/testlib/src/main/resources/java/targetExclude/TargetExcludeNoMatchFormatted.test
@@ -1,0 +1,4 @@
+// my-copyright
+import foo.Bar;
+
+class Bar {}

--- a/testlib/src/main/resources/java/targetExclude/TargetExcludeNoMatchUnformatted.test
+++ b/testlib/src/main/resources/java/targetExclude/TargetExcludeNoMatchUnformatted.test
@@ -1,0 +1,3 @@
+import foo.Bar;
+
+class Bar {}


### PR DESCRIPTION
With a non-null `toggleFence`, `com.diffplug.gradle.spotless.FormatExtension#setupTask` creates a new `List` via `List.of()`. Also having a non-null `targetExcludeContentPattern` leads to an `UnsupportedOperationException` thrown by `List.replaceAll`, because `List.of` yields an immutable list.

The issue is reproducible via:
```kotlin
spotless {
  java {
    licenseHeader('// my-copyright')
    toggleOffOn() // adds the 'toggleFence'
    targetExcludeIfContentContains('excludeMe') // adds the 'targetExcludeContentPattern'
  }
```

Change includes (integeration) tests.