### PR TITLE
feat: Add `RemoveUnusedDeclarations`

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedDeclarationsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedDeclarationsStep.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.java;
 
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.glue.pjf.PalantirJavaFormatFormatterFormatSourceAndFixImportsAndDeclarationsFunc;
 import com.diffplug.spotless.glue.pjf.PalantirJavaFormatFormatterFunc;
 
 /** Uses google-java-format or cleanthat.UnnecessaryImport, but only to remove unused imports. */
@@ -23,6 +24,6 @@ public interface RemoveUnusedDeclarationsStep {
 	String NAME = "removeUnusedImports";
 
 	static FormatterStep create() {
-		return new PalantirJavaFormatFormatterFunc("PALANTIR", true);
+		return new PalantirJavaFormatFormatterFormatSourceAndFixImportsAndDeclarationsFunc("PALANTIR", true);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedDeclarationsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedDeclarationsStep.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2025 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.java;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.glue.pjf.PalantirJavaFormatFormatterFunc;
+
+/** Uses google-java-format or cleanthat.UnnecessaryImport, but only to remove unused imports. */
+public interface RemoveUnusedDeclarationsStep {
+	String NAME = "removeUnusedImports";
+
+	static FormatterStep create() {
+		return new PalantirJavaFormatFormatterFunc("PALANTIR", true);
+	}
+}

--- a/lib/src/palantirJavaFormat/java/com/diffplug/spotless/glue/pjf/PalantirJavaFormatFormatterFunc.java
+++ b/lib/src/palantirJavaFormat/java/com/diffplug/spotless/glue/pjf/PalantirJavaFormatFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,12 @@
  */
 package com.diffplug.spotless.glue.pjf;
 
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.List;
+
+import javax.annotation.Nullable;
 
 import com.palantir.javaformat.java.Formatter;
 import com.palantir.javaformat.java.ImportOrderer;
@@ -24,8 +28,10 @@ import com.palantir.javaformat.java.JavaFormatterOptions;
 import com.palantir.javaformat.java.RemoveUnusedImports;
 
 import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.Lint;
 
-public class PalantirJavaFormatFormatterFunc implements FormatterFunc {
+public class PalantirJavaFormatFormatterFunc implements FormatterFunc, FormatterStep {
 
 	private final Formatter formatter;
 
@@ -52,7 +58,17 @@ public class PalantirJavaFormatFormatterFunc implements FormatterFunc {
 		String source = input;
 		source = ImportOrderer.reorderImports(source, formatterStyle);
 		source = RemoveUnusedImports.removeUnusedImports(source);
-		return formatter.formatSource(source);
+		return formatter.formatSourceAndFixImportsAndDeclarations(source);
+	}
+
+	@Override
+	public String apply(String unix, File file) throws Exception {
+		return FormatterFunc.super.apply(unix, file);
+	}
+
+	@Override
+	public List<Lint> lint(String content, File file) throws Exception {
+		return FormatterFunc.super.lint(content, file);
 	}
 
 	@Override
@@ -69,5 +85,20 @@ public class PalantirJavaFormatFormatterFunc implements FormatterFunc {
 		} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
 			throw new IllegalStateException("Cannot enable formatJavadoc option, make sure you are using Palantir with version 2.36.0 or later", e);
 		}
+	}
+
+	@Override
+	public String getName() {
+		return toString();
+	}
+
+	@Nullable @Override
+	public String format(String rawUnix, File file) throws Exception {
+		return apply(rawUnix);
+	}
+
+	@Override
+	public void close() throws Exception {
+
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -40,6 +40,7 @@ import com.diffplug.spotless.java.FormatAnnotationsStep;
 import com.diffplug.spotless.java.GoogleJavaFormatStep;
 import com.diffplug.spotless.java.ImportOrderStep;
 import com.diffplug.spotless.java.PalantirJavaFormatStep;
+import com.diffplug.spotless.java.RemoveUnusedDeclarationsStep;
 import com.diffplug.spotless.java.RemoveUnusedImportsStep;
 import com.diffplug.spotless.java.RemoveWildcardImportsStep;
 
@@ -154,6 +155,10 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 
 	public void removeWildcardImports() {
 		addStep(RemoveWildcardImportsStep.create());
+	}
+
+	public void removeUnusedDeclarations() {
+		addStep(RemoveUnusedDeclarationsStep.create());
 	}
 
 	/** Uses the <a href="https://github.com/google/google-java-format">google-java-format</a> jar to format source code. */


### PR DESCRIPTION
integration of:

- https://github.com/palantir/palantir-java-format/pull/1342

  ## feat: Add `RemoveUnusedDeclarations` formatting rule
  
  This PR introduces a new Java formatting rule that automatically removes redundant modifiers and declarations that are either:
  - Implicitly provided by Java language specifications
  - Unnecessarily verbose without adding clarity
  - Obsolete in modern Java versions
  
  ### Motivation
  
  During codebase modernization efforts (#2524), we identified recurring patterns where:
  1. Developers explicitly declare language defaults (e.g., `public` in interfaces)
  2. Projects maintain legacy modifier patterns (e.g., `final static` instead of `static final`)
  3. Modern Java features aren't fully leveraged (records, sealed classes)
  
  As highlighted in [this comment](https://github.com/diffplug/spotless/pull/2524#issuecomment-3002059471), such redundancies:
  - Increase cognitive load during code reviews
  - Create maintenance overhead
  - Reduce code consistency
  
  ### Key Features
  
  The rule handles:
  - **Interface members**:
    - Removes redundant `public`, `static`, `final`, `abstract` modifiers
    - Example: `public static final int CONST` → `int CONST`
  
  - **Nested types**:
    - Simplifies modifiers in inner classes/interfaces
    - Example: `public static class Inner` → `static class Inner`
  
  - **Enum declarations**:
    - Removes redundant modifiers on constants and methods
    - Example: `public static final VALUE` → `VALUE`
  
  - **Modern Java features**:
    - Optimizes record components (`public final` params → implicit)
    - Simplifies sealed class hierarchies
  
  - **Annotation declarations**:
    - Removes redundant modifiers on annotation elements
    - Preserves special syntax (`@interface` formatting)
  
  ### Benefits
  
  1. **Reduced Noise**:
     - Eliminate redundant modifiers in typical codebases
     - Focuses attention on meaningful declarations
  
  2. **Maintenance Efficiency**:
     - Automatic updates when Java language defaults change
     - Consistent application across entire codebase
  
  3. **Modern Java Support**:
     - First-class handling of records and sealed classes
     - Future-proof for new language features
  
  4. **Non-intrusive**:
     - Preserves all actual semantics
     - Only removes truly redundant declarations
  
  ### Implementation Notes
  
  - Built as a standalone step compatible with existing formatting pipelines
  - Preserves all non-redundant modifiers (e.g., keeps `private` when meaningful)
  - Handles special cases like `@Nullable final` parameters
  - Comprehensive test coverage
  
  ### Integration
  
  Works seamlessly with:
  - Google Java Format
  - Spotless (via [#2530](https://github.com/diffplug/spotless/pull/2530))
  - Any Java formatting pipeline
