### PR TITLE
[prone] Apply `UnnecessaryLambda`

### DIFF
--- a/gradle/error-prone.gradle
+++ b/gradle/error-prone.gradle
@@ -1,5 +1,3 @@
-import static java.lang.System.getenv
-
 apply plugin: 'net.ltgt.errorprone'
 
 dependencies {
@@ -9,25 +7,10 @@ dependencies {
 
 tasks.withType(JavaCompile).configureEach {
 	options.errorprone {
-		disable( // not patchable
-				'FormatStringConcatenation',
+		disable( // consider fix, or reasoning.
 				'FunctionalInterfaceMethodChanged',
 				'JavaxInjectOnAbstractMethod',
 				'OverridesJavaxInjectableMethod',
-				'ReturnValueIgnored',
-				'Slf4jLogStatement',
-				'MissingSummary',
-				// patchable
-				'LexicographicalAnnotationAttributeListing',
-				'LexicographicalAnnotationListing',
-				'NonStaticImport',
-				'Slf4jLoggerDeclaration', // logger -> log
-				'StaticImport',
-				// critical, finds lots of bugs... unused configs and stuff.
-				'Unused',
-				'UnusedMethod',
-				'UnusedParameters',
-				'UnusedVariable',
 				)
 		error(
 				'AmbiguousJsonCreator',
@@ -49,45 +32,19 @@ tasks.withType(JavaCompile).configureEach {
 				'PrimitiveComparison',
 				'RedundantStringConversion',
 				'RedundantStringEscape',
+				'ReturnValueIgnored',
 				'SelfAssignment',
 				'StringJoin',
 				'StringJoining',
+				'UnnecessarilyFullyQualified',
+				'UnnecessaryLambda',
 				)
-		// fixme bug: this only happens when the file is dirty!
-		// up2date checking (caching) must consider file changes, as file is currently corrupt!
-		// fix SelfTest.java:L22 ForbidGradleInternal(import org.gradle.api.internal.project.ProjectInternal;)
-		errorproneArgs.add('-XepExcludedPaths:.*/SelfTest.java')
-		if (!getenv().containsKey('CI') && getenv('IN_PLACE')?.toBoolean()) {
-			errorproneArgs.addAll(
-					'-XepPatchLocation:IN_PLACE',
-					'-XepPatchChecks:' +
-					'AmbiguousJsonCreator,' +
-					'ArrayEquals,' +
-					'AssertJNullnessAssertion,' +
-					'AutowiredConstructor,' +
-					'CanonicalAnnotationSyntax,' +
-					'CollectorMutability,' +
-					'ConstantNaming,' +
-					'DirectReturn,' +
-					'EmptyMethod,' +
-					'ExplicitArgumentEnumeration,' +
-					'ExplicitEnumOrdering,' +
-					'FormatStringConcatenation,' +
-					'IdentityConversion,' +
-					'ImmutablesSortedSetComparator,' +
-					'IsInstanceLambdaUsage,' +
-					'MockitoMockClassReference,' +
-					'MockitoStubbing,' +
-					'NestedOptionals,' +
-					'PrimitiveComparison,' +
-					'RedundantStringConversion,' +
-					'RedundantStringEscape,' +
-					'SelfAssignment,' +
-					'Slf4jLogStatement,' +
-					'StringJoin,' +
-					'StringJoining,' +
-					'TimeZoneUsage,'
-					)
-		}
+		// bug: this only happens when the file is dirty.
+		// might be an up2date (caching) issue, as file is currently in corrupt state.
+		// ForbidGradleInternal(import org.gradle.api.internal.project.ProjectInternal;)
+		errorproneArgs.add('-XepExcludedPaths:' +
+				'.*/SelfTest.java|' +
+				'.*/GradleIntegrationHarness.java'
+				)
 	}
 }

--- a/lib-extra/src/cdt/java/com/diffplug/spotless/extra/glue/cdt/EclipseCdtFormatterStepImpl.java
+++ b/lib-extra/src/cdt/java/com/diffplug/spotless/extra/glue/cdt/EclipseCdtFormatterStepImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.cdt.core.ToolFactory;
 import org.eclipse.cdt.core.formatter.CodeFormatter;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -35,7 +36,7 @@ public class EclipseCdtFormatterStepImpl {
 		Map<String, String> settingsMap = stream.collect(Collectors.toMap(
 				e -> String.valueOf(e.getKey()),
 				e -> String.valueOf(e.getValue())));
-		codeFormatter = org.eclipse.cdt.core.ToolFactory.createDefaultCodeFormatter(settingsMap);
+		codeFormatter = ToolFactory.createDefaultCodeFormatter(settingsMap);
 	}
 
 	/** Formatting C/C++ string */

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ class GitAttributesTest extends ResourceHarness {
 		setFile(".gitattributes").toContent(StringPrinter.buildStringFromLines(
 				"* eol=lf",
 				"*.MF eol=crlf"));
-		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), () -> testFiles());
+		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), this::testFiles);
 		Assertions.assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\n");
 		Assertions.assertThat(policy.getEndingFor(newFile("subfolder/someFile"))).isEqualTo("\n");
 		Assertions.assertThat(policy.getEndingFor(newFile("MANIFEST.MF"))).isEqualTo("\r\n");
@@ -100,7 +100,7 @@ class GitAttributesTest extends ResourceHarness {
 				"[core]",
 				"autocrlf=true",
 				"eol=lf"));
-		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), () -> testFiles());
+		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), this::testFiles);
 		Assertions.assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\r\n");
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.diffplug.gradle.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.Charset;
 
@@ -51,7 +53,7 @@ class EncodingTest extends GradleIntegrationHarness {
 				"    encoding 'US-ASCII'",
 				"}");
 		setFile("test.java").toContent("µ");
-		gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");
+		assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput()).doesNotContain("Encoding error!");
 		assertFile("test.java").hasContent("µ");
 	}
 
@@ -75,7 +77,7 @@ class EncodingTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.java").toContent("µ");
 		setFile("utf32.encoded").toContent("µ", Charset.forName("UTF-32"));
-		gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");
+		assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput()).doesNotContain("Encoding error!");
 		assertFile("test.java").hasContent("µ");
 		assertFile("utf32.encoded").hasContent("µ", Charset.forName("UTF-32"));
 	}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -66,7 +66,7 @@ public class ArtifactResolver {
 			excludeTransitive.add(EXCLUDE_ALL_TRANSITIVES);
 		}
 		List<Dependency> dependencies = mavenCoordinates.stream()
-				.map(coordinateString -> new DefaultArtifact(coordinateString))
+				.map(DefaultArtifact::new)
 				.map(artifact -> new Dependency(artifact, null, null, excludeTransitive))
 				.collect(toList());
 		CollectRequest collectRequest = new CollectRequest(dependencies, null, repositories);

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -143,19 +143,16 @@ public class TestProvisioner {
 		return MAVEN_CENTRAL.get();
 	}
 
-	private static final Supplier<Provisioner> MAVEN_CENTRAL = Suppliers.memoize(() -> caching("mavenCentral", () -> createWithRepositories(repo -> repo.mavenCentral())));
+	private static final Supplier<Provisioner> MAVEN_CENTRAL = Suppliers.memoize(() -> caching("mavenCentral", () -> createWithRepositories(RepositoryHandler::mavenCentral)));
 
 	/** Creates a Provisioner for the local maven repo for development purpose. */
 	public static Provisioner mavenLocal() {
-		return MAVEN_LOCAL.get();
+		return createWithRepositories(RepositoryHandler::mavenLocal);
 	}
-
-	private static final Supplier<Provisioner> MAVEN_LOCAL = () -> createWithRepositories(repo -> repo.mavenLocal());
 
 	/** Creates a Provisioner for the Sonatype snapshots maven repo for development purpose. */
 	public static Provisioner snapshots() {
-		return SNAPSHOTS.get();
+		return createWithRepositories(repo -> repo.maven(setup -> setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots")));
 	}
 
-	private static final Supplier<Provisioner> SNAPSHOTS = () -> createWithRepositories(repo -> repo.maven(setup -> setup.setUrl("https://oss.sonatype.org/content/repositories/snapshots")));
 }

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
@@ -196,7 +196,7 @@ class FormatterPropertiesTest extends ResourceHarness {
 
 		/** Check that the values form all valid files are part of the settings properties. */
 		public FormatterSettingsAssert containsSpecificValuesOf(Collection<File> files) {
-			files.forEach(file -> containsSpecificValuesOf(file));
+			files.forEach(this::containsSpecificValuesOf);
 			return this;
 		}
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
@@ -18,6 +18,7 @@ package com.diffplug.spotless.generic;
 import java.io.File;
 import java.util.Arrays;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.StringPrinter;
@@ -132,7 +133,7 @@ class FenceStepTest extends ResourceHarness {
 			return uppercase ? "uppercase" : "lowercase";
 		}
 
-		@org.jetbrains.annotations.Nullable @Override
+		@Nullable @Override
 		public String format(String rawUnix, File file) throws Exception {
 			return uppercase ? rawUnix.toUpperCase() : rawUnix.toLowerCase();
 		}


### PR DESCRIPTION


- https://github.com/google/error-prone/issues/5289


ReturnValueIgnored:
```
  Did you mean 'final class EncodingTest extends GradleIntegrationHarness {'?
/Users/vincent.potucek/IdeaProjects/spotless/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java:54: error: [ReturnValueIgnored] Return value of 'contains' must be used
                gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");
                                                                                                 ^
    (see https://errorprone.info/bugpattern/ReturnValueIgnored)
  Did you mean 'assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!")).isTrue();' or 'var unused = gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");' or to remove this line?
/Users/vincent.potucek/IdeaProjects/spotless/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/EncodingTest.java:78: error: [ReturnValueIgnored] Return value of 'contains' must be used
                gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");
                                                                                                 ^
    (see https://errorprone.info/bugpattern/ReturnValueIgnored)
  Did you mean 'assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!")).isTrue();' or 'var unused = gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput().contains("Encoding error!");' or to remove this line?
```