### PR TITLE
Remove wildcard imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Added support for removing wildcard imports via `removeWildcardImports` step. ([#649](https://github.com/diffplug/spotless/issues/649))
 
 ## [3.1.2] - 2025-05-27
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/java/RemoveWildcardImportsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/RemoveWildcardImportsStep.java
@@ -1,0 +1,17 @@
+package com.diffplug.spotless.java;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.generic.ReplaceRegexStep;
+
+/** Removes any wildcard import statements. */
+public final class RemoveWildcardImportsStep {
+	private RemoveWildcardImportsStep() {}
+
+	public static FormatterStep create() {
+		// matches lines like 'import foo.*;' or 'import static foo.*;'
+		return ReplaceRegexStep.create(
+			"removeWildcardImports",
+			"(?m)^import\\s+(?:static\\s+)?[^;\\n]*\\*;\\R?",
+			"");
+	}
+}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+* Added `removeWildcardImports()` step for Java, removing wildcard import statements. ([#649](https://github.com/diffplug/spotless/issues/649))
 
 ## [7.0.4] - 2025-05-27
 ### Fixed

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -188,6 +188,7 @@ spotless {
     importOrderFile('eclipse-import-order.txt') // import order file as exported from eclipse
 
     removeUnusedImports()
+    removeWildcardImports()
 
     // Cleanthat will refactor your code, but it may break your style: apply it before your formatter
     cleanthat()          // has its own section below
@@ -225,6 +226,16 @@ spotless {
   // optional: you may switch for `google-java-format` as underlying engine to `cleanthat-javaparser-unnecessaryimport`
   // which enables processing any language level source file with a JDK8+ Runtime
   removeUnusedImports('cleanthat-javaparser-unnecessaryimport')
+```
+
+### removeWildcardImports
+
+```
+spotless {
+  java {
+  removeWildcardImports()
+  }
+}
 ```
 
 ### google-java-format

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -40,6 +40,7 @@ import com.diffplug.spotless.java.FormatAnnotationsStep;
 import com.diffplug.spotless.java.GoogleJavaFormatStep;
 import com.diffplug.spotless.java.ImportOrderStep;
 import com.diffplug.spotless.java.PalantirJavaFormatStep;
+import com.diffplug.spotless.java.RemoveWildcardImportsStep;
 import com.diffplug.spotless.java.RemoveUnusedImportsStep;
 
 public class JavaExtension extends FormatExtension implements HasBuiltinDelimiterForLicense, JvmLang {
@@ -149,6 +150,10 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 	public void removeUnusedImports(String formatter) {
 		addStep(RemoveUnusedImportsStep.create(formatter, provisioner()));
+	}
+
+	public void removeWildcardImports() {
+		addStep(RemoveWildcardImportsStep.create());
 	}
 
 	/** Uses the <a href="https://github.com/google/google-java-format">google-java-format</a> jar to format source code. */

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,7 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Added `<removeWildcardImports />` step for Java, removing wildcard import statements. ([#649](https://github.com/diffplug/spotless/issues/649))
 
 ## [2.44.5] - 2025-05-27
 ### Changed

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -210,6 +210,7 @@ any other maven phase (i.e. compile) then it can be configured as below;
     </importOrder>
 
     <removeUnusedImports /> <!-- self-explanatory -->
+    <removeWildcardImports /> <!-- drop any import ending with '*' -->
 
     <formatAnnotations />  <!-- fixes formatting of type annotations, see below -->
 
@@ -226,6 +227,12 @@ any other maven phase (i.e. compile) then it can be configured as below;
 <removeUnusedImports>
   <engine>google-java-format</engine>    <!-- optional. Defaults to `google-java-format`. Can be switched to `cleanthat-javaparser-unnecessaryimport` (e.g. to process JDK17 source files with a JDK8+ Runtime) -->
 </removeUnusedImports>
+```
+
+### removeWildcardImports
+
+```xml
+<removeWildcardImports/>
 ```
 
 ### google-java-format

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Java.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Java.java
@@ -76,6 +76,10 @@ public class Java extends FormatterFactory {
 		addStepFactory(removeUnusedImports);
 	}
 
+	public void addRemoveWildcardImports(RemoveWildcardImports removeWildcardImports) {
+		addStepFactory(removeWildcardImports);
+	}
+
 	public void addFormatAnnotations(FormatAnnotations formatAnnotations) {
 		addStepFactory(formatAnnotations);
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/RemoveWildcardImports.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/RemoveWildcardImports.java
@@ -1,0 +1,13 @@
+package com.diffplug.spotless.maven.java;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.java.RemoveWildcardImportsStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+
+public class RemoveWildcardImports implements FormatterStepFactory {
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig config) {
+		return RemoveWildcardImportsStep.create();
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveWildcardImportsStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveWildcardImportsStepTest.java
@@ -1,0 +1,18 @@
+package com.diffplug.spotless.maven.java;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+class RemoveWildcardImportsStepTest extends MavenIntegrationHarness {
+
+	@Test
+	void testRemoveWildcardImports() throws Exception {
+		writePomWithJavaSteps("<removeWildcardImports/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/removewildcardimports/JavaCodeWildcardsUnformatted.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/removewildcardimports/JavaCodeWildcardsFormatted.test");
+	}
+}

--- a/testlib/src/main/resources/java/removewildcardimports/JavaCodeWildcardsFormatted.test
+++ b/testlib/src/main/resources/java/removewildcardimports/JavaCodeWildcardsFormatted.test
@@ -1,0 +1,4 @@
+import java.util.List;
+import mylib.Helper;
+
+public class Test {}

--- a/testlib/src/main/resources/java/removewildcardimports/JavaCodeWildcardsUnformatted.test
+++ b/testlib/src/main/resources/java/removewildcardimports/JavaCodeWildcardsUnformatted.test
@@ -1,0 +1,6 @@
+import java.util.*;
+import static java.util.Collections.*;
+import java.util.List;
+import mylib.Helper;
+
+public class Test {}


### PR DESCRIPTION

I have just opened a PR to help us say “goodbye” to those sneaky wildcard imports (like import java.util.*;) whenever Spotless tidies up our Java files. Wildcard imports can make it hard to see exactly which classes you’re relying on, so this change introduces a new <removeWildcardImports/> step in the Spotless plugin that:

Spots any import foo.*; lines in your source

Removes them outright (so your IDE or build tools can regenerate only the exact imports you need)

[Add remove wildcards imports when formating and ordering imports. #649](https://github.com/diffplug/spotless/issues/649)
[Unused wildcard imports aren’t removed (needed to block import foo.*;) #240](https://github.com/diffplug/spotless/issues/240)
[How to block import-star (*) wildcards in the Maven/Eclipse JDT formatter #832](https://github.com/diffplug/spotless/issues/832)