### PR TITLE
biome step: Allow specifying path to JSON config file directly, requires biome 2.0 or higher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x.
+* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x. ([#2548](https://github.com/diffplug/spotless/pull/2548))
 
 ## [3.2.0] - 2025-07-07
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x.
 
 ## [3.2.0] - 2025-07-07
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ If you get something running, we'd love to host your plugin within this repo as 
 
 To run all tests, simply do
 
-> gradlew test
+> ./gradlew test
 
 Since that takes some time, you might only want to run the tests
 concerning what you are working on:

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
@@ -15,10 +15,15 @@
  */
 package com.diffplug.spotless.biome;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Settings and constants for Biome to use.
  */
 public final class BiomeSettings {
+	private static final Logger logger = LoggerFactory.getLogger(BiomeSettings.class);
+
 	private final static String CONFIG_NAME = "biome.json";
 	private final static String DEFAULT_VERSION = "1.2.0";
 	private final static String DOWNLOAD_FILE_PATTERN = "biome-%s-%s-%s";
@@ -71,5 +76,38 @@ public final class BiomeSettings {
 	 */
 	public static String shortName() {
 		return SHORT_NAME;
+	}
+
+	/**
+	 * Checks if the version of Biome is equal to or higher than the given major, minor, and patch version.
+	 * @param version The version string to check, e.g. "1.2.3".
+	 * @param major The major version to compare against.
+	 * @param minor The minor version to compare against.
+	 * @param patch The patch version to compare against.
+	 * @return true if the version is higher than or equal to the given major, minor, and patch version,
+	 */
+	public static boolean versionHigherThanOrEqualTo(String version, int major, int minor, int patch) {
+		try {
+			final var versionParts = version.split("\\.");
+			if (versionParts.length < 3) {
+				return false;
+			}
+			final var actualMajor = Integer.parseInt(versionParts[0]);
+			final var actualMinor = Integer.parseInt(versionParts[1]);
+			final var actualPatch = Integer.parseInt(versionParts[2]);
+			if (actualMajor > major) {
+				return true;
+			}
+			if (actualMajor == major && actualMinor > minor) {
+				return true;
+			}
+			if (actualMajor == major && actualMinor == minor && actualPatch > patch) {
+				return true;
+			}
+			return actualMajor == major && actualMinor == minor && actualPatch == patch;
+		} catch (final Exception e) {
+			logger.warn("Failed to parse biome version string '{}'. Expected format is 'major.minor.patch'.", version, e);
+			return false;
+		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
@@ -191,18 +191,21 @@ public class BiomeStep {
 	/**
 	 * Checks the Biome config path. When the config path does not exist or when it
 	 * does not contain a file named {@code biome.json}, an error is thrown.
+	 * @param configPath The path to validate.
+	 * @param version The version of Biome.
 	 */
-	private static void validateBiomeConfigPath(String configPath) {
+	private static void validateBiomeConfigPath(String configPath, String version) {
 		if (configPath == null) {
 			return;
 		}
+		var atLeastV2 = BiomeSettings.versionHigherThanOrEqualTo(version, 2, 0, 0);
 		var path = Paths.get(configPath);
-		var config = path.resolve(BiomeSettings.configName());
+		var configFile = Files.isRegularFile(path) && atLeastV2 ? path : path.resolve(BiomeSettings.configName());
 		if (!Files.exists(path)) {
 			throw new IllegalArgumentException("Biome config directory does not exist: " + path);
 		}
-		if (!Files.exists(config)) {
-			throw new IllegalArgumentException("Biome config does not exist: " + config);
+		if (!Files.exists(configFile)) {
+			throw new IllegalArgumentException("Biome config does not exist: " + configFile);
 		}
 	}
 
@@ -240,11 +243,10 @@ public class BiomeStep {
 	}
 
 	/**
-	 * Sets the path to the directory with the {@code biome.json} config file. When
-	 * no config path is set, the default configuration is used.
+	 * Sets the path to the Biome configuration. Must be either a directory with a file named {@code biome.json}, or
+	 * a file with the Biome config as JSON. When no config path is set, the default configuration is used.
 	 *
-	 * @param configPath Config path to use. Must point to a directory which contains
-	 *                   a file named {@code biome.json}.
+	 * @param configPath Config path to use.
 	 * @return This builder instance for chaining method calls.
 	 */
 	public BiomeStep withConfigPath(String configPath) {
@@ -296,7 +298,7 @@ public class BiomeStep {
 	private State createState() throws IOException, InterruptedException {
 		var resolvedPathToExe = resolveExe();
 		validateBiomeExecutable(resolvedPathToExe);
-		validateBiomeConfigPath(configPath);
+		validateBiomeConfigPath(configPath, version);
 		logger.debug("Using Biome executable located at  '{}'", resolvedPathToExe);
 		var exeSignature = FileSignature.signAsList(Collections.singleton(new File(resolvedPathToExe)));
 		makeExecutable(resolvedPathToExe);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x.
+* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x. ([#2548](https://github.com/diffplug/spotless/pull/2548))
 
 ## [7.1.0] - 2025-07-07
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x.
 
 ## [7.1.0] - 2025-07-07
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1432,14 +1432,14 @@ spotless {
     target 'src/*/webapp/**/*.js'
 
     // Download Biome from the network if not already downloaded, see below for more info
-    biome('1.2.0')
+    biome('2.1.0')
 
     // (optional) Path to the directory with the biome.json conig file
-    biome('1.2.0').configPath("path/config/dir")
+    biome('2.1.0').configPath("path/config/dir")
 
     // (optional) Biome will auto detect the language based on the file extension.
     // See below for possible values.
-    biome('1.2.0').language("js")
+    biome('2.1.0').language("js")
   }
 }
 ```
@@ -1451,15 +1451,15 @@ more formats:
 spotless {
   format 'biome-js', {
     target '**/*.js'
-    biome('1.2.0')
+    biome('2.1.0')
   }
   format 'biome-ts', {
     target '**/*.ts'
-    biome('1.2.0')
+    biome('2.1.0')
   }
   format 'biome-json', {
     target '**/*.json'
-    biome('1.2.0')
+    biome('2.1.0')
   }
 }
 ```
@@ -1476,6 +1476,7 @@ Note: Due to a limitation of biome, if the name of a file matches a pattern in
 the `ignore` option of the specified `biome.json` configuration file, it will not be
 formatted, even if included in the biome configuration section of the Gradle settings
 file.
+
 You could specify a different `biome.json` configuration file without an `ignore`
 pattern to circumvent this.
 
@@ -1553,7 +1554,29 @@ spotless {
     target '**/*.js','**/*.ts','**/*.json'
     // Must point to the directory with the "biome.json" config file -->
     // Relative paths are resolved against the project's base directory -->
-    biome('1.2.0').configPath('./config')
+    biome('2.1.0').configPath('./config')
+  }
+}
+```
+
+__If spotless does not format any files__, this might be because you excluded those files in you biome.json
+configuration file. If you are using biome 2.x, you can create a custom config file for spotless and inherit from
+your main config file like this:
+
+```jsonc
+// biome-spotless.json
+{
+  "extends": "./biome.json",
+  "include": ["**"]
+}
+```
+
+Then simply specify the path to this file in your spotless configuration:
+
+```gradle
+spotless {
+  format 'biome', {
+    biome('2.1.0').configPath('./config/biome-spotless.json')
   }
 }
 ```

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BiomeStepConfig.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BiomeStepConfig.java
@@ -31,10 +31,9 @@ import com.diffplug.spotless.biome.BiomeStep;
 
 public abstract class BiomeStepConfig<Self extends BiomeStepConfig<Self>> {
 	/**
-	 * Optional path to the directory with configuration file for Biome. The file
-	 * must be named {@code biome.json}. When none is given, the default
-	 * configuration is used. If this is a relative path, it is resolved against the
-	 * project's base directory.
+	 * Optional path to the configuration file for Biome. Must be either a directory that contains a file named
+	 * {@code biome.json}, or a file that contains the Biome config as JSON. When none is given, the default
+	 * configuration is used. If this is a relative path, it is resolved against the project's base directory.
 	 */
 	@Nullable private Object configPath;
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BiomeIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/BiomeIntegrationTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 import org.owasp.encoder.Encode;
 
@@ -220,6 +222,34 @@ class BiomeIntegrationTest extends GradleIntegrationHarness {
 				"    format 'mybiome', {",
 				"        target '**/*.js'",
 				"        biome('1.2.0').configPath('" + Encode.forJava(path) + "')",
+				"    }",
+				"}");
+		setFile("biome_test.js").toResource("biome/js/longLineBefore.js");
+		setFile("configs/biome.json").toResource("biome/config/line-width-120.json");
+
+		var spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertFile("biome_test.js").sameAsResource("biome/js/longLineAfter120.js");
+	}
+
+	/**
+	 * Tests that a path to a Biome config JSON file can be specified (requires biome 2.x).
+	 *
+	 * @throws Exception When a test failure occurs.
+	 */
+	@Test
+	void configPathFile() throws Exception {
+		var path = newFile("configs").getAbsolutePath();
+		var file = new File(path, "biome.json").getAbsolutePath();
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    format 'mybiome', {",
+				"        target '**/*.js'",
+				"        biome('2.1.0').configPath('" + Encode.forJava(file) + "')",
 				"    }",
 				"}");
 		setFile("biome_test.js").toResource("biome/js/longLineBefore.js");

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x.
 
 ## [2.45.0] - 2025-07-07
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,7 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x.
+* Allow specifying path to Biome JSON config file directly in `biome` step. Requires biome 2.x. ([#2548](https://github.com/diffplug/spotless/pull/2548))
 
 ## [2.45.0] - 2025-07-07
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1530,9 +1530,9 @@ Note regarding CSS: Biome supports formatting CSS as of 1.8.0 (experimental, opt
 
       <biome>
         <!-- Download Biome from the network if not already downloaded, see below for more info  -->
-        <version>1.2.0</version>
+        <version>2.1.1</version>
 
-        <!-- (optional) Path to the directory with the biome.json conig file -->
+        <!-- (optional) Path to the directory with the biome.json config file -->
         <configPath>${project.basedir}/path/to/config/dir</configPath>
 
         <!-- (optional) Biome will auto-detect the language based on the file extension. -->
@@ -1583,7 +1583,7 @@ To download the Biome binary from the network, just specify a version:
 
 ```xml
 <biome>
-  <version>1.2.0</version>
+  <version>2.1.0</version>
 </biome>
 ```
 
@@ -1594,7 +1594,7 @@ Biome binaries (defaults to `~/.m2/repository/com/diffplug/spotless/spotless-dat
 
 ```xml
 <biome>
-  <version>1.2.0</version>
+  <version>2.1.0</version>
   <!-- Relative paths are resolved against the project's base directory -->
   <downloadDir>${user.home}/biome</downloadDir>
 </biome>
@@ -1631,7 +1631,28 @@ Biome is used. To use a custom configuration:
 <biome>
   <!-- Must point to the directory with the "biome.json" config file -->
   <!-- Relative paths are resolved against the project's base directory -->
+  <!-- Starting with biome 2.x, you can also pass the path to a JSON config file directly. -->
   <configPath>${project.basedir}</configPath>
+</biome>
+```
+
+__If spotless does not format any files__, this might be because you excluded those files in you biome.json
+configuration file. If you are using biome 2.x, you can create a custom config file for spotless and inherit from
+your main config file like this:
+
+```jsonc
+// biome-spotless.json
+{
+  "extends": "./biome.json",
+  "include": ["**"]
+}
+```
+
+Then simply specify the path to this file in your spotless configuration:
+
+```xml
+<biome>
+  <configPath>${project.basedir}/biome-spotless.json</configPath>
 </biome>
 ```
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/AbstractBiome.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/AbstractBiome.java
@@ -37,10 +37,9 @@ public abstract class AbstractBiome implements FormatterStepFactory {
 	protected AbstractBiome() {}
 
 	/**
-	 * Optional path to the directory with configuration file for Biome. The file
-	 * must be named {@code biome.json}. When none is given, the default
-	 * configuration is used. If this is a relative path, it is resolved against the
-	 * project's base directory.
+	 * Optional path to the configuration file for Biome. Must be either a directory that contains a file named
+	 * {@code biome.json}, or a file that contains the Biome config as JSON. When none is given, the default
+	 * configuration is used. If this is a relative path, it is resolved against the project's base directory.
 	 */
 	@Parameter
 	private String configPath;

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/biome/BiomeMavenTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/biome/BiomeMavenTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.owasp.encoder.Encode.forXml;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
@@ -133,6 +135,23 @@ class BiomeMavenTest extends MavenIntegrationHarness {
 		var path = newFile("configs").getAbsolutePath();
 		writePomWithBiomeSteps("**/*.js",
 				"<biome><version>1.2.0</version><configPath>" + forXml(path) + "</configPath></biome>");
+		setFile("biome_test.js").toResource("biome/js/longLineBefore.js");
+		setFile("configs/biome.json").toResource("biome/config/line-width-120.json");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile("biome_test.js").sameAsResource("biome/js/longLineAfter120.js");
+	}
+
+	/**
+	 * Tests that a path to a Biome config JSON file can be specified (requires biome 2.x).
+	 *
+	 * @throws Exception When a test failure occurs.
+	 */
+	@Test
+	void configPathFile() throws Exception {
+		var path = newFile("configs").getAbsolutePath();
+		var file = new File(path, "biome.json").getAbsolutePath();
+		writePomWithBiomeSteps("**/*.js",
+				"<biome><version>2.1.1</version><configPath>" + forXml(file) + "</configPath></biome>");
 		setFile("biome_test.js").toResource("biome/js/longLineBefore.js");
 		setFile("configs/biome.json").toResource("biome/config/line-width-120.json");
 		mavenRunner().withArguments("spotless:apply").runNoError();

--- a/testlib/src/test/java/com/diffplug/spotless/biome/BiomeStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/biome/BiomeStepTest.java
@@ -15,8 +15,11 @@
  */
 package com.diffplug.spotless.biome;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -53,7 +56,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectCjs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.cjs", "biome/js/fileAfter.cjs");
 		}
@@ -64,7 +67,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectCts() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.cts", "biome/ts/fileAfter.cts");
 		}
@@ -76,7 +79,7 @@ class BiomeStepTest extends ResourceHarness {
 		@Test
 		void testAutoDetectCssExperimental() {
 			var path = createBiomeConfig("biome/config/css-enabled.json");
-			var step = BiomeStep.withExeDownload("1.8.3", downloadDir.toString()).withConfigPath(path).create();
+			var step = BiomeStep.withExeDownload("1.8.3", downloadDir).withConfigPath(path.toString()).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/css/fileBefore.css", "biome/css/fileAfter.css");
 		}
@@ -87,7 +90,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectCssStable() {
-			var step = BiomeStep.withExeDownload("1.9.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.9.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/css/fileBefore.css", "biome/css/fileAfter.css");
 		}
@@ -98,7 +101,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectJs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.js", "biome/js/fileAfter.js");
 		}
@@ -109,7 +112,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectJson() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/json/fileBefore.json", "biome/json/fileAfter.json");
 		}
@@ -120,7 +123,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectJsonc() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/jsonc/fileBefore.jsonc", "biome/jsonc/fileAfter.jsonc");
 		}
@@ -131,7 +134,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectJsx() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.jsx", "biome/js/fileAfter.jsx");
 		}
@@ -142,7 +145,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectMjs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.mjs", "biome/js/fileAfter.mjs");
 		}
@@ -153,7 +156,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectMts() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.mts", "biome/ts/fileAfter.mts");
 		}
@@ -164,7 +167,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectTs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.ts", "biome/ts/fileAfter.ts");
 		}
@@ -175,7 +178,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testAutoDetectTsx() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.tsx", "biome/ts/fileAfter.tsx");
 		}
@@ -188,7 +191,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void preservesIgnoredFiles() {
-			var step = BiomeStep.withExeDownload("1.5.0", downloadDir.toString()).create();
+			var step = BiomeStep.withExeDownload("1.5.0", downloadDir).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/json/package.json", "biome/json/packageAfter.json");
 		}
@@ -228,7 +231,7 @@ class BiomeStepTest extends ResourceHarness {
 		@Test
 		void testLineWidth120() {
 			var path = createBiomeConfig("biome/config/line-width-120.json");
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withConfigPath(path).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withConfigPath(path.toString()).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/longLineBefore.js", "biome/js/longLineAfter120.js");
 		}
@@ -239,11 +242,36 @@ class BiomeStepTest extends ResourceHarness {
 		@Test
 		void testLineWidth80() {
 			var path = createBiomeConfig("biome/config/line-width-80.json");
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withConfigPath(path).create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withConfigPath(path.toString()).create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/longLineBefore.js", "biome/js/longLineAfter80.js");
 		}
 
+		/**
+		 * Test the path to the JSON config file can be specified directly (requires biome 2.x).
+		 */
+		@Test
+		void testPathToFile() {
+			var path = createBiomeConfig("biome/config/line-width-80.json").resolve("biome.json");
+			assertTrue(Files.isRegularFile(path));
+			assertTrue(Files.exists(path));
+			var step = BiomeStep.withExeDownload("2.1.1", downloadDir).withConfigPath(path.toString()).create();
+			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
+			stepHarness.testResource("biome/js/longLineBefore.js", "biome/js/longLineAfter80.js");
+		}
+
+		/**
+		 * Test the path to the folder with the biome.json config file can be specified.
+		 */
+		@Test
+		void testPathToDirectory() {
+			var path = createBiomeConfig("biome/config/line-width-80.json");
+			assertTrue(Files.isDirectory(path));
+			assertTrue(Files.exists(path));
+			var step = BiomeStep.withExeDownload("2.1.1", downloadDir).withConfigPath(path.toString()).create();
+			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
+			stepHarness.testResource("biome/js/longLineBefore.js", "biome/js/longLineAfter80.js");
+		}
 	}
 
 	/**
@@ -257,7 +285,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageCjs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("js").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("js").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.cjs", "biome/js/fileAfter.cjs");
 		}
@@ -269,7 +297,7 @@ class BiomeStepTest extends ResourceHarness {
 		@Test
 		void testSetLanguageCssExperimental() {
 			var path = createBiomeConfig("biome/config/css-enabled.json");
-			var step = BiomeStep.withExeDownload("1.8.3", downloadDir.toString()).withConfigPath(path).withLanguage("css").create();
+			var step = BiomeStep.withExeDownload("1.8.3", downloadDir).withConfigPath(path.toString()).withLanguage("css").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/css/fileBefore.css", "biome/css/fileAfter.css");
 		}
@@ -280,7 +308,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageCssStable() {
-			var step = BiomeStep.withExeDownload("1.9.0", downloadDir.toString()).withLanguage("css").create();
+			var step = BiomeStep.withExeDownload("1.9.0", downloadDir).withLanguage("css").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/css/fileBefore.css", "biome/css/fileAfter.css");
 		}
@@ -291,7 +319,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageCts() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("ts").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("ts").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.cts", "biome/ts/fileAfter.cts");
 		}
@@ -302,7 +330,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageJs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("js").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("js").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.js", "biome/js/fileAfter.js");
 		}
@@ -313,7 +341,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageJson() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("json").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("json").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/json/fileBefore.json", "biome/json/fileAfter.json");
 		}
@@ -324,7 +352,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageJsonc() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("jsonc").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("jsonc").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/jsonc/fileBefore.jsonc", "biome/jsonc/fileAfter.jsonc");
 		}
@@ -335,7 +363,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageJsx() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("jsx").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("jsx").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.jsx", "biome/js/fileAfter.jsx");
 		}
@@ -346,7 +374,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageMjs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("js").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("js").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/js/fileBefore.mjs", "biome/js/fileAfter.mjs");
 		}
@@ -357,7 +385,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageMts() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("ts").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("ts").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.mts", "biome/ts/fileAfter.mts");
 		}
@@ -368,7 +396,7 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageTs() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("ts").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("ts").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.ts", "biome/ts/fileAfter.ts");
 		}
@@ -379,17 +407,17 @@ class BiomeStepTest extends ResourceHarness {
 		 */
 		@Test
 		void testSetLanguageTsx() {
-			var step = BiomeStep.withExeDownload("1.2.0", downloadDir.toString()).withLanguage("tsx").create();
+			var step = BiomeStep.withExeDownload("1.2.0", downloadDir).withLanguage("tsx").create();
 			var stepHarness = StepHarnessWithFile.forStep(BiomeStepTest.this, step);
 			stepHarness.testResource("biome/ts/fileBefore.tsx", "biome/ts/fileAfter.tsx");
 		}
 	}
 
-	private String createBiomeConfig(String name) {
+	private Path createBiomeConfig(String name) {
 		var config = createTestFile(name).toPath();
 		var dir = config.getParent();
-		var rome = dir.resolve("biome.json");
-		ThrowingEx.run(() -> Files.copy(config, rome));
-		return dir.toString();
+		var biomeConfig = dir.resolve("biome.json");
+		ThrowingEx.run(() -> Files.copy(config, biomeConfig));
+		return dir;
 	}
 }


### PR DESCRIPTION
Not urgent, so feel free to merge and release when you have time.

Starting with biome 2.0, they now allow specifying a configuration file directly. Previously, we had to specify a folder that had to contain a `biome.json` file. This can be useful when you need to adjust some biome settings for use with spotless. biome now allows creating a config file that inherits from another file, and overwrite only selected settings.

This PR adjust the spotless wrapper for biome to allow specifying configuration files directly, and adds a test for that scenario.

For example:

```jsonc
// biome-spotless.json
{
  "extends": ["./biome.json"],
  "files": {
    "includes": ["**"]
  }
}
```

```jsonc
// biome.json
{
  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
  "formatter": {
    "enabled": true,
    "indentStyle": "space",
    "indentWidth": 2,
    "lineWidth": 120
  },
  "files": {
    "maxSize": 5097152,
    "includes": []
  }
}
```

```xml
<biome>
  <configPath>${project.basedir}/biome-spotless.json</configPath>
</biome>
```

---

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [x] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
