### PR TITLE
✨ feat(scalafmt): enforce version consistency between library and config file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Changed
+* scalafmt: enforce version consistency between the version configured in Spotless and the version declared in Scalafmt config file ([#2460](https://github.com/diffplug/spotless/issues/2460))
+
 ## [3.1.2] - 2025-05-27
 ### Fixed
 * Fix `UnsupportedOperationException` in the Gradle plugin when using `targetExcludeContent[Pattern]` ([#2487](https://github.com/diffplug/spotless/pull/2487))

--- a/lib/src/scalafmt/java/com/diffplug/spotless/glue/scalafmt/ScalafmtFormatterFunc.java
+++ b/lib/src/scalafmt/java/com/diffplug/spotless/glue/scalafmt/ScalafmtFormatterFunc.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.scalafmt.Scalafmt;
+import org.scalafmt.Versions;
 import org.scalafmt.config.ScalafmtConfig;
 import org.scalafmt.config.ScalafmtConfig$;
 
@@ -44,6 +45,16 @@ public class ScalafmtFormatterFunc implements FormatterFunc.NeedsFile {
 			File file = configSignature.getOnlyFile();
 			String configStr = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 			config = Scalafmt.parseHoconConfig(configStr).get();
+		}
+
+		// This check is to raise awareness to the user that the version of the config file is currently not used.
+		// Context: https://github.com/diffplug/spotless/issues/2460
+		// This check should be removed when Spotless dynamically loads the proper version of the Scalafmt library.
+		String scalafmtLibraryVersion = Versions.version();
+		if (!config.version().equals(scalafmtLibraryVersion)) {
+			throw new IllegalArgumentException(
+				"Spotless is using " + scalafmtLibraryVersion + " but the config file declares " + config.version() +
+					". Both must match. Update the version declared in the plugin's settings and/or the config file.");
 		}
 	}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Changed
+* scalafmt: enforce version consistency between the version configured in Spotless and the version declared in Scalafmt config file ([#2460](https://github.com/diffplug/spotless/issues/2460))
+
 ## [7.0.4] - 2025-05-27
 ### Fixed
 * Fix `UnsupportedOperationException` in the Gradle plugin when using `targetExcludeContent[Pattern]` ([#2487](https://github.com/diffplug/spotless/pull/2487))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Changed
+* scalafmt: enforce version consistency between the version configured in Spotless and the version declared in Scalafmt config file ([#2460](https://github.com/diffplug/spotless/issues/2460))
+
 ## [2.44.5] - 2025-05-27
 ### Changed
 * Bump default `eclipse` version to latest `4.34` -> `4.35`. ([#2458](https://github.com/diffplug/spotless/pull/2458))


### PR DESCRIPTION
Closes #2460

As suggested in https://github.com/diffplug/spotless/issues/2460#issuecomment-2785070757, this is a first step to raise awareness to users that the version declared in the config file is not used.

We might work on dynamically loading the right Scalafmt JAR in another PR.
