### PR TITLE
add git pre push hook

### DIFF
--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
@@ -1,0 +1,169 @@
+package com.diffplug.spotless;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * Abstract class responsible for installing a Git pre-push hook in a repository.
+ * This class ensures that specific checks and logic are run before a push operation in Git.
+ *
+ * Subclasses should define specific behavior for hook installation by implementing the required abstract methods.
+ */
+public abstract class GitPrePushHookInstaller {
+
+	/**
+	 * Logger for recording informational and error messages during the installation process.
+	 */
+	protected final GitPreHookLogger logger;
+
+	/**
+	 * The root directory of the Git repository where the hook will be installed.
+	 */
+	protected final File root;
+
+	/**
+	 * Constructor to initialize the GitPrePushHookInstaller with a logger and repository root path.
+	 *
+	 * @param logger The logger for recording messages.
+	 * @param root   The root directory of the Git repository.
+	 */
+	public GitPrePushHookInstaller(GitPreHookLogger logger, File root) {
+		this.logger = logger;
+		this.root = root;
+	}
+
+	/**
+	 * Installs the Git pre-push hook into the repository.
+	 *
+	 * <p>This method checks for the following:
+	 * <ul>
+	 *   <li>Ensures Git is installed and the `.git/config` file exists.</li>
+	 *   <li>Checks if an executor required by the hook is available.</li>
+	 *   <li>Creates and writes the pre-push hook file if it does not exist.</li>
+	 *   <li>Skips installation if the hook is already installed.</li>
+	 * </ul>
+	 * If an issue occurs during installation, error messages are logged.
+	 *
+	 * @throws Exception if any error occurs during installation.
+	 */
+	public void install() throws Exception {
+		logger.info("Installing git pre-push hook");
+
+		if (!isGitInstalled()) {
+			logger.error("Git not found in root directory");
+			return;
+		}
+
+		if (!isExecutorInstalled()) {
+			return;
+		}
+
+		var hookContent = "";
+		final var gitHookFile = root.toPath().resolve(".git/hooks/pre-push").toFile();
+		if (!gitHookFile.exists()) {
+			logger.info("Git pre-push hook not found, creating it");
+			gitHookFile.getParentFile().mkdirs();
+			if (!gitHookFile.createNewFile()) {
+				logger.error("Failed to create pre-push hook file");
+				return;
+			}
+
+			if (!gitHookFile.setExecutable(true, false)) {
+				logger.error("Can not make file executable");
+				return;
+			}
+
+			hookContent += "#!/bin/sh\n";
+		}
+
+		if (isGitHookInstalled(gitHookFile)) {
+			logger.info("Skipping, git pre-push hook already installed %s", gitHookFile.getAbsolutePath());
+			return;
+		}
+
+		hookContent += preHookContent();
+		writeFile(gitHookFile, hookContent);
+
+		logger.info("Git pre-push hook installed successfully to the file %s", gitHookFile.getAbsolutePath());
+	}
+
+	/**
+	 * Checks if the required executor for performing the desired pre-push actions is installed.
+	 *
+	 * @return {@code true} if the executor is installed, {@code false} otherwise.
+	 */
+	protected abstract boolean isExecutorInstalled();
+
+	/**
+	 * Provides the content of the hook that should be inserted into the pre-push script.
+	 *
+	 * @return A string representing the content to include in the pre-push script.
+	 */
+	protected abstract String preHookContent();
+
+	/**
+	 * Checks if Git is installed by validating the existence of `.git/config` in the repository root.
+	 *
+	 * @return {@code true} if Git is installed, {@code false} otherwise.
+	 */
+	private boolean isGitInstalled() {
+		return root.toPath().resolve(".git/config").toFile().exists();
+	}
+
+	/**
+	 * Verifies if the pre-push hook file already contains the custom Spotless hook content.
+	 *
+	 * @param gitHookFile The file representing the Git hook.
+	 * @return {@code true} if the hook is already installed, {@code false} otherwise.
+	 * @throws Exception if an error occurs when reading the file.
+	 */
+	private boolean isGitHookInstalled(File gitHookFile) throws Exception {
+		final var hook = Files.readString(gitHookFile.toPath(), UTF_8);
+		return hook.contains("##### SPOTLESS HOOK START #####");
+	}
+
+	/**
+	 * Writes the specified content into a file.
+	 *
+	 * @param file    The file to which the content should be written.
+	 * @param content The content to write into the file.
+	 * @throws IOException if an error occurs while writing to the file.
+	 */
+	private void writeFile(File file, String content) throws IOException {
+		try (final var writer = new FileWriter(file, UTF_8, true)) {
+			writer.write(content);
+		}
+	}
+
+	/**
+	 * Generates a pre-push template script that defines the commands to check and apply changes
+	 * using an executor and Spotless.
+	 *
+	 * @param executor      The tool to execute the check and apply commands.
+	 * @param commandCheck  The command to check for issues.
+	 * @param commandApply  The command to apply corrections.
+	 * @return A string template representing the Spotless Git pre-push hook content.
+	 */
+	protected String preHookTemplate(String executor, String commandCheck, String commandApply) {
+		var spotlessHook = "\n";
+		spotlessHook += "\n##### SPOTLESS HOOK START #####";
+		spotlessHook += "\nSPOTLESS_EXECUTOR=" + executor;
+		spotlessHook += "\nif ! $SPOTLESS_EXECUTOR " + commandCheck + " ; then";
+		spotlessHook += "\n    echo 1>&2 \"spotless found problems, running " + commandApply + "; commit the result and re-push\"";
+		spotlessHook += "\n    $SPOTLESS_EXECUTOR " + commandApply;
+		spotlessHook += "\n    exit 1";
+		spotlessHook += "\nfi";
+		spotlessHook += "\n##### SPOTLESS HOOK END #####";
+		spotlessHook += "\n\n";
+		return spotlessHook;
+	}
+
+	public interface GitPreHookLogger {
+		void info(String format, Object... arguments);
+		void error(String format, Object... arguments);
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerGradle.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerGradle.java
@@ -1,0 +1,42 @@
+package com.diffplug.spotless;
+
+import java.io.File;
+
+/**
+ * Implementation of {@link GitPrePushHookInstaller} specifically for Gradle-based projects.
+ * This class installs a Git pre-push hook that uses Gradle's `gradlew` executable to check and apply Spotless formatting.
+ */
+public class GitPrePushHookInstallerGradle extends GitPrePushHookInstaller {
+
+	/**
+	 * The Gradle wrapper file (`gradlew`) located in the root directory of the project.
+	 */
+	private final File gradlew;
+
+	public GitPrePushHookInstallerGradle(GitPreHookLogger logger, File root) {
+		super(logger, root);
+		this.gradlew = root.toPath().resolve("gradlew").toFile();
+	}
+
+	/**
+	 * Checks if the Gradle wrapper (`gradlew`) is present in the root directory.
+	 * This ensures that the executor used for formatting (`spotlessCheck` and `spotlessApply`) is available.
+	 *
+	 * @return {@code true} if the Gradle wrapper is found, {@code false} otherwise.
+	 *         An error is logged if the wrapper is not found.
+	 */
+	@Override
+	protected boolean isExecutorInstalled() {
+		if (gradlew.exists()) {
+			return true;
+		}
+
+		logger.error("Failed to find gradlew in root directory");
+		return false;
+	}
+
+	@Override
+	protected String preHookContent() {
+		return preHookTemplate(gradlew.getAbsolutePath(), "spotlessCheck", "spotlessApply");
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerMaven.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerMaven.java
@@ -1,0 +1,32 @@
+package com.diffplug.spotless;
+
+import java.io.File;
+
+/**
+ * Implementation of {@link GitPrePushHookInstaller} specifically for Maven-based projects.
+ * This class installs a Git pre-push hook that uses Maven to check and apply Spotless formatting.
+ */
+public class GitPrePushHookInstallerMaven extends GitPrePushHookInstaller {
+
+	public GitPrePushHookInstallerMaven(GitPreHookLogger logger, File root) {
+		super(logger, root);
+	}
+
+	/**
+	 * Confirms that Maven is installed and available for use.
+	 *
+	 * <p>This method assumes that if this code is running, then Maven is already properly installed and configured,
+	 * so it always returns {@code true}.
+	 *
+	 * @return {@code true}, indicating that Maven is available.
+	 */
+	@Override
+	protected boolean isExecutorInstalled() {
+		return true;
+	}
+
+	@Override
+	protected String preHookContent() {
+		return preHookTemplate("mvn", "spotless:check", "spotless:apply");
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -38,14 +38,17 @@ public abstract class SpotlessExtension {
 	private final RegisterDependenciesTask registerDependenciesTask;
 
 	protected static final String TASK_GROUP = LifecycleBasePlugin.VERIFICATION_GROUP;
+	protected static final String BUILD_SETUP_TASK_GROUP = "build setup";
 	protected static final String CHECK_DESCRIPTION = "Checks that sourcecode satisfies formatting steps.";
 	protected static final String APPLY_DESCRIPTION = "Applies code formatting steps to sourcecode in-place.";
+	protected static final String INSTALL_GIT_PRE_PUSH_HOOK_DESCRIPTION = "Installs Spotless Git pre-push hook.";
 
 	static final String EXTENSION = "spotless";
 	static final String EXTENSION_PREDECLARE = "spotlessPredeclare";
 	static final String CHECK = "Check";
 	static final String APPLY = "Apply";
 	static final String DIAGNOSE = "Diagnose";
+	static final String INSTALL_GIT_PRE_PUSH_HOOK = "InstallGitPrePushHook";
 
 	protected SpotlessExtension(Project project) {
 		this.project = requireNonNull(project);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -23,7 +23,7 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 public class SpotlessExtensionImpl extends SpotlessExtension {
-	final TaskProvider<?> rootCheckTask, rootApplyTask, rootDiagnoseTask;
+	final TaskProvider<?> rootCheckTask, rootApplyTask, rootDiagnoseTask, rootInstallPreHook;
 
 	public SpotlessExtensionImpl(Project project) {
 		super(project);
@@ -37,6 +37,10 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 		});
 		rootDiagnoseTask = project.getTasks().register(EXTENSION + DIAGNOSE, task -> {
 			task.setGroup(TASK_GROUP); // no description on purpose
+		});
+		rootInstallPreHook = project.getTasks().register(EXTENSION + INSTALL_GIT_PRE_PUSH_HOOK, SpotlessInstallPrePushHookTask.class, task -> {
+			task.setGroup(BUILD_SETUP_TASK_GROUP);
+			task.setDescription(INSTALL_GIT_PRE_PUSH_HOOK_DESCRIPTION);
 		});
 
 		project.afterEvaluate(unused -> {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessInstallPrePushHookTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessInstallPrePushHookTask.java
@@ -1,0 +1,46 @@
+package com.diffplug.gradle.spotless;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
+
+import com.diffplug.spotless.GitPrePushHookInstaller.GitPreHookLogger;
+import com.diffplug.spotless.GitPrePushHookInstallerGradle;
+
+/**
+ * A Gradle task responsible for installing a Git pre-push hook for the Spotless plugin.
+ * This hook ensures that Spotless formatting rules are automatically checked and applied
+ * before performing a Git push operation.
+ *
+ * <p>The task leverages {@link GitPrePushHookInstallerGradle} to implement the installation process.
+ */
+@DisableCachingByDefault(because = "not worth caching")
+public class SpotlessInstallPrePushHookTask extends DefaultTask {
+
+	/**
+	 * Executes the task to install the Git pre-push hook.
+	 *
+	 * <p>This method creates an instance of {@link GitPrePushHookInstallerGradle},
+	 * providing a logger to record informational and error messages during the installation process.
+	 * The installer then installs the hook in the root directory of the Gradle project.
+	 *
+	 * @throws Exception if an error occurs during the hook installation process.
+	 */
+	@TaskAction
+	public void performAction() throws Exception {
+		final var logger = new GitPreHookLogger() {
+			@Override
+			public void info(String format, Object... arguments) {
+				getLogger().lifecycle(String.format(format, arguments));
+			}
+
+			@Override
+			public void error(String format, Object... arguments) {
+				getLogger().error(String.format(format, arguments));
+			}
+		};
+
+		final var installer = new GitPrePushHookInstallerGradle(logger, getProject().getRootDir());
+		installer.install();
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessInstallPrePushHookTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessInstallPrePushHookTaskTest.java
@@ -1,0 +1,70 @@
+package com.diffplug.gradle.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SpotlessInstallPrePushHookTaskTest extends GradleIntegrationHarness {
+
+	@Test
+	public void should_create_pre_hook_file_when_hook_file_does_not_exists() throws Exception {
+		// given
+		final var gradlew = setFile("gradlew").toContent("");
+		setFile(".git/config").toContent("");
+		setFile("build.gradle").toLines(
+			"plugins {",
+			"    id 'java'",
+			"    id 'com.diffplug.spotless'",
+			"}",
+			"repositories { mavenCentral() }"
+		);
+
+		// when
+		var output = gradleRunner()
+			.withArguments("spotlessInstallGitPrePushHook")
+			.build()
+			.getOutput();
+
+		// then
+		assertThat(output).contains("Installing git pre-push hook");
+		assertThat(output).contains("Git pre-push hook not found, creating it");
+		assertThat(output).contains("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push"));
+
+		final var content = getTestResource("git_pre_hook/pre-push.created")
+			.replace("${executor}", gradlew.getAbsolutePath())
+			.replace("${checkCommand}", "spotlessCheck")
+			.replace("${applyCommand}", "spotlessApply");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	@Test
+	public void should_append_to_existing_pre_hook_file_when_hook_file_exists() throws Exception {
+		// given
+		final var gradlew = setFile("gradlew").toContent("");
+		setFile(".git/config").toContent("");
+		setFile("build.gradle").toLines(
+			"plugins {",
+			"    id 'java'",
+			"    id 'com.diffplug.spotless'",
+			"}",
+			"repositories { mavenCentral() }"
+		);
+		setFile(".git/hooks/pre-push").toResource("git_pre_hook/pre-push.existing");
+
+		// when
+		final var output = gradleRunner()
+			.withArguments("spotlessInstallGitPrePushHook")
+			.build()
+			.getOutput();
+
+		// then
+		assertThat(output).contains("Installing git pre-push hook");
+		assertThat(output).contains("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push"));
+
+		final var content = getTestResource("git_pre_hook/pre-push.existing-added")
+			.replace("${executor}", gradlew.getAbsolutePath())
+			.replace("${checkCommand}", "spotlessCheck")
+			.replace("${applyCommand}", "spotlessApply");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -91,6 +91,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	static final String GOAL_CHECK = "check";
 	static final String GOAL_APPLY = "apply";
+	static final String GOAL_PRE_PUSH_HOOK = "install-git-pre-push-hook";
 
 	@Component
 	private RepositorySystem repositorySystem;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojo.java
@@ -1,0 +1,63 @@
+package com.diffplug.spotless.maven;
+
+import java.io.File;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.diffplug.spotless.GitPrePushHookInstaller.GitPreHookLogger;
+import com.diffplug.spotless.GitPrePushHookInstallerMaven;
+
+/**
+ * A Maven Mojo responsible for installing a Git pre-push hook for the Spotless plugin.
+ * This hook ensures that Spotless formatting rules are automatically checked and applied
+ * before performing a Git push operation.
+ *
+ * <p>The class leverages {@link GitPrePushHookInstallerMaven} to perform the installation process
+ * and uses a Maven logger to log installation events and errors to the console.
+ */
+@Mojo(name = AbstractSpotlessMojo.GOAL_PRE_PUSH_HOOK, threadSafe = true)
+public class SpotlessInstallPrePushHookMojo extends AbstractMojo {
+
+	/**
+	 * The base directory of the Maven project where the Git pre-push hook will be installed.
+	 * This parameter is automatically set to the root directory of the current project.
+	 */
+	@Parameter(defaultValue = "${project.basedir}", readonly = true, required = true)
+	private File baseDir;
+
+	/**
+	 * Executes the Mojo, installing the Git pre-push hook for the Spotless plugin.
+	 *
+	 * <p>This method creates an instance of {@link GitPrePushHookInstallerMaven},
+	 * providing a logger for logging the process of hook installation and any potential errors.
+	 * The installation process runs in the root directory of the current Maven project.
+	 *
+	 * @throws MojoExecutionException if an error occurs during the installation process.
+	 * @throws MojoFailureException   if the hook fails to install for any reason.
+	 */
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		final var logger = new GitPreHookLogger() {
+			@Override
+			public void info(String format, Object... arguments) {
+				getLog().info(String.format(format, arguments));
+			}
+
+			@Override
+			public void error(String format, Object... arguments) {
+				getLog().error(String.format(format, arguments));
+			}
+		};
+
+		try {
+			final var installer = new GitPrePushHookInstallerMaven(logger, baseDir);
+			installer.install();
+		} catch (Exception e) {
+			throw new MojoExecutionException("Unable to install pre-push hook", e);
+		}
+	}
+}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojoTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojoTest.java
@@ -1,0 +1,69 @@
+package com.diffplug.spotless.maven;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
+
+	@Test
+	public void should_create_pre_hook_file_when_hook_file_does_not_exists() throws Exception {
+		// given
+		setFile(".git/config").toContent("");
+		setFile("license.txt").toResource("license/TestLicense");
+		writePomWithJavaLicenseHeaderStep();
+
+		// when
+		final var output = mavenRunner()
+			.withArguments("spotless:install-git-pre-push-hook")
+			.runNoError()
+			.stdOutUtf8();
+
+		// then
+		assertThat(output).contains("Installing git pre-push hook");
+		assertThat(output).contains("Git pre-push hook not found, creating it");
+		assertThat(output).contains("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push"));
+
+
+		final var content = getTestResource("git_pre_hook/pre-push.created")
+			.replace("${executor}", "mvn")
+			.replace("${checkCommand}", "spotless:check")
+			.replace("${applyCommand}", "spotless:apply");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	@Test
+	public void should_append_to_existing_pre_hook_file_when_hook_file_exists() throws Exception {
+		// given
+		setFile(".git/config").toContent("");
+		setFile("license.txt").toResource("license/TestLicense");
+		setFile(".git/hooks/pre-push").toResource("git_pre_hook/pre-push.existing");
+
+		writePomWithJavaLicenseHeaderStep();
+
+		// when
+		final var output = mavenRunner()
+			.withArguments("spotless:install-git-pre-push-hook")
+			.runNoError()
+			.stdOutUtf8();
+
+		// then
+		assertThat(output).contains("Installing git pre-push hook");
+		assertThat(output).contains("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push"));
+
+		final var content = getTestResource("git_pre_hook/pre-push.existing-added")
+			.replace("${executor}", "mvn")
+			.replace("${checkCommand}", "spotless:check")
+			.replace("${applyCommand}", "spotless:apply");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	private void writePomWithJavaLicenseHeaderStep() throws IOException {
+		writePomWithJavaSteps(
+			"<licenseHeader>",
+			"  <file>${basedir}/license.txt</file>",
+			"</licenseHeader>");
+	}
+}

--- a/testlib/src/main/resources/git_pre_hook/pre-push.created
+++ b/testlib/src/main/resources/git_pre_hook/pre-push.created
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+
+##### SPOTLESS HOOK START #####
+SPOTLESS_EXECUTOR=${executor}
+if ! $SPOTLESS_EXECUTOR ${checkCommand} ; then
+    echo 1>&2 "spotless found problems, running ${applyCommand}; commit the result and re-push"
+    $SPOTLESS_EXECUTOR ${applyCommand}
+    exit 1
+fi
+##### SPOTLESS HOOK END #####
+

--- a/testlib/src/main/resources/git_pre_hook/pre-push.existing
+++ b/testlib/src/main/resources/git_pre_hook/pre-push.existing
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+#
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+
+while read local_ref local_oid remote_ref remote_oid
+do
+        if test "$local_oid" = "$zero"
+        then
+                # Handle delete
+                :
+        else
+                if test "$remote_oid" = "$zero"
+                then
+                        # New branch, examine all commits
+                        range="$local_oid"
+                else
+                        # Update to existing branch, examine new commits
+                        range="$remote_oid..$local_oid"
+                fi
+
+                # Check for WIP commit
+                commit=$(git rev-list -n 1 --grep '^WIP' "$range")
+                if test -n "$commit"
+                then
+                        echo >&2 "Found WIP commit in $local_ref, not pushing"
+                        exit 1
+                fi
+        fi
+done

--- a/testlib/src/main/resources/git_pre_hook/pre-push.existing-added
+++ b/testlib/src/main/resources/git_pre_hook/pre-push.existing-added
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+#
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+
+while read local_ref local_oid remote_ref remote_oid
+do
+        if test "$local_oid" = "$zero"
+        then
+                # Handle delete
+                :
+        else
+                if test "$remote_oid" = "$zero"
+                then
+                        # New branch, examine all commits
+                        range="$local_oid"
+                else
+                        # Update to existing branch, examine new commits
+                        range="$remote_oid..$local_oid"
+                fi
+
+                # Check for WIP commit
+                commit=$(git rev-list -n 1 --grep '^WIP' "$range")
+                if test -n "$commit"
+                then
+                        echo >&2 "Found WIP commit in $local_ref, not pushing"
+                        exit 1
+                fi
+        fi
+done
+
+
+##### SPOTLESS HOOK START #####
+SPOTLESS_EXECUTOR=${executor}
+if ! $SPOTLESS_EXECUTOR ${checkCommand} ; then
+    echo 1>&2 "spotless found problems, running ${applyCommand}; commit the result and re-push"
+    $SPOTLESS_EXECUTOR ${applyCommand}
+    exit 1
+fi
+##### SPOTLESS HOOK END #####
+

--- a/testlib/src/test/java/com/diffplug/spotless/GitPrePushHookInstallerTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/GitPrePushHookInstallerTest.java
@@ -1,0 +1,148 @@
+package com.diffplug.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.GitPrePushHookInstaller.GitPreHookLogger;
+
+class GitPrePushHookInstallerTest extends ResourceHarness {
+	private final List<String> logs = new ArrayList<>();
+	private final GitPreHookLogger logger = new GitPreHookLogger() {
+		@Override
+		public void info(String format, Object... arguments) {
+			logs.add(String.format(format, arguments));
+		}
+
+		@Override
+		public void error(String format, Object... arguments) {
+			logs.add(String.format(format, arguments));
+		}
+	};
+
+	@Test
+	public void should_not_create_pre_hook_file_when_git_is_not_installed() throws Exception {
+	    // given
+		final var gradle = new GitPrePushHookInstallerGradle(logger, rootFolder());
+
+	    // when
+		gradle.install();
+
+	    // then
+		assertThat(logs).hasSize(2);
+		assertThat(logs).element(0).isEqualTo("Installing git pre-push hook");
+		assertThat(logs).element(1).isEqualTo("Git not found in root directory");
+		assertThat(newFile(".git/hooks/pre-push")).doesNotExist();
+	}
+
+	@Test
+	public void should_not_create_pre_hook_file_when_gradlew_is_not_installed() throws Exception {
+		// given
+		final var gradle = new GitPrePushHookInstallerGradle(logger, rootFolder());
+		setFile(".git/config").toContent("");
+
+		// when
+		gradle.install();
+
+		// then
+		assertThat(logs).hasSize(2);
+		assertThat(logs).element(0).isEqualTo("Installing git pre-push hook");
+		assertThat(logs).element(1).isEqualTo("Failed to find gradlew in root directory");
+		assertThat(newFile(".git/hooks/pre-push")).doesNotExist();
+	}
+
+	@Test
+	public void should_not_create_pre_hook_file_when_hook_already_installed() throws Exception {
+		// given
+		final var gradle = new GitPrePushHookInstallerGradle(logger, rootFolder());
+		final var hookFile = setFile(".git/hooks/pre-push").toResource("git_pre_hook/pre-push.existing-added");
+
+		setFile("gradlew").toContent("");
+		setFile(".git/config").toContent("");
+
+		// when
+		gradle.install();
+
+		// then
+		assertThat(logs).hasSize(2);
+		assertThat(logs).element(0).isEqualTo("Installing git pre-push hook");
+		assertThat(logs).element(1).isEqualTo("Skipping, git pre-push hook already installed " + hookFile.getAbsolutePath());
+		assertThat(hookFile).content().isEqualTo(getTestResource("git_pre_hook/pre-push.existing-added"));
+	}
+
+	@Test
+	public void should_create_pre_hook_file_when_hook_file_does_not_exists() throws Exception {
+		// given
+		final var gradle = new GitPrePushHookInstallerGradle(logger, rootFolder());
+		final var gradlew = setFile("gradlew").toContent("");
+		setFile(".git/config").toContent("");
+
+		// when
+		gradle.install();
+
+		// then
+		assertThat(logs).hasSize(3);
+		assertThat(logs).element(0).isEqualTo("Installing git pre-push hook");
+		assertThat(logs).element(1).isEqualTo("Git pre-push hook not found, creating it");
+		assertThat(logs).element(2).isEqualTo("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push").getAbsolutePath());
+
+		final var content = gradleHookContent("git_pre_hook/pre-push.created");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	@Test
+	public void should_append_to_existing_pre_hook_file_when_hook_file_exists() throws Exception {
+		// given
+		final var gradle = new GitPrePushHookInstallerGradle(logger, rootFolder());
+		final var gradlew = setFile("gradlew").toContent("");
+		setFile(".git/config").toContent("");
+		setFile(".git/hooks/pre-push").toResource("git_pre_hook/pre-push.existing");
+
+		// when
+		gradle.install();
+
+		// then
+		assertThat(logs).hasSize(2);
+		assertThat(logs).element(0).isEqualTo("Installing git pre-push hook");
+		assertThat(logs).element(1).isEqualTo("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push").getAbsolutePath());
+
+		final var content = gradleHookContent("git_pre_hook/pre-push.existing-added");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	@Test
+	public void should_create_pre_hook_file_for_maven_when_hook_file_does_not_exists() throws Exception {
+		// given
+		final var gradle = new GitPrePushHookInstallerMaven(logger, rootFolder());
+		setFile(".git/config").toContent("");
+
+		// when
+		gradle.install();
+
+		// then
+		assertThat(logs).hasSize(3);
+		assertThat(logs).element(0).isEqualTo("Installing git pre-push hook");
+		assertThat(logs).element(1).isEqualTo("Git pre-push hook not found, creating it");
+		assertThat(logs).element(2).isEqualTo("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push").getAbsolutePath());
+
+		final var content = mavenHookContent("git_pre_hook/pre-push.created");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	private String gradleHookContent(String resourcePath) {
+		return getTestResource(resourcePath)
+			.replace("${executor}", setFile("gradlew").toContent("").getAbsolutePath())
+			.replace("${checkCommand}", "spotlessCheck")
+			.replace("${applyCommand}", "spotlessApply");
+	}
+
+	private String mavenHookContent(String resourcePath) {
+		return getTestResource(resourcePath)
+			.replace("${executor}", "mvn")
+			.replace("${checkCommand}", "spotless:check")
+			.replace("${applyCommand}", "spotless:apply");
+	}
+}


### PR DESCRIPTION
### What this PR does
This PR adds support for installing a Git pre-push hook that runs spotlessCheck before pushing to a remote repository.

✅ For Gradle: new task spotlessInstallGitPrePushHook
✅ For Maven: new goal spotless:install-git-pre-push-hook
☑️ The logic is shared in a new class: GitPrePushHookInstaller in the core library.

### Why I added this
Sometimes spotlessCheck fails in CI/CD, but locally everything seems fine.
This often happens when developers use the console to work with Git (like I do):

```
git commit -m "message"
git push
```

They don’t always install IDE plugins or hooks.
So I created a command that adds a pre-push Git hook — it checks formatting before code is pushed.
This way:

formatting problems are found earlier;

developers don’t need to set up extra tools manually;

pushes won’t break CI.

### Changes in this PR
Added shared code to install a Git hook (GitPrePushHookInstaller)

Gradle: added spotlessInstallGitPrePushHook task

Maven: added spotless:install-git-pre-push-hook goal

Updated CHANGES.md for core lib, Gradle, and Maven plugins

Let me know if you want to support pre-commit hooks too, or prefer other ways to configure it.