### PR TITLE
Call `getProperty` can be simplified for `line.separator`

### DIFF
--- a/lib-extra/src/groovy/java/com/diffplug/spotless/extra/glue/groovy/GrEclipseFormatterStepImpl.java
+++ b/lib-extra/src/groovy/java/com/diffplug/spotless/extra/glue/groovy/GrEclipseFormatterStepImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.diffplug.spotless.extra.glue.groovy;
+
+import static java.lang.System.lineSeparator;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -143,7 +145,7 @@ public class GrEclipseFormatterStepImpl {
 			}
 			for (Throwable error : errors) {
 				error.printStackTrace();
-				string.append(System.lineSeparator());
+				string.append(lineSeparator());
 				string.append(error.getMessage());
 			}
 

--- a/lib/src/main/java/com/diffplug/spotless/Jvm.java
+++ b/lib/src/main/java/com/diffplug/spotless/Jvm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.diffplug.spotless;
+
+import static java.lang.System.lineSeparator;
 
 import java.io.File;
 import java.util.Arrays;
@@ -255,7 +257,7 @@ public final class Jvm {
 		public String toString() {
 			return String.format("%s alternatives:%n", fmtName) +
 					jvm2fmtMaxVersion.entrySet().stream().map(
-							e -> String.format("- Version %s requires JVM %d+", e.getValue(), e.getKey())).collect(Collectors.joining(System.lineSeparator()));
+							e -> String.format("- Version %s requires JVM %d+", e.getValue(), e.getKey())).collect(Collectors.joining(lineSeparator()));
 		}
 
 		@SuppressFBWarnings("SE_COMPARATOR_SHOULD_BE_SERIALIZABLE")

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.diffplug.spotless;
+
+import static java.lang.System.lineSeparator;
 
 import java.io.File;
 import java.io.FileReader;
@@ -151,7 +153,7 @@ public enum LineEnding {
 	private static final Policy UNIX_POLICY = new ConstantLineEndingPolicy(UNIX.str());
     private static final Policy MAC_CLASSIC_POLICY = new ConstantLineEndingPolicy(MAC_CLASSIC.str());
     private static final Policy PRESERVE_POLICY = new PreserveLineEndingPolicy();
-	private static final String _platformNative = System.getProperty("line.separator");
+	private static final String _platformNative = lineSeparator();
 	private static final Policy _platformNativePolicy = new ConstantLineEndingPolicy(_platformNative);
 	private static final boolean nativeIsWin = _platformNative.equals(WINDOWS.str());
 

--- a/lib/src/main/java/com/diffplug/spotless/groovy/RemoveSemicolonsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/groovy/RemoveSemicolonsStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.diffplug.spotless.groovy;
+
+import static java.lang.System.lineSeparator;
 
 import java.io.BufferedReader;
 import java.io.Serializable;
@@ -51,7 +53,7 @@ public final class RemoveSemicolonsStep implements Serializable {
 					String line;
 					while ((line = reader.readLine()) != null) {
 						result.append(removeSemicolon(line));
-						result.append(System.lineSeparator());
+						result.append(lineSeparator());
 					}
 					return result.toString();
 				}

--- a/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
+++ b/lib/src/main/java/com/diffplug/spotless/pom/SortPomCfg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.pom;
 
+import static java.lang.System.lineSeparator;
+
 import java.io.Serializable;
 
 // Class and members must be public, otherwise we get failed to access class com.diffplug.spotless.pom.SortPomInternalState from class com.diffplug.spotless.pom.SortPomFormatterFunc (com.diffplug.spotless.pom.SortPomInternalState is in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @682bd3c4; com.diffplug.spotless.pom.SortPomFormatterFunc is in unnamed module of loader com.diffplug.spotless.pom.DelegatingClassLoader @573284a5)
@@ -25,7 +27,7 @@ public class SortPomCfg implements Serializable {
 
 	public String encoding = "UTF-8";
 
-	public String lineSeparator = System.getProperty("line.separator");
+	public String lineSeparator = lineSeparator();
 
 	public boolean expandEmptyElements = true;
 

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.diffplug.spotless.sql.dbeaver;
+
+import static java.lang.System.lineSeparator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,7 +69,7 @@ public class SQLTokenizedFormatter {
 		}
 
 		if (isSqlEndsWithNewLine) {
-			after.append(getDefaultLineSeparator());
+			after.append(lineSeparator());
 		}
 
 		return after.toString();
@@ -388,15 +390,11 @@ public class SQLTokenizedFormatter {
 		return sqlDialect.getKeywordType(name) == DBPKeywordType.FUNCTION;
 	}
 
-	private static String getDefaultLineSeparator() {
-		return System.getProperty("line.separator", "\n");
-	}
-
 	private int insertReturnAndIndent(final List<FormatterToken> argList, final int argIndex, final int argIndent) {
 		if (functionBracket.contains(Boolean.TRUE))
 			return 0;
 		try {
-			final String defaultLineSeparator = getDefaultLineSeparator();
+			final String defaultLineSeparator = lineSeparator();
 			StringBuilder s = new StringBuilder(defaultLineSeparator);
 			for (int index = 0; index < argIndent; index++) {
 				s.append(formatterCfg.getIndentString());


### PR DESCRIPTION
Call `getProperty` can be simplified for `line.separator`.

discovering by:

- https://github.com/diffplug/spotless/pull/2520