### PR TITLE
[prone] Add `ConstantNaming`

### DIFF
--- a/gradle/error-prone.gradle
+++ b/gradle/error-prone.gradle
@@ -19,11 +19,16 @@ dependencies {
 tasks.withType(JavaCompile).configureEach {
 	options.errorprone {
 		disableAllChecks = true // consider removal to avoid error prone error´s, following convention over configuration.
-		error('RedundantStringConversion')
+		error(
+				'ConstantNaming',
+				'RedundantStringConversion',
+				)
 		if (!getenv().containsKey('CI') && getenv('IN_PLACE')?.toBoolean()) {
 			errorproneArgs.addAll(
 					'-XepPatchLocation:IN_PLACE',
-					'-XepPatchChecks:RedundantStringConversion'
+					'-XepPatchChecks:' +
+					'ConstantNaming,' +
+					'RedundantStringConversion,'
 					)
 		}
 	}

--- a/lib/src/compatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot49Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot49Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot49Dot0Adapter implements KtLintCompatAdapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(KtLintCompat0Dot49Dot0Adapter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(KtLintCompat0Dot49Dot0Adapter.class);
 
 	private static final List<EditorConfigProperty<?>> DEFAULT_EDITOR_CONFIG_PROPERTIES;
 

--- a/lib/src/compatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0Adapter.java
+++ b/lib/src/compatKtLint0Dot50Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat0Dot50Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat0Dot50Dot0Adapter implements KtLintCompatAdapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(KtLintCompat0Dot50Dot0Adapter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(KtLintCompat0Dot50Dot0Adapter.class);
 
 	private static final List<EditorConfigProperty<?>> DEFAULT_EDITOR_CONFIG_PROPERTIES;
 

--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ import kotlin.jvm.functions.Function2;
 
 public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(KtLintCompat1Dot0Dot0Adapter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(KtLintCompat1Dot0Dot0Adapter.class);
 
 	private static final List<EditorConfigProperty<?>> DEFAULT_EDITOR_CONFIG_PROPERTIES;
 

--- a/lib/src/main/java/com/diffplug/spotless/DirtyState.java
+++ b/lib/src/main/java/com/diffplug/spotless/DirtyState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,19 +31,18 @@ import javax.annotation.Nullable;
  * then you can call {@link #writeCanonicalTo(OutputStream)} to get the canonical form of the given file.
  */
 public class DirtyState {
-	@Nullable
-	private final byte[] canonicalBytes;
+	@Nullable private final byte[] canonicalBytes;
 
 	DirtyState(@Nullable byte[] canonicalBytes) {
 		this.canonicalBytes = canonicalBytes;
 	}
 
 	public boolean isClean() {
-		return this == isClean;
+		return this == IS_CLEAN;
 	}
 
 	public boolean didNotConverge() {
-		return this == didNotConverge;
+		return this == DID_NOT_CONVERGE;
 	}
 
 	byte[] canonicalBytes() {
@@ -63,11 +62,11 @@ public class DirtyState {
 
 	/** Returns the DirtyState which corresponds to {@code isClean()}. */
 	public static DirtyState clean() {
-		return isClean;
+		return IS_CLEAN;
 	}
 
-	static final DirtyState didNotConverge = new DirtyState(null);
-	static final DirtyState isClean = new DirtyState(null);
+	static final DirtyState DID_NOT_CONVERGE = new DirtyState(null);
+	static final DirtyState IS_CLEAN = new DirtyState(null);
 
 	public static DirtyState of(Formatter formatter, File file) throws IOException {
 		return of(formatter, file, Files.readAllBytes(file.toPath()));
@@ -101,7 +100,7 @@ public class DirtyState {
 		// if F(input) == input, then the formatter is well-behaving and the input is clean
 		byte[] formattedBytes = formatted.getBytes(formatter.getEncoding());
 		if (Arrays.equals(rawBytes, formattedBytes)) {
-			return isClean;
+			return IS_CLEAN;
 		}
 
 		// F(input) != input, so we'll do a padded check
@@ -113,7 +112,7 @@ public class DirtyState {
 
 		PaddedCell cell = PaddedCell.check(formatter, file, rawUnix, exceptionPerStep);
 		if (!cell.isResolvable()) {
-			return didNotConverge;
+			return DID_NOT_CONVERGE;
 		}
 
 		// get the canonical bytes
@@ -124,7 +123,7 @@ public class DirtyState {
 			// and write them to disk if needed
 			return new DirtyState(canonicalBytes);
 		} else {
-			return isClean;
+			return IS_CLEAN;
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -93,7 +93,7 @@ public final class FileSignature implements Serializable {
 
 		int i = 0;
 		for (File file : this.files) {
-			signatures[i] = cache.sign(file);
+			signatures[i] = CACHE.sign(file);
 			++i;
 		}
 	}
@@ -146,11 +146,11 @@ public final class FileSignature implements Serializable {
 		}
 	}
 
-	private static final boolean machineIsWin = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+	private static final boolean MACHINE_IS_WIN = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
 
 	/** Returns true if this JVM is running on a windows machine. */
 	public static boolean machineIsWin() {
-		return machineIsWin;
+		return MACHINE_IS_WIN;
 	}
 
 	/** Transforms a native path to a unix one. */
@@ -179,7 +179,7 @@ public final class FileSignature implements Serializable {
 	 * the jars which constitute any given formatter live in a central cache, but will be signed
 	 * over and over.  To save this I/O, we maintain a cache, invalidated by lastModified time.
 	 */
-	static final Cache cache = new Cache();
+	static final Cache CACHE = new Cache();
 
 	private static final class Cache {
 		Map<String, Sig> cache = new HashMap<>();

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -143,13 +143,13 @@ public final class Formatter implements Serializable, AutoCloseable {
 		for (int i = 0; i < formatter.getSteps().size(); i++) {
 			Throwable exception = exceptionPerStep.get(i);
 			if (exception != null && exception != LintState.formatStepCausedNoChange()) {
-				logger.error("Step '{}' found problem in '{}':\n{}", formatter.getSteps().get(i).getName(), file.getName(), exception.getMessage(), exception);
+				LOGGER.error("Step '{}' found problem in '{}':\n{}", formatter.getSteps().get(i).getName(), file.getName(), exception.getMessage(), exception);
 				throw ThrowingEx.asRuntimeRethrowError(exception);
 			}
 		}
 	}
 
-	private static final Logger logger = LoggerFactory.getLogger(Formatter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Formatter.class);
 
 	/**
 	 * Returns the result of calling all of the FormatterSteps, while also

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class JarState implements Serializable {
 
-	private static final Logger logger = LoggerFactory.getLogger(JarState.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(JarState.class);
 
 	// Let the classloader be overridden for tools using different approaches to classloading
 	@Nullable private static ClassLoader forcedClassLoader;
@@ -53,7 +53,7 @@ public final class JarState implements Serializable {
 	/** Overrides the classloader used by all JarStates. */
 	public static void setForcedClassLoader(@Nullable ClassLoader forcedClassLoader) {
 		if (!Objects.equals(JarState.forcedClassLoader, forcedClassLoader)) {
-			logger.info("Overriding the forced classloader for JarState from {} to {}", JarState.forcedClassLoader, forcedClassLoader);
+			LOGGER.info("Overriding the forced classloader for JarState from {} to {}", JarState.forcedClassLoader, forcedClassLoader);
 		}
 		JarState.forcedClassLoader = forcedClassLoader;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -84,7 +84,7 @@ public enum LineEnding {
 	/** Should use {@link #createPolicy(File, Supplier)} instead, but this will work iff its a path-independent LineEnding policy. */
 	public Policy createPolicy() {
 		switch (this) {
-		case PLATFORM_NATIVE:	return _platformNativePolicy;
+		case PLATFORM_NATIVE:	return _PLATFORM_NATIVE_POLICY;
 		case WINDOWS:			return WINDOWS_POLICY;
 		case UNIX:				return UNIX_POLICY;
 		case MAC_CLASSIC:		return MAC_CLASSIC_POLICY;
@@ -152,9 +152,9 @@ public enum LineEnding {
 	private static final Policy UNIX_POLICY = new ConstantLineEndingPolicy(UNIX.str());
     private static final Policy MAC_CLASSIC_POLICY = new ConstantLineEndingPolicy(MAC_CLASSIC.str());
     private static final Policy PRESERVE_POLICY = new PreserveLineEndingPolicy();
-	private static final String _platformNative = System.getProperty("line.separator");
-	private static final Policy _platformNativePolicy = new ConstantLineEndingPolicy(_platformNative);
-	private static final boolean nativeIsWin = _platformNative.equals(WINDOWS.str());
+	private static final String _PLATFORM_NATIVE = System.getProperty("line.separator");
+	private static final Policy _PLATFORM_NATIVE_POLICY = new ConstantLineEndingPolicy(_PLATFORM_NATIVE);
+	private static final boolean NATIVE_IS_WIN = _PLATFORM_NATIVE.equals(WINDOWS.str());
 
 	/**
 	 * @deprecated Using the system-native line endings to detect the windows operating system has turned out
@@ -164,13 +164,13 @@ public enum LineEnding {
 	 */
 	@Deprecated
 	public static boolean nativeIsWin() {
-		return nativeIsWin;
+		return NATIVE_IS_WIN;
 	}
 
 	/** Returns the standard line ending for this policy. */
 	public String str() {
 		switch (this) {
-		case PLATFORM_NATIVE:	return _platformNative;
+		case PLATFORM_NATIVE:	return _PLATFORM_NATIVE;
 		case WINDOWS:			return "\r\n";
 		case UNIX:				return "\n";
 		case MAC_CLASSIC:		return "\r";

--- a/lib/src/main/java/com/diffplug/spotless/LintState.java
+++ b/lib/src/main/java/com/diffplug/spotless/LintState.java
@@ -197,10 +197,10 @@ public class LintState {
 
 	/** Returns the DirtyState which corresponds to {@code isClean()}. */
 	public static LintState clean() {
-		return isClean;
+		return IS_CLEAN;
 	}
 
-	private static final LintState isClean = new LintState(DirtyState.clean(), null);
+	private static final LintState IS_CLEAN = new LintState(DirtyState.clean(), null);
 
 	static Throwable formatStepCausedNoChange() {
 		return FormatterCausedNoChange.INSTANCE;

--- a/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
+++ b/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
@@ -76,7 +76,7 @@ public final class SpotlessCache {
 	}
 
 	static SpotlessCache instance() {
-		return instance;
+		return INSTANCE;
 	}
 
 	/**
@@ -84,9 +84,9 @@ public final class SpotlessCache {
 	 */
 	private static void clear() {
 		List<URLClassLoader> toDelete;
-		synchronized (instance) {
-			toDelete = new ArrayList<>(instance.cache.values());
-			instance.cache.clear();
+		synchronized (INSTANCE) {
+			toDelete = new ArrayList<>(INSTANCE.cache.values());
+			INSTANCE.cache.clear();
 		}
 		for (URLClassLoader classLoader : toDelete) {
 			try {
@@ -104,7 +104,7 @@ public final class SpotlessCache {
 	 * If {@code key} is null, the clear will always happen (as though null != null).
 	 */
 	public static boolean clearOnce(@Nullable Object key) {
-		synchronized (instance) {
+		synchronized (INSTANCE) {
 			if (key == null) {
 				lastClear = null;
 			} else if (key.equals(lastClear)) {
@@ -117,5 +117,5 @@ public final class SpotlessCache {
 		return true;
 	}
 
-	private static final SpotlessCache instance = new SpotlessCache();
+	private static final SpotlessCache INSTANCE = new SpotlessCache();
 }

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * <a href="https://github.com/biomejs/biome">https://github.com/biomejs/biome</a>.
  */
 final class BiomeExecutableDownloader {
-	private static final Logger logger = LoggerFactory.getLogger(BiomeExecutableDownloader.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BiomeExecutableDownloader.class);
 
 	/**
 	 * The checksum algorithm to use for checking the integrity of downloaded files.
@@ -106,7 +106,7 @@ final class BiomeExecutableDownloader {
 		if (executableDir != null) {
 			Files.createDirectories(executableDir);
 		}
-		logger.info("Attempting to download Biome from '{}' to '{}'", url, executablePath);
+		LOGGER.info("Attempting to download Biome from '{}' to '{}'", url, executablePath);
 		var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
 		var handler = BodyHandlers.ofFile(executablePath, WRITE_OPTIONS);
 		var response = HttpClient.newBuilder().followRedirects(Redirect.NORMAL).build().send(request, handler);
@@ -118,7 +118,7 @@ final class BiomeExecutableDownloader {
 			throw new IOException("Failed to download file from " + url + ", file is empty or does not exist");
 		}
 		writeChecksumFile(downloadedFile, checksumPath);
-		logger.debug("Biome was downloaded successfully to '{}'", downloadedFile);
+		LOGGER.debug("Biome was downloaded successfully to '{}'", downloadedFile);
 		return downloadedFile;
 	}
 
@@ -142,13 +142,13 @@ final class BiomeExecutableDownloader {
 	 */
 	public Path ensureDownloaded(String version) throws IOException, InterruptedException {
 		var platform = Platform.guess();
-		logger.debug("Ensuring that Biome for platform '{}' is downloaded", platform);
+		LOGGER.debug("Ensuring that Biome for platform '{}' is downloaded", platform);
 		var existing = findDownloaded(version);
 		if (existing.isPresent()) {
-			logger.debug("Biome was already downloaded, using executable at '{}'", existing.orElseThrow());
+			LOGGER.debug("Biome was already downloaded, using executable at '{}'", existing.orElseThrow());
 			return existing.orElseThrow();
 		} else {
-			logger.debug("Biome was not yet downloaded, attempting to download executable");
+			LOGGER.debug("Biome was not yet downloaded, attempting to download executable");
 			return download(version);
 		}
 	}
@@ -169,7 +169,7 @@ final class BiomeExecutableDownloader {
 	public Optional<Path> findDownloaded(String version) throws IOException {
 		var platform = Platform.guess();
 		var executablePath = getExecutablePath(version, platform);
-		logger.debug("Checking Biome executable at {}", executablePath);
+		LOGGER.debug("Checking Biome executable at {}", executablePath);
 		return checkFileWithChecksum(executablePath) ? Optional.ofNullable(executablePath) : Optional.empty();
 	}
 
@@ -183,26 +183,26 @@ final class BiomeExecutableDownloader {
 	 */
 	private boolean checkFileWithChecksum(Path filePath) {
 		if (!Files.exists(filePath)) {
-			logger.debug("File '{}' does not exist yet", filePath);
+			LOGGER.debug("File '{}' does not exist yet", filePath);
 			return false;
 		}
 		if (Files.isDirectory(filePath)) {
-			logger.debug("File '{}' exists, but is a directory", filePath);
+			LOGGER.debug("File '{}' exists, but is a directory", filePath);
 			return false;
 		}
 		var checksumPath = getChecksumPath(filePath);
 		if (!Files.exists(checksumPath)) {
-			logger.debug("File '{}' exists, but checksum file '{}' does not", filePath, checksumPath);
+			LOGGER.debug("File '{}' exists, but checksum file '{}' does not", filePath, checksumPath);
 			return false;
 		}
 		if (Files.isDirectory(checksumPath)) {
-			logger.debug("Checksum file '{}' exists, but is a directory", checksumPath);
+			LOGGER.debug("Checksum file '{}' exists, but is a directory", checksumPath);
 			return false;
 		}
 		try {
 			var actualChecksum = computeChecksum(filePath, CHECKSUM_ALGORITHM);
 			var expectedChecksum = readTextFile(checksumPath, StandardCharsets.ISO_8859_1);
-			logger.debug("Expected checksum: {}, actual checksum: {}", expectedChecksum, actualChecksum);
+			LOGGER.debug("Expected checksum: {}, actual checksum: {}", expectedChecksum, actualChecksum);
 			return Objects.equals(expectedChecksum, actualChecksum);
 		} catch (final IOException ignored) {
 			return false;

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeSettings.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * Settings and constants for Biome to use.
  */
 public final class BiomeSettings {
-	private static final Logger logger = LoggerFactory.getLogger(BiomeSettings.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BiomeSettings.class);
 
 	private static final String CONFIG_NAME = "biome.json";
 	private static final String DEFAULT_VERSION = "1.2.0";
@@ -106,7 +106,7 @@ public final class BiomeSettings {
 			}
 			return actualMajor == major && actualMinor == minor && actualPatch == patch;
 		} catch (final Exception e) {
-			logger.warn("Failed to parse biome version string '{}'. Expected format is 'major.minor.patch'.", version, e);
+			LOGGER.warn("Failed to parse biome version string '{}'. Expected format is 'major.minor.patch'.", version, e);
 			return false;
 		}
 	}

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
@@ -43,7 +43,7 @@ import com.diffplug.spotless.ProcessRunner;
  * the network when no executable path is provided explicitly.
  */
 public final class BiomeStep {
-	private static final Logger logger = LoggerFactory.getLogger(BiomeStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(BiomeStep.class);
 
 	/**
 	 * Path to the directory with the {@code biome.json} config file, can be
@@ -136,7 +136,7 @@ public final class BiomeStep {
 			newPermissions.add(permission);
 			Files.setPosixFilePermissions(file, newPermissions);
 		} catch (final Exception ignore) {
-			logger.debug("Unable to add POSIX permission '{}' to file '{}'", permission, file);
+			LOGGER.debug("Unable to add POSIX permission '{}' to file '{}'", permission, file);
 		}
 	}
 
@@ -298,7 +298,7 @@ public final class BiomeStep {
 		var resolvedPathToExe = resolveExe();
 		validateBiomeExecutable(resolvedPathToExe);
 		validateBiomeConfigPath(configPath, version);
-		logger.debug("Using Biome executable located at  '{}'", resolvedPathToExe);
+		LOGGER.debug("Using Biome executable located at  '{}'", resolvedPathToExe);
 		var exeSignature = FileSignature.signAsList(Set.of(new File(resolvedPathToExe)));
 		makeExecutable(resolvedPathToExe);
 		return new State(resolvedPathToExe, exeSignature, configPath, language);
@@ -421,13 +421,13 @@ public final class BiomeStep {
 		private String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
 			var stdin = input.getBytes(StandardCharsets.UTF_8);
 			var args = buildBiomeCommand(file);
-			if (logger.isDebugEnabled()) {
-				logger.debug("Running Biome command to format code: '{}'", String.join(", ", args));
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("Running Biome command to format code: '{}'", String.join(", ", args));
 			}
 			var runnerResult = runner.exec(stdin, args);
 			var stdErr = runnerResult.stdErrUtf8();
 			if (!stdErr.isEmpty()) {
-				logger.warn("Biome stderr ouptut for file '{}'\n{}", file, stdErr.trim());
+				LOGGER.warn("Biome stderr ouptut for file '{}'\n{}", file, stdErr.trim());
 			}
 			var formatted = runnerResult.assertExitZero(StandardCharsets.UTF_8);
 			// When biome encounters an ignored file, it does not output any formatted code

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -203,10 +203,10 @@ public final class LicenseHeaderStep {
 		return UNSUPPORTED_JVM_FILES_FILTER;
 	}
 
-	public static final String spotlessSetLicenseHeaderYearsFromGitHistory = "spotlessSetLicenseHeaderYearsFromGitHistory";
+	public static final String SPOTLESS_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY = "spotlessSetLicenseHeaderYearsFromGitHistory";
 
 	public static String FLAG_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY() {
-		return spotlessSetLicenseHeaderYearsFromGitHistory;
+		return SPOTLESS_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY;
 	}
 
 	private static final class Runtime implements Serializable {

--- a/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
@@ -47,7 +47,7 @@ public final class FormatAnnotationsStep implements Serializable {
 	 * A type annotation is an annotation that is meta-annotated with @Target({ElementType.TYPE_USE}).
 	 * A type annotation should be formatted on the same line as the type it qualifies.
 	 */
-	private static final List<String> defaultTypeAnnotations =
+	private static final List<String> DEFAULT_TYPE_ANNOTATIONS =
 			// Use simple names because Spotless has no access to the
 			// fully-qualified names or the definitions of the type qualifiers.
 			Arrays.asList(
@@ -431,21 +431,21 @@ public final class FormatAnnotationsStep implements Serializable {
 		@Serial
 		private static final long serialVersionUID = 1L;
 
-		private final Set<String> typeAnnotations = new HashSet<>(defaultTypeAnnotations);
+		private final Set<String> typeAnnotations = new HashSet<>(DEFAULT_TYPE_ANNOTATIONS);
 
 		// group 1 is the basename of the annotation.
-		private static final String annoNoArgRegex = "@(?:[A-Za-z_][A-Za-z0-9_.]*\\.)?([A-Za-z_][A-Za-z0-9_]*)";
+		private static final String ANNO_NO_ARG_REGEX = "@(?:[A-Za-z_][A-Za-z0-9_.]*\\.)?([A-Za-z_][A-Za-z0-9_]*)";
 		// 3 non-empty cases:  ()  (".*")  (.*)
-		private static final String annoArgRegex = "(?:\\(\\)|\\(\"[^\"]*\"\\)|\\([^\")][^)]*\\))?";
+		private static final String ANNO_ARG_REGEX = "(?:\\(\\)|\\(\"[^\"]*\"\\)|\\([^\")][^)]*\\))?";
 		// group 1 is the basename of the annotation.
-		private static final String annoRegex = annoNoArgRegex + annoArgRegex;
-		private static final String trailingAnnoRegex = annoRegex + "$";
-		private static final Pattern trailingAnnoPattern = Pattern.compile(trailingAnnoRegex);
+		private static final String ANNO_REGEX = ANNO_NO_ARG_REGEX + ANNO_ARG_REGEX;
+		private static final String TRAILING_ANNO_REGEX = ANNO_REGEX + "$";
+		private static final Pattern TRAILING_ANNO_PATTERN = Pattern.compile(TRAILING_ANNO_REGEX);
 
 		// Heuristic: matches if the line might be within a //, /*, or Javadoc comment.
-		private static final Pattern withinCommentPattern = Pattern.compile("//|/\\*(?!.*/*/)|^[ \t]*\\*[ \t]");
+		private static final Pattern WITHIN_COMMENT_PATTERN = Pattern.compile("//|/\\*(?!.*/*/)|^[ \t]*\\*[ \t]");
 		// Don't move an annotation to the start of a comment line.
-		private static final Pattern startsWithCommentPattern = Pattern.compile("^[ \t]*(//|/\\*$|/\\*|void\\b)");
+		private static final Pattern STARTS_WITH_COMMENT_PATTERN = Pattern.compile("^[ \t]*(//|/\\*$|/\\*|void\\b)");
 
 		/**
 		 * @param addedTypeAnnotations simple names to add to Spotless's default list
@@ -473,7 +473,7 @@ public final class FormatAnnotationsStep implements Serializable {
 				String line = lines[i];
 				if (endsWithTypeAnnotation(line)) {
 					String nextLine = lines[i + 1];
-					if (startsWithCommentPattern.matcher(nextLine).find()) {
+					if (STARTS_WITH_COMMENT_PATTERN.matcher(nextLine).find()) {
 						continue;
 					}
 					lines[i] = "";
@@ -490,14 +490,14 @@ public final class FormatAnnotationsStep implements Serializable {
 		boolean endsWithTypeAnnotation(String unixLine) {
 			// Remove trailing newline.
 			String line = unixLine.replaceAll("\\s+$", "");
-			Matcher m = trailingAnnoPattern.matcher(line);
+			Matcher m = TRAILING_ANNO_PATTERN.matcher(line);
 			if (!m.find()) {
 				return false;
 			}
 			String preceding = line.substring(0, m.start());
 			String basename = m.group(1);
 
-			if (withinCommentPattern.matcher(preceding).find()) {
+			if (WITHIN_COMMENT_PATTERN.matcher(preceding).find()) {
 				return false;
 			}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
@@ -40,7 +40,7 @@ import com.diffplug.spotless.npm.EslintRestService.FormatOption;
 
 public final class EslintFormatterStep {
 
-	private static final Logger logger = LoggerFactory.getLogger(EslintFormatterStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(EslintFormatterStep.class);
 
 	public static final String NAME = "eslint-format";
 
@@ -109,7 +109,7 @@ public final class EslintFormatterStep {
 				// If any config files are provided, we need to make sure they are at the same location as the node modules
 				// as eslint will try to resolve plugin/config names relatively to the config file location and some
 				// eslint configs contain relative paths to additional config files (such as tsconfig.json e.g.)
-				logger.debug("Copying config file <{}> to <{}> and using the copy", origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
+				LOGGER.debug("Copying config file <{}> to <{}> and using the copy", origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
 				File configFileCopy = NpmResourceHelper.copyFileToDir(origEslintConfig.getEslintConfigPath(), nodeServerLayout.nodeModulesDir());
 				this.eslintConfigInUse = this.origEslintConfig.withEslintConfigPath(configFileCopy).verify();
 			}
@@ -119,7 +119,7 @@ public final class EslintFormatterStep {
 		@Nonnull
 		public FormatterFunc createFormatterFunc() {
 			try {
-				logger.info("Creating formatter function (starting server)");
+				LOGGER.info("Creating formatter function (starting server)");
 				Runtime runtime = toRuntime();
 				ServerProcessInfo eslintRestServer = runtime.npmRunServer();
 				EslintRestService restService = new EslintRestService(eslintRestServer.getBaseUrl());
@@ -130,11 +130,11 @@ public final class EslintFormatterStep {
 		}
 
 		private void endServer(BaseNpmRestService restService, ServerProcessInfo restServer) throws Exception {
-			logger.info("Closing formatting function (ending server).");
+			LOGGER.info("Closing formatting function (ending server).");
 			try {
 				restService.shutdown();
 			} catch (Throwable t) {
-				logger.info("Failed to request shutdown of rest service via api. Trying via process.", t);
+				LOGGER.info("Failed to request shutdown of rest service via api. Trying via process.", t);
 			}
 			restServer.close();
 		}

--- a/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
@@ -39,7 +39,7 @@ interface ExclusiveFolderAccess {
 
 	final class ExclusiveFolderAccessSharedMutex implements ExclusiveFolderAccess {
 
-		private static final ConcurrentHashMap<String, Lock> mutexes = new ConcurrentHashMap<>();
+		private static final ConcurrentHashMap<String, Lock> MUTEXES = new ConcurrentHashMap<>();
 
 		private final String path;
 
@@ -48,7 +48,7 @@ interface ExclusiveFolderAccess {
 		}
 
 		private Lock getMutex() {
-			return mutexes.computeIfAbsent(path, k -> new ReentrantLock());
+			return MUTEXES.computeIfAbsent(path, k -> new ReentrantLock());
 		}
 
 		@Override

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeApp.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeApp.java
@@ -29,9 +29,9 @@ import com.diffplug.spotless.ProcessRunner;
 
 public class NodeApp {
 
-	private static final Logger logger = LoggerFactory.getLogger(NodeApp.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NodeApp.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	@Nonnull
 	protected final NodeServerLayout nodeServerLayout;
@@ -54,10 +54,10 @@ public class NodeApp {
 
 	private static NpmProcessFactory processFactory(NpmFormatterStepLocations formatterStepLocations) {
 		if (formatterStepLocations.cacheDir() != null) {
-			logger.info("Caching npm install results in {}.", formatterStepLocations.cacheDir());
+			LOGGER.info("Caching npm install results in {}.", formatterStepLocations.cacheDir());
 			return NodeModulesCachingNpmProcessFactory.create(formatterStepLocations.cacheDir());
 		}
-		logger.debug("Not caching npm install results.");
+		LOGGER.debug("Not caching npm install results.");
 		return StandardNpmProcessFactory.INSTANCE;
 	}
 
@@ -70,7 +70,7 @@ public class NodeApp {
 	}
 
 	void prepareNodeAppLayout() {
-		timedLogger.withInfo("Preparing {} for npm step {}.", this.nodeServerLayout, getClass().getName()).run(() -> {
+		TIMED_LOGGER.withInfo("Preparing {} for npm step {}.", this.nodeServerLayout, getClass().getName()).run(() -> {
 			NpmResourceHelper.assertDirectoryExists(nodeServerLayout.nodeModulesDir());
 			NpmResourceHelper.writeUtf8StringToFile(nodeServerLayout.packageJsonFile(), this.npmConfig.getPackageJsonContent());
 			if (this.npmConfig.getServeScriptContent() != null) {
@@ -87,7 +87,7 @@ public class NodeApp {
 	}
 
 	void npmInstall() {
-		timedLogger.withInfo("Installing npm dependencies for {} with {}.", this.nodeServerLayout, this.npmProcessFactory.describe())
+		TIMED_LOGGER.withInfo("Installing npm dependencies for {} with {}.", this.nodeServerLayout, this.npmProcessFactory.describe())
 				.run(this::optimizedNpmInstall);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
@@ -29,9 +29,9 @@ import com.diffplug.spotless.ProcessRunner.Result;
 
 public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFactory {
 
-	private static final Logger logger = LoggerFactory.getLogger(NodeModulesCachingNpmProcessFactory.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NodeModulesCachingNpmProcessFactory.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	private final File cacheDir;
 
@@ -84,11 +84,11 @@ public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFact
 		public Result waitFor() {
 			String entryName = entryName();
 			if (shadowCopy.entryExists(entryName, NodeServerLayout.NODE_MODULES)) {
-				timedLogger.withInfo("Using cached node_modules for {} from {}", entryName, cacheDir)
+				TIMED_LOGGER.withInfo("Using cached node_modules for {} from {}", entryName, cacheDir)
 						.run(() -> shadowCopy.copyEntryInto(entryName(), NodeServerLayout.NODE_MODULES, nodeServerLayout.nodeModulesDir()));
 				return new CachedResult();
 			} else {
-				Result result = timedLogger.withInfo("calling actual npm install {}", actualNpmInstallProcess.describe())
+				Result result = TIMED_LOGGER.withInfo("calling actual npm install {}", actualNpmInstallProcess.describe())
 						.call(actualNpmInstallProcess::waitFor);
 				assert result.exitCode() == 0;
 				storeShadowCopy(entryName);
@@ -97,7 +97,7 @@ public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFact
 		}
 
 		private void storeShadowCopy(String entryName) {
-			timedLogger.withInfo("Caching node_modules for {} in {}", entryName, cacheDir)
+			TIMED_LOGGER.withInfo("Caching node_modules for {} in {}", entryName, cacheDir)
 					.run(() -> shadowCopy.addEntry(entryName(), new File(nodeServerLayout.nodeModulesDir(), NodeServerLayout.NODE_MODULES)));
 		}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeServeApp.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeServeApp.java
@@ -26,16 +26,16 @@ import com.diffplug.spotless.ProcessRunner;
 
 public class NodeServeApp extends NodeApp {
 
-	private static final Logger logger = LoggerFactory.getLogger(NodeApp.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NodeApp.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	public NodeServeApp(@Nonnull NodeServerLayout nodeServerLayout, @Nonnull NpmConfig npmConfig, @Nonnull NpmFormatterStepLocations formatterStepLocations) {
 		super(nodeServerLayout, npmConfig, formatterStepLocations);
 	}
 
 	ProcessRunner.LongRunningProcess startNpmServeProcess(UUID nodeServerInstanceId) {
-		return timedLogger.withInfo("Starting npm based server in {} with {}.", this.nodeServerLayout.nodeModulesDir(), this.npmProcessFactory.describe())
+		return TIMED_LOGGER.withInfo("Starting npm based server in {} with {}.", this.nodeServerLayout.nodeModulesDir(), this.npmProcessFactory.describe())
 				.call(() -> npmProcessFactory.createNpmServeProcess(nodeServerLayout, formatterStepLocations, nodeServerInstanceId).start());
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -39,9 +39,9 @@ import com.diffplug.spotless.ThrowingEx;
 
 abstract class NpmFormatterStepStateBase implements Serializable {
 
-	private static final Logger logger = LoggerFactory.getLogger(NpmFormatterStepStateBase.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(NpmFormatterStepStateBase.class);
 
-	private static final TimedLogger timedLogger = TimedLogger.forLogger(logger);
+	private static final TimedLogger TIMED_LOGGER = TimedLogger.forLogger(LOGGER);
 
 	@Serial
 	private static final long serialVersionUID = 1460749955865959948L;
@@ -132,11 +132,11 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 						if (server.isAlive()) {
 							server.destroyForcibly();
 							ProcessRunner.Result result = server.result();
-							logger.info("Launching npm server process failed. Process result:\n{}", result);
+							LOGGER.info("Launching npm server process failed. Process result:\n{}", result);
 						}
 					} catch (Throwable t) {
 						ProcessRunner.Result result = ThrowingEx.get(server::result);
-						logger.debug("Unable to forcibly end the server process. Process result:\n{}", result, t);
+						LOGGER.debug("Unable to forcibly end the server process. Process result:\n{}", result, t);
 					}
 					throw timeoutException;
 				}
@@ -194,15 +194,15 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 		@Override
 		public void close() throws Exception {
 			try {
-				logger.trace("Closing npm server in directory <{}> and port <{}>",
+				LOGGER.trace("Closing npm server in directory <{}> and port <{}>",
 						serverPortFile.getParent(), serverPort);
 
 				if (server.isAlive()) {
 					boolean ended = server.waitFor(5, TimeUnit.SECONDS);
 					if (!ended) {
-						logger.info("Force-Closing npm server in directory <{}> and port <{}>", serverPortFile.getParent(), serverPort);
+						LOGGER.info("Force-Closing npm server in directory <{}> and port <{}>", serverPortFile.getParent(), serverPort);
 						server.destroyForcibly().waitFor();
-						logger.trace("Force-Closing npm server in directory <{}> and port <{}> -- Finished", serverPortFile.getParent(), serverPort);
+						LOGGER.trace("Force-Closing npm server in directory <{}> and port <{}> -- Finished", serverPortFile.getParent(), serverPort);
 					}
 				}
 			} finally {

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierFormatterStep.java
@@ -36,7 +36,7 @@ import com.diffplug.spotless.ThrowingEx;
 
 public final class PrettierFormatterStep {
 
-	private static final Logger logger = LoggerFactory.getLogger(PrettierFormatterStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(PrettierFormatterStep.class);
 
 	public static final String NAME = "prettier-format";
 
@@ -86,7 +86,7 @@ public final class PrettierFormatterStep {
 		@Nonnull
 		public FormatterFunc createFormatterFunc() {
 			try {
-				logger.info("creating formatter function (starting server)");
+				LOGGER.info("creating formatter function (starting server)");
 				ServerProcessInfo prettierRestServer = toRuntime().npmRunServer();
 				PrettierRestService restService = new PrettierRestService(prettierRestServer.getBaseUrl());
 				String prettierConfigOptions = restService.resolveConfig(this.prettierConfig.getPrettierConfigPath(), this.prettierConfig.getOptions());
@@ -97,11 +97,11 @@ public final class PrettierFormatterStep {
 		}
 
 		private void endServer(PrettierRestService restService, ServerProcessInfo restServer) throws Exception {
-			logger.info("Closing formatting function (ending server).");
+			LOGGER.info("Closing formatting function (ending server).");
 			try {
 				restService.shutdown();
 			} catch (Throwable t) {
-				logger.info("Failed to request shutdown of rest service via api. Trying via process.", t);
+				LOGGER.info("Failed to request shutdown of rest service via api. Trying via process.", t);
 			}
 			restServer.close();
 		}

--- a/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/TsFmtFormatterStep.java
@@ -38,7 +38,7 @@ import com.diffplug.spotless.ThrowingEx;
 
 public final class TsFmtFormatterStep {
 
-	private static final Logger logger = LoggerFactory.getLogger(TsFmtFormatterStep.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(TsFmtFormatterStep.class);
 
 	public static final String NAME = "tsfmt-format";
 
@@ -121,7 +121,7 @@ public final class TsFmtFormatterStep {
 			try {
 				restService.shutdown();
 			} catch (Throwable t) {
-				logger.info("Failed to request shutdown of rest service via api. Trying via process.", t);
+				LOGGER.info("Failed to request shutdown of rest service via api. Trying via process.", t);
 			}
 			restServer.close();
 		}

--- a/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class ReflectionHelper {
-	private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+	private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 	private final RdfFormatterStep.State state;
 	private final ClassLoader classLoader;
 	private final Class<?> JenaRdfDataMgrClass;
@@ -202,10 +202,10 @@ class ReflectionHelper {
 			long col = (long) args[2];
 			String severity = method.getName();
 			if ("warning".equals(severity) && !state.getConfig().isFailOnWarning()) {
-				logger.warn("{}({},{}): {}", this.filePath, line, col, message);
+				LOGGER.warn("{}({},{}): {}", this.filePath, line, col, message);
 			} else {
 				if ("warning".equals(severity)) {
-					logger.error("Formatter fails because of a parser warning. To make the formatter succeed in"
+					LOGGER.error("Formatter fails because of a parser warning. To make the formatter succeed in"
 							+ "the presence of warnings, set the configuration parameter 'failOnWarning' to 'false' (default: 'true')");
 				}
 				throw new RuntimeException(

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -37,7 +37,7 @@ import com.diffplug.spotless.annotations.Internal;
 public class SQLTokenizedFormatter {
 
 	private static final String[] JOIN_BEGIN = {"LEFT", "RIGHT", "INNER", "OUTER", "JOIN"};
-	private static final SQLDialect sqlDialect = SQLDialect.INSTANCE;
+	private static final SQLDialect SQL_DIALECT = SQLDialect.INSTANCE;
 	private DBeaverSQLFormatterConfiguration formatterCfg;
 	private List<Boolean> functionBracket = new ArrayList<>();
 	private List<String> statementDelimiters = new ArrayList<>(2);
@@ -251,7 +251,7 @@ public class SQLTokenizedFormatter {
 				}
 			} else if (token.getType() == TokenType.COMMENT) {
 				boolean isComment = false;
-				String[] slComments = sqlDialect.getSingleLineComments();
+				String[] slComments = SQL_DIALECT.getSingleLineComments();
 				for (String slc : slComments) {
 					if (token.getString().startsWith(slc)) {
 						isComment = true;
@@ -259,7 +259,7 @@ public class SQLTokenizedFormatter {
 					}
 				}
 				if (!isComment) {
-					Pair<String, String> mlComments = sqlDialect.getMultiLineComments();
+					Pair<String, String> mlComments = SQL_DIALECT.getMultiLineComments();
 					if (token.getString().startsWith(mlComments.getFirst())) {
 						index += insertReturnAndIndent(argList, index + 1, indent);
 					}
@@ -385,7 +385,7 @@ public class SQLTokenizedFormatter {
 	}
 
 	private boolean isFunction(String name) {
-		return sqlDialect.getKeywordType(name) == DBPKeywordType.FUNCTION;
+		return SQL_DIALECT.getKeywordType(name) == DBPKeywordType.FUNCTION;
 	}
 
 	private static String getDefaultLineSeparator() {
@@ -406,7 +406,7 @@ public class SQLTokenizedFormatter {
 				final FormatterToken token = argList.get(argIndex);
 				final FormatterToken prevToken = argList.get(argIndex - 1);
 				if (token.getType() == TokenType.COMMENT
-						&& isCommentLine(sqlDialect, token.getString())
+						&& isCommentLine(SQL_DIALECT, token.getString())
 						&& prevToken.getType() != TokenType.END) {
 					s.setCharAt(0, ' ');
 					s.setLength(1);

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokensParser.java
@@ -31,8 +31,8 @@ import java.util.Set;
  */
 class SQLTokensParser {
 
-	private static final String[] twoCharacterSymbol = {"<>", "<=", ">=", "||", "()", "!=", ":=", ".*"};
-	private static final SQLDialect sqlDialect = SQLDialect.INSTANCE;
+	private static final String[] TWO_CHARACTER_SYMBOL = {"<>", "<=", ">=", "||", "()", "!=", ":=", ".*"};
+	private static final SQLDialect SQL_DIALECT = SQLDialect.INSTANCE;
 
 	private final String[][] quoteStrings;
 	private final char structSeparator;
@@ -44,10 +44,10 @@ class SQLTokensParser {
 	private int fPos;
 
 	SQLTokensParser() {
-		this.structSeparator = sqlDialect.getStructSeparator();
-		this.catalogSeparator = sqlDialect.getCatalogSeparator();
-		this.quoteStrings = sqlDialect.getIdentifierQuoteStrings();
-		this.singleLineComments = sqlDialect.getSingleLineComments();
+		this.structSeparator = SQL_DIALECT.getStructSeparator();
+		this.catalogSeparator = SQL_DIALECT.getCatalogSeparator();
+		this.quoteStrings = SQL_DIALECT.getIdentifierQuoteStrings();
+		this.singleLineComments = SQL_DIALECT.getSingleLineComments();
 		this.singleLineCommentStart = new char[this.singleLineComments.length];
 		for (int i = 0; i < singleLineComments.length; i++) {
 			if (singleLineComments[i].isEmpty()) {
@@ -188,7 +188,7 @@ class SQLTokensParser {
 				}
 				return new FormatterToken(TokenType.COMMAND, word + s, start_pos);
 			}
-			if (sqlDialect.getKeywordType(word) != null) {
+			if (SQL_DIALECT.getKeywordType(word) != null) {
 				return new FormatterToken(TokenType.KEYWORD, word, start_pos);
 			}
 			return new FormatterToken(TokenType.NAME, word, start_pos);
@@ -250,7 +250,7 @@ class SQLTokensParser {
 					return new FormatterToken(TokenType.SYMBOL, s.toString(), start_pos);
 				}
 				char ch2 = fBefore.charAt(fPos);
-				for (String aTwoCharacterSymbol : twoCharacterSymbol) {
+				for (String aTwoCharacterSymbol : TWO_CHARACTER_SYMBOL) {
 					if (aTwoCharacterSymbol.charAt(0) == fChar && aTwoCharacterSymbol.charAt(1) == ch2) {
 						fPos++;
 						s.append(ch2);

--- a/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
+++ b/lib/src/sortPom/java/com/diffplug/spotless/glue/pom/SortPomFormatterFunc.java
@@ -33,7 +33,7 @@ import sortpom.logger.SortPomLogger;
 import sortpom.parameter.PluginParameters;
 
 public class SortPomFormatterFunc implements FormatterFunc {
-	private static final Logger logger = LoggerFactory.getLogger(SortPomFormatterFunc.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SortPomFormatterFunc.class);
 	private final SortPomCfg cfg;
 
 	public SortPomFormatterFunc(SortPomCfg cfg) {
@@ -101,19 +101,19 @@ public class SortPomFormatterFunc implements FormatterFunc {
 
 		@Override
 		public void warn(String content) {
-			logger.warn(content);
+			LOGGER.warn(content);
 		}
 
 		@Override
 		public void info(String content) {
 			if (!quiet) {
-				logger.info(content);
+				LOGGER.info(content);
 			}
 		}
 
 		@Override
 		public void error(String content) {
-			logger.error(content);
+			LOGGER.error(content);
 		}
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -83,7 +83,7 @@ import groovy.lang.Closure;
 /** Adds a {@code spotless{Name}Check} and {@code spotless{Name}Apply} task. */
 public class FormatExtension {
 
-	private static final Logger logger = LoggerFactory.getLogger(FormatExtension.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(FormatExtension.class);
 
 	final SpotlessExtension spotless;
 	final List<Action<FormatExtension>> lazyActions = new ArrayList<>();
@@ -469,9 +469,9 @@ public class FormatExtension {
 	 */
 	public void custom(String name, FormatterFunc formatter) {
 		requireNonNull(formatter, "formatter");
-		if (badSemverOfGradle() < badSemver(SpotlessPlugin.VER_GRADLE_minVersionForCustom)) {
+		if (badSemverOfGradle() < badSemver(SpotlessPlugin.VER_GRADLE_MIN_VERSION_FOR_CUSTOM)) {
 			throw new GradleException("The 'custom' method is only available if you are using Gradle "
-					+ SpotlessPlugin.VER_GRADLE_minVersionForCustom
+					+ SpotlessPlugin.VER_GRADLE_MIN_VERSION_FOR_CUSTOM
 					+ " or newer, this is "
 					+ GradleVersion.current().getVersion());
 		}
@@ -548,7 +548,7 @@ public class FormatExtension {
 	}
 
 	private static void logDeprecation(String methodName, String replacement) {
-		logger.warn("'{}' is deprecated, use '{}' in your gradle build script instead.", methodName, replacement);
+		LOGGER.warn("'{}' is deprecated, use '{}' in your gradle build script instead.", methodName, replacement);
 	}
 
 	/** Ensures formatting of files via native binary. */

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -142,7 +142,7 @@ final class GradleProvisioner {
 		};
 	}
 
-	private static final Logger logger = LoggerFactory.getLogger(GradleProvisioner.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(GradleProvisioner.class);
 
 	/** Models a request to the provisioner. */
 	private static class Request {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPlugin.java
@@ -27,14 +27,14 @@ import com.diffplug.spotless.SpotlessCache;
 
 public class SpotlessPlugin implements Plugin<Project> {
 	static final String SPOTLESS_MODERN = "spotlessModern";
-	static final String VER_GRADLE_min = "7.3";
-	static final String VER_GRADLE_minVersionForCustom = "8.4";
+	static final String VER_GRADLE_MIN = "7.3";
+	static final String VER_GRADLE_MIN_VERSION_FOR_CUSTOM = "8.4";
 	private static final int MINIMUM_JRE = 17;
 
 	@Override
 	public void apply(Project project) {
 		if (SpotlessPluginRedirect.gradleIsTooOld()) {
-			throw new GradleException("Spotless requires Gradle " + VER_GRADLE_min + " or newer, this was " + GradleVersion.current().getVersion());
+			throw new GradleException("Spotless requires Gradle " + VER_GRADLE_MIN + " or newer, this was " + GradleVersion.current().getVersion());
 		}
 		if (Jvm.version() < MINIMUM_JRE) {
 			throw new GradleException("Spotless requires JRE " + MINIMUM_JRE + " or newer, this was " + JavaVersion.current() + ".\n"

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPluginRedirect.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessPluginRedirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class SpotlessPluginRedirect implements Plugin<Project> {
 	}
 
 	static boolean gradleIsTooOld() {
-		return badSemverOfGradle() < badSemver(SpotlessPlugin.VER_GRADLE_min);
+		return badSemverOfGradle() < badSemver(SpotlessPlugin.VER_GRADLE_MIN);
 	}
 
 	@Override
@@ -73,7 +73,7 @@ public class SpotlessPluginRedirect implements Plugin<Project> {
 				"If you like the idea behind 'ratchetFrom', you should checkout spotless-changelog",
 				"https://github.com/diffplug/spotless-changelog");
 		if (gradleIsTooOld()) {
-			errorMsg = errorMsg.replace("To migrate:\n", "To migrate:\n- Upgrade Gradle to " + SpotlessPlugin.VER_GRADLE_min + " or newer (you're on " + GradleVersion.current().getVersion() + ")\n");
+			errorMsg = errorMsg.replace("To migrate:\n", "To migrate:\n- Upgrade Gradle to " + SpotlessPlugin.VER_GRADLE_MIN + " or newer (you're on " + GradleVersion.current().getVersion() + ")\n");
 		}
 		throw new GradleException(errorMsg);
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIntegrationHarness.java
@@ -44,12 +44,12 @@ import com.diffplug.spotless.ResourceHarness;
 
 public class GradleIntegrationHarness extends ResourceHarness {
 	public enum GradleVersionSupport {
-		MINIMUM(SpotlessPlugin.VER_GRADLE_min),
+		MINIMUM(SpotlessPlugin.VER_GRADLE_MIN),
 
 		// https://docs.gradle.org/7.5/userguide/configuration_cache.html#config_cache:stable
 		STABLE_CONFIGURATION_CACHE("7.5"),
 
-		CUSTOM_STEPS(SpotlessPlugin.VER_GRADLE_minVersionForCustom),
+		CUSTOM_STEPS(SpotlessPlugin.VER_GRADLE_MIN_VERSION_FOR_CUSTOM),
 
 		;
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.maven;
 
 import static com.diffplug.common.base.Strings.isNullOrEmpty;
+import static com.diffplug.spotless.generic.LicenseHeaderStep.SPOTLESS_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY;
 import static java.util.stream.Collectors.toList;
 
 import java.io.File;
@@ -58,7 +59,6 @@ import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.LintState;
 import com.diffplug.spotless.LintSuppression;
 import com.diffplug.spotless.Provisioner;
-import com.diffplug.spotless.generic.LicenseHeaderStep;
 import com.diffplug.spotless.maven.antlr4.Antlr4;
 import com.diffplug.spotless.maven.cpp.Cpp;
 import com.diffplug.spotless.maven.css.Css;
@@ -210,7 +210,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter(property = "spotlessFiles")
 	private String filePatterns;
 
-	@Parameter(property = LicenseHeaderStep.spotlessSetLicenseHeaderYearsFromGitHistory)
+	@Parameter(property = SPOTLESS_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY)
 	private String setLicenseHeaderYearsFromGitHistory;
 
 	@Parameter

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Ktlint.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Ktlint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import com.diffplug.spotless.maven.FormatterStepConfig;
 import com.diffplug.spotless.maven.FormatterStepFactory;
 
 public class Ktlint implements FormatterStepFactory {
-	private static final File defaultEditorConfig = new File(".editorconfig");
+	private static final File DEFAULT_EDITOR_CONFIG = new File(".editorconfig");
 
 	@Parameter
 	private String version;
@@ -46,8 +46,8 @@ public class Ktlint implements FormatterStepFactory {
 	public FormatterStep newFormatterStep(final FormatterStepConfig stepConfig) {
 		String ktlintVersion = version != null ? version : KtLintStep.defaultVersion();
 		FileSignature configPath = null;
-		if (editorConfigPath == null && defaultEditorConfig.exists()) {
-			editorConfigPath = defaultEditorConfig.getPath();
+		if (editorConfigPath == null && DEFAULT_EDITOR_CONFIG.exists()) {
+			editorConfigPath = DEFAULT_EDITOR_CONFIG.getPath();
 		}
 		if (editorConfigPath != null) {
 			configPath = ThrowingEx.get(() -> FileSignature.signAsList(stepConfig.getFileLocator().locateFile(editorConfigPath)));

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -17,6 +17,8 @@ recipeList:
   - org.openrewrite.java.format.NormalizeLineBreaks
   - org.openrewrite.java.format.RemoveTrailingWhitespace
   - org.openrewrite.java.migrate.UpgradeToJava17
+  - org.openrewrite.java.migrate.lang.StringRulesRecipes
+  - org.openrewrite.java.migrate.util.JavaLangAPIs
   - org.openrewrite.java.migrate.util.JavaUtilAPIs
   - org.openrewrite.java.migrate.util.MigrateInflaterDeflaterToClose
   - org.openrewrite.java.migrate.util.ReplaceStreamCollectWithToList
@@ -62,6 +64,7 @@ recipeList:
   - tech.picnic.errorprone.refasterrules.StreamRulesRecipes
   - tech.picnic.errorprone.refasterrules.StringRulesRecipes
   - tech.picnic.errorprone.refasterrules.TimeRulesRecipes
+  # - org.openrewrite.java.migrate.lang.FindVirtualThreadOpportunities # don't want to use: https://github.com/diffplug/spotless/pull/2684#discussion_r2433831887
 ---
 name: com.diffplug.spotless.openrewrite.SpotlessFormat
 styleConfigs:

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -140,22 +140,22 @@ public class TestProvisioner {
 
 	/** Creates a Provisioner for the mavenCentral repo. */
 	public static Provisioner mavenCentral() {
-		return mavenCentral.get();
+		return MAVEN_CENTRAL.get();
 	}
 
-	private static final Supplier<Provisioner> mavenCentral = Suppliers.memoize(() -> caching("mavenCentral", () -> createWithRepositories(repo -> repo.mavenCentral())));
+	private static final Supplier<Provisioner> MAVEN_CENTRAL = Suppliers.memoize(() -> caching("mavenCentral", () -> createWithRepositories(repo -> repo.mavenCentral())));
 
 	/** Creates a Provisioner for the local maven repo for development purpose. */
 	public static Provisioner mavenLocal() {
-		return mavenLocal.get();
+		return MAVEN_LOCAL.get();
 	}
 
-	private static final Supplier<Provisioner> mavenLocal = () -> createWithRepositories(repo -> repo.mavenLocal());
+	private static final Supplier<Provisioner> MAVEN_LOCAL = () -> createWithRepositories(repo -> repo.mavenLocal());
 
 	/** Creates a Provisioner for the Sonatype snapshots maven repo for development purpose. */
 	public static Provisioner snapshots() {
-		return snapshots.get();
+		return SNAPSHOTS.get();
 	}
 
-	private static final Supplier<Provisioner> snapshots = () -> createWithRepositories(repo -> repo.maven(setup -> setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots")));
+	private static final Supplier<Provisioner> SNAPSHOTS = () -> createWithRepositories(repo -> repo.maven(setup -> setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots")));
 }

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -31,24 +31,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 
 class FileSignatureTest extends ResourceHarness {
-	private static final String[] inputPaths = {"A", "C", "C", "A", "B"};
-	private static final String[] expectedPathList = inputPaths;
-	private static final String[] expectedPathSet = {"A", "B", "C"};
+	private static final String[] INPUT_PATHS = {"A", "C", "C", "A", "B"};
+	private static final String[] EXPECTED_PATH_LIST = INPUT_PATHS;
+	private static final String[] EXPECTED_PATH_SET = {"A", "B", "C"};
 
 	@Test
 	void testFromList() throws IOException {
-		Collection<File> inputFiles = getTestFiles(inputPaths);
+		Collection<File> inputFiles = getTestFiles(INPUT_PATHS);
 		FileSignature signature = FileSignature.signAsList(inputFiles);
-		Collection<File> expectedFiles = getTestFiles(expectedPathList);
+		Collection<File> expectedFiles = getTestFiles(EXPECTED_PATH_LIST);
 		Collection<File> outputFiles = signature.files();
 		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
 	}
 
 	@Test
 	void testFromSet() throws IOException {
-		Collection<File> inputFiles = getTestFiles(inputPaths);
+		Collection<File> inputFiles = getTestFiles(INPUT_PATHS);
 		FileSignature signature = FileSignature.signAsSet(inputFiles);
-		Collection<File> expectedFiles = getTestFiles(expectedPathSet);
+		Collection<File> expectedFiles = getTestFiles(EXPECTED_PATH_SET);
 		Collection<File> outputFiles = signature.files();
 		assertThat(outputFiles).containsExactlyElementsOf(expectedFiles);
 	}
@@ -63,7 +63,7 @@ class FileSignatureTest extends ResourceHarness {
 	@Test
 	void testFromFilesAndDirectory() throws IOException {
 		File dir = new File(rootFolder(), "dir");
-		List<File> files = getTestFiles(inputPaths);
+		List<File> files = getTestFiles(INPUT_PATHS);
 		files.add(dir);
 		Collections.shuffle(files);
 		assertThatThrownBy(() -> FileSignature.signAsList(files))

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -33,7 +33,7 @@ import com.diffplug.spotless.generic.LicenseHeaderStep.YearMode;
 
 class LicenseHeaderStepTest extends ResourceHarness {
 	private static final String FILE_NO_LICENSE = "license/FileWithoutLicenseHeader.test";
-	private static final String package_ = LicenseHeaderStep.DEFAULT_JAVA_HEADER_DELIMITER;
+	private static final String PACKAGE_ = LicenseHeaderStep.DEFAULT_JAVA_HEADER_DELIMITER;
 	private static final String HEADER_WITH_$YEAR = "This is a fake license, $YEAR. ACME corp.";
 	private static final String HEADER_WITH_RANGE_TO_$YEAR = "This is a fake license with range, 2009-$YEAR. ACME corp.";
 	private static final String HEADER_WITH_$FILE = "This is a fake license, $FILE. ACME corp.";
@@ -41,7 +41,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void parseExistingYear() throws Exception {
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), package_).build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_).build())
 				// has existing
 				.test(hasHeader("This is a fake license, 2007. ACME corp."), hasHeader("This is a fake license, 2007. ACME corp."))
 				// if prefix changes, the year will get set to today
@@ -52,14 +52,14 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void fromHeader() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(getTestResource("license/TestLicense"), package_).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(getTestResource("license/TestLicense"), PACKAGE_).build();
 		StepHarness.forStep(step)
 				.testResource("license/MissingLicense.test", "license/HasLicense.test");
 	}
 
 	@Test
 	void should_apply_license_containing_YEAR_token() throws Throwable {
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), package_).build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_).build())
 				.test(getTestResource(FILE_NO_LICENSE), hasHeaderYear(currentYear()))
 				.testUnaffected(hasHeaderYear(currentYear()))
 				.testUnaffected(hasHeaderYear("2003"))
@@ -69,7 +69,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 				.test(hasHeaderYear("not a year"), hasHeaderYear(currentYear()));
 		// Check with variant
 		String otherFakeLicense = "This is a fake license. Copyright $YEAR ACME corp.";
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(otherFakeLicense), package_).build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(otherFakeLicense), PACKAGE_).build())
 				.test(getTestResource(FILE_NO_LICENSE), hasHeaderYear(otherFakeLicense, currentYear()))
 				.testUnaffected(hasHeaderYear(otherFakeLicense, currentYear()))
 				.test(hasHeader("This is a fake license. Copyright "), hasHeaderYear(otherFakeLicense, currentYear()))
@@ -79,13 +79,13 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 		//Check when token is of the format $today.year
 		String HEADER_WITH_YEAR_INTELLIJ = "This is a fake license, $today.year. ACME corp.";
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_YEAR_INTELLIJ), package_).build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_YEAR_INTELLIJ), PACKAGE_).build())
 				.test(hasHeader(HEADER_WITH_YEAR_INTELLIJ), hasHeader(HEADER_WITH_YEAR_INTELLIJ.replace("$today.year", currentYear())));
 	}
 
 	@Test
 	void updateYearWithLatest() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), package_)
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_)
 				.withYearMode(YearMode.UPDATE_TO_TODAY)
 				.build();
 		StepHarness.forStep(step)
@@ -96,21 +96,21 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_apply_license_containing_YEAR_token_with_non_default_year_separator() throws Throwable {
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), package_).withYearSeparator(", ").build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_).withYearSeparator(", ").build())
 				.testUnaffected(hasHeaderYear("1990, 2015"))
 				.test(hasHeaderYear("1990-2015"), hasHeaderYear("1990, 2015"));
 	}
 
 	@Test
 	void should_apply_license_containing_YEAR_token_with_special_character_in_year_separator() throws Throwable {
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), package_).withYearSeparator("(").build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_).withYearSeparator("(").build())
 				.testUnaffected(hasHeaderYear("1990(2015"))
 				.test(hasHeaderYear("1990-2015"), hasHeaderYear("1990(2015"));
 	}
 
 	@Test
 	void should_apply_license_containing_YEAR_token_with_custom_separator() throws Throwable {
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), package_).build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_).build())
 				.test(getTestResource(FILE_NO_LICENSE), hasHeaderYear(currentYear()))
 				.testUnaffected(hasHeaderYear(currentYear()))
 				.testUnaffected(hasHeaderYear("2003"))
@@ -120,7 +120,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_remove_header_when_empty() throws Throwable {
-		StepHarness.forStep(LicenseHeaderStep.headerDelimiter("", package_).build())
+		StepHarness.forStep(LicenseHeaderStep.headerDelimiter("", PACKAGE_).build())
 				.testUnaffected(getTestResource("license/MissingLicense.test"))
 				.test(getTestResource("license/HasLicense.test"), getTestResource("license/MissingLicense.test"));
 	}
@@ -244,14 +244,14 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_apply_license_containing_YEAR_token_in_range() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_RANGE_TO_$YEAR), package_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_RANGE_TO_$YEAR), PACKAGE_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
 		StepHarness.forStep(step).test(hasHeaderWithRangeAndWithYearTo("2015"), hasHeaderWithRangeAndWithYearTo(currentYear()));
 	}
 
 	@Test
 	void should_update_year_for_license_with_address() throws Throwable {
 		int currentYear = LocalDate.now(ZoneOffset.UTC).getYear();
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), package_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), PACKAGE_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
 		StepHarness.forStep(step).test(
 				hasHeader(licenceWithAddress().replace("$YEAR", "2015")),
 				hasHeader(licenceWithAddress().replace("$YEAR", "2015-" + currentYear)));
@@ -259,7 +259,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_preserve_year_for_license_with_address() throws Throwable {
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), package_).withYearMode(YearMode.PRESERVE).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), PACKAGE_).withYearMode(YearMode.PRESERVE).build();
 		StepHarness.forStep(step).test(
 				hasHeader(licenceWithAddress().replace("$YEAR", "2015").replace("FooBar Inc. All", "FooBar Inc.  All")),
 				hasHeader(licenceWithAddress().replace("$YEAR", "2015")));
@@ -267,7 +267,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_apply_license_containing_filename_token() throws Exception {
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$FILE), package_).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$FILE), PACKAGE_).build();
 		StepHarnessWithFile.forStep(this, step)
 				.test("Test.java", getTestResource(FILE_NO_LICENSE), hasHeaderFileName(HEADER_WITH_$FILE, "Test.java"))
 				.testUnaffected(new File("Test.java"), hasHeaderFileName(HEADER_WITH_$FILE, "Test.java"));
@@ -275,7 +275,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_update_license_containing_filename_token() throws Exception {
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$FILE), package_).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$FILE), PACKAGE_).build();
 		StepHarnessWithFile.forStep(this, step)
 				.test("After.java",
 						hasHeaderFileName(HEADER_WITH_$FILE, "Before.java"),
@@ -284,7 +284,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_apply_license_containing_YEAR_filename_token() throws Exception {
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR_$FILE), package_).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR_$FILE), PACKAGE_).build();
 		StepHarnessWithFile.forStep(this, step)
 				.test("Test.java",
 						getTestResource(FILE_NO_LICENSE),
@@ -295,7 +295,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	void noPackage() throws Throwable {
 		String header = header(getTestResource("license/TestLicense"));
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header, package_).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header, PACKAGE_).build();
 		StepHarness.forStep(step)
 				.test(ResourceHarness.getTestResource("license/HelloWorld_java.test"), header + ResourceHarness.getTestResource("license/HelloWorld_java.test"))
 				.test(ResourceHarness.getTestResource("license/HelloWorld_withImport_java.test"), header + ResourceHarness.getTestResource("license/HelloWorld_withImport_java.test"));
@@ -305,7 +305,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 	@Test
 	void moduleInfo() throws Throwable {
 		String header = header(getTestResource("license/TestLicense"));
-		FormatterStep step = LicenseHeaderStep.headerDelimiter(header, package_).build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header, PACKAGE_).build();
 		StepHarness.forStep(step)
 				.test(ResourceHarness.getTestResource("license/module-info.test"), header + ResourceHarness.getTestResource("license/module-info.test"));
 	}

--- a/testlib/src/test/java/com/diffplug/spotless/markdown/FlexmarkStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/markdown/FlexmarkStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,11 @@ import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.TestProvisioner;
 
 class FlexmarkStepTest {
-	private static final String oldestSupported = "0.62.2";
+	private static final String OLDEST_SUPPORTED = "0.62.2";
 
 	@Test
 	void behaviorOldest() {
-		StepHarness.forStep(FlexmarkStep.create(oldestSupported, TestProvisioner.mavenCentral()))
+		StepHarness.forStep(FlexmarkStep.create(OLDEST_SUPPORTED, TestProvisioner.mavenCentral()))
 				.testResource(
 						"markdown/flexmark/FlexmarkUnformatted.md",
 						"markdown/flexmark/FlexmarkFormatted.md");


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
