### PR TITLE
feat: Add `ReplaceObsoletesStep`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Add support for removing wildcard imports via `removeWildcardImports` step. ([#2517](https://github.com/diffplug/spotless/pull/2517))
+* Add support for removing generic obsoletes imports via `replaceObsoletes` step. ([#2530](https://github.com/diffplug/spotless/pull/2530))
 
 ## [3.1.2] - 2025-05-27
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/generic/ReplaceObsoletesStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/ReplaceObsoletesStep.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2025 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.generic;
+
+import static java.util.regex.Pattern.MULTILINE;
+import static java.util.regex.Pattern.compile;
+
+import java.io.File;
+
+import com.diffplug.spotless.FormatterStep;
+
+public final class ReplaceObsoletesStep implements FormatterStep {
+
+	private static final long serialVersionUID = -6643164760547140534L;
+
+	private ReplaceObsoletesStep() {}
+
+	public static FormatterStep forJava() {
+		return new ReplaceObsoletesStep();
+	}
+
+	@Override
+	public String getName() {
+		return "replaceObsoletes";
+	}
+
+	@Override
+	public String format(String rawUnix, File file) throws Exception {
+		return removeRedundantAbstractInInterfaces(
+				removeRedundantPublicStaticInEnumsAndInterfaces(
+						removeRedundantInitializations("float|double", "0(?:\\.0)?(?:f|d)?",
+								removeRedundantInitializations("int|long|short|byte", "0(?:L)?",
+										removeRedundantInitializations("String|\\w+", "null",
+												removeRedundantInitializations("boolean", "false",
+														replaceLineSeparator(rawUnix)))))));
+	}
+
+	private static String replaceLineSeparator(String input) {
+		return compile(
+				"System\\.getProperty\\(\"line\\.separator\"(?:\\s*,\\s*\"\\\\n\")?\\)|" +
+						"String\\s+\\w+\\s*=\\s*System\\.getProperty\\(\"line\\.separator\"(?:\\s*,\\s*\"\\\\n\")?\\)\\s*;",
+				MULTILINE)
+				.matcher(input)
+				.replaceAll(match -> match.group().contains("String")
+						? "String " + match.group().split("\\s+")[1].split("=")[0].trim() + " = System.lineSeparator();"
+						: "System.lineSeparator()");
+	}
+
+	private String removeRedundantInitializations(String typePattern, String defaultValuePattern, String input) {
+		return compile(
+				"([a-zA-Z]+\\s+(?:" + typePattern + ")\\s+\\w+)\\s*=\\s*" + defaultValuePattern + "\\s*;",
+				MULTILINE)
+				.matcher(input)
+				.replaceAll("$1;");
+	}
+
+	private String removeRedundantPublicStaticInEnumsAndInterfaces(String input) {
+		// Handle enum constants
+		String processed = compile(
+				"(enum\\s+\\w+\\s*\\{[^}]*?)(public\\s+static\\s+)(\\w+\\s*,\\s*|\\w+\\s*;)",
+				MULTILINE)
+				.matcher(input)
+				.replaceAll("$1$3");
+
+		// Handle enum methods
+		processed = compile(
+				"(enum\\s+\\w+\\s*\\{[^}]*?)(public\\s+static\\s+)(\\w+\\s+\\w+\\s*\\([^)]*\\)\\s*(?:throws\\s+[\\w.]+(?:\\s*,\\s*[\\w.]+)*\\s*)?\\{)",
+				MULTILINE)
+				.matcher(processed)
+				.replaceAll("$1$3");
+
+		// Handle interface constants - keep 'final' but remove 'public static'
+		processed = compile(
+				"(interface\\s+\\w+\\s*\\{[^}]*?)(public\\s+static\\s+)(final\\s+)(\\w+\\s+\\w+\\s*=)",
+				MULTILINE)
+				.matcher(processed)
+				.replaceAll("$1$3$4");
+
+		// Handle interface methods
+		processed = compile(
+				"(interface\\s+\\w+\\s*\\{[^}]*?)(public\\s+static\\s+)(\\w+\\s+\\w+\\s*\\([^)]*\\)\\s*(?:throws\\s+[\\w.]+(?:\\s*,\\s*[\\w.]+)*\\s*)?;)",
+				MULTILINE)
+				.matcher(processed)
+				.replaceAll("$1$3");
+
+		// Handle interface inner classes
+		processed = compile(
+				"(interface\\s+\\w+\\s*\\{[^}]*?)(public\\s+static\\s+)(class\\s+\\w+\\s*\\{)",
+				MULTILINE)
+				.matcher(processed)
+				.replaceAll("$1$3");
+
+		return processed;
+	}
+
+	private String removeRedundantAbstractInInterfaces(String input) {
+		// Handle abstract methods in interfaces
+		return compile(
+				"(interface\\s+\\w+\\s*\\{[^}]*?)(?:public\\s+)?abstract\\s+(\\w+\\s+\\w+\\s*\\([^)]*\\)\\s*(?:throws\\s+[\\w.]+(?:\\s*,\\s*[\\w.]+)*\\s*)?;)",
+				MULTILINE)
+				.matcher(input)
+				.replaceAll("$1$2");
+	}
+
+	@Override
+	public void close() throws Exception {}
+}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Add support for removing wildcard imports via `removeWildcardImports` step. ([#2517](https://github.com/diffplug/spotless/pull/2517))
+* Add support for removing generic obsoletes imports via `replaceObsoletes` step. ([#2530](https://github.com/diffplug/spotless/pull/2530))
 
 ## [7.0.4] - 2025-05-27
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 * Add support for removing wildcard imports via `removeWildcardImports` step. ([#2517](https://github.com/diffplug/spotless/pull/2517))
+* Add support for removing generic obsoletes imports via `replaceObsoletes` step. ([#2530](https://github.com/diffplug/spotless/pull/2530))
 
 ## [2.44.5] - 2025-05-27
 ### Changed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Java.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Java.java
@@ -80,6 +80,10 @@ public class Java extends FormatterFactory {
 		addStepFactory(removeWildcardImports);
 	}
 
+	public void addReplaceObsoletes(ReplaceObsoletes replaceObsoletes) {
+		addStepFactory(replaceObsoletes);
+	}
+
 	public void addFormatAnnotations(FormatAnnotations formatAnnotations) {
 		addStepFactory(formatAnnotations);
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ReplaceObsoletes.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ReplaceObsoletes.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.java;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.generic.ReplaceObsoletesStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+
+public class ReplaceObsoletes implements FormatterStepFactory {
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig config) {
+		return ReplaceObsoletesStep.forJava();
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ReplaceObsoletesStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ReplaceObsoletesStepTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016-2025 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.java;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+class ReplaceObsoletesStepTest extends MavenIntegrationHarness {
+	@Test
+	void testSortPomCfg() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/SortPomCfgPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/SortPomCfgPost.test");
+	}
+
+	@Test
+	void testSystemLineSeparator() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/SystemLineSeparatorPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/SystemLineSeparatorPost.test");
+	}
+
+	@Test
+	void testBooleanInitializers() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/BooleanInitializersPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/BooleanInitializersPost.test");
+	}
+
+	@Test
+	void testNullInitializers() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/NullInitializersPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/NullInitializersPost.test");
+	}
+
+	@Test
+	void testIntInitializers() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/IntInitializersPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/IntInitializersPost.test");
+	}
+
+	@Test
+	void testEnumPublicStatic() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/EnumPublicStaticPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/EnumPublicStaticPost.test");
+	}
+
+	@Test
+	void testInterfacePublicStatic() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/InterfacePublicStaticPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/InterfacePublicStaticPost.test");
+	}
+
+	@Test
+	@Disabled("feature envy: (edge case/hard to implement) having a dedicated method")
+	void testSQLTokenizedFormatterPost() throws Exception {
+		writePomWithJavaSteps("<replaceObsoletes/>");
+
+		String path = "src/main/java/test.java";
+		setFile(path).toResource("java/replaceobsoletes/SQLTokenizedFormatterPre.test");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("java/replaceobsoletes/SQLTokenizedFormatterPost.test");
+	}
+
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/BooleanInitializersPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/BooleanInitializersPost.test
@@ -1,0 +1,5 @@
+public class Test {
+    public boolean flag1;
+    public boolean flag2 = true;
+    public boolean flag3;
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/BooleanInitializersPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/BooleanInitializersPre.test
@@ -1,0 +1,5 @@
+public class Test {
+    public boolean flag1 = false;
+    public boolean flag2 = true;
+    public boolean flag3 = false;
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/EnumPublicStaticPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/EnumPublicStaticPost.test
@@ -1,0 +1,6 @@
+public enum TestEnum {
+    VALUE1,
+    VALUE2;
+
+    void method() {}
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/EnumPublicStaticPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/EnumPublicStaticPre.test
@@ -1,0 +1,6 @@
+public enum TestEnum {
+    public static VALUE1,
+    public static VALUE2;
+
+    public static void method() {}
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/IntInitializersPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/IntInitializersPost.test
@@ -1,0 +1,14 @@
+public class Test {
+public int int1;
+public int int2 = 1;
+public long long1;
+public long long2 = 1L;
+public float float1;
+public float float2 = 1.0f;
+public double double1;
+public double double2 = 1.0;
+public short short1;
+public short short2 = 1;
+public byte byte1;
+public byte byte2 = 1;
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/IntInitializersPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/IntInitializersPre.test
@@ -1,0 +1,14 @@
+public class Test {
+public int int1 = 0;
+public int int2 = 1;
+public long long1 = 0L;
+public long long2 = 1L;
+public float float1 = 0.0f;
+public float float2 = 1.0f;
+public double double1 = 0.0;
+public double double2 = 1.0;
+public short short1 = 0;
+public short short2 = 1;
+public byte byte1 = 0;
+public byte byte2 = 1;
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/InterfacePublicStaticPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/InterfacePublicStaticPost.test
@@ -1,0 +1,5 @@
+interface TestInterface {
+    final int CONSTANT = 1;
+    void method();
+    class InnerClass {}
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/InterfacePublicStaticPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/InterfacePublicStaticPre.test
@@ -1,0 +1,5 @@
+interface TestInterface {
+    public static final int CONSTANT = 1;
+    public abstract void method();
+    public static class InnerClass {}
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/NullInitializersPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/NullInitializersPost.test
@@ -1,0 +1,8 @@
+public class Test {
+    public String str1;
+    public String str2 = "value";
+    public Object obj1;
+    public Foo Foo1;
+    public Foo Foo2 = "null";
+    public Object obj2 = new Object();
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/NullInitializersPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/NullInitializersPre.test
@@ -1,0 +1,8 @@
+public class Test {
+    public String str1 = null;
+    public String str2 = "value";
+    public Object obj1 = null;
+    public Foo Foo1 = null;
+    public Foo Foo2 = "null";
+    public Object obj2 = new Object();
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/SQLTokenizedFormatterPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/SQLTokenizedFormatterPost.test
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.sql.dbeaver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import com.diffplug.spotless.annotations.Internal;
+
+/**
+ * **Warning:** Use this class at your own risk. It is an implementation detail and is not
+ * guaranteed to exist in future versions.
+ * <p>
+ * Forked from
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * <p>
+ * Based on SQLTokenizedFormatter from https://github.com/serge-rider/dbeaver,
+ * which itself is licensed under the Apache 2.0 license.
+ */
+@Internal
+public class SQLTokenizedFormatter {
+
+	private void insertReturnAndIndent(final List<FormatterToken> argList, final int argIndex, final int argIndent) {
+		final String defaultLineSeparator = System.lineSeparator();
+	}
+
+
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/SQLTokenizedFormatterPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/SQLTokenizedFormatterPre.test
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.sql.dbeaver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import com.diffplug.spotless.annotations.Internal;
+
+/**
+ * **Warning:** Use this class at your own risk. It is an implementation detail and is not
+ * guaranteed to exist in future versions.
+ * <p>
+ * Forked from
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2017 Serge Rider (serge@jkiss.org)
+ * <p>
+ * Based on SQLTokenizedFormatter from https://github.com/serge-rider/dbeaver,
+ * which itself is licensed under the Apache 2.0 license.
+ */
+@Internal
+public class SQLTokenizedFormatter {
+
+	private static String getDefaultLineSeparator() {
+		return System.getProperty("line.separator", "\n");
+	}
+
+	private void insertReturnAndIndent(final List<FormatterToken> argList, final int argIndex, final int argIndent) {
+		final String defaultLineSeparator = getDefaultLineSeparator();
+	}
+
+
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/SortPomCfgPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/SortPomCfgPost.test
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021-2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.pom;
+
+import java.io.Serializable;
+
+// Class and members must be public, otherwise we get failed to access class com.diffplug.spotless.pom.SortPomInternalState from class com.diffplug.spotless.pom.SortPomFormatterFunc (com.diffplug.spotless.pom.SortPomInternalState is in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @682bd3c4; com.diffplug.spotless.pom.SortPomFormatterFunc is in unnamed module of loader com.diffplug.spotless.pom.DelegatingClassLoader @573284a5)
+public class SortPomCfg implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	public String version = "4.0.0";
+
+	public String encoding = "UTF-8";
+
+	public String lineSeparator = System.lineSeparator();
+
+	public boolean expandEmptyElements = true;
+
+	public boolean spaceBeforeCloseEmptyElement;
+
+	public boolean keepBlankLines = true;
+
+	public boolean endWithNewline = true;
+
+	public int nrOfIndentSpace = 2;
+
+	public boolean indentBlankLines;
+
+	public boolean indentSchemaLocation;
+
+	public String indentAttribute;
+
+	public String predefinedSortOrder = "recommended_2008_06";
+
+	public boolean quiet;
+
+	public String sortOrderFile;
+
+	public String sortDependencies;
+
+	public String sortDependencyManagement;
+
+	public String sortDependencyExclusions;
+
+	public String sortPlugins;
+
+	public boolean sortProperties;
+
+	public boolean sortModules;
+
+	public boolean sortExecutions;
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/SortPomCfgPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/SortPomCfgPre.test
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021-2024 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.pom;
+
+import java.io.Serializable;
+
+// Class and members must be public, otherwise we get failed to access class com.diffplug.spotless.pom.SortPomInternalState from class com.diffplug.spotless.pom.SortPomFormatterFunc (com.diffplug.spotless.pom.SortPomInternalState is in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @682bd3c4; com.diffplug.spotless.pom.SortPomFormatterFunc is in unnamed module of loader com.diffplug.spotless.pom.DelegatingClassLoader @573284a5)
+public class SortPomCfg implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	public String version = "4.0.0";
+
+	public String encoding = "UTF-8";
+
+	public String lineSeparator = System.getProperty("line.separator");
+
+	public boolean expandEmptyElements = true;
+
+	public boolean spaceBeforeCloseEmptyElement = false;
+
+	public boolean keepBlankLines = true;
+
+	public boolean endWithNewline = true;
+
+	public int nrOfIndentSpace = 2;
+
+	public boolean indentBlankLines = false;
+
+	public boolean indentSchemaLocation = false;
+
+	public String indentAttribute = null;
+
+	public String predefinedSortOrder = "recommended_2008_06";
+
+	public boolean quiet = false;
+
+	public String sortOrderFile = null;
+
+	public String sortDependencies = null;
+
+	public String sortDependencyManagement = null;
+
+	public String sortDependencyExclusions = null;
+
+	public String sortPlugins = null;
+
+	public boolean sortProperties = false;
+
+	public boolean sortModules = false;
+
+	public boolean sortExecutions = false;
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/SystemLineSeparatorPost.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/SystemLineSeparatorPost.test
@@ -1,0 +1,4 @@
+public class Test {
+    public String lineSeparator = System.lineSeparator();
+    public String lineSeparator2 = System.lineSeparator();
+}

--- a/testlib/src/main/resources/java/replaceobsoletes/SystemLineSeparatorPre.test
+++ b/testlib/src/main/resources/java/replaceobsoletes/SystemLineSeparatorPre.test
@@ -1,0 +1,4 @@
+public class Test {
+    public String lineSeparator = System.getProperty("line.separator");
+    public String lineSeparator2 = System.getProperty("line.separator", "\n");
+}


### PR DESCRIPTION
feat: Add `ReplaceObsoletesStep`

This PR introduces a new step to remove common boilerplate code, such as:
- Redundant declarations reimplementing Java defaults
- Unnecessary explicit language defaults
- Other similar redundancies

**Motivation:**  
Discovered during the review of:
- #2524 
  - This [comment](https://github.com/diffplug/spotless/pull/2524#issuecomment-3002059471) highlighting the need for such cleanup.

**Benefits:**
- Reduces noise in codebases
- Eliminates unnecessary maintenance of obvious defaults
- Follows DRY and CoC principles
