### PR TITLE
use default field for default test path

### DIFF
--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -231,9 +231,9 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	}
 
 	private void checkKtlintOfficialStyle() throws IOException {
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		testPath = "src/main/kotlin/Main.kt";
+		setFile(testPath).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile(path).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
+		assertFile(testPath).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,9 @@ class MavenProvisionerTest extends MavenIntegrationHarness {
 	}
 
 	private void assertResolveDependenciesWorks() throws Exception {
-		String path = "src/main/java/test.java";
 		String unformattedContent = "package  a;";
-		setFile(path).toContent(unformattedContent);
+		setFile(testPath).toContent(unformattedContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(unformattedContent.replace("  ", " "));
+		assertFile(testPath).hasContent(unformattedContent.replace("  ", " "));
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/antlr4/Antlr4FormatterTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/antlr4/Antlr4FormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,9 +46,9 @@ class Antlr4FormatterTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest() throws Exception {
-		String path = "src/main/antlr4/Hello.g4";
-		setFile(path).toResource("antlr4/Hello.unformatted.g4");
+		testPath = "src/main/antlr4/Hello.g4";
+		setFile(testPath).toResource("antlr4/Hello.unformatted.g4");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("antlr4/Hello.formatted.g4");
+		assertFile(testPath).sameAsResource("antlr4/Hello.formatted.g4");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/IndentTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/IndentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,8 @@ class IndentTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String source, String target) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource(source);
+		setFile(testPath).toResource(source);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(target);
+		assertFile(testPath).sameAsResource(target);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/Jsr223Test.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/Jsr223Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,8 @@ public class Jsr223Test extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(testPath).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(testPath).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,11 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 				"  </content>",
 				"</licenseHeader>");
 
-		String path = "src/test/cpp/file.c++";
+		testPath = "src/test/cpp/file.c++";
 		String cppContent = "#include <whatsoever.h>";
-		setFile(path).toContent(cppContent);
+		setFile(testPath).toContent(cppContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(cppLicense + '\n' + cppContent);
+		assertFile(testPath).hasContent(cppLicense + '\n' + cppContent);
 	}
 
 	@Test
@@ -61,10 +61,10 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 				"  </content>",
 				"</licenseHeader>");
 
-		String path = "src/main/groovy/test.groovy";
-		setFile(path).toResource("license/MissingLicense.test");
+		testPath = "src/main/groovy/test.groovy";
+		setFile(testPath).toResource("license/MissingLicense.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("license/HasLicense.test");
+		assertFile(testPath).sameAsResource("license/HasLicense.test");
 	}
 
 	@Test
@@ -123,12 +123,12 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 				"  </content>",
 				"</licenseHeader>");
 
-		String path = "src/main/kotlin/test.kt";
+		testPath = "src/main/kotlin/test.kt";
 		String noLicenseHeader = getTestResource("kotlin/licenseheader/KotlinCodeWithoutHeader.test");
 
-		setFile(path).toContent(noLicenseHeader);
+		setFile(testPath).toContent(noLicenseHeader);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(KOTLIN_LICENSE_HEADER + '\n' + noLicenseHeader);
+		assertFile(testPath).hasContent(KOTLIN_LICENSE_HEADER + '\n' + noLicenseHeader);
 	}
 
 	@Test
@@ -142,10 +142,9 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest() throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("license/MissingLicense.test");
+		setFile(testPath).toResource("license/MissingLicense.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("license/HasLicense.test");
+		assertFile(testPath).sameAsResource("license/HasLicense.test");
 	}
 
 	private void testUnsupportedFile(String file) throws Exception {
@@ -156,12 +155,12 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 				"  </content>",
 				"</licenseHeader>");
 
-		String path = "src/main/java/com/diffplug/spotless/" + file;
-		setFile(path).toResource("license/" + file + ".test");
+		testPath = "src/main/java/com/diffplug/spotless/" + file;
+		setFile(testPath).toResource("license/" + file + ".test");
 
 		mavenRunner().withArguments("spotless:apply").runNoError();
 
 		// file should remain the same
-		assertFile(path).sameAsResource("license/" + file + ".test");
+		assertFile(testPath).sameAsResource("license/" + file + ".test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LineEndingsTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LineEndingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,10 +44,9 @@ class LineEndingsTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(testPath).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(testPath).hasContent(targetContent);
 	}
 
 	private String getClassWithLineEndings(String lineEnding) {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/NativeCmdTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/NativeCmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,8 @@ public class NativeCmdTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(testPath).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(testPath).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceRegexTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceRegexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,8 @@ class ReplaceRegexTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(testPath).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(testPath).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,8 @@ class ReplaceTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(testPath).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(testPath).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/TrimTrailingWhitespaceTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/TrimTrailingWhitespaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,9 @@ class TrimTrailingWhitespaceTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(testPath).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(testPath).hasContent(targetContent);
 	}
 
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/GrEclipseTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/GrEclipseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ class GrEclipseTest extends MavenIntegrationHarness {
 	void testEclipse() throws Exception {
 		writePomWithGrEclipse();
 
-		String path = "src/main/groovy/test.groovy";
-		setFile(path).toResource("groovy/greclipse/format/unformatted.test");
+		testPath = "src/main/groovy/test.groovy";
+		setFile(testPath).toResource("groovy/greclipse/format/unformatted.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("groovy/greclipse/format/formatted.test");
+		assertFile(testPath).sameAsResource("groovy/greclipse/format/formatted.test");
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/ImportOrderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/ImportOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,9 @@ class ImportOrderTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String expectedResource) throws Exception {
-		String path = "src/main/groovy/test.groovy";
-		setFile(path).toResource("java/importsorter/GroovyCodeUnsortedMisplacedImports.test");
+		testPath = "src/main/groovy/test.groovy";
+		setFile(testPath).toResource("java/importsorter/GroovyCodeUnsortedMisplacedImports.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(expectedResource);
+		assertFile(testPath).sameAsResource(expectedResource);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/RemoveSemicolonsTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/RemoveSemicolonsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,16 +37,16 @@ class RemoveSemicolonsTest extends MavenIntegrationHarness {
 	void testRemoveSemicolons() throws Exception {
 		writePomWithGroovySteps("<removeSemicolons/>");
 
-		String path = "src/main/groovy/test.groovy";
-		setFile(path).toResource("groovy/removeSemicolons/GroovyCodeWithSemicolons.test");
+		testPath = "src/main/groovy/test.groovy";
+		setFile(testPath).toResource("groovy/removeSemicolons/GroovyCodeWithSemicolons.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("groovy/removeSemicolons/GroovyCodeWithSemicolonsFormatted.test");
+		assertFile(testPath).sameAsResource("groovy/removeSemicolons/GroovyCodeWithSemicolonsFormatted.test");
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/groovy/test.groovy";
-		setFile(path).toContent(sourceContent);
+		testPath = "src/main/groovy/test.groovy";
+		setFile(testPath).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(testPath).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/UpToDateCheckingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,8 +246,8 @@ class UpToDateCheckingTest extends MavenIntegrationHarness {
 	private List<File> writeFiles(String resource, String suffix, int count) throws IOException {
 		List<File> result = new ArrayList<>(count);
 		for (int i = 0; i < count; i++) {
-			String path = "src/main/java/test_" + suffix + "_" + i + ".java";
-			File file = setFile(path).toResource(resource);
+			testPath = "src/main/java/test_" + suffix + "_" + i + ".java";
+			File file = setFile(testPath).toResource(resource);
 			result.add(file);
 		}
 		return result;

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,10 +101,9 @@ class CleanthatJavaRefactorerTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String dirtyPath, String cleanPath) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/cleanthat/" + dirtyPath);
+		setFile(testPath).toResource("java/cleanthat/" + dirtyPath);
 		// .withRemoteDebug(21654)
 		Assertions.assertThat(mavenRunner().withArguments("spotless:apply").runNoError().stdOutUtf8()).doesNotContain("[ERROR]");
-		assertFile(path).sameAsResource("java/cleanthat/" + cleanPath);
+		assertFile(testPath).sameAsResource("java/cleanthat/" + cleanPath);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/EclipseFormatStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/EclipseFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ class EclipseFormatStepTest extends MavenIntegrationHarness {
 				"</eclipse>");
 		setFile("formatter.xml").toResource("java/eclipse/formatter.xml");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/eclipse/JavaCodeUnformatted.test");
+		testPath = "src/main/java/test.java";
+		setFile(testPath).toResource("java/eclipse/JavaCodeUnformatted.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/eclipse/JavaCodeFormatted.test");
+		assertFile(testPath).sameAsResource("java/eclipse/JavaCodeFormatted.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/FormatAnnotationsStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/FormatAnnotationsStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,19 +25,19 @@ class FormatAnnotationsStepTest extends MavenIntegrationHarness {
 	void testFormatAnnotations() throws Exception {
 		writePomWithJavaSteps("<formatAnnotations/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/formatannotations/FormatAnnotationsTestInput.test");
+		testPath = "src/main/java/test.java";
+		setFile(testPath).toResource("java/formatannotations/FormatAnnotationsTestInput.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/formatannotations/FormatAnnotationsTestOutput.test");
+		assertFile(testPath).sameAsResource("java/formatannotations/FormatAnnotationsTestOutput.test");
 	}
 
 	@Test
 	void testFormatAnnotationsAccessModifiers() throws Exception {
 		writePomWithJavaSteps("<formatAnnotations/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/formatannotations/FormatAnnotationsAccessModifiersInput.test");
+		testPath = "src/main/java/test.java";
+		setFile(testPath).toResource("java/formatannotations/FormatAnnotationsAccessModifiersInput.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/formatannotations/FormatAnnotationsAccessModifiersOutput.test");
+		assertFile(testPath).sameAsResource("java/formatannotations/FormatAnnotationsAccessModifiersOutput.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/GoogleJavaFormatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/GoogleJavaFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,9 +80,8 @@ class GoogleJavaFormatTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String targetResource, String sourceResource) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource(sourceResource);
+		setFile(testPath).toResource(sourceResource);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(targetResource);
+		assertFile(testPath).sameAsResource(targetResource);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ImportOrderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ImportOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,8 @@ class ImportOrderTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String expectedResource) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/importsorter/JavaCodeUnsortedImports.test");
+		setFile(testPath).toResource("java/importsorter/JavaCodeUnsortedImports.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(expectedResource);
+		assertFile(testPath).sameAsResource(expectedResource);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/PalantirJavaFormatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/PalantirJavaFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,9 +52,8 @@ class PalantirJavaFormatTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String targetResource, String sourceResource) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource(sourceResource);
+		setFile(testPath).toResource(sourceResource);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(targetResource);
+		assertFile(testPath).sameAsResource(targetResource);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveUnusedImportsStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveUnusedImportsStepTest.java
@@ -25,9 +25,9 @@ class RemoveUnusedImportsStepTest extends MavenIntegrationHarness {
 	void testRemoveUnusedInports() throws Exception {
 		writePomWithJavaSteps("<removeUnusedImports/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/removeunusedimports/JavaCodeWithPackageUnformatted.test");
+		testPath = "src/main/java/test.java";
+		setFile(testPath).toResource("java/removeunusedimports/JavaCodeWithPackageUnformatted.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/removeunusedimports/JavaCodeWithPackageFormatted.test");
+		assertFile(testPath).sameAsResource("java/removeunusedimports/JavaCodeWithPackageFormatted.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveWildcardImportsStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveWildcardImportsStepTest.java
@@ -25,9 +25,8 @@ class RemoveWildcardImportsStepTest extends MavenIntegrationHarness {
 	void testRemoveWildcardImports() throws Exception {
 		writePomWithJavaSteps("<removeWildcardImports/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/removewildcardimports/JavaCodeWildcardsUnformatted.test");
+		setFile(testPath).toResource("java/removewildcardimports/JavaCodeWildcardsUnformatted.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/removewildcardimports/JavaCodeWildcardsFormatted.test");
+		assertFile(testPath).sameAsResource("java/removewildcardimports/JavaCodeWildcardsFormatted.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/DiktatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ class DiktatTest extends MavenIntegrationHarness {
 
 		writePomWithKotlinSteps("<diktat/>");
 
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/diktat/main.dirty");
+		testPath = "src/main/kotlin/Main.kt";
+		setFile(testPath).toResource("kotlin/diktat/main.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("kotlin/diktat/main.clean");
+		assertFile(testPath).sameAsResource("kotlin/diktat/main.clean");
 
 	}
 
@@ -43,10 +43,10 @@ class DiktatTest extends MavenIntegrationHarness {
 				"  <version>1.2.1</version>",
 				"</diktat>");
 
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/diktat/main.dirty");
+		testPath = "src/main/kotlin/Main.kt";
+		setFile(testPath).toResource("kotlin/diktat/main.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("kotlin/diktat/main.clean");
+		assertFile(testPath).sameAsResource("kotlin/diktat/main.clean");
 	}
 
 	@Test
@@ -60,10 +60,10 @@ class DiktatTest extends MavenIntegrationHarness {
 				"  <configFile>" + conf.getAbsolutePath() + "</configFile>",
 				"</diktat>");
 
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/diktat/main.dirty");
+		testPath = "src/main/kotlin/Main.kt";
+		setFile(testPath).toResource("kotlin/diktat/main.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("kotlin/diktat/main.clean");
+		assertFile(testPath).sameAsResource("kotlin/diktat/main.clean");
 	}
 
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -26,10 +26,10 @@ class KtlintTest extends MavenIntegrationHarness {
 	void testKtlint() throws Exception {
 		writePomWithKotlinSteps("<ktlint/>");
 
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/ktlint/basic.dirty");
+		testPath = "src/main/kotlin/Main.kt";
+		setFile(testPath).toResource("kotlin/ktlint/basic.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("kotlin/ktlint/basic.clean");
+		assertFile(testPath).sameAsResource("kotlin/ktlint/basic.clean");
 	}
 
 	@Test
@@ -41,10 +41,10 @@ class KtlintTest extends MavenIntegrationHarness {
 				"  </editorConfigOverride>\n" +
 				"</ktlint>");
 
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		testPath = "src/main/kotlin/Main.kt";
+		setFile(testPath).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
+		assertFile(testPath).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
 	}
 
 	@Test
@@ -92,9 +92,9 @@ class KtlintTest extends MavenIntegrationHarness {
 	}
 
 	private void checkKtlintOfficialStyle() throws Exception {
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		testPath = "src/main/kotlin/Main.kt";
+		setFile(testPath).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
+		assertFile(testPath).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmStepsWithNpmInstallCacheTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmStepsWithNpmInstallCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <prettierVersion>1.16.4</prettierVersion>",
 				"  <configFile>.prettierrc.yml</configFile>",
 				"</prettier>");
-		Result result = run("typescript", suffix);
+		Result result = run(suffix);
 		Assertions.assertThat(result.stdOutUtf8()).doesNotContain("Caching node_modules for").doesNotContain("Using cached node_modules for");
 	}
 
@@ -61,7 +61,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <configFile>.prettierrc.yml</configFile>",
 				"  <npmInstallCache>true</npmInstallCache>",
 				"</prettier>");
-		Result result = run("typescript", suffix);
+		Result result = run(suffix);
 		Assertions.assertThat(result.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME)
@@ -78,7 +78,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <configFile>.prettierrc.yml</configFile>",
 				"  <npmInstallCache>true</npmInstallCache>",
 				"</prettier>");
-		Result result1 = run("typescript", suffix);
+		Result result1 = run(suffix);
 		Assertions.assertThat(result1.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME)
@@ -87,7 +87,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 		// recursively delete target folder to simulate a fresh run (except the default cache folder)
 		recursiveDelete(Paths.get(rootFolder().getAbsolutePath(), "target"), SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME);
 
-		Result result2 = run("typescript", suffix);
+		Result result2 = run(suffix);
 		Assertions.assertThat(result2.stdOutUtf8())
 				.doesNotContain("Caching node_modules for")
 				.contains(SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME)
@@ -104,7 +104,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <configFile>.prettierrc.yml</configFile>",
 				"  <npmInstallCache>" + cacheDir.getAbsolutePath() + "</npmInstallCache>",
 				"</prettier>");
-		Result result = run("typescript", suffix);
+		Result result = run(suffix);
 		Assertions.assertThat(result.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(Path.of(cacheDir.getAbsolutePath()).toAbsolutePath().toString())
@@ -122,7 +122,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <configFile>.prettierrc.yml</configFile>",
 				"  <npmInstallCache>" + cacheDir.getAbsolutePath() + "</npmInstallCache>",
 				"</prettier>");
-		Result result1 = run("typescript", suffix);
+		Result result1 = run(suffix);
 		Assertions.assertThat(result1.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(Path.of(cacheDir.getAbsolutePath()).toAbsolutePath().toString())
@@ -131,7 +131,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 		// recursively delete target folder to simulate a fresh run
 		recursiveDelete(Paths.get(rootFolder().getAbsolutePath(), "target"), null);
 
-		Result result2 = run("typescript", suffix);
+		Result result2 = run(suffix);
 		Assertions.assertThat(result2.stdOutUtf8())
 				.doesNotContain("Caching node_modules for")
 				.contains(Path.of(cacheDir.getAbsolutePath()).toAbsolutePath().toString())
@@ -142,19 +142,18 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 		Files.walkFileTree(path, new RecursiveDelete(exclusion));
 	}
 
-	private Result run(String kind, String suffix) throws IOException, InterruptedException {
-		String path = prepareRun(kind, suffix);
+	private Result run(String suffix) throws IOException, InterruptedException {
+		prepareRun("typescript", suffix);
 		Result result = mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("npm/prettier/filetypes/" + kind + "/" + kind + ".clean");
+		assertFile(testPath).sameAsResource("npm/prettier/filetypes/" + "typescript" + "/" + "typescript" + ".clean");
 		return result;
 	}
 
-	private String prepareRun(String kind, String suffix) throws IOException {
+	private void prepareRun(String kind, String suffix) throws IOException {
 		String configPath = ".prettierrc.yml";
 		setFile(configPath).toResource("npm/prettier/filetypes/" + kind + "/" + ".prettierrc.yml");
-		String path = "src/main/" + kind + "/test." + suffix;
-		setFile(path).toResource("npm/prettier/filetypes/" + kind + "/" + kind + ".dirty");
-		return path;
+		testPath = "src/main/" + kind + "/test." + suffix;
+		setFile(testPath).toResource("npm/prettier/filetypes/" + kind + "/" + kind + ".dirty");
 	}
 
 	private static class RecursiveDelete extends SimpleFileVisitor<Path> {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmTestsWithDynamicallyInstalledNpmInstallationTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmTestsWithDynamicallyInstalledNpmInstallationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,11 +38,11 @@ public class NpmTestsWithDynamicallyInstalledNpmInstallationTest extends MavenIn
 		String suffix = "ts";
 		String configPath = ".prettierrc.yml";
 		setFile(configPath).toResource("npm/prettier/filetypes/" + kind + "/" + ".prettierrc.yml");
-		String path = "src/main/" + kind + "/test." + suffix;
-		setFile(path).toResource("npm/prettier/filetypes/" + kind + "/" + kind + ".dirty");
+		testPath = "src/main/" + kind + "/test." + suffix;
+		setFile(testPath).toResource("npm/prettier/filetypes/" + kind + "/" + kind + ".dirty");
 
 		mavenRunner().withArguments(installNpmMavenGoal(), "spotless:apply").runNoError();
-		assertFile(path).sameAsResource("npm/prettier/filetypes/" + kind + "/" + kind + ".clean");
+		assertFile(testPath).sameAsResource("npm/prettier/filetypes/" + kind + "/" + kind + ".clean");
 	}
 
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/prettier/PrettierFormatStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/prettier/PrettierFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,21 +30,19 @@ import com.diffplug.spotless.tag.NpmTest;
 class PrettierFormatStepTest extends MavenIntegrationHarness {
 
 	private void run(String kind, String suffix) throws IOException, InterruptedException {
-		String path = prepareRun(kind, suffix);
+		prepareRun(kind, suffix);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("npm/prettier/filetypes/" + kind + "/" + kind + ".clean");
+		assertFile(testPath).sameAsResource("npm/prettier/filetypes/" + kind + "/" + kind + ".clean");
 	}
 
-	private String prepareRun(String kind, String suffix) throws IOException {
-		String configPath = ".prettierrc.yml";
-		setFile(configPath).toResource("npm/prettier/filetypes/" + kind + "/" + ".prettierrc.yml");
-		String path = "src/main/" + kind + "/test." + suffix;
-		setFile(path).toResource("npm/prettier/filetypes/" + kind + "/" + kind + ".dirty");
-		return path;
+	private void prepareRun(String kind, String suffix) throws IOException {
+		setFile(".prettierrc.yml").toResource("npm/prettier/filetypes/" + kind + "/" + ".prettierrc.yml");
+		testPath = "src/main/" + kind + "/test." + suffix;
+		setFile(testPath).toResource("npm/prettier/filetypes/" + kind + "/" + kind + ".dirty");
 	}
 
-	private ProcessRunner.Result runExpectingError(String kind, String suffix) throws IOException, InterruptedException {
-		String path = prepareRun(kind, suffix);
+	private ProcessRunner.Result runExpectingError(String suffix) throws IOException, InterruptedException {
+		prepareRun("typescript", suffix);
 		return mavenRunner().withArguments("spotless:apply").runHasError();
 	}
 
@@ -258,7 +256,7 @@ class PrettierFormatStepTest extends MavenIntegrationHarness {
 				"  <prettierVersion>1.16.4</prettierVersion>",
 				"  <configFile>.prettierrc.yml</configFile>",
 				"</prettier>");
-		ProcessRunner.Result result = runExpectingError("typescript", suffix);
+		ProcessRunner.Result result = runExpectingError(suffix);
 		assertThat(result.stdOutUtf8()).containsPattern("Running npm command.*npm install.* failed with exit code: 1");
 	}
 
@@ -276,7 +274,7 @@ class PrettierFormatStepTest extends MavenIntegrationHarness {
 				"  <configFile>.prettierrc.yml</configFile>",
 				"  <npmrc>${basedir}/.custom_npmrc</npmrc>",
 				"</prettier>");
-		ProcessRunner.Result result = runExpectingError("typescript", suffix);
+		ProcessRunner.Result result = runExpectingError(suffix);
 		assertThat(result.stdOutUtf8()).containsPattern("Running npm command.*npm install.* failed with exit code: 1");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/scala/ScalafmtTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/scala/ScalafmtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ class ScalafmtTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String s) throws Exception {
-		String path = "src/main/scala/test.scala";
-		setFile(path).toResource("scala/scalafmt/basic.dirty");
+		testPath = "src/main/scala/test.scala";
+		setFile(testPath).toResource("scala/scalafmt/basic.dirty");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(s);
+		assertFile(testPath).sameAsResource(s);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/typescript/TypescriptFormatStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/typescript/TypescriptFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,9 @@ class TypescriptFormatStepTest extends MavenIntegrationHarness {
 	}
 
 	private void runTsfmt(String kind) throws IOException, InterruptedException {
-		String path = prepareRunTsfmt(kind);
+		prepareRunTsfmt(kind);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("npm/tsfmt/" + kind + "/" + kind + ".clean");
+		assertFile(testPath).sameAsResource("npm/tsfmt/" + kind + "/" + kind + ".clean");
 	}
 
 	private String prepareRunTsfmt(String kind) throws IOException {
@@ -113,10 +113,10 @@ class TypescriptFormatStepTest extends MavenIntegrationHarness {
 
 	@Test
 	void testTypescript_2_Configs() throws Exception {
-		String path = "src/main/typescript/test.ts";
+		testPath = "src/main/typescript/test.ts";
 
 		writePomWithTypescriptSteps(
-				path,
+				testPath,
 				"<tsfmt>",
 				"  <vscodeFile>${basedir}/tslint.json</vscodeFile>",
 				"  <tsfmtFile>${basedir}/tslint.json</tsfmtFile>",
@@ -124,7 +124,7 @@ class TypescriptFormatStepTest extends MavenIntegrationHarness {
 		setFile("vscode.json").toResource("npm/tsfmt/vscode/vscode.json");
 		setFile("tsfmt.json").toResource("npm/tsfmt/tsfmt/tsfmt.json");
 
-		setFile(path).toResource("npm/tsfmt/tsfmt/tsfmt.dirty");
+		setFile(testPath).toResource("npm/tsfmt/tsfmt/tsfmt.dirty");
 		ProcessRunner.Result result = mavenRunner().withArguments("spotless:apply").runHasError();
 		assertThat(result.stdOutUtf8()).contains("must specify exactly one configFile or config");
 	}

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -42,6 +42,12 @@ import com.diffplug.common.base.Errors;
 import com.diffplug.common.io.Resources;
 
 public class ResourceHarness {
+
+	/**
+	 * default test testPath.
+	 */
+	protected String testPath = "src/main/java/test.java";
+
 	/**
 	 * On OS X, the temp folder is a symlink,
 	 * and some of gradle's stuff breaks symlinks.


### PR DESCRIPTION
consolidating common field access.

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)


@iddeepak


if this is acceptable then i would update changed as well. 