### PR TITLE
Windows Compatibility Fix for Git Pre-push Hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, release]
   workflow_dispatch:
 
 concurrency:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `GitPrePushHookInstaller` didn't work on windows, now fixed. ([#2562](https://github.com/diffplug/spotless/pull/2562))
 
 ## [3.3.0] - 2025-07-20
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Locale;
 
 /**
  * Abstract class responsible for installing a Git pre-push hook in a repository.
@@ -225,7 +226,7 @@ public abstract class GitPrePushHookInstaller {
 		}
 
 		logger.info("Local %s wrapper (%s) not found, falling back to global command '%s'",
-			executor.name().toLowerCase(), executor.wrapper, executor.global);
+				executor.name().toLowerCase(Locale.ROOT), executor.wrapper, executor.global);
 
 		return executor.global;
 	}
@@ -258,7 +259,7 @@ public abstract class GitPrePushHookInstaller {
 	 * @return true if the current OS is Windows, false otherwise
 	 */
 	private boolean isWindows() {
-		return System.getProperty("os.name").toLowerCase().startsWith("win");
+		return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("win");
 	}
 
 	/**
@@ -296,8 +297,7 @@ public abstract class GitPrePushHookInstaller {
 	}
 
 	public enum Executor {
-		GRADLE("gradlew", "gradle"),
-		MAVEN("mvnw", "mvn"), ;
+		GRADLE("gradlew", "gradle"), MAVEN("mvnw", "mvn"),;
 
 		public final String wrapper;
 		public final String global;

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerGradle.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerGradle.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static com.diffplug.spotless.GitPrePushHookInstaller.Executor.GRADLE;
+
 import java.io.File;
 
 /**
@@ -23,14 +25,8 @@ import java.io.File;
  */
 public class GitPrePushHookInstallerGradle extends GitPrePushHookInstaller {
 
-	/**
-	 * The Gradle wrapper file (`gradlew`) located in the root directory of the project.
-	 */
-	private final File gradlew;
-
 	public GitPrePushHookInstallerGradle(GitPreHookLogger logger, File root) {
 		super(logger, root);
-		this.gradlew = root.toPath().resolve("gradlew").toFile();
 	}
 
 	/**
@@ -38,15 +34,6 @@ public class GitPrePushHookInstallerGradle extends GitPrePushHookInstaller {
 	 */
 	@Override
 	protected String preHookContent() {
-		return preHookTemplate(executorPath(), "spotlessCheck", "spotlessApply");
-	}
-
-	private String executorPath() {
-		if (gradlew.exists()) {
-			return gradlew.getAbsolutePath();
-		}
-
-		logger.info("Gradle wrapper is not installed, using global gradle");
-		return "gradle";
+		return preHookTemplate(GRADLE, "spotlessCheck", "spotlessApply");
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerMaven.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerMaven.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static com.diffplug.spotless.GitPrePushHookInstaller.Executor.MAVEN;
+
 import java.io.File;
 
 /**
@@ -23,11 +25,8 @@ import java.io.File;
  */
 public class GitPrePushHookInstallerMaven extends GitPrePushHookInstaller {
 
-	private final File mvnw;
-
 	public GitPrePushHookInstallerMaven(GitPreHookLogger logger, File root) {
 		super(logger, root);
-		this.mvnw = root.toPath().resolve("mvnw").toFile();
 	}
 
 	/**
@@ -35,15 +34,6 @@ public class GitPrePushHookInstallerMaven extends GitPrePushHookInstaller {
 	 */
 	@Override
 	protected String preHookContent() {
-		return preHookTemplate(executorPath(), "spotless:check", "spotless:apply");
-	}
-
-	private String executorPath() {
-		if (mvnw.exists()) {
-			return mvnw.getAbsolutePath();
-		}
-
-		logger.info("Maven wrapper is not installed, using global maven");
-		return "mvn";
+		return preHookTemplate(MAVEN, "spotless:check", "spotless:apply");
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `spotlessInstallGitPrePushHook` didn't work on windows, now fixed. ([#2562](https://github.com/diffplug/spotless/pull/2562))
 
 ## [7.2.0] - 2025-07-20
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* `spotless:install-git-pre-push-hook` didn't work on windows, now fixed. ([#2562](https://github.com/diffplug/spotless/pull/2562))
 
 ## [2.46.0] - 2025-07-20
 ### Added

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenRunner.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenRunner.java
@@ -56,6 +56,11 @@ public class MavenRunner {
 		return this;
 	}
 
+	public MavenRunner withEnvironment(String key, String value) {
+		environment.put(key, value);
+		return this;
+	}
+
 	public MavenRunner withRunner(ProcessRunner runner) {
 		this.runner = runner;
 		return this;

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojoTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojoTest.java
@@ -19,9 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.ProcessRunner;
 
 class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
 
@@ -29,14 +34,11 @@ class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
 	public void should_create_pre_hook_file_when_hook_file_does_not_exists() throws Exception {
 		// given
 		setFile(".git/config").toContent("");
-		setFile("license.txt").toResource("license/TestLicense");
+		setFile("license.txt").toResource("git_pre_hook/TestLicense.txt");
 		writePomWithJavaLicenseHeaderStep();
 
 		// when
-		final var output = mavenRunner()
-				.withArguments("spotless:install-git-pre-push-hook")
-				.runNoError()
-				.stdOutUtf8();
+		final var output = runMaven("spotless:install-git-pre-push-hook");
 
 		// then
 		assertThat(output).contains("Installing git pre-push hook");
@@ -51,16 +53,13 @@ class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
 	public void should_append_to_existing_pre_hook_file_when_hook_file_exists() throws Exception {
 		// given
 		setFile(".git/config").toContent("");
-		setFile("license.txt").toResource("license/TestLicense");
+		setFile("license.txt").toResource("git_pre_hook/TestLicense.txt");
 		setFile(".git/hooks/pre-push").toResource("git_pre_hook/pre-push.existing");
 
 		writePomWithJavaLicenseHeaderStep();
 
 		// when
-		final var output = mavenRunner()
-				.withArguments("spotless:install-git-pre-push-hook")
-				.runNoError()
-				.stdOutUtf8();
+		final var output = runMaven("spotless:install-git-pre-push-hook");
 
 		// then
 		assertThat(output).contains("Installing git pre-push hook");
@@ -68,6 +67,30 @@ class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
 
 		final var hookContent = getHookContent("git_pre_hook/pre-push.existing-installed-end-tpl");
 		assertFile(".git/hooks/pre-push").hasContent(hookContent);
+	}
+
+	@Test
+	public void should_execute_pre_push_script() throws Exception {
+		// given
+		setFile("license.txt").toResource("git_pre_hook/TestLicense.txt");
+		setFile(".git/config").toContent("");
+		setFile("src/main/java/com.github.youribonnaffe.gradle.format/Java8Test.java").toResource("git_pre_hook/MissingLicense.test");
+		writePomWithJavaLicenseHeaderStep();
+
+		// when
+		// install pre-hook
+		final var output = runMaven("spotless:install-git-pre-push-hook");
+
+		final var result = executeHookScript(".git/hooks/pre-push");
+
+		// then
+		assertThat(output).contains("Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push"));
+
+		assertThat(result.stdErrUtf8()).startsWith("spotless found problems, running spotless:apply; commit the result and re-push");
+		assertThat(result.exitCode()).isEqualTo(1);
+
+		final var fileContent = read("src/main/java/com.github.youribonnaffe.gradle.format/Java8Test.java");
+		assertThat(fileContent).startsWith("this is a test license!\n");
 	}
 
 	private void writePomWithJavaLicenseHeaderStep() throws IOException {
@@ -86,8 +109,12 @@ class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
 				.replace("${applyCommand}", "spotless:apply");
 	}
 
+	private boolean isWindows() {
+		return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("win");
+	}
+
 	private File executorWrapperFile() {
-		if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("win")) {
+		if (isWindows()) {
 			final var bat = newFile("mvnw.bat");
 			if (bat.exists()) {
 				return bat;
@@ -97,5 +124,58 @@ class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
 		}
 
 		return newFile("mvnw");
+	}
+
+	private String runMaven(String command) throws Exception {
+		return mavenRunner()
+				.withArguments(command)
+				.withEnvironment("JAVA_HOME", System.getProperty("java.home"))
+				.runNoError()
+				.stdOutUtf8();
+	}
+
+	private ProcessRunner.Result executeHookScript(String hookFile) throws Exception {
+		try (final var runner = new ProcessRunner()) {
+			String executor = "sh";
+			if (isWindows()) {
+				final var bashPath = findGitBashExecutable();
+				if (bashPath.isEmpty()) {
+					throw new RuntimeException("Could not find git bash executable");
+				}
+
+				executor = bashPath.get();
+			}
+
+			return runner.exec(rootFolder(), Map.of("JAVA_HOME", System.getProperty("java.home")), null, List.of(executor, hookFile));
+		}
+	}
+
+	private Optional<String> findGitBashExecutable() {
+		// 1. Check environment variable
+		final var envPath = System.getenv("GIT_BASH");
+		if (envPath != null && new File(envPath).exists()) {
+			return Optional.of(envPath);
+		}
+
+		// 2. Check common install paths
+		final var commonPaths = List.of(
+				"C:\\Program Files\\Git\\bin\\bash.exe",
+				"C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+				"C:\\Program Files\\Git\\usr\\bin\\bash.exe");
+
+		for (var path : commonPaths) {
+			if (new File(path).exists()) {
+				return Optional.of(path);
+			}
+		}
+
+		// 3. Try bash from PATH
+		try {
+			Process process = new ProcessBuilder("bash", "--version").start();
+			process.waitFor();
+			return Optional.of("bash"); // just use "bash"
+		} catch (Exception e) {
+			return Optional.empty();
+		}
 	}
 }

--- a/testlib/src/main/resources/git_pre_hook/MissingLicense.test
+++ b/testlib/src/main/resources/git_pre_hook/MissingLicense.test
@@ -1,0 +1,28 @@
+package com.github.youribonnaffe.gradle.format;
+
+import java.util.function.Function;
+
+
+public class Java8Test {
+    public void doStuff() throws Exception {
+        Function<String, Integer> example = Integer::parseInt;
+        example.andThen(val -> {
+            return val + 2;
+        } );
+        SimpleEnum val = SimpleEnum.A;
+        switch (val) {
+            case A:
+                break;
+            case B:
+                break;
+            case C:
+                break;
+            default:
+                throw new Exception();
+        }
+    }
+
+    public enum SimpleEnum {
+        A, B, C;
+    }
+}

--- a/testlib/src/main/resources/git_pre_hook/TestLicense.txt
+++ b/testlib/src/main/resources/git_pre_hook/TestLicense.txt
@@ -1,0 +1,1 @@
+this is a test license!


### PR DESCRIPTION
This PR fixes execution issues of the generated Git hook on Windows systems.

### What's changed
- Correct platform detection using `System.getProperty("os.name").toLowerCase().startsWith("win")`
- Automatically uses `mvnw.cmd / gradlew.bat` on Windows instead of plain `mvnw / gradlew`
- Uses relative paths (`./mvnw.cmd, ./gradlew.bat`) for better portability and shell compatibility
- Falls back to using globally installed `mvn` or `gradle` if wrapper is not found
- Avoids absolute paths, which can break on Windows because `File.getAbsolutePath()` returns backslashes (\) that are not valid in POSIX-compliant sh scripts used by Git hooks

### Why
On Windows, Git hooks are executed via sh (e.g., Git Bash), which does not recognize `.cmd` without an explicit extension and correct formatting.
Additionally, absolute paths on Windows (e.g., `D:\project\mvnw.cmd`) use backslashes, which cause `D:projectmvnw.cmd command not found` errors in shell scripts.
These changes ensure consistent behavior across platforms and make the Git hook portable and reliable.