### PR TITLE
[openrewrite] `StringRulesRecipes`

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.Properties;
 
 import javax.annotation.Nullable;
@@ -127,7 +127,7 @@ public abstract class EquoBasedStepBuilder {
 		var roundtrippableState = new EquoStep(formatterVersion, settingProperties, settingXml, FileSignature.promise(settingsFiles), JarState.promise(() -> {
 			P2QueryResult query;
 			try {
-				if (null != cacheDirectory) {
+				if (cacheDirectory != null) {
 					CacheLocations.override_p2data = cacheDirectory.toPath().resolve("dev/equo/p2-data").toFile();
 				}
 				query = createModelWithMirrors().query(P2ClientCache.PREFER_OFFLINE, P2QueryCache.ALLOW);
@@ -190,8 +190,8 @@ public abstract class EquoBasedStepBuilder {
 				ImmutableMap<String, String> stepProperties) {
 
 			this.semanticVersion = semanticVersion;
-			this.settingProperties = Optional.ofNullable(settingProperties).orElse(new ArrayList<>());
-			this.settingXml = Optional.ofNullable(settingXml).orElse(new ArrayList<>());
+			this.settingProperties = Objects.requireNonNullElse(settingProperties, new ArrayList<>());
+			this.settingXml = Objects.requireNonNullElse(settingXml, new ArrayList<>());
 			this.settingsPromise = settingsPromise;
 			this.jarPromise = jarPromise;
 			this.stepProperties = stepProperties;
@@ -218,8 +218,8 @@ public abstract class EquoBasedStepBuilder {
 		public State(String semanticVersion, JarState jarState, List<String> settingProperties, List<String> settingXml, FileSignature settingsFiles, ImmutableMap<String, String> stepProperties) {
 			this.semanticVersion = semanticVersion;
 			this.jarState = jarState;
-			this.settingProperties = Optional.ofNullable(settingProperties).orElse(new ArrayList<>());
-			this.settingXml = Optional.ofNullable(settingXml).orElse(new ArrayList<>());
+			this.settingProperties = Objects.requireNonNullElse(settingProperties, new ArrayList<>());
+			this.settingXml = Objects.requireNonNullElse(settingXml, new ArrayList<>());
 			this.settingsFiles = settingsFiles;
 			this.stepProperties = stepProperties;
 		}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java
@@ -70,7 +70,7 @@ public final class EclipseCdtFormatterStep {
 					} catch (InvocationTargetException exceptionWrapper) {
 						Throwable throwable = exceptionWrapper.getTargetException();
 						Exception exception = throwable instanceof Exception e ? e : null;
-						throw null == exception ? exceptionWrapper : exception;
+						throw exception == null ? exceptionWrapper : exception;
 					}
 				});
 	}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java
@@ -96,7 +96,7 @@ public final class GrEclipseFormatterStep {
 					} catch (InvocationTargetException exceptionWrapper) {
 						Throwable throwable = exceptionWrapper.getTargetException();
 						Exception exception = throwable instanceof Exception e ? e : null;
-						throw null == exception ? exceptionWrapper : exception;
+						throw exception == null ? exceptionWrapper : exception;
 					}
 				});
 	}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java
@@ -68,7 +68,7 @@ public enum EclipseWtpFormatterStep {
 			} catch (InvocationTargetException exceptionWrapper) {
 				Throwable throwable = exceptionWrapper.getTargetException();
 				Exception exception = throwable instanceof Exception e ? e : null;
-				throw null == exception ? exceptionWrapper : exception;
+				throw exception == null ? exceptionWrapper : exception;
 			}
 		};
 	}
@@ -86,7 +86,7 @@ public enum EclipseWtpFormatterStep {
 				} catch (InvocationTargetException exceptionWrapper) {
 					Throwable throwable = exceptionWrapper.getTargetException();
 					Exception exception = throwable instanceof Exception e ? e : null;
-					throw null == exception ? exceptionWrapper : exception;
+					throw exception == null ? exceptionWrapper : exception;
 				}
 			}
 		});

--- a/lib/src/main/java/com/diffplug/spotless/FilterByContentPatternFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FilterByContentPatternFormatterStep.java
@@ -65,7 +65,7 @@ final class FilterByContentPatternFormatterStep extends DelegateFormatterStep {
 		}
 		FilterByContentPatternFormatterStep that = (FilterByContentPatternFormatterStep) o;
 		return Objects.equals(delegateStep, that.delegateStep)
-				&& Objects.equals(onMatch, that.onMatch)
+				&& onMatch == that.onMatch
 				&& Objects.equals(contentPattern.pattern(), that.contentPattern.pattern());
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -132,7 +131,7 @@ public final class JarState implements Serializable {
 		Objects.requireNonNull(provisioner, "provisioner");
 		Set<File> jars = provisioner.provisionWithTransitives(withTransitives, mavenCoordinates);
 		if (jars.isEmpty()) {
-			throw new NoSuchElementException("Resolved to an empty result: " + mavenCoordinates.stream().collect(Collectors.joining(", ")));
+			throw new NoSuchElementException("Resolved to an empty result: " + String.join(", ", mavenCoordinates));
 		}
 		FileSignature fileSignature = FileSignature.signAsSet(jars);
 		return new JarState(fileSignature);

--- a/lib/src/main/java/com/diffplug/spotless/Jvm.java
+++ b/lib/src/main/java/com/diffplug/spotless/Jvm.java
@@ -89,10 +89,10 @@ public final class Jvm {
 		 */
 		public Support<V> add(int minimumJvmVersion, V maxFormatterVersion) {
 			Objects.requireNonNull(maxFormatterVersion);
-			if (null != jvm2fmtMaxVersion.put(minimumJvmVersion, maxFormatterVersion)) {
+			if (jvm2fmtMaxVersion.put(minimumJvmVersion, maxFormatterVersion) != null) {
 				throw new IllegalArgumentException("Added duplicate entry for JVM %d+.".formatted(minimumJvmVersion));
 			}
-			if (null != fmtMaxVersion2jvmVersion.put(maxFormatterVersion, minimumJvmVersion)) {
+			if (fmtMaxVersion2jvmVersion.put(maxFormatterVersion, minimumJvmVersion) != null) {
 				throw new IllegalArgumentException("Added duplicate entry for formatter version %s.".formatted(maxFormatterVersion));
 			}
 			verifyVersionRangesDoNotIntersect(jvm2fmtMaxVersion, minimumJvmVersion, maxFormatterVersion);
@@ -101,7 +101,7 @@ public final class Jvm {
 
 		public Support<V> addMin(int minimumJvmVersion, V minFormatterVersion) {
 			Objects.requireNonNull(minFormatterVersion);
-			if (null != jvm2fmtMinVersion.put(minimumJvmVersion, minFormatterVersion)) {
+			if (jvm2fmtMinVersion.put(minimumJvmVersion, minFormatterVersion) != null) {
 				throw new IllegalArgumentException("Added duplicate entry for JVM %d+.".formatted(minimumJvmVersion));
 			}
 			verifyVersionRangesDoNotIntersect(jvm2fmtMinVersion, minimumJvmVersion, minFormatterVersion);
@@ -110,11 +110,11 @@ public final class Jvm {
 
 		private void verifyVersionRangesDoNotIntersect(NavigableMap<Integer, V> jvm2fmtVersion, int minimumJvmVersion, V formatterVersion) {
 			Map.Entry<Integer, V> lower = jvm2fmtVersion.lowerEntry(minimumJvmVersion);
-			if ((null != lower) && (fmtVersionComparator.compare(formatterVersion, lower.getValue()) <= 0)) {
+			if ((lower != null) && (fmtVersionComparator.compare(formatterVersion, lower.getValue()) <= 0)) {
 				throw new IllegalArgumentException("%d/%s should be lower than %d/%s".formatted(minimumJvmVersion, formatterVersion, lower.getKey(), lower.getValue()));
 			}
 			Map.Entry<Integer, V> higher = jvm2fmtVersion.higherEntry(minimumJvmVersion);
-			if ((null != higher) && (fmtVersionComparator.compare(formatterVersion, higher.getValue()) >= 0)) {
+			if ((higher != null) && (fmtVersionComparator.compare(formatterVersion, higher.getValue()) >= 0)) {
 				throw new IllegalArgumentException("%d/%s should be higher than %d/%s".formatted(minimumJvmVersion, formatterVersion, higher.getKey(), higher.getValue()));
 			}
 		}
@@ -122,12 +122,12 @@ public final class Jvm {
 		/** @return Highest formatter version recommended for this JVM (null, if JVM not supported) */
 		@Nullable public V getRecommendedFormatterVersion() {
 			Integer configuredJvmVersionOrNull = jvm2fmtMaxVersion.floorKey(Jvm.version());
-			return null == configuredJvmVersionOrNull ? null : jvm2fmtMaxVersion.get(configuredJvmVersionOrNull);
+			return configuredJvmVersionOrNull == null ? null : jvm2fmtMaxVersion.get(configuredJvmVersionOrNull);
 		}
 
 		@Nullable public V getMinimumRequiredFormatterVersion() {
 			Integer configuredJvmVersionOrNull = jvm2fmtMinVersion.floorKey(Jvm.version());
-			return null == configuredJvmVersionOrNull ? null : jvm2fmtMinVersion.get(configuredJvmVersionOrNull);
+			return configuredJvmVersionOrNull == null ? null : jvm2fmtMinVersion.get(configuredJvmVersionOrNull);
 		}
 
 		/**
@@ -151,7 +151,7 @@ public final class Jvm {
 			}
 			// check if the formatter version is too low for the jvm version
 			V minimumFormatterVersion = getMinimumRequiredFormatterVersion();
-			if ((null != minimumFormatterVersion) && (fmtVersionComparator.compare(fmtVersion, minimumFormatterVersion) < 0)) {
+			if ((minimumFormatterVersion != null) && (fmtVersionComparator.compare(fmtVersion, minimumFormatterVersion) < 0)) {
 				return "You are running Spotless on JVM %d. This requires %s of at least %s (you are using %s).%n".formatted(Jvm.version(), fmtName, minimumFormatterVersion, fmtVersion);
 			}
 			// otherwise all is well
@@ -162,11 +162,11 @@ public final class Jvm {
 			StringBuilder builder = new StringBuilder();
 			builder.append("You are running Spotless on JVM %d".formatted(Jvm.version()));
 			V recommendedFmtVersionOrNull = getRecommendedFormatterVersion();
-			if (null != recommendedFmtVersionOrNull) {
+			if (recommendedFmtVersionOrNull != null) {
 				builder.append(", which limits you to %s %s.%n".formatted(fmtName, recommendedFmtVersionOrNull));
 			} else {
 				Entry<V, Integer> nextFmtVersionOrNull = fmtMaxVersion2jvmVersion.ceilingEntry(fmtVersion);
-				if (null != nextFmtVersionOrNull) {
+				if (nextFmtVersionOrNull != null) {
 					builder.append(". %s %s requires JVM %d+".formatted(fmtName, fmtVersion, nextFmtVersionOrNull.getValue()));
 				}
 				builder.append(".%n".formatted());
@@ -176,10 +176,10 @@ public final class Jvm {
 
 		private int getRequiredJvmVersion(V fmtVersion) {
 			Entry<V, Integer> entry = fmtMaxVersion2jvmVersion.ceilingEntry(fmtVersion);
-			if (null == entry) {
+			if (entry == null) {
 				entry = fmtMaxVersion2jvmVersion.lastEntry();
 			}
-			if (null != entry) {
+			if (entry != null) {
 				V maxKnownFmtVersion = jvm2fmtMaxVersion.get(entry.getValue());
 				if (fmtVersionComparator.compare(fmtVersion, maxKnownFmtVersion) <= 0) {
 					return entry.getValue();
@@ -227,20 +227,20 @@ public final class Jvm {
 			// check if the formatter is not supported on this jvm
 			V minimumFormatterVersion = getMinimumRequiredFormatterVersion();
 			V recommendedFmtVersionOrNull = getRecommendedFormatterVersion();
-			if ((null != minimumFormatterVersion) && (fmtVersionComparator.compare(fmtVersion, minimumFormatterVersion) < 0)) {
+			if ((minimumFormatterVersion != null) && (fmtVersionComparator.compare(fmtVersion, minimumFormatterVersion) < 0)) {
 				builder.append("You are running Spotless on JVM %d. This requires %s of at least %s.%n".formatted(Jvm.version(), fmtName, minimumFormatterVersion));
 				builder.append("You are using %s %s.%n".formatted(fmtName, fmtVersion));
-				if (null != recommendedFmtVersionOrNull) {
+				if (recommendedFmtVersionOrNull != null) {
 					builder.append("%s %s is the recommended version, which may have fixed this problem.%n".formatted(fmtName, recommendedFmtVersionOrNull));
 				}
 				// check if the formatter is outdated on this jvm
-			} else if (null != recommendedFmtVersionOrNull && (fmtVersionComparator.compare(fmtVersion, recommendedFmtVersionOrNull) < 0)) {
+			} else if (recommendedFmtVersionOrNull != null && (fmtVersionComparator.compare(fmtVersion, recommendedFmtVersionOrNull) < 0)) {
 				builder.append("%s %s is currently being used, but outdated.%n".formatted(fmtName, fmtVersion));
 				builder.append("%s %s is the recommended version, which may have fixed this problem.%n".formatted(fmtName, recommendedFmtVersionOrNull));
 				builder.append("%s %s requires JVM %d+.".formatted(fmtName, recommendedFmtVersionOrNull, getRequiredJvmVersion(recommendedFmtVersionOrNull)));
 			} else {
 				V higherFormatterVersionOrNull = fmtMaxVersion2jvmVersion.higherKey(fmtVersion);
-				if (null != higherFormatterVersionOrNull) {
+				if (higherFormatterVersionOrNull != null) {
 					builder.append(buildUpgradeJvmMessage(fmtVersion));
 					Integer higherJvmVersion = fmtMaxVersion2jvmVersion.get(higherFormatterVersionOrNull);
 					builder.append("If you upgrade your JVM to %d+, then you can use %s %s, which may have fixed this problem.".formatted(higherJvmVersion, fmtName, higherFormatterVersionOrNull));

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
@@ -145,8 +145,8 @@ final class BiomeExecutableDownloader {
 		logger.debug("Ensuring that Biome for platform '{}' is downloaded", platform);
 		var existing = findDownloaded(version);
 		if (existing.isPresent()) {
-			logger.debug("Biome was already downloaded, using executable at '{}'", existing.get());
-			return existing.get();
+			logger.debug("Biome was already downloaded, using executable at '{}'", existing.orElseThrow());
+			return existing.orElseThrow();
 		} else {
 			logger.debug("Biome was not yet downloaded, attempting to download executable");
 			return download(version);

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -241,9 +241,9 @@ public final class LicenseHeaderStep {
 			Optional<String> yearToken = getYearToken(licenseHeader);
 			if (yearToken.isPresent()) {
 				this.yearToday = String.valueOf(YearMonth.now().getYear());
-				int yearTokenIndex = licenseHeader.indexOf(yearToken.get());
+				int yearTokenIndex = licenseHeader.indexOf(yearToken.orElseThrow());
 				this.beforeYear = licenseHeader.substring(0, yearTokenIndex);
-				this.afterYear = licenseHeader.substring(yearTokenIndex + yearToken.get().length());
+				this.afterYear = licenseHeader.substring(yearTokenIndex + yearToken.orElseThrow().length());
 				this.yearSepOrFull = yearSeparator;
 				this.updateYearWithLatest = updateYearWithLatest;
 

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -390,45 +389,45 @@ public final class KtfmtStep implements Serializable {
 			if (options != null) {
 				if (BadSemver.version(version) < BadSemver.version(0, 17)) {
 					formattingOptions = formattingOptions.getClass().getConstructor(int.class, int.class, int.class).newInstance(
-							/* maxWidth = */ Optional.ofNullable(options.maxWidth).orElse((Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Optional.ofNullable(options.blockIndent).orElse((Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Optional.ofNullable(options.continuationIndent).orElse((Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)));
+							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)));
 				} else if (BadSemver.version(version) < BadSemver.version(0, 19)) {
 					formattingOptions = formattingOptions.getClass().getConstructor(int.class, int.class, int.class, boolean.class, boolean.class).newInstance(
-							/* maxWidth = */ Optional.ofNullable(options.maxWidth).orElse((Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Optional.ofNullable(options.blockIndent).orElse((Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Optional.ofNullable(options.continuationIndent).orElse((Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Optional.ofNullable(options.removeUnusedImports).orElse((Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions));
 				} else if (BadSemver.version(version) < BadSemver.version(0, 47)) {
 					Class<?> styleClass = classLoader.loadClass(formattingOptionsClass.getName() + "$Style");
 					formattingOptions = formattingOptions.getClass().getConstructor(styleClass, int.class, int.class, int.class, boolean.class, boolean.class).newInstance(
 							/* style = */ formattingOptionsClass.getMethod("getStyle").invoke(formattingOptions),
-							/* maxWidth = */ Optional.ofNullable(options.maxWidth).orElse((Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Optional.ofNullable(options.blockIndent).orElse((Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Optional.ofNullable(options.continuationIndent).orElse((Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Optional.ofNullable(options.removeUnusedImports).orElse((Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions));
 				} else if (BadSemver.version(version) < BadSemver.version(0, 57)) {
 					Class<?> styleClass = classLoader.loadClass(formattingOptionsClass.getName() + "$Style");
 					formattingOptions = formattingOptions.getClass().getConstructor(styleClass, int.class, int.class, int.class, boolean.class, boolean.class, boolean.class).newInstance(
 							/* style = */ formattingOptionsClass.getMethod("getStyle").invoke(formattingOptions),
-							/* maxWidth = */ Optional.ofNullable(options.maxWidth).orElse((Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Optional.ofNullable(options.blockIndent).orElse((Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Optional.ofNullable(options.continuationIndent).orElse((Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Optional.ofNullable(options.removeUnusedImports).orElse((Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions),
-							/* manageTrailingCommas = */ Optional.ofNullable(getManageTrailingCommasFrom(options.trailingCommaManagementStrategy)).orElse((Boolean) formattingOptionsClass.getMethod("getManageTrailingCommas").invoke(formattingOptions)));
+							/* manageTrailingCommas = */ Objects.requireNonNullElse(getManageTrailingCommasFrom(options.trailingCommaManagementStrategy), (Boolean) formattingOptionsClass.getMethod("getManageTrailingCommas").invoke(formattingOptions)));
 				} else {
 					Class<?> styleClass = classLoader.loadClass(formattingOptionsClass.getName() + "$Style");
 					formattingOptions = formattingOptions.getClass().getConstructor(styleClass, int.class, int.class, int.class, boolean.class, boolean.class, TrailingCommaManagementStrategy.class).newInstance(
 							/* style = */ formattingOptionsClass.getMethod("getStyle").invoke(formattingOptions),
-							/* maxWidth = */ Optional.ofNullable(options.maxWidth).orElse((Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Optional.ofNullable(options.blockIndent).orElse((Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Optional.ofNullable(options.continuationIndent).orElse((Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Optional.ofNullable(options.removeUnusedImports).orElse((Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions),
-							/* trailingCommaManagementStrategy */ Optional.ofNullable(options.trailingCommaManagementStrategy).orElse((TrailingCommaManagementStrategy) formattingOptionsClass.getMethod("getTrailingCommaManagementStrategy").invoke(formattingOptions)));
+							/* trailingCommaManagementStrategy */ Objects.requireNonNullElse(options.trailingCommaManagementStrategy, (TrailingCommaManagementStrategy) formattingOptionsClass.getMethod("getTrailingCommaManagementStrategy").invoke(formattingOptions)));
 				}
 			}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmPathResolver.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmPathResolver.java
@@ -85,13 +85,10 @@ public class NpmPathResolver implements Serializable {
 	}
 
 	public String resolveNpmrcContent() {
-		File npmrcFile = Optional.ofNullable(this.explicitNpmrcFile)
-				.orElseGet(() -> new NpmrcResolver(additionalNpmrcLocations).tryFind()
-						.orElse(null));
-		if (npmrcFile != null) {
-			return NpmResourceHelper.readUtf8StringFromFile(npmrcFile);
-		}
-		return null;
+		return Optional.ofNullable(explicitNpmrcFile)
+				.or(() -> new NpmrcResolver(additionalNpmrcLocations).tryFind())
+				.map(NpmResourceHelper::readUtf8StringFromFile)
+				.orElse(null);
 	}
 
 }

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -137,7 +137,7 @@ public final class PrettierFormatterStep {
 				return prettierConfigOptions;
 			}
 			// if the file has no name, we  cannot use it
-			if (file.getName().trim().isEmpty()) {
+			if (file.getName().isBlank()) {
 				return prettierConfigOptions;
 			}
 			// if it is not there, we add it at the beginning of the Options

--- a/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
@@ -100,8 +100,8 @@ class ReflectionHelper {
 		this.TurtleFormatFormattingStyleClass = classLoader.loadClass("de.atextor.turtle.formatter.FormattingStyle");
 		Class<?>[] innerClasses = TurtleFormatFormattingStyleClass.getDeclaredClasses();
 		this.TurtleFormatFormattingStyleBuilderClass = Arrays.stream(innerClasses)
-				.filter(c -> "FormattingStyleBuilder".equals(c.getSimpleName())).findFirst().get();
-		this.TurtleFormatKnownPrefix = Arrays.stream(innerClasses).filter(c -> "KnownPrefix".equals(c.getSimpleName())).findFirst().get();
+				.filter(c -> "FormattingStyleBuilder".equals(c.getSimpleName())).findFirst().orElseThrow();
+		this.TurtleFormatKnownPrefix = Arrays.stream(innerClasses).filter(c -> "KnownPrefix".equals(c.getSimpleName())).findFirst().orElseThrow();
 		this.getSubject = JenaStatementClass.getMethod("getSubject");
 		this.getPredicate = JenaStatementClass.getMethod("getPredicate");
 		this.getObject = JenaStatementClass.getMethod("getObject");

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -293,8 +293,8 @@ public class SQLTokenizedFormatter {
 			FormatterToken t4 = argList.get(index - 4);
 
 			if ("(".equals(t4.getString())
-					&& t3.getString().trim().isEmpty()
-					&& t1.getString().trim().isEmpty()
+					&& t3.getString().isBlank()
+					&& t1.getString().isBlank()
 					&& ")".equalsIgnoreCase(t0.getString())) {
 				t4.setString(t4.getString() + t2.getString() + t0.getString());
 				argList.remove(index);

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static com.diffplug.common.base.Strings.isNullOrEmpty;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
@@ -229,7 +230,7 @@ public class GradleIntegrationHarness extends ResourceHarness {
 
 	private static File getTestKitDir() {
 		String gradleUserHome = System.getenv("GRADLE_USER_HOME");
-		if (gradleUserHome == null || gradleUserHome.isEmpty()) {
+		if (isNullOrEmpty(gradleUserHome)) {
 			gradleUserHome = new File(System.getProperty("user.home"), ".gradle").getAbsolutePath();
 		}
 		return new File(gradleUserHome, "testkit");

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.maven;
 
+import static com.diffplug.common.base.Strings.isNullOrEmpty;
 import static java.util.stream.Collectors.toList;
 
 import java.io.File;
@@ -304,11 +305,11 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		try {
 			final List<File> files;
 			if (ratchetFrom.isPresent()) {
-				files = collectFilesFromGit(formatterFactory, ratchetFrom.get());
+				files = collectFilesFromGit(formatterFactory, ratchetFrom.orElseThrow());
 			} else {
 				files = collectFilesFromFormatterFactory(formatterFactory);
 			}
-			if (filePatterns == null || filePatterns.isEmpty()) {
+			if (isNullOrEmpty(filePatterns)) {
 				return files;
 			}
 			final String[] includePatterns = this.filePatterns.split(",");

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.maven;
 
+import static com.diffplug.common.base.Strings.isNullOrEmpty;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -114,6 +116,6 @@ public class SpotlessApplyMojo extends AbstractSpotlessMojo {
 	}
 
 	private boolean isIdeHook() {
-		return !(spotlessIdeHook == null || spotlessIdeHook.isEmpty());
+		return !isNullOrEmpty(spotlessIdeHook);
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/EclipseCdt.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/EclipseCdt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class EclipseCdt implements FormatterStepFactory {
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
 		EquoBasedStepBuilder eclipseConfig = EclipseCdtFormatterStep.createBuilder(stepConfig.getProvisioner());
 		eclipseConfig.setVersion(version == null ? EclipseCdtFormatterStep.defaultVersion() : version);
-		if (null != file) {
+		if (file != null) {
 			File settingsFile = stepConfig.getFileLocator().locateFile(file);
 			eclipseConfig.setPreferences(Arrays.asList(settingsFile));
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/EclipseWtp.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/EclipseWtp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class EclipseWtp implements FormatterStepFactory {
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
 		EclipseBasedStepBuilder eclipseConfig = type.createBuilder(stepConfig.getProvisioner());
 		eclipseConfig.setVersion(version == null ? EclipseWtpFormatterStep.defaultVersion() : version);
-		if (null != files) {
+		if (files != null) {
 			eclipseConfig.setPreferences(
 					stream(files).map(file -> stepConfig.getFileLocator().locateFile(file)).collect(toList()));
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/groovy/GrEclipse.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/groovy/GrEclipse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class GrEclipse implements FormatterStepFactory {
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
 		EquoBasedStepBuilder grEclipseConfig = GrEclipseFormatterStep.createBuilder(stepConfig.getProvisioner());
 		grEclipseConfig.setVersion(version == null ? GrEclipseFormatterStep.defaultVersion() : version);
-		if (null != file) {
+		if (file != null) {
 			File settingsFile = stepConfig.getFileLocator().locateFile(file);
 			grEclipseConfig.setPreferences(Arrays.asList(settingsFile));
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java
@@ -61,30 +61,30 @@ public class Eclipse implements FormatterStepFactory {
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {
 		EclipseJdtFormatterStep.Builder eclipseConfig = EclipseJdtFormatterStep.createBuilder(stepConfig.getProvisioner());
 		eclipseConfig.setVersion(version == null ? EclipseJdtFormatterStep.defaultVersion() : version);
-		if (null != file) {
+		if (file != null) {
 			File settingsFile = stepConfig.getFileLocator().locateFile(file);
 			eclipseConfig.setPreferences(Arrays.asList(settingsFile));
 		}
 		eclipseConfig.setP2Mirrors(p2Mirrors);
-		if (null != cacheDirectory) {
+		if (cacheDirectory != null) {
 			eclipseConfig.setCacheDirectory(cacheDirectory);
 		}
-		if (null != sortMembersEnabled) {
+		if (sortMembersEnabled != null) {
 			eclipseConfig.sortMembersEnabled(sortMembersEnabled);
 		}
-		if (null != sortMembersOrder) {
+		if (sortMembersOrder != null) {
 			eclipseConfig.sortMembersOrder(sortMembersOrder);
 		}
-		if (null != sortMembersDoNotSortFields) {
+		if (sortMembersDoNotSortFields != null) {
 			eclipseConfig.sortMembersDoNotSortFields(sortMembersDoNotSortFields);
 		}
-		if (null != sortMembersVisibilityOrder) {
+		if (sortMembersVisibilityOrder != null) {
 			eclipseConfig.sortMembersVisibilityOrder(sortMembersVisibilityOrder);
 		}
-		if (null != sortMembersVisibilityOrderEnabled) {
+		if (sortMembersVisibilityOrderEnabled != null) {
 			eclipseConfig.sortMembersVisibilityOrderEnabled(sortMembersVisibilityOrderEnabled);
 		}
-		if (null != cacheDirectory) {
+		if (cacheDirectory != null) {
 			eclipseConfig.setCacheDirectory(cacheDirectory);
 		}
 		return eclipseConfig.build();

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojoTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojoTest.java
@@ -143,7 +143,7 @@ class SpotlessInstallPrePushHookMojoTest extends MavenIntegrationHarness {
 					throw new RuntimeException("Could not find git bash executable");
 				}
 
-				executor = bashPath.get();
+				executor = bashPath.orElseThrow();
 			}
 
 			return runner.exec(rootFolder(), Map.of("JAVA_HOME", System.getProperty("java.home")), null, List.of(executor, hookFile));

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -9,8 +9,12 @@ tags:
   - static-analysis
   - cleanup
 recipeList:
+  - org.openrewrite.gradle.EnableGradleBuildCache
+  - org.openrewrite.gradle.EnableGradleParallelExecution
   - org.openrewrite.gradle.GradleBestPractices
   - org.openrewrite.java.RemoveUnusedImports
+  - org.openrewrite.java.format.NormalizeFormat
+  - org.openrewrite.java.format.NormalizeLineBreaks
   - org.openrewrite.java.format.RemoveTrailingWhitespace
   - org.openrewrite.java.migrate.UpgradeToJava17
   - org.openrewrite.java.recipes.JavaRecipeBestPractices
@@ -37,13 +41,17 @@ recipeList:
   - tech.picnic.errorprone.refasterrules.ClassRulesRecipes
   - tech.picnic.errorprone.refasterrules.CollectionRulesRecipes
   - tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes
+  - tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
   - tech.picnic.errorprone.refasterrules.FileRulesRecipes
+  - tech.picnic.errorprone.refasterrules.MapRulesRecipes
   - tech.picnic.errorprone.refasterrules.MicrometerRulesRecipes
+  - tech.picnic.errorprone.refasterrules.MockitoRulesRecipes
+  - tech.picnic.errorprone.refasterrules.NullRulesRecipes
+  - tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
   - tech.picnic.errorprone.refasterrules.PatternRulesRecipes
   - tech.picnic.errorprone.refasterrules.PreconditionsRulesRecipes
   - tech.picnic.errorprone.refasterrules.PrimitiveRulesRecipes
   - tech.picnic.errorprone.refasterrules.StreamRulesRecipes
+  - tech.picnic.errorprone.refasterrules.StringRulesRecipes
   - tech.picnic.errorprone.refasterrules.TimeRulesRecipes
-  # - org.openrewrite.staticanalysis.CodeCleanup # bug https://github.com/openrewrite/rewrite/pull/6084
-  # - org.openrewrite.staticanalysis.UnnecessaryThrows # bug
 ---

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -127,7 +127,7 @@ public class ResourceHarness {
 	public static String getTestResource(String filename) {
 		Optional<URL> resourceUrl = getTestResourceUrl(filename);
 		if (resourceUrl.isPresent()) {
-			return ThrowingEx.get(() -> LineEnding.toUnix(Resources.toString(resourceUrl.get(), StandardCharsets.UTF_8)));
+			return ThrowingEx.get(() -> LineEnding.toUnix(Resources.toString(resourceUrl.orElseThrow(), StandardCharsets.UTF_8)));
 		}
 		throw new IllegalArgumentException("No such resource " + filename);
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
@@ -208,13 +208,13 @@ class FormatterPropertiesTest extends ResourceHarness {
 			Properties settingsProps = actual.getProperties();
 			for (String expectedValue : VALID_VALUES) {
 				// A parsable (valid) file contains keys of the following format
-				String validValueName = null == expectedValue ? "null" : expectedValue;
+				String validValueName = expectedValue == null ? "null" : expectedValue;
 				String key = "%s.%s".formatted(fileName, validValueName);
 				if (!settingsProps.containsKey(key)) {
 					failWithMessage("Key <%s> not part of formatter settings.", key);
 				}
 				String value = settingsProps.getProperty(key);
-				if ((null != expectedValue) && (!expectedValue.equals(value))) {
+				if ((expectedValue != null) && (!expectedValue.equals(value))) {
 					failWithMessage("Value of key <%s> is '%s' and not '%s' as expected.", key, value, expectedValue);
 				}
 			}

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/KtfmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/KtfmtStepTest.java
@@ -19,7 +19,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
-import com.diffplug.spotless.*;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.ResourceHarness;
+import com.diffplug.spotless.SerializableEqualityTester;
+import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.TestProvisioner;
 
 class KtfmtStepTest extends ResourceHarness {
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/pom/SortPomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import com.diffplug.spotless.*;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.ResourceHarness;
+import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.TestProvisioner;
 
 public class SortPomTest extends ResourceHarness {
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/rdf/RdfFormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/rdf/RdfFormatterTest.java
@@ -119,7 +119,7 @@ public class RdfFormatterTest extends ResourceHarness {
 			if (output.isEmpty()) {
 				throw new IllegalStateException("'after' directory %s is missing file %s corresponding to 'before' file %s".formatted(afterDir, input.getFileName(), input));
 			}
-			arguments.add(Arguments.of(unixRelative(input), unixRelative(output.get())));
+			arguments.add(Arguments.of(unixRelative(input), unixRelative(output.orElseThrow())));
 		}
 		return arguments;
 	}


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)






```
Changes have been made to lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$RequireNonNullElseRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
            tech.picnic.errorprone.refasterrules.OptionalRulesRecipes$OptionalOrElseThrowRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/Jvm.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNullRecipe
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNotNullRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
            tech.picnic.errorprone.refasterrules.OptionalRulesRecipes$OptionalOrElseThrowRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/FilterByContentPatternFormatterStep.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
            tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
            tech.picnic.errorprone.refasterrules.OptionalRulesRecipes$OptionalOrElseThrowRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/npm/NpmPathResolver.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$RequireNonNullElseGetRecipe
Changes have been made to lib-extra/src/main/java/com/diffplug/spotless/extra/wtp/EclipseWtpFormatterStep.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNullRecipe
Changes have been made to lib-extra/src/main/java/com/diffplug/spotless/extra/cpp/EclipseCdtFormatterStep.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNullRecipe
Changes have been made to lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNotNullRecipe
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$RequireNonNullElseRecipe
Changes have been made to lib-extra/src/main/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStep.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNullRecipe
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/java/Eclipse.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNotNullRecipe
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
            tech.picnic.errorprone.refasterrules.OptionalRulesRecipes$OptionalOrElseThrowRecipe
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/EclipseCdt.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNotNullRecipe
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/EclipseWtp.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNotNullRecipe
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/groovy/GrEclipse.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNotNullRecipe
Changes have been made to plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojoTest.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
            tech.picnic.errorprone.refasterrules.OptionalRulesRecipes$OptionalOrElseThrowRecipe
Changes have been made to testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
            tech.picnic.errorprone.refasterrules.OptionalRulesRecipes$OptionalOrElseThrowRecipe
Changes have been made to testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.NullRulesRecipes
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNullRecipe
            tech.picnic.errorprone.refasterrules.NullRulesRecipes$IsNotNullRecipe
Changes have been made to testlib/src/test/java/com/diffplug/spotless/rdf/RdfFormatterTest.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.OptionalRulesRecipes
            tech.picnic.errorprone.refasterrules.OptionalRulesRecipes$OptionalOrElseThrowRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.StringRulesRecipes
            tech.picnic.errorprone.refasterrules.StringRulesRecipes$StringIsBlankRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/JarState.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.StringRulesRecipes
            tech.picnic.errorprone.refasterrules.StringRulesRecipes$JoinStringsRecipe
Changes have been made to lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.StringRulesRecipes
            tech.picnic.errorprone.refasterrules.StringRulesRecipes$StringIsBlankRecipe
Changes have been made to plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.StringRulesRecipes
            tech.picnic.errorprone.refasterrules.StringRulesRecipes$StringIsNullOrEmptyRecipe
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.StringRulesRecipes
            tech.picnic.errorprone.refasterrules.StringRulesRecipes$StringIsNullOrEmptyRecipe
Changes have been made to plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java by:
    com.diffplug.spotless.openrewrite.SanityCheck
        tech.picnic.errorprone.refasterrules.StringRulesRecipes
            tech.picnic.errorprone.refasterrules.StringRulesRecipes$StringIsNullOrEmptyRecipe
Please review and commit the results.

Estimate time saved: 1h 40m
```

