### PR TITLE
Add JRE 25 to the test matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         kind: [maven, gradle]
         # Test on the latest Java version once Gradle & Maven support it.
-        jre: [17, 21, 24]
+        jre: [17, 21, 25]
         os: [ubuntu-latest, windows-latest]
         include:
           # npm on linux only (crazy slow on windows)

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -121,6 +121,7 @@ public class GoogleJavaFormatStep implements Serializable {
 			.addMin(11, "1.8") // we only support google-java-format >= 1.8 due to api changes
 			.addMin(16, "1.10.0") // java 16 requires at least 1.10.0 due to jdk api changes in JavaTokenizer
 			.addMin(21, "1.17.0") // java 21 requires at least 1.17.0 due to https://github.com/google/google-java-format/issues/898
+			.addMin(25, "1.27.0")
 			.add(17, "1.28.0"); // default version
 
 	public static String defaultGroupArtifact() {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GoogleJavaFormatIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GoogleJavaFormatIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ class GoogleJavaFormatIntegrationTest extends GradleIntegrationHarness {
 				"spotless {",
 				"    java {",
 				"        target file('test.java')",
-				"        googleJavaFormat('1.17.0')",
+				"        googleJavaFormat('1.27.0')",
 				"    }",
 				"}");
 
@@ -41,8 +41,8 @@ class GoogleJavaFormatIntegrationTest extends GradleIntegrationHarness {
 
 		checkRunsThenUpToDate();
 		replace("build.gradle",
-				"googleJavaFormat('1.17.0')",
-				"googleJavaFormat()");
+				"googleJavaFormat('1.27.0')",
+				"googleJavaFormat('1.28.0')");
 		checkRunsThenUpToDate();
 	}
 
@@ -57,7 +57,7 @@ class GoogleJavaFormatIntegrationTest extends GradleIntegrationHarness {
 				"spotless {",
 				"    java {",
 				"        target file('test.java')",
-				"        googleJavaFormat('1.17.0').aosp().reorderImports(true)",
+				"        googleJavaFormat('1.27.0').aosp().reorderImports(true)",
 				"    }",
 				"}");
 
@@ -67,8 +67,8 @@ class GoogleJavaFormatIntegrationTest extends GradleIntegrationHarness {
 
 		checkRunsThenUpToDate();
 		replace("build.gradle",
-				"googleJavaFormat('1.17.0')",
-				"googleJavaFormat()");
+				"googleJavaFormat('1.27.0')",
+				"googleJavaFormat('1.28.0')");
 		checkRunsThenUpToDate();
 	}
 
@@ -83,7 +83,7 @@ class GoogleJavaFormatIntegrationTest extends GradleIntegrationHarness {
 				"spotless {",
 				"    java {",
 				"        target file('test.java')",
-				"        googleJavaFormat('1.17.0').skipJavadocFormatting()",
+				"        googleJavaFormat('1.27.0').skipJavadocFormatting()",
 				"    }",
 				"}");
 
@@ -93,8 +93,8 @@ class GoogleJavaFormatIntegrationTest extends GradleIntegrationHarness {
 
 		checkRunsThenUpToDate();
 		replace("build.gradle",
-				"googleJavaFormat('1.17.0')",
-				"googleJavaFormat()");
+				"googleJavaFormat('1.27.0')",
+				"googleJavaFormat('1.28.0')");
 		checkRunsThenUpToDate();
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -57,8 +57,11 @@ public class GradleIntegrationHarness extends ResourceHarness {
 		GradleVersionSupport(String version) {
 			String minVersionForRunningJRE;
 			switch (Jvm.version()) {
+			case 26:
+				throw new UnsupportedOperationException("TODO: gradle compat for " + Jvm.version() + " https://docs.gradle.org/current/userguide/compatibility.html");
 			case 25:
-				// TODO: https://docs.gradle.org/current/userguide/compatibility.html
+				minVersionForRunningJRE = "9.1.0";
+				break;
 			case 24:
 				minVersionForRunningJRE = "8.14";
 				break;

--- a/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/PalantirJavaFormatStepTest.java
@@ -52,7 +52,7 @@ class PalantirJavaFormatStepTest extends ResourceHarness {
 
 	@Test
 	void formatJavadoc() throws Exception {
-		FormatterStep step = PalantirJavaFormatStep.create("2.57.0", "PALANTIR", true, TestProvisioner.mavenCentral());
+		FormatterStep step = PalantirJavaFormatStep.create("2.71.0", "PALANTIR", true, TestProvisioner.mavenCentral());
 		StepHarness.forStep(step)
 				.testResource("java/palantirjavaformat/JavaCodeWithJavaDocUnformatted.test", "java/palantirjavaformat/JavaCodeWithJavaDocFormatted.test")
 				.testResource("java/palantirjavaformat/JavaCodeWithPackageUnformatted.test", "java/palantirjavaformat/JavaCodeWithPackageFormatted.test");

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtLintStepTest.java
@@ -23,8 +23,12 @@ import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
 class KtLintStepTest extends ResourceHarness {
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void works0_48_0() {
 		FormatterStep step = KtLintStep.create("0.48.0", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
@@ -33,6 +37,7 @@ class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void works0_48_1() {
 		FormatterStep step = KtLintStep.create("0.48.1", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
@@ -41,6 +46,7 @@ class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void works0_49_0() {
 		FormatterStep step = KtLintStep.create("0.49.0", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
@@ -49,6 +55,7 @@ class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void works0_49_1() {
 		FormatterStep step = KtLintStep.create("0.49.1", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)
@@ -57,6 +64,7 @@ class KtLintStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void works0_50_0() {
 		FormatterStep step = KtLintStep.create("0.50.0", TestProvisioner.mavenCentral());
 		StepHarnessWithFile.forStep(this, step)

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtfmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtfmtStepTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.*;
 
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
 class KtfmtStepTest extends ResourceHarness {
 	@Test
 	void behavior() throws Exception {
@@ -37,6 +40,7 @@ class KtfmtStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void dropboxStyle_0_16() throws Exception {
 		KtfmtStep.KtfmtFormattingOptions options = new KtfmtStep.KtfmtFormattingOptions();
 		FormatterStep step = KtfmtStep.create("0.16", TestProvisioner.mavenCentral(), KtfmtStep.Style.DROPBOX, options);
@@ -44,6 +48,7 @@ class KtfmtStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void dropboxStyle_0_18() throws Exception {
 		KtfmtStep.KtfmtFormattingOptions options = new KtfmtStep.KtfmtFormattingOptions();
 		FormatterStep step = KtfmtStep.create("0.18", TestProvisioner.mavenCentral(), KtfmtStep.Style.DROPBOX, options);
@@ -51,6 +56,7 @@ class KtfmtStepTest extends ResourceHarness {
 	}
 
 	@Test
+	@DisabledOnJre(JRE.JAVA_25)
 	void dropboxStyle_0_22() throws Exception {
 		KtfmtStep.KtfmtFormattingOptions options = new KtfmtStep.KtfmtFormattingOptions();
 		FormatterStep step = KtfmtStep.create("0.22", TestProvisioner.mavenCentral(), KtfmtStep.Style.DROPBOX, options);


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
