### PR TITLE
[openrewrite] add `JavaSecurityBestPractices`

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,15 +22,29 @@ jobs:
         with:
           script: |
             try {
+              // Get username - prioritize sender (the person who triggered the event)
+              const username = github.event.sender?.login ||
+                              github.event.comment?.user?.login;
+
+              if (!username) {
+                console.log('Could not determine username from event payload');
+                console.log(`Event type: ${github.event_name}`);
+                console.log(`Event payload keys: ${Object.keys(github.event).join(', ')}`);
+                return false;
+              }
+
+              console.log(`Checking team membership for user: ${username} (triggered by ${github.event_name} event)`);
+
               const { data } = await github.rest.teams.getMembershipForUserInOrg({
                 org: 'diffplug',
                 team_slug: 'spotless',
-                username: github.event.sender.login
+                username: username
               });
-              console.log(`User ${github.event.sender.login} membership status: ${data.state}`);
+              console.log(`User ${username} membership status: ${data.state}`);
               return data.state === 'active';
             } catch (error) {
-              console.log(`User ${github.event.sender.login} is not a member of the Spotless team`);
+              const username = github.event.sender?.login || github.event.comment?.user?.login || 'unknown user';
+              console.log(`User ${username} is not a member of the Spotless team or error occurred: ${error.message}`);
               return false;
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ spotless {
 }
 
 dependencies {
-	rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:3.14.1"))
+	rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:3.15.0"))
 	rewrite("org.openrewrite.recipe:rewrite-migrate-java:3.18.0")
+	rewrite('org.openrewrite.recipe:rewrite-java-security:3.19.0')
+	rewrite('org.openrewrite.recipe:rewrite-rewrite:0.13.0')
+	rewrite('org.openrewrite.recipe:rewrite-static-analysis:2.17.0')
+	rewrite('org.openrewrite.recipe:rewrite-third-party:0.27.0')
 }

--- a/gradle/rewrite.gradle
+++ b/gradle/rewrite.gradle
@@ -1,7 +1,56 @@
 apply plugin: 'org.openrewrite.rewrite'
 
 rewrite {
-	activeRecipe("org.openrewrite.java.migrate.UpgradeToJava17")
+	activeRecipe(
+			'org.openrewrite.gradle.GradleBestPractices',
+			'org.openrewrite.java.RemoveUnusedImports',
+			'org.openrewrite.java.migrate.UpgradeToJava17',
+			'org.openrewrite.java.recipes.JavaRecipeBestPractices',
+			'org.openrewrite.java.recipes.RecipeTestingBestPractices',
+			'org.openrewrite.java.security.JavaSecurityBestPractices',
+			'org.openrewrite.staticanalysis.JavaApiBestPractices',
+			'org.openrewrite.staticanalysis.LowercasePackage',
+			'org.openrewrite.staticanalysis.MissingOverrideAnnotation',
+			'org.openrewrite.staticanalysis.ModifierOrder',
+			'org.openrewrite.staticanalysis.NoFinalizer',
+			'org.openrewrite.staticanalysis.RemoveUnusedLocalVariables',
+			'org.openrewrite.staticanalysis.RemoveUnusedPrivateFields',
+			'org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods',
+			'org.openrewrite.gradle.GradleBestPractices',
+			'org.openrewrite.java.RemoveUnusedImports',
+			'org.openrewrite.java.migrate.UpgradeToJava17',
+			'org.openrewrite.staticanalysis.LowercasePackage',
+			'org.openrewrite.staticanalysis.MissingOverrideAnnotation',
+			'org.openrewrite.staticanalysis.ModifierOrder',
+			'org.openrewrite.staticanalysis.NoFinalizer',
+			'org.openrewrite.staticanalysis.RemoveUnusedLocalVariables',
+			'org.openrewrite.staticanalysis.RemoveUnusedPrivateFields',
+			'org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods',
+			'tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.CharSequenceRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.ClassRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.CollectionRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.FileRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.MicrometerRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.PatternRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.PreconditionsRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.PrimitiveRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.StreamRulesRecipes',
+			'tech.picnic.errorprone.refasterrules.TimeRulesRecipes'
+			)
+	exclusions.addAll( // bugs
+			'**_gradle_node_plugin_example_**',
+			'**gradle/changelog.gradle',
+			'**gradle/java-publish.gradle',
+			'**idea/full.clean.java',
+			'**java-setup.gradle',
+			'**lib-extra/build.gradle',
+			'**lib/build.gradle',
+			'**package-info.java',
+			'**plugin-maven/build.gradle',
+			'**settings.gradle'
+			)
 	exportDatatables = true
 	failOnDryRunResults = true
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -1,17 +1,5 @@
 apply plugin: 'com.diffplug.spotless'
 spotless {
-	def noInternalDepsClosure = {
-		String text = it
-		/*
-		 * No good way to get around using this import:
-		 * https://github.com/gradle/gradle/issues/3191
-		 */
-		String regex = "import org\\.gradle\\.api\\.internal\\.(?!plugins\\.DslObject)(?!project\\.ProjectInternal)"
-		if ((text.contains('import org.gradle.internal.') || text.find(regex)) &&
-				!text.contains('def noInternalDepsClosure')) {
-			throw new AssertionError("Accidental internal import")
-		}
-	}
 	if (project != rootProject) {
 		// the rootProject doesn't have any java
 		java {
@@ -22,9 +10,9 @@ spotless {
 			eclipse().configFile rootProject.file('gradle/spotless.eclipseformat.xml')
 			trimTrailingWhitespace()
 			removeUnusedImports()
-			removeWildcardImports()
 			formatAnnotations()
-			custom 'noInternalDeps', noInternalDepsClosure
+			forbidWildcardImports()
+			forbidRegex('ForbidGradleInternal', 'import org\\.gradle\\.api\\.internal\\.(.*)', "Don't use Gradle's internal API")
 		}
 	}
 	groovyGradle {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -146,7 +146,7 @@ public final class GitAttributesLineEndings {
 		private static final long serialVersionUID = -2534772773057900619L;
 
 		/** this is transient, to simulate PathSensitive.RELATIVE */
-		transient final String rootDir;
+		final transient String rootDir;
 		/** the line ending used for most files */
 		final String defaultEnding;
 		/** any exceptions to that default, in terms of relative path from rootDir */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,9 +132,9 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 		return treeWalk.idEqual(TREE, WORKDIR);
 	}
 
-	private final static int TREE = 0;
-	private final static int INDEX = 1;
-	private final static int WORKDIR = 2;
+	private static final int TREE = 0;
+	private static final int INDEX = 1;
+	private static final int WORKDIR = 2;
 
 	Map<File, Repository> gitRoots = new HashMap<>();
 	Table<Repository, String, ObjectId> rootTreeShaCache = HashBasedTable.create();

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -251,7 +251,7 @@ public final class DiffMessageFormatter {
 	}
 
 	private static Map.Entry<Integer, String> diff(CleanProvider formatter, File file) throws IOException {
-		String raw = new String(Files.readAllBytes(file.toPath()), formatter.getEncoding());
+		String raw = Files.readString(file.toPath(), formatter.getEncoding());
 		String rawUnix = LineEnding.toUnix(raw);
 		String formatted = formatter.getFormatted(file, rawUnix);
 		String formattedUnix = LineEnding.toUnix(formatted);

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.extra.eclipse.EquoResourceHarness;
 
 public class GrEclipseFormatterStepTest extends EquoResourceHarness {
-	private final static String INPUT = "class F{ def m(){} }";
-	private final static String EXPECTED = "class F{\n\tdef m(){}\n}";
+	private static final String INPUT = "class F{ def m(){} }";
+	private static final String EXPECTED = "class F{\n\tdef m(){}\n}";
 
 	public GrEclipseFormatterStepTest() {
 		super(GrEclipseFormatterStep.createBuilder(TestProvisioner.mavenCentral()));

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -33,7 +34,7 @@ import com.diffplug.spotless.TestProvisioner;
 import com.diffplug.spotless.extra.eclipse.EclipseResourceHarness;
 
 public class EclipseWtpFormatterStepTest {
-	private final static Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support("Oldest Version").add(8, "4.8.0");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support("Oldest Version").add(8, "4.8.0");
 
 	private static class NestedTests extends EclipseResourceHarness {
 		private final String unformatted, formatted;
@@ -76,7 +77,7 @@ public class EclipseWtpFormatterStepTest {
 		private File createPropertyFile(Consumer<Properties> config) throws IOException {
 			Properties configProps = new Properties();
 			config.accept(configProps);
-			File tempFile = File.createTempFile("EclipseWtpFormatterStepTest-", ".properties");
+			File tempFile = Files.createTempFile("EclipseWtpFormatterStepTest-", ".properties").toFile();
 			OutputStream tempOut = new FileOutputStream(tempFile);
 			configProps.store(tempOut, "test properties");
 			tempOut.flush();

--- a/lib/src/jackson/java/com/diffplug/spotless/glue/json/JacksonJsonFormatterFunc.java
+++ b/lib/src/jackson/java/com/diffplug/spotless/glue/json/JacksonJsonFormatterFunc.java
@@ -52,6 +52,7 @@ public class JacksonJsonFormatterFunc extends AJacksonFormatterFunc {
 	 * @return a {@link JsonFactory}. May be overridden to handle alternative formats.
 	 * @see <a href="https://github.com/FasterXML/jackson-dataformats-text">jackson-dataformats-text</a>
 	 */
+	@Override
 	protected JsonFactory makeJsonFactory() {
 		JsonFactory jsonFactory = new JsonFactoryBuilder().build();
 

--- a/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -113,7 +114,7 @@ public final class FormatterProperties {
 
 	public static FormatterProperties merge(Properties... properties) {
 		FormatterProperties merged = new FormatterProperties();
-		List.of(properties).stream().forEach((source) -> merged.properties.putAll(source));
+		List.of(properties).forEach((source) -> merged.properties.putAll(source));
 		return merged;
 	}
 
@@ -201,6 +202,21 @@ public final class FormatterProperties {
 			private Node getRootNode(final InputStream is) throws IOException, IllegalArgumentException {
 				try {
 					DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+					try {
+						dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
+						dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+						dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+
+						dbf.setXIncludeAware(false);
+						dbf.setExpandEntityReferences(false);
+
+						dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+					} catch (ParserConfigurationException e) {
+						throw new IllegalStateException("Some features are not supported by your XML processor.", e);
+					}
 					/*
 					 * It is not required to validate or normalize attribute values for
 					 * the XMLs currently supported. Disabling validation is supported by

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
@@ -172,7 +172,7 @@ public abstract class GitPrePushHookInstaller {
 	 *                  such as file reading or writing errors
 	 */
 	private void uninstall(File gitHookFile) throws Exception {
-		final var hook = Files.readString(gitHookFile.toPath(), UTF_8);
+		final var hook = Files.readString(gitHookFile.toPath());
 		final int hookStart = hook.indexOf(HOOK_HEADER);
 		final int hookEnd = hook.indexOf(HOOK_FOOTER) + HOOK_FOOTER.length(); // hookEnd exclusive, so must be last symbol \n
 
@@ -323,7 +323,7 @@ public abstract class GitPrePushHookInstaller {
 	 * @throws Exception if an error occurs when reading the file.
 	 */
 	private boolean isGitHookInstalled(File gitHookFile) throws Exception {
-		final var hook = Files.readString(gitHookFile.toPath(), UTF_8);
+		final var hook = Files.readString(gitHookFile.toPath());
 		return hook.contains(HOOK_HEADER) && hook.contains(HOOK_FOOTER);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/NoLambda.java
+++ b/lib/src/main/java/com/diffplug/spotless/NoLambda.java
@@ -44,7 +44,7 @@ public interface NoLambda extends Serializable {
 	public byte[] toBytes();
 
 	/** An implementation of NoLambda in which equality is based on the serialized representation of itself. */
-	public static abstract class EqualityBasedOnSerialization implements NoLambda {
+	public abstract static class EqualityBasedOnSerialization implements NoLambda {
 		@Serial
 		private static final long serialVersionUID = 1733798699224768949L;
 

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
@@ -24,12 +24,12 @@ import org.slf4j.LoggerFactory;
 public final class BiomeSettings {
 	private static final Logger logger = LoggerFactory.getLogger(BiomeSettings.class);
 
-	private final static String CONFIG_NAME = "biome.json";
-	private final static String DEFAULT_VERSION = "1.2.0";
-	private final static String DOWNLOAD_FILE_PATTERN = "biome-%s-%s-%s";
-	private final static String SHORT_NAME = "biome";
-	private final static String URL_PATTERN_1X = "https://github.com/biomejs/biome/releases/download/cli%%2Fv%s/biome-%s";
-	private final static String URL_PATTERN_2X = "https://github.com/biomejs/biome/releases/download/%%40biomejs%%2Fbiome%%40%s/biome-%s";
+	private static final String CONFIG_NAME = "biome.json";
+	private static final String DEFAULT_VERSION = "1.2.0";
+	private static final String DOWNLOAD_FILE_PATTERN = "biome-%s-%s-%s";
+	private static final String SHORT_NAME = "biome";
+	private static final String URL_PATTERN_1X = "https://github.com/biomejs/biome/releases/download/cli%%2Fv%s/biome-%s";
+	private static final String URL_PATTERN_2X = "https://github.com/biomejs/biome/releases/download/%%40biomejs%%2Fbiome%%40%s/biome-%s";
 
 	private BiomeSettings() {}
 

--- a/lib/src/main/java/com/diffplug/spotless/generic/IdeaStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/IdeaStep.java
@@ -213,7 +213,7 @@ public final class IdeaStep {
 
 		private String format(IdeaStepFormatterCleanupResources ideaStepFormatterCleanupResources, String unix, File file) throws Exception {
 			// since we cannot directly work with the file, we need to write the unix string to a temporary file
-			File tempFile = File.createTempFile("spotless", file.getName());
+			File tempFile = Files.createTempFile("spotless", file.getName()).toFile();
 			try {
 				Files.write(tempFile.toPath(), unix.getBytes(StandardCharsets.UTF_8));
 				List<String> params = getParams(tempFile);
@@ -224,7 +224,7 @@ public final class IdeaStep {
 				LOGGER.debug("command finished with exit code: {}", result.exitCode());
 				LOGGER.debug("command finished with stdout: {}",
 						result.assertExitZero(StandardCharsets.UTF_8));
-				return Files.readString(tempFile.toPath(), StandardCharsets.UTF_8);
+				return Files.readString(tempFile.toPath());
 			} finally {
 				Files.delete(tempFile.toPath());
 			}

--- a/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
@@ -435,7 +435,6 @@ public final class FormatAnnotationsStep implements Serializable {
 
 		// group 1 is the basename of the annotation.
 		private static final String annoNoArgRegex = "@(?:[A-Za-z_][A-Za-z0-9_.]*\\.)?([A-Za-z_][A-Za-z0-9_]*)";
-		private static final Pattern annoNoArgPattern = Pattern.compile(annoNoArgRegex);
 		// 3 non-empty cases:  ()  (".*")  (.*)
 		private static final String annoArgRegex = "(?:\\(\\)|\\(\"[^\"]*\"\\)|\\([^\")][^)]*\\))?";
 		// group 1 is the basename of the annotation.

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -82,9 +82,9 @@ public class KtfmtStep implements Serializable {
 		;
 		// @formatter:on
 
-		final private String format;
-		final private String since;
-		final private @Nullable String until;
+		private final String format;
+		private final String since;
+		private final @Nullable String until;
 
 		Style(String format, String since) {
 			this.format = format;

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeServerLayout.java
@@ -96,7 +96,7 @@ class NodeServerLayout {
 		// check if it is NOT empty
 		return ThrowingEx.get(() -> {
 			try (Stream<Path> entries = Files.list(nodeModulesInstallDirPath)) {
-				return entries.findFirst().isPresent();
+				return entries.findAny().isPresent();
 			}
 		});
 	}

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ public class PrettierFormatterStep {
 				return prettierConfigOptions;
 			}
 			// if the file has no name, we  cannot use it
-			if (file.getName().trim().length() == 0) {
+			if (file.getName().trim().isEmpty()) {
 				return prettierConfigOptions;
 			}
 			// if it is not there, we add it at the beginning of the Options

--- a/lib/src/main/java/com/diffplug/spotless/npm/SimpleRestClient.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/SimpleRestClient.java
@@ -93,7 +93,7 @@ class SimpleRestClient {
 		}
 	}
 
-	static abstract class SimpleRestException extends RuntimeException {
+	abstract static class SimpleRestException extends RuntimeException {
 		private static final long serialVersionUID = -8260821395756603787L;
 
 		public SimpleRestException() {}

--- a/lib/src/main/java/com/diffplug/spotless/npm/StandardNpmProcessFactory.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/StandardNpmProcessFactory.java
@@ -42,7 +42,7 @@ public class StandardNpmProcessFactory implements NpmProcessFactory {
 		return new NpmServe(nodeServerLayout.nodeModulesDir(), formatterStepLocations, nodeServerInstanceId);
 	}
 
-	private static abstract class AbstractStandardNpmProcess {
+	private abstract static class AbstractStandardNpmProcess {
 		protected final ProcessRunner processRunner = ProcessRunner.usingRingBuffersOfCapacity(100 * 1024); // 100kB
 
 		protected final File workingDir;

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/FormatterToken.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/FormatterToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ class FormatterToken {
 		return fPos;
 	}
 
+	@Override
 	public String toString() {
 		final StringBuilder buf = new StringBuilder();
 		buf.append(getClass().getName());

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/KeywordCase.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/KeywordCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,16 +22,19 @@ import java.util.Locale;
  */
 enum KeywordCase {
 	UPPER {
+		@Override
 		public String transform(String value) {
 			return value.toUpperCase(Locale.ENGLISH);
 		}
 	},
 	LOWER {
+		@Override
 		public String transform(String value) {
 			return value.toLowerCase(Locale.ENGLISH);
 		}
 	},
 	ORIGINAL {
+		@Override
 		public String transform(String value) {
 			return value;
 		}

--- a/lib/src/scalafmt/java/com/diffplug/spotless/glue/scalafmt/ScalafmtFormatterFunc.java
+++ b/lib/src/scalafmt/java/com/diffplug/spotless/glue/scalafmt/ScalafmtFormatterFunc.java
@@ -17,7 +17,6 @@ package com.diffplug.spotless.glue.scalafmt;
 
 import java.io.File;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.scalafmt.Scalafmt;
@@ -43,7 +42,7 @@ public class ScalafmtFormatterFunc implements FormatterFunc.NeedsFile {
 			config = (ScalafmtConfig) method.invoke(ScalafmtConfig$.MODULE$);
 		} else {
 			File file = configSignature.getOnlyFile();
-			String configStr = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+			String configStr = Files.readString(file.toPath());
 			config = Scalafmt.parseHoconConfig(configStr).get();
 		}
 

--- a/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
+++ b/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 package com.diffplug.spotless.glue.pom;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -41,7 +43,7 @@ public class SortPomFormatterFunc implements FormatterFunc {
 	@Override
 	public String apply(String input) throws Exception {
 		// SortPom expects a file to sort, so we write the input into a temporary file
-		File pom = File.createTempFile("pom", ".xml");
+		File pom = Files.createTempFile("pom", ".xml").toFile();
 		pom.deleteOnExit();
 		try (BufferedWriter writer = new BufferedWriter(new FileWriter(pom, Charset.forName(cfg.encoding)))) {
 			writer.write(input);

--- a/lib/src/testCompatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint0Dot48Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot48Dot0AdapterTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -61,7 +60,7 @@ public class KtLintCompat0Dot48Dot0AdapterTest {
 		try (InputStream is = KtLintCompat0Dot48Dot0AdapterTest.class.getResourceAsStream("/" + name)) {
 			Files.copy(is, path.resolve(name));
 		}
-		return new String(Files.readAllBytes(path.resolve(name)), StandardCharsets.UTF_8);
+		return Files.readString(path.resolve(name));
 	}
 
 }

--- a/lib/src/testCompatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0AdapterTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -59,7 +58,7 @@ public class KtLintCompat0Dot49Dot0AdapterTest {
 		try (InputStream is = KtLintCompat0Dot49Dot0AdapterTest.class.getResourceAsStream("/" + name)) {
 			Files.copy(is, path.resolve(name));
 		}
-		return new String(Files.readAllBytes(path.resolve(name)), StandardCharsets.UTF_8);
+		return Files.readString(path.resolve(name));
 	}
 
 }

--- a/lib/src/testCompatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0AdapterTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -59,7 +58,7 @@ public class KtLintCompat0Dot50Dot0AdapterTest {
 		try (InputStream is = KtLintCompat0Dot50Dot0AdapterTest.class.getResourceAsStream("/" + name)) {
 			Files.copy(is, path.resolve(name));
 		}
-		return new String(Files.readAllBytes(path.resolve(name)), StandardCharsets.UTF_8);
+		return Files.readString(path.resolve(name));
 	}
 
 }

--- a/lib/src/testCompatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0AdapterTest.java
+++ b/lib/src/testCompatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0AdapterTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -59,7 +58,7 @@ public class KtLintCompat1Dot0Dot0AdapterTest {
 		try (InputStream is = KtLintCompat1Dot0Dot0AdapterTest.class.getResourceAsStream("/" + name)) {
 			Files.copy(is, path.resolve(name));
 		}
-		return new String(Files.readAllBytes(path.resolve(name)), StandardCharsets.UTF_8);
+		return Files.readString(path.resolve(name));
 	}
 
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CssExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CssExtension.java
@@ -43,6 +43,7 @@ public class CssExtension extends FormatExtension {
 	 * offline, you can specify the path to the Biome executable via
 	 * {@code biome().pathToExe(...)}.
 	 */
+	@Override
 	public BiomeCss biome() {
 		return biome(null);
 	}
@@ -54,6 +55,7 @@ public class CssExtension extends FormatExtension {
 	 * {@code biome().pathToExe(...)}.
 	 * @param version Biome version to use.
 	 */
+	@Override
 	public BiomeCss biome(String version) {
 		var biomeConfig = new BiomeCss(version);
 		addStep(biomeConfig.createStep());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -748,7 +748,7 @@ public class FormatExtension {
 			replaceStep.accept(createStep());
 		}
 
-		abstract protected FormatterStep createStep();
+		protected abstract FormatterStep createStep();
 
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,9 +47,9 @@ class IdeHook {
 		}
 	}
 
-	final static String PROPERTY = "spotlessIdeHook";
-	final static String USE_STD_IN = "spotlessIdeHookUseStdIn";
-	final static String USE_STD_OUT = "spotlessIdeHookUseStdOut";
+	static final String PROPERTY = "spotlessIdeHook";
+	static final String USE_STD_IN = "spotlessIdeHookUseStdIn";
+	static final String USE_STD_OUT = "spotlessIdeHookUseStdOut";
 
 	private static void dumpIsClean() {
 		System.err.println("IS CLEAN");

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavascriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavascriptExtension.java
@@ -58,7 +58,7 @@ public class JavascriptExtension extends FormatExtension {
 		return eslint;
 	}
 
-	public static abstract class EslintBaseConfig<T extends EslintBaseConfig<?>>
+	public abstract static class EslintBaseConfig<T extends EslintBaseConfig<?>>
 			extends NpmStepConfig<EslintBaseConfig<T>> {
 		Map<String, String> devDependencies = new LinkedHashMap<>();
 
@@ -100,6 +100,7 @@ public class JavascriptExtension extends FormatExtension {
 			super(getProject(), JavascriptExtension.this::replaceStep, devDependencies);
 		}
 
+		@Override
 		public FormatterStep createStep() {
 			final Project project = getProject();
 
@@ -140,11 +141,13 @@ public class JavascriptExtension extends FormatExtension {
 	 * offline, you can specify the path to the Biome executable via
 	 * {@code biome().pathToExe(...)}.
 	 */
+	@Override
 	public BiomeJs biome() {
 		return biome(null);
 	}
 
 	/** Downloads the given Biome version from the network. */
+	@Override
 	public BiomeJs biome(String version) {
 		var biomeConfig = new BiomeJs(version);
 		addStep(biomeConfig.createStep());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JsonExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JsonExtension.java
@@ -63,11 +63,13 @@ public class JsonExtension extends FormatExtension {
 	 * offline, you can specify the path to the Biome executable via
 	 * {@code biome().pathToExe(...)}.
 	 */
+	@Override
 	public BiomeJson biome() {
 		return biome(null);
 	}
 
 	/** Downloads the given Biome version from the network. */
+	@Override
 	public BiomeJson biome(String version) {
 		var biomeConfig = new BiomeJson(version);
 		addStep(biomeConfig.createStep());

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java
@@ -55,6 +55,7 @@ public abstract class SpotlessTaskImpl extends SpotlessTask {
 	abstract Property<IdeHook.State> getIdeHookState();
 
 	@Internal
+	@Override
 	abstract DirectoryProperty getProjectDir();
 
 	void init(Provider<SpotlessTaskService> service) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +57,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
 
-	@Nullable
-	GradleProvisioner.DedupingProvisioner predeclaredProvisioner;
+	@Nullable GradleProvisioner.DedupingProvisioner predeclaredProvisioner;
 
 	Provisioner provisionerFor(SpotlessExtension spotless) {
 		if (spotless instanceof SpotlessExtensionPredeclare) {
@@ -110,7 +109,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 		}
 	}
 
-	static abstract class ClientTask extends DefaultTask {
+	abstract static class ClientTask extends DefaultTask {
 		@Internal
 		abstract Property<File> getSpotlessCleanDirectory();
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
@@ -112,6 +112,7 @@ public class TypescriptExtension extends FormatExtension {
 			return this;
 		}
 
+		@Override
 		public FormatterStep createStep() {
 			final Project project = getProject();
 
@@ -207,6 +208,7 @@ public class TypescriptExtension extends FormatExtension {
 			return this;
 		}
 
+		@Override
 		public FormatterStep createStep() {
 			final Project project = getProject();
 
@@ -228,11 +230,13 @@ public class TypescriptExtension extends FormatExtension {
 	 * offline, you can specify the path to the Biome executable via
 	 * {@code biome().pathToExe(...)}.
 	 */
+	@Override
 	public BiomeTs biome() {
 		return biome(null);
 	}
 
 	/** Downloads the given Biome version from the network. */
+	@Override
 	public BiomeTs biome(String version) {
 		var biomeConfig = new BiomeTs(version);
 		addStep(biomeConfig.createStep());

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -414,8 +414,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private List<FormatterStepFactory> getFormatterStepFactories() {
-		return Stream.of(licenseHeader)
-				.filter(Objects::nonNull)
+		return Stream.ofNullable(licenseHeader)
 				.collect(toList());
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import org.eclipse.aether.resolution.DependencyResult;
 
 public class ArtifactResolver {
 
-	private final static Exclusion EXCLUDE_ALL_TRANSITIVES = new Exclusion("*", "*", "*", "*");
+	private static final Exclusion EXCLUDE_ALL_TRANSITIVES = new Exclusion("*", "*", "*", "*");
 
 	private final RepositorySystem repositorySystem;
 	private final RepositorySystemSession session;

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ public interface UpToDateChecker extends AutoCloseable {
 
 	void setUpToDate(Path file);
 
+	@Override
 	void close();
 
 	static UpToDateChecker noop(MavenProject project, Path indexFile, Log log) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,7 @@ public class Eclipse implements FormatterStepFactory {
 		return eclipseConfig.build();
 	}
 
+	@Override
 	public void init(RepositorySystemSession repositorySystemSession) {
 		this.cacheDirectory = repositorySystemSession.getLocalRepository().getBasedir();
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/javascript/EslintJs.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/javascript/EslintJs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,12 @@ import com.diffplug.spotless.npm.EslintFormatterStep;
 
 public class EslintJs extends AbstractEslint {
 
+	@Override
 	protected EslintConfig eslintConfig(FormatterStepConfig stepConfig) {
 		return new EslintConfig(this.configFile != null ? stepConfig.getFileLocator().locateFile(this.configFile) : null, this.configJs);
 	}
 
+	@Override
 	protected Map<String, String> createDefaultDependencies() {
 		return this.eslintVersion == null ? EslintFormatterStep.defaultDevDependencies() : EslintFormatterStep.defaultDevDependenciesWithEslint(this.eslintVersion);
 	}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-	id 'com.diffplug.spotless' version '7.2.1' apply false
+	id 'com.diffplug.spotless' version '8.0.0' apply false
 	// https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 	id 'com.gradle.plugin-publish' version '2.0.0' apply false
 	// https://github.com/gradle-nexus/publish-plugin/releases
@@ -20,10 +20,10 @@ plugins {
 	// https://github.com/davidburstrom/version-compatibility-gradle-plugin/tags
 	id 'io.github.davidburstrom.version-compatibility' version '0.5.0' apply false
 	// https://plugins.gradle.org/plugin/com.gradle.develocity
-	id 'com.gradle.develocity' version '3.19.2'
+	id 'com.gradle.develocity' version '4.2'
 	// https://github.com/equodev/equo-ide/blob/main/plugin-gradle/CHANGELOG.md
 	id 'dev.equo.ide' version '1.7.8' apply false
-	id 'org.openrewrite.rewrite' version '7.16.0' apply false
+	id 'org.openrewrite.rewrite' version '7.17.0' apply false
 }
 
 dependencyResolutionManagement {

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -111,7 +111,7 @@ public class ResourceHarness {
 	}
 
 	public String read(Path path, Charset encoding) throws IOException {
-		return new String(Files.readAllBytes(path), encoding);
+		return Files.readString(path, encoding);
 	}
 
 	public void replace(String path, String toReplace, String replaceWith) throws IOException {
@@ -214,7 +214,7 @@ public class ResourceHarness {
 		}
 
 		public void matches(Consumer<AbstractCharSequenceAssert<?, String>> conditions) throws IOException {
-			String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+			String content = Files.readString(file.toPath());
 			conditions.accept(assertThat(content));
 		}
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 
 class FileSignatureTest extends ResourceHarness {
-	private final static String[] inputPaths = {"A", "C", "C", "A", "B"};
-	private final static String[] expectedPathList = inputPaths;
-	private final static String[] expectedPathSet = {"A", "B", "C"};
+	private static final String[] inputPaths = {"A", "C", "C", "A", "B"};
+	private static final String[] expectedPathList = inputPaths;
+	private static final String[] expectedPathSet = {"A", "B", "C"};
 
 	@Test
 	void testFromList() throws IOException {

--- a/testlib/src/test/java/com/diffplug/spotless/GitPrePushHookInstallerTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/GitPrePushHookInstallerTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.GitPrePushHookInstaller.GitPreHookLogger;
 
 class GitPrePushHookInstallerTest extends ResourceHarness {
-	private final static String OS = System.getProperty("os.name");
+	private static final String OS = System.getProperty("os.name");
 
 	private final List<String> logs = new CopyOnWriteArrayList<>();
 	private final GitPreHookLogger logger = new GitPreHookLogger() {

--- a/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/JvmTest.java
@@ -43,8 +43,8 @@ class JvmTest {
 	@Test
 	void supportAdd() {
 		Integer differentVersions[] = {0, 1, 2};
-		Arrays.asList(differentVersions).stream().forEach(v -> testSupport.add(v + Jvm.version(), v.toString()));
-		Arrays.asList(differentVersions).stream().forEach(v -> assertThat(testSupport.toString()).contains("Version %d".formatted(v)));
+		Arrays.asList(differentVersions).forEach(v -> testSupport.add(v + Jvm.version(), v.toString()));
+		Arrays.asList(differentVersions).forEach(v -> assertThat(testSupport.toString()).contains("Version %d".formatted(v)));
 		assertThat(testSupport.toString()).contains("%s alternatives".formatted(TEST_NAME));
 	}
 


### PR DESCRIPTION




```console
All sources parsed, running active recipes: org.openrewrite.gradle.GradleBestPractices, org.openrewrite.java.RemoveUnusedImports, org.openrewrite.java.migrate.UpgradeToJava17, org.openrewrite.java.recipes.JavaRecipeBestPractices, org.openrewrite.java.recipes.RecipeTestingBestPractices, org.openrewrite.java.security.JavaSecurityBestPractices, org.openrewrite.staticanalysis.JavaApiBestPractices, org.openrewrite.staticanalysis.LowercasePackage, org.openrewrite.staticanalysis.MissingOverrideAnnotation, org.openrewrite.staticanalysis.ModifierOrder, org.openrewrite.staticanalysis.NoFinalizer, org.openrewrite.staticanalysis.RemoveUnusedLocalVariables, org.openrewrite.staticanalysis.RemoveUnusedPrivateFields, org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods, org.openrewrite.gradle.GradleBestPractices, org.openrewrite.java.RemoveUnusedImports, org.openrewrite.java.migrate.UpgradeToJava17, org.openrewrite.java.recipes.JavaRecipeBestPractices, org.openrewrite.java.recipes.RecipeTestingBestPractices, org.openrewrite.java.security.JavaSecurityBestPractices, org.openrewrite.staticanalysis.JavaApiBestPractices, org.openrewrite.staticanalysis.LowercasePackage, org.openrewrite.staticanalysis.MissingOverrideAnnotation, org.openrewrite.staticanalysis.ModifierOrder, org.openrewrite.staticanalysis.NoFinalizer, org.openrewrite.staticanalysis.RemoveUnusedLocalVariables, org.openrewrite.staticanalysis.RemoveUnusedPrivateFields, org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods, org.openrewrite.gradle.GradleBestPractices, org.openrewrite.java.RemoveUnusedImports, org.openrewrite.java.migrate.UpgradeToJava17, org.openrewrite.java.recipes.JavaRecipeBestPractices, org.openrewrite.java.recipes.RecipeTestingBestPractices, org.openrewrite.java.security.JavaSecurityBestPractices, org.openrewrite.staticanalysis.JavaApiBestPractices, org.openrewrite.staticanalysis.LowercasePackage, org.openrewrite.staticanalysis.MissingOverrideAnnotation, org.openrewrite.staticanalysis.ModifierOrder, org.openrewrite.staticanalysis.NoFinalizer, org.openrewrite.staticanalysis.RemoveUnusedLocalVariables, org.openrewrite.staticanalysis.RemoveUnusedPrivateFields, org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods, org.openrewrite.gradle.GradleBestPractices, org.openrewrite.java.RemoveUnusedImports, org.openrewrite.java.migrate.UpgradeToJava17, org.openrewrite.java.recipes.JavaRecipeBestPractices, org.openrewrite.java.recipes.RecipeTestingBestPractices, org.openrewrite.java.security.JavaSecurityBestPractices, org.openrewrite.staticanalysis.JavaApiBestPractices, org.openrewrite.staticanalysis.LowercasePackage, org.openrewrite.staticanalysis.MissingOverrideAnnotation, org.openrewrite.staticanalysis.ModifierOrder, org.openrewrite.staticanalysis.NoFinalizer, org.openrewrite.staticanalysis.RemoveUnusedLocalVariables, org.openrewrite.staticanalysis.RemoveUnusedPrivateFields, org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods, org.openrewrite.gradle.GradleBestPractices, org.openrewrite.java.RemoveUnusedImports, org.openrewrite.java.migrate.UpgradeToJava17, org.openrewrite.java.recipes.JavaRecipeBestPractices, org.openrewrite.java.recipes.RecipeTestingBestPractices, org.openrewrite.java.security.JavaSecurityBestPractices, org.openrewrite.staticanalysis.JavaApiBestPractices, org.openrewrite.staticanalysis.LowercasePackage, org.openrewrite.staticanalysis.MissingOverrideAnnotation, org.openrewrite.staticanalysis.ModifierOrder, org.openrewrite.staticanalysis.NoFinalizer, org.openrewrite.staticanalysis.RemoveUnusedLocalVariables, org.openrewrite.staticanalysis.RemoveUnusedPrivateFields, org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods, org.openrewrite.gradle.GradleBestPractices, org.openrewrite.java.RemoveUnusedImports, org.openrewrite.java.migrate.UpgradeToJava17, org.openrewrite.java.recipes.JavaRecipeBestPractices, org.openrewrite.java.recipes.RecipeTestingBestPractices, org.openrewrite.java.security.JavaSecurityBestPractices, org.openrewrite.staticanalysis.JavaApiBestPractices, org.openrewrite.staticanalysis.LowercasePackage, org.openrewrite.staticanalysis.MissingOverrideAnnotation, org.openrewrite.staticanalysis.ModifierOrder, org.openrewrite.staticanalysis.NoFinalizer, org.openrewrite.staticanalysis.RemoveUnusedLocalVariables, org.openrewrite.staticanalysis.RemoveUnusedPrivateFields, org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
Changes have been made to lib/src/main/java/com/diffplug/spotless/FormatterProperties.java by:
    org.openrewrite.java.security.JavaSecurityBestPractices
        org.openrewrite.java.security.XmlParserXXEVulnerability
Changes have been made to lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java by:
    org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
Changes have been made to lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib/src/main/java/com/diffplug/spotless/NoLambda.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib/src/main/java/com/diffplug/spotless/generic/IdeaStep.java by:
    org.openrewrite.java.security.JavaSecurityBestPractices
        org.openrewrite.java.security.SecureTempFileCreation
Changes have been made to lib/src/main/java/com/diffplug/spotless/npm/SimpleRestClient.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib/src/main/java/com/diffplug/spotless/npm/StandardNpmProcessFactory.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib/src/main/java/com/diffplug/spotless/sql/dbeaver/FormatterToken.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to lib/src/main/java/com/diffplug/spotless/sql/dbeaver/KeywordCase.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to lib/src/jackson/java/com/diffplug/spotless/glue/json/JacksonJsonFormatterFunc.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java by:
    org.openrewrite.java.security.JavaSecurityBestPractices
        org.openrewrite.java.security.SecureTempFileCreation
Changes have been made to lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib-extra/src/test/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStepTest.java by:
    org.openrewrite.java.security.JavaSecurityBestPractices
        org.openrewrite.java.security.SecureTempFileCreation
        org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepTest.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JsonExtension.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/CssExtension.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavascriptExtension.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
        org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskImpl.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to plugin-gradle/src/main/java/com/diffplug/gradle/spotless/IdeHook.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/incremental/UpToDateChecker.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/javascript/EslintJs.java by:
    org.openrewrite.staticanalysis.MissingOverrideAnnotation
Changes have been made to testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Changes have been made to testlib/src/test/java/com/diffplug/spotless/GitPrePushHookInstallerTest.java by:
    org.openrewrite.staticanalysis.ModifierOrder
Please review and commit the results.
Estimate time saved: 1h 36m
close() called when useCnt is already zero for Repository[/Users/vincent.potucek/IdeaProjects/spotless/.git]
```