### PR TITLE
give `SSOT/SPOT` on default field `TEST_PATH` to avoid `DRY`

### DIFF
--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigAvoidanceTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigAvoidanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class ConfigAvoidanceTest extends GradleIntegrationHarness {
 				"tasks.named('check').configure {",
 				"   dependsOn(canary)",
 				"}");
-		setFile("src/main/java/test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		setFile(TEST_PATH).toResource("java/googlejavaformat/JavaCodeUnformatted.test");
 
 		String help = gradleRunner().withArguments("help").build().getOutput();
 		Assertions.assertThat(help).doesNotContain("Canary was configured");

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GroovyExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GroovyExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,13 +53,13 @@ class GroovyExtensionTest extends GradleIntegrationHarness {
 
 		String withoutHeader = getTestResource("groovy/licenseheader/JavaCodeWithoutHeader.test");
 
-		setFile("src/main/java/test.java").toContent(withoutHeader);
+		setFile(TEST_PATH).toContent(withoutHeader);
 		setFile("src/main/groovy/test.java").toContent(withoutHeader);
 		setFile("src/main/groovy/test.groovy").toContent(withoutHeader);
 
 		gradleRunner().withArguments("spotlessApply").build();
 
-		assertFile("src/main/java/test.java").hasContent(withoutHeader);
+		assertFile(TEST_PATH).hasContent(withoutHeader);
 		assertFile("src/main/groovy/test.groovy").hasContent(HEADER + "\n" + withoutHeader);
 		if (excludeJava) {
 			assertFile("src/main/groovy/test.java").hasContent(withoutHeader);

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
@@ -35,13 +35,13 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 				"        googleJavaFormat()",
 				"    }",
 				"}");
-		setFile("src/main/java/test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		setFile(TEST_PATH).toResource("java/googlejavaformat/JavaCodeUnformatted.test");
 		setFile("src/main/groovy/test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
 		setFile("src/main/groovy/test.groovy").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
 
 		gradleRunner().withArguments("spotlessApply").build();
 
-		assertFile("src/main/java/test.java").sameAsResource("java/googlejavaformat/JavaCodeFormatted.test");
+		assertFile(TEST_PATH).sameAsResource("java/googlejavaformat/JavaCodeFormatted.test");
 		assertFile("src/main/groovy/test.java").sameAsResource("java/googlejavaformat/JavaCodeFormatted.test");
 		assertFile("src/main/groovy/test.groovy").sameAsResource("java/googlejavaformat/JavaCodeUnformatted.test");
 	}
@@ -76,9 +76,9 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 				"  java {  removeUnusedImports('cleanthat-javaparser-unnecessaryimport')  }",
 				"}");
 
-		setFile("src/main/java/test.java").toResource("java/removeunusedimports/Jdk17TextBlockUnformatted.test");
+		setFile(TEST_PATH).toResource("java/removeunusedimports/Jdk17TextBlockUnformatted.test");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/java/test.java").sameAsResource("java/removeunusedimports/Jdk17TextBlockFormatted.test");
+		assertFile(TEST_PATH).sameAsResource("java/removeunusedimports/Jdk17TextBlockFormatted.test");
 	}
 
 	@Test
@@ -122,9 +122,9 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 				"  }",
 				"}");
 
-		setFile("src/main/java/test.java").toResource("java/targetExclude/TargetExcludeNoMatchUnformatted.test");
+		setFile(TEST_PATH).toResource("java/targetExclude/TargetExcludeNoMatchUnformatted.test");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/java/test.java").sameAsResource("java/targetExclude/TargetExcludeNoMatchFormatted.test");
+		assertFile(TEST_PATH).sameAsResource("java/targetExclude/TargetExcludeNoMatchFormatted.test");
 	}
 
 	/**
@@ -148,8 +148,8 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 				"  }",
 				"}");
 
-		setFile("src/main/java/test.java").toResource("java/targetExclude/TargetExcludeMatch.test");
+		setFile(TEST_PATH).toResource("java/targetExclude/TargetExcludeMatch.test");
 		gradleRunner().withArguments("spotlessApply").build();
-		assertFile("src/main/java/test.java").sameAsResource("java/targetExclude/TargetExcludeMatch.test");
+		assertFile(TEST_PATH).sameAsResource("java/targetExclude/TargetExcludeMatch.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenProvisionerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,9 @@ class MavenProvisionerTest extends MavenIntegrationHarness {
 	}
 
 	private void assertResolveDependenciesWorks() throws Exception {
-		String path = "src/main/java/test.java";
 		String unformattedContent = "package  a;";
-		setFile(path).toContent(unformattedContent);
+		setFile(TEST_PATH).toContent(unformattedContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(unformattedContent.replace("  ", " "));
+		assertFile(TEST_PATH).hasContent(unformattedContent.replace("  ", " "));
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/EclipseWtpTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/EclipseWtpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ class EclipseWtpTest extends MavenIntegrationHarness {
 		String notFormatted = "<a><b>   c</b></a>";
 		String formatted = "<a>\n\t<b> c</b>\n</a>";
 		//writePomWithFormatSteps includes java. WTP does not care about file extensions.
-		setFile("src/main/java/test.java").toContent(notFormatted);
+		setFile(TEST_PATH).toContent(notFormatted);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile("src/main/java/test.java").hasContent(formatted);
+		assertFile(TEST_PATH).hasContent(formatted);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/EndWithNewlineTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/EndWithNewlineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@ class EndWithNewlineTest extends MavenIntegrationHarness {
 	private void runTest() throws Exception {
 		String noTrailingNewline = "public class Java {}";
 		String hasTrailingNewline = noTrailingNewline + "\n";
-		setFile("src/main/java/test.java").toContent(noTrailingNewline);
+		setFile(TEST_PATH).toContent(noTrailingNewline);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile("src/main/java/test.java").hasContent(hasTrailingNewline);
+		assertFile(TEST_PATH).hasContent(hasTrailingNewline);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/IndentTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/IndentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,8 @@ class IndentTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String source, String target) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource(source);
+		setFile(TEST_PATH).toResource(source);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(target);
+		assertFile(TEST_PATH).sameAsResource(target);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/Jsr223Test.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/Jsr223Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,8 @@ public class Jsr223Test extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(TEST_PATH).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(TEST_PATH).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,10 +142,9 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest() throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("license/MissingLicense.test");
+		setFile(TEST_PATH).toResource("license/MissingLicense.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("license/HasLicense.test");
+		assertFile(TEST_PATH).sameAsResource("license/HasLicense.test");
 	}
 
 	private void testUnsupportedFile(String file) throws Exception {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LineEndingsTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LineEndingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,10 +44,9 @@ class LineEndingsTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(TEST_PATH).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(TEST_PATH).hasContent(targetContent);
 	}
 
 	private String getClassWithLineEndings(String lineEnding) {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/NativeCmdTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/NativeCmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,8 @@ public class NativeCmdTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(TEST_PATH).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(TEST_PATH).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceRegexTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceRegexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,8 @@ class ReplaceRegexTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(TEST_PATH).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(TEST_PATH).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/ReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,8 @@ class ReplaceTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(TEST_PATH).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(TEST_PATH).hasContent(targetContent);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/TrimTrailingWhitespaceTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/TrimTrailingWhitespaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,9 @@ class TrimTrailingWhitespaceTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String sourceContent, String targetContent) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toContent(sourceContent);
+		setFile(TEST_PATH).toContent(sourceContent);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).hasContent(targetContent);
+		assertFile(TEST_PATH).hasContent(targetContent);
 	}
 
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/GrEclipseTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/groovy/GrEclipseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,9 +37,8 @@ class GrEclipseTest extends MavenIntegrationHarness {
 	void doesNotFormatJavaFiles() throws Exception {
 		writePomWithGrEclipse();
 
-		String javaPath = "src/main/java/test.java";
 		String testJavaPath = "src/test/java/test.java";
-		setFile(javaPath).toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		setFile(TEST_PATH).toResource("java/googlejavaformat/JavaCodeUnformatted.test");
 		setFile(testJavaPath).toResource("java/googlejavaformat/JavaCodeUnformatted.test");
 
 		String groovyPath = "src/main/groovy/test.groovy";
@@ -49,7 +48,7 @@ class GrEclipseTest extends MavenIntegrationHarness {
 
 		mavenRunner().withArguments("spotless:apply").runNoError();
 
-		assertFile(javaPath).sameAsResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		assertFile(TEST_PATH).sameAsResource("java/googlejavaformat/JavaCodeUnformatted.test");
 		assertFile(testJavaPath).sameAsResource("java/googlejavaformat/JavaCodeUnformatted.test");
 
 		assertFile(groovyPath).sameAsResource("groovy/greclipse/format/formatted.test");

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,10 +101,8 @@ class CleanthatJavaRefactorerTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String dirtyPath, String cleanPath) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/cleanthat/" + dirtyPath);
-		// .withRemoteDebug(21654)
+		setFile(TEST_PATH).toResource("java/cleanthat/" + dirtyPath);
 		Assertions.assertThat(mavenRunner().withArguments("spotless:apply").runNoError().stdOutUtf8()).doesNotContain("[ERROR]");
-		assertFile(path).sameAsResource("java/cleanthat/" + cleanPath);
+		assertFile(TEST_PATH).sameAsResource("java/cleanthat/" + cleanPath);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/EclipseFormatStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/EclipseFormatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,8 @@ class EclipseFormatStepTest extends MavenIntegrationHarness {
 				"</eclipse>");
 		setFile("formatter.xml").toResource("java/eclipse/formatter.xml");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/eclipse/JavaCodeUnformatted.test");
+		setFile(TEST_PATH).toResource("java/eclipse/JavaCodeUnformatted.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/eclipse/JavaCodeFormatted.test");
+		assertFile(TEST_PATH).sameAsResource("java/eclipse/JavaCodeFormatted.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/FormatAnnotationsStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/FormatAnnotationsStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,19 +25,17 @@ class FormatAnnotationsStepTest extends MavenIntegrationHarness {
 	void testFormatAnnotations() throws Exception {
 		writePomWithJavaSteps("<formatAnnotations/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/formatannotations/FormatAnnotationsTestInput.test");
+		setFile(TEST_PATH).toResource("java/formatannotations/FormatAnnotationsTestInput.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/formatannotations/FormatAnnotationsTestOutput.test");
+		assertFile(TEST_PATH).sameAsResource("java/formatannotations/FormatAnnotationsTestOutput.test");
 	}
 
 	@Test
 	void testFormatAnnotationsAccessModifiers() throws Exception {
 		writePomWithJavaSteps("<formatAnnotations/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/formatannotations/FormatAnnotationsAccessModifiersInput.test");
+		setFile(TEST_PATH).toResource("java/formatannotations/FormatAnnotationsAccessModifiersInput.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/formatannotations/FormatAnnotationsAccessModifiersOutput.test");
+		assertFile(TEST_PATH).sameAsResource("java/formatannotations/FormatAnnotationsAccessModifiersOutput.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/GoogleJavaFormatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/GoogleJavaFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,9 +80,8 @@ class GoogleJavaFormatTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String targetResource, String sourceResource) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource(sourceResource);
+		setFile(TEST_PATH).toResource(sourceResource);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(targetResource);
+		assertFile(TEST_PATH).sameAsResource(targetResource);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ImportOrderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/ImportOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,8 @@ class ImportOrderTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String expectedResource) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/importsorter/JavaCodeUnsortedImports.test");
+		setFile(TEST_PATH).toResource("java/importsorter/JavaCodeUnsortedImports.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(expectedResource);
+		assertFile(TEST_PATH).sameAsResource(expectedResource);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/PalantirJavaFormatTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/PalantirJavaFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,9 +52,8 @@ class PalantirJavaFormatTest extends MavenIntegrationHarness {
 	}
 
 	private void runTest(String targetResource, String sourceResource) throws Exception {
-		String path = "src/main/java/test.java";
-		setFile(path).toResource(sourceResource);
+		setFile(TEST_PATH).toResource(sourceResource);
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource(targetResource);
+		assertFile(TEST_PATH).sameAsResource(targetResource);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveUnusedImportsStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveUnusedImportsStepTest.java
@@ -25,9 +25,8 @@ class RemoveUnusedImportsStepTest extends MavenIntegrationHarness {
 	void testRemoveUnusedInports() throws Exception {
 		writePomWithJavaSteps("<removeUnusedImports/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/removeunusedimports/JavaCodeWithPackageUnformatted.test");
+		setFile(TEST_PATH).toResource("java/removeunusedimports/JavaCodeWithPackageUnformatted.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/removeunusedimports/JavaCodeWithPackageFormatted.test");
+		assertFile(TEST_PATH).sameAsResource("java/removeunusedimports/JavaCodeWithPackageFormatted.test");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveWildcardImportsStepTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/RemoveWildcardImportsStepTest.java
@@ -25,9 +25,8 @@ class RemoveWildcardImportsStepTest extends MavenIntegrationHarness {
 	void testRemoveWildcardImports() throws Exception {
 		writePomWithJavaSteps("<removeWildcardImports/>");
 
-		String path = "src/main/java/test.java";
-		setFile(path).toResource("java/removewildcardimports/JavaCodeWildcardsUnformatted.test");
+		setFile(TEST_PATH).toResource("java/removewildcardimports/JavaCodeWildcardsUnformatted.test");
 		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("java/removewildcardimports/JavaCodeWildcardsFormatted.test");
+		assertFile(TEST_PATH).sameAsResource("java/removewildcardimports/JavaCodeWildcardsFormatted.test");
 	}
 }

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -42,6 +42,12 @@ import com.diffplug.common.base.Errors;
 import com.diffplug.common.io.Resources;
 
 public class ResourceHarness {
+
+	/**
+	 * default test path.
+	 */
+	protected static final String TEST_PATH = "src/main/java/test.java";
+
 	/**
 	 * On OS X, the temp folder is a symlink,
 	 * and some of gradle's stuff breaks symlinks.


### PR DESCRIPTION


After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)


- https://github.com/diffplug/spotless/pull/2574