### PR TITLE
format files in batches with idea

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+* Add batching to IDEA formatter ([#2662](https://github.com/diffplug/spotless/pull/2662))
 
 ## [4.0.0] - 2025-09-24
 ### Changes

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+* Add `batchSize` to `<idea>` formatter which determines the number of files to format in a single IDEA invocation (default=100) ([#2662](https://github.com/diffplug/spotless/pull/2662))
 
 ## [8.0.0] - 2025-09-24
 ### Changed

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -1657,6 +1657,9 @@ spotless {
 
     // if idea is not on your path, you must specify the path to the executable
     idea().binaryPath('/path/to/idea')
+    
+    // to set the number of files per IDEA involcation (default: 100)
+    idea().batchSize(100)
   }
 }
 ```
@@ -1666,7 +1669,6 @@ See [here](../INTELLIJ_IDEA_SCREENSHOTS.md) for an explanation on how to extract
 
 ### Limitations
 - Currently, only IntelliJ IDEA is supported - none of the other jetbrains IDE. Consider opening a PR if you want to change this.
-- Launching IntelliJ IDEA from the command line is pretty expensive and as of now, we do this for each file. If you want to change this, consider opening a PR.
 
 ## Generic steps
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+* Add `batchSize` to `<idea>` formatter which determines the number of files to format in a single IDEA invocation (default=100) ([#2662](https://github.com/diffplug/spotless/pull/2662))
 
 ## [3.0.0] - 2025-09-24
 ### Changes

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1733,6 +1733,8 @@ Spotless provides access to IntelliJ IDEA's command line formatter.
         <withDefaults>false</withDefaults>
         <!-- if idea is not on your path, you must specify the path to the executable -->
         <binaryPath>/path/to/idea</binaryPath>
+        <!-- the number of files to format in one idea invocation (default: 100) -->
+        <batchSize>100</batchSize>
       </idea>
     </format>
   </formats>
@@ -1744,7 +1746,6 @@ See [here](../INTELLIJ_IDEA_SCREENSHOTS.md) for an explanation on how to extract
 
 ### Limitations
 - Currently, only IntelliJ IDEA is supported - none of the other jetbrains IDE. Consider opening a PR if you want to change this.
-- Launching IntelliJ IDEA from the command line is pretty expensive and as of now, we do this for each file. If you want to change this, consider opening a PR.
 
 ## Generic steps
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Idea.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Idea.java
@@ -33,12 +33,16 @@ public class Idea implements FormatterStepFactory {
 	@Parameter
 	private Boolean withDefaults = true;
 
+	@Parameter
+	private Integer batchSize = IdeaStep.DEFAULT_BATCH_SIZE;
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		return IdeaStep.newBuilder(config.getFileLocator().getBuildDir())
 				.setUseDefaults(withDefaults)
 				.setCodeStyleSettingsPath(codeStyleSettingsPath)
 				.setBinaryPath(binaryPath)
+				.setBatchSize(batchSize)
 				.build();
 	}
 }


### PR DESCRIPTION
- Improve performance of IntelliJ IDEA formatter by batching files for each invocation of idea executable.

Note: this PR heavily relied on copilot to assist.