### PR TITLE
[prone] fix warning `StaticImport`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  sanityCheck:
+  sanity-check:
+    name: SanityCheck
     runs-on: ubuntu-latest
     env:
       buildcacheuser: ${{ secrets.BUILDCACHE_USER }}
@@ -35,7 +36,7 @@ jobs:
       - name: assemble testClasses
         run: ./gradlew assemble testClasses
   build:
-    needs: sanityCheck
+    needs: sanity-check
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +108,7 @@ jobs:
   # Status check that is required in branch protection rules.
   final-status:
     needs:
-      - sanityCheck
+      - sanity-check
       - build
     runs-on: ubuntu-latest
     if: always()

--- a/gradle/error-prone.gradle
+++ b/gradle/error-prone.gradle
@@ -1,16 +1,32 @@
-apply plugin: 'net.ltgt.errorprone'
+import static java.lang.System.getenv
 
-dependencies {
-	errorprone('com.google.errorprone:error_prone_core:2.42.0')
-	errorprone('tech.picnic.error-prone-support:error-prone-contrib:0.26.0')
-}
+apply plugin: 'net.ltgt.errorprone'
 
 tasks.withType(JavaCompile).configureEach {
 	options.errorprone {
-		disable( // consider fix, or reasoning.
+		disableAllWarnings = true // https://github.com/diffplug/spotless/issues/2745 https://github.com/google/error-prone/issues/5365
+		disable(
+				// consider fix, or reasoning.
+				'AnnotateFormatMethod', // We don`t want to use ErrorProne's annotations.
+				'CheckReturnValue', // We don`t want to use ErrorProne's annotations.
+				'CollectorMutability', // for freedom global exclude, might whitelist. https://github.com/diffplug/spotless/pull/2744#discussion_r2553042130
+				'DoNotCallSuggester', // We don`t want to use ErrorProne's annotations.
 				'FunctionalInterfaceMethodChanged',
+				'ImmutableEnumChecker', // We don`t want to use ErrorProne's annotations.
+				'InlineMeSuggester', // We don`t want to use ErrorProne's annotations.
+				'JUnitClassModifiers',
 				'JavaxInjectOnAbstractMethod',
+				'LexicographicalAnnotationAttributeListing',
+				'NonStaticImport',
+				'StaticImport',
+				'LexicographicalAnnotationListing',
 				'OverridesJavaxInjectableMethod',
+				'ReturnValueIgnored', // We don`t want to use ErrorProne's annotations.
+				// bug
+				'FieldMissingNullable',
+				'Slf4jLogStatement',
+				'Slf4jLoggerDeclaration',
+				'Var'
 				)
 		error(
 				'AmbiguousJsonCreator',
@@ -26,14 +42,17 @@ tasks.withType(JavaCompile).configureEach {
 				'IdentityConversion',
 				'ImmutablesSortedSetComparator',
 				'IsInstanceLambdaUsage',
+				'MissingOverride',
 				'MockitoMockClassReference',
 				'MockitoStubbing',
 				'NestedOptionals',
+				'NonStaticImport',
 				'PrimitiveComparison',
 				'RedundantStringConversion',
 				'RedundantStringEscape',
 				'ReturnValueIgnored',
 				'SelfAssignment',
+				'StaticImport',
 				'StringJoin',
 				'StringJoining',
 				'UnnecessarilyFullyQualified',
@@ -41,10 +60,24 @@ tasks.withType(JavaCompile).configureEach {
 				)
 		// bug: this only happens when the file is dirty.
 		// might be an up2date (caching) issue, as file is currently in corrupt state.
-		// ForbidGradleInternal(import org.gradle.api.internal.project.ProjectInternal;)
-		errorproneArgs.add('-XepExcludedPaths:' +
-				'.*/SelfTest.java|' +
-				'.*/GradleIntegrationHarness.java'
+		// ForbidGradleInternal(import
+		excludedPaths.set(
+				'.*/GradleIntegrationHarness.java|'+
+				'.*/SelfTest.java'
 				)
+		if (!getenv().containsKey('CI') && getenv('IN_PLACE')?.toBoolean()) {
+			errorproneArgs.addAll(
+					'-XepPatchLocation:IN_PLACE', // how to prevent/ignore? @CanIgnoreReturnValue
+					'-XepPatchChecks:' +
+					'MissingOverride,' +
+					'NonStaticImport,' +
+					'StaticImport'
+					)
+		}
 	}
+}
+
+dependencies {
+	errorprone('com.google.errorprone:error_prone_core:2.42.0')
+	errorprone('tech.picnic.error-prone-support:error-prone-contrib:0.26.0')
 }

--- a/lib-extra/src/cdt/java/com/diffplug/spotless/extra/glue/cdt/EclipseCdtFormatterStepImpl.java
+++ b/lib-extra/src/cdt/java/com/diffplug/spotless/extra/glue/cdt/EclipseCdtFormatterStepImpl.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.extra.glue.cdt;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.cdt.core.ToolFactory;
@@ -33,7 +34,7 @@ public class EclipseCdtFormatterStepImpl {
 
 	public EclipseCdtFormatterStepImpl(Properties settings) throws Exception {
 		Stream<Entry<Object, Object>> stream = settings.entrySet().stream();
-		Map<String, String> settingsMap = stream.collect(Collectors.toMap(
+		Map<String, String> settingsMap = stream.collect(toMap(
 				e -> String.valueOf(e.getKey()),
 				e -> String.valueOf(e.getValue())));
 		codeFormatter = ToolFactory.createDefaultCodeFormatter(settingsMap);

--- a/lib-extra/src/groovy/java/com/diffplug/spotless/extra/glue/groovy/GrEclipseFormatterStepImpl.java
+++ b/lib-extra/src/groovy/java/com/diffplug/spotless/extra/glue/groovy/GrEclipseFormatterStepImpl.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.extra.glue.groovy;
 
+import static java.util.Collections.synchronizedList;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -111,7 +112,7 @@ public class GrEclipseFormatterStepImpl {
 			 * We need a synchronized list here, in case multiple instantiations
 			 * run in parallel.
 			 */
-			errors = Collections.synchronizedList(new ArrayList<>());
+			errors = synchronizedList(new ArrayList<>());
 			ILog groovyLogger = GroovyCoreActivator.getDefault().getLog();
 			groovyLogger.addLogListener(this);
 			synchronized (GroovyLogManager.manager) {

--- a/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/EclipseJdtFormatterStepImpl.java
+++ b/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/EclipseJdtFormatterStepImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless.extra.glue.jdt;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.internal.compiler.env.IModule;
@@ -37,7 +38,7 @@ public class EclipseJdtFormatterStepImpl {
 	private final EclipseJdtSortMembers.SortProperties sortProperties;
 
 	public EclipseJdtFormatterStepImpl(Properties formatterSettings, Map<String, String> sortProperties) {
-		Map<String, String> options = formatterSettings.entrySet().stream().collect(Collectors.toMap(
+		Map<String, String> options = formatterSettings.entrySet().stream().collect(toMap(
 				e -> String.valueOf(e.getKey()),
 				e -> String.valueOf(e.getValue()),
 				(prev, next) -> next,

--- a/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/EclipseJdtSortMembers.java
+++ b/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/EclipseJdtSortMembers.java
@@ -98,64 +98,84 @@ public final class EclipseJdtSortMembers {
 			this.contents = contents;
 		}
 
+		@Override
 		public void addBufferChangedListener(IBufferChangedListener listener) {}
 
+		@Override
 		public void append(char[] text) {}
 
+		@Override
 		public void append(String text) {}
 
+		@Override
 		public void close() {}
 
+		@Override
 		public char getChar(int position) {
 			return '\u0000';
 		}
 
+		@Override
 		public char[] getCharacters() {
 			return contents.toCharArray();
 		}
 
+		@Override
 		public String getContents() {
 			return contents;
 		}
 
+		@Override
 		public int getLength() {
 			return 0;
 		}
 
+		@Override
 		public IOpenable getOwner() {
 			return null;
 		}
 
+		@Override
 		public String getText(int offset, int length) {
 			return null;
 		}
 
+		@Override
 		public IResource getUnderlyingResource() {
 			return null;
 		}
 
+		@Override
 		public boolean hasUnsavedChanges() {
 			return false;
 		}
 
+		@Override
 		public boolean isClosed() {
 			return false;
 		}
 
+		@Override
 		public boolean isReadOnly() {
 			return true;
 		}
 
+		@Override
 		public void removeBufferChangedListener(IBufferChangedListener listener) {}
 
+		@Override
 		public void replace(int position, int length, char[] text) {}
 
+		@Override
 		public void replace(int position, int length, String text) {}
 
+		@Override
 		public void save(IProgressMonitor progress, boolean force) {}
 
+		@Override
 		public void setContents(char[] contents) {}
 
+		@Override
 		public void setContents(String contents) {
 			this.contents = contents;
 		}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EclipseBasedStepBuilder.java
@@ -15,15 +15,16 @@
  */
 package com.diffplug.spotless.extra;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 
 import com.diffplug.common.base.Errors;
@@ -69,10 +70,10 @@ public class EclipseBasedStepBuilder {
 
 	/** Initialize valid default configuration, taking latest version */
 	public EclipseBasedStepBuilder(String formatterName, String formatterStepExt, Provisioner jarProvisioner, SerializedFunction<State, FormatterFunc> stateToFormatter) {
-		this.formatterName = Objects.requireNonNull(formatterName, "formatterName");
-		this.formatterStepExt = Objects.requireNonNull(formatterStepExt, "formatterStepExt");
-		this.jarProvisioner = Objects.requireNonNull(jarProvisioner, "jarProvisioner");
-		this.stateToFormatter = Objects.requireNonNull(stateToFormatter, "stateToFormatter");
+		this.formatterName = requireNonNull(formatterName, "formatterName");
+		this.formatterStepExt = requireNonNull(formatterStepExt, "formatterStepExt");
+		this.jarProvisioner = requireNonNull(jarProvisioner, "jarProvisioner");
+		this.stateToFormatter = requireNonNull(stateToFormatter, "stateToFormatter");
 		formatterVersion = "No version set"; //Will fail creation
 	}
 
@@ -91,7 +92,7 @@ public class EclipseBasedStepBuilder {
 			throw new IllegalArgumentException("No such version " + version + ", expected at " + url);
 		}
 		byte[] content = toByteArray(depsFile);
-		String allLines = new String(content, StandardCharsets.UTF_8);
+		String allLines = new String(content, UTF_8);
 		String[] lines = allLines.split("\n");
 		dependencies.clear();
 		for (String line : lines) {

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/EquoBasedStepBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.extra;
 
+import static java.util.Objects.requireNonNullElse;
 import static java.util.stream.Collectors.toMap;
 
 import java.io.File;
@@ -24,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 
 import javax.annotation.Nullable;
@@ -190,8 +190,8 @@ public abstract class EquoBasedStepBuilder {
 				ImmutableMap<String, String> stepProperties) {
 
 			this.semanticVersion = semanticVersion;
-			this.settingProperties = Objects.requireNonNullElse(settingProperties, new ArrayList<>());
-			this.settingXml = Objects.requireNonNullElse(settingXml, new ArrayList<>());
+			this.settingProperties = requireNonNullElse(settingProperties, new ArrayList<>());
+			this.settingXml = requireNonNullElse(settingXml, new ArrayList<>());
 			this.settingsPromise = settingsPromise;
 			this.jarPromise = jarPromise;
 			this.stepProperties = stepProperties;
@@ -218,8 +218,8 @@ public abstract class EquoBasedStepBuilder {
 		public State(String semanticVersion, JarState jarState, List<String> settingProperties, List<String> settingXml, FileSignature settingsFiles, ImmutableMap<String, String> stepProperties) {
 			this.semanticVersion = semanticVersion;
 			this.jarState = jarState;
-			this.settingProperties = Objects.requireNonNullElse(settingProperties, new ArrayList<>());
-			this.settingXml = Objects.requireNonNullElse(settingXml, new ArrayList<>());
+			this.settingProperties = requireNonNullElse(settingProperties, new ArrayList<>());
+			this.settingXml = requireNonNullElse(settingXml, new ArrayList<>());
 			this.settingsFiles = settingsFiles;
 			this.stepProperties = stepProperties;
 		}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitAttributesLineEndings.java
@@ -15,17 +15,18 @@
  */
 package com.diffplug.spotless.extra;
 
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -120,8 +121,8 @@ public final class GitAttributesLineEndings {
 		transient Supplier<Iterable<File>> toFormat;
 
 		RelocatablePolicy(File projectDir, Supplier<Iterable<File>> toFormat) {
-			this.projectDir = Objects.requireNonNull(projectDir, "projectDir");
-			this.toFormat = Objects.requireNonNull(toFormat, "toFormat");
+			this.projectDir = requireNonNull(projectDir, "projectDir");
+			this.toFormat = requireNonNull(toFormat, "toFormat");
 		}
 
 		@Override
@@ -260,10 +261,10 @@ public final class GitAttributesLineEndings {
 		final String defaultEnding;
 
 		private Runtime(List<AttributesRule> infoRules, @Nullable File workTree, Config config, List<AttributesRule> globalRules) {
-			this.infoRules = Objects.requireNonNull(infoRules);
+			this.infoRules = requireNonNull(infoRules);
 			this.workTree = workTree;
 			this.defaultEnding = findDefaultLineEnding(config).str();
-			this.globalRules = Objects.requireNonNull(globalRules);
+			this.globalRules = requireNonNull(globalRules);
 		}
 
 		private static final String KEY_EOL = "eol";
@@ -389,7 +390,7 @@ public final class GitAttributesLineEndings {
 				LOGGER.warn("Problem parsing {}", file.getAbsolutePath(), e);
 			}
 		}
-		return Collections.emptyList();
+		return emptyList();
 	}
 
 	/** Parses an attribute value from a list of rules, returning null if there is no match for the given key. */

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/LibExtraPreconditions.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/LibExtraPreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package com.diffplug.spotless.extra;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 final class LibExtraPreconditions {
 	// prevent direct instantiation
 	private LibExtraPreconditions() {}
 
 	static <T, I extends Iterable<T>> I requireElementsNonNull(I elements) {
-		Objects.requireNonNull(elements);
+		requireNonNull(elements);
 		for (Object element : elements) {
-			Objects.requireNonNull(element);
+			requireNonNull(element);
 		}
 		return elements;
 	}

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/integration/DiffMessageFormatter.java
@@ -15,6 +15,9 @@
  */
 package com.diffplug.spotless.extra.integration;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +28,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Objects;
 
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.diff.Edit;
@@ -62,8 +64,8 @@ public final class DiffMessageFormatter {
 		private final Formatter formatter;
 
 		CleanProviderFormatter(Path rootDir, Formatter formatter) {
-			this.rootDir = Objects.requireNonNull(rootDir);
-			this.formatter = Objects.requireNonNull(formatter);
+			this.rootDir = requireNonNull(rootDir);
+			this.formatter = requireNonNull(formatter);
 		}
 
 		@Override
@@ -121,7 +123,7 @@ public final class DiffMessageFormatter {
 
 		/** "Run 'gradlew spotlessApply' to fix these violations." */
 		public Builder runToFix(String runToFix) {
-			this.runToFix = Objects.requireNonNull(runToFix);
+			this.runToFix = requireNonNull(runToFix);
 			return this;
 		}
 
@@ -136,7 +138,7 @@ public final class DiffMessageFormatter {
 		}
 
 		public Builder problemFiles(List<File> problemFiles) {
-			this.problemFiles = Objects.requireNonNull(problemFiles);
+			this.problemFiles = requireNonNull(problemFiles);
 			Preconditions.checkArgument(!problemFiles.isEmpty(), "cannot be empty");
 			return this;
 		}
@@ -144,9 +146,9 @@ public final class DiffMessageFormatter {
 		/** Returns the error message. */
 		public String getMessage() {
 			try {
-				Objects.requireNonNull(runToFix, "runToFix");
-				Objects.requireNonNull(formatter, "formatter");
-				Objects.requireNonNull(problemFiles, "problemFiles");
+				requireNonNull(runToFix, "runToFix");
+				requireNonNull(formatter, "formatter");
+				requireNonNull(problemFiles, "problemFiles");
 				DiffMessageFormatter diffFormater = new DiffMessageFormatter(formatter, problemFiles);
 				return "The following files had format violations:\n"
 						+ diffFormater.buffer
@@ -166,7 +168,7 @@ public final class DiffMessageFormatter {
 	private final CleanProvider formatter;
 
 	private DiffMessageFormatter(CleanProvider formatter, List<File> problemFiles) throws IOException {
-		this.formatter = Objects.requireNonNull(formatter, "formatter");
+		this.formatter = requireNonNull(formatter, "formatter");
 		ListIterator<File> problemIter = problemFiles.listIterator();
 		while (problemIter.hasNext() && numLines < MAX_CHECK_MESSAGE_LINES) {
 			File file = problemIter.next();
@@ -275,8 +277,8 @@ public final class DiffMessageFormatter {
 		dirty = visibleWhitespaceLineEndings(dirty, whitespace, lineEndings);
 		clean = visibleWhitespaceLineEndings(clean, whitespace, lineEndings);
 
-		RawText a = new RawText(dirty.getBytes(StandardCharsets.UTF_8));
-		RawText b = new RawText(clean.getBytes(StandardCharsets.UTF_8));
+		RawText a = new RawText(dirty.getBytes(UTF_8));
+		RawText b = new RawText(clean.getBytes(UTF_8));
 		EditList edits = new EditList();
 		edits.addAll(MyersDiff.INSTANCE.diff(RawTextComparator.DEFAULT, a, b));
 

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitAttributesTest.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.spotless.extra;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.Test;
@@ -56,27 +57,27 @@ class GitAttributesTest extends ResourceHarness {
 				"*.MF eol=crlf"));
 		{
 			GitAttributesLineEndings.AttributesCache cache = new GitAttributesLineEndings.AttributesCache();
-			Assertions.assertThat(cache.valueFor(newFile("someFile"), "eol")).isEqualTo("lf");
-			Assertions.assertThat(cache.valueFor(newFile("subfolder/someFile"), "eol")).isEqualTo("lf");
-			Assertions.assertThat(cache.valueFor(newFile("MANIFEST.MF"), "eol")).isEqualTo("crlf");
-			Assertions.assertThat(cache.valueFor(newFile("subfolder/MANIFEST.MF"), "eol")).isEqualTo("crlf");
+			assertThat(cache.valueFor(newFile("someFile"), "eol")).isEqualTo("lf");
+			assertThat(cache.valueFor(newFile("subfolder/someFile"), "eol")).isEqualTo("lf");
+			assertThat(cache.valueFor(newFile("MANIFEST.MF"), "eol")).isEqualTo("crlf");
+			assertThat(cache.valueFor(newFile("subfolder/MANIFEST.MF"), "eol")).isEqualTo("crlf");
 
 			// write out a .gitattributes for the subfolder
 			setFile("subfolder/.gitattributes").toContent("* eol=lf");
 
 			// it shouldn't change anything, because it's cached
-			Assertions.assertThat(cache.valueFor(newFile("someFile"), "eol")).isEqualTo("lf");
-			Assertions.assertThat(cache.valueFor(newFile("subfolder/someFile"), "eol")).isEqualTo("lf");
-			Assertions.assertThat(cache.valueFor(newFile("MANIFEST.MF"), "eol")).isEqualTo("crlf");
-			Assertions.assertThat(cache.valueFor(newFile("subfolder/MANIFEST.MF"), "eol")).isEqualTo("crlf");
+			assertThat(cache.valueFor(newFile("someFile"), "eol")).isEqualTo("lf");
+			assertThat(cache.valueFor(newFile("subfolder/someFile"), "eol")).isEqualTo("lf");
+			assertThat(cache.valueFor(newFile("MANIFEST.MF"), "eol")).isEqualTo("crlf");
+			assertThat(cache.valueFor(newFile("subfolder/MANIFEST.MF"), "eol")).isEqualTo("crlf");
 		}
 		{
 			// but if we make a new cache, it should change
 			GitAttributesLineEndings.AttributesCache cache = new GitAttributesLineEndings.AttributesCache();
-			Assertions.assertThat(cache.valueFor(newFile("someFile"), "eol")).isEqualTo("lf");
-			Assertions.assertThat(cache.valueFor(newFile("subfolder/someFile"), "eol")).isEqualTo("lf");
-			Assertions.assertThat(cache.valueFor(newFile("MANIFEST.MF"), "eol")).isEqualTo("crlf");
-			Assertions.assertThat(cache.valueFor(newFile("subfolder/MANIFEST.MF"), "eol")).isEqualTo("lf");
+			assertThat(cache.valueFor(newFile("someFile"), "eol")).isEqualTo("lf");
+			assertThat(cache.valueFor(newFile("subfolder/someFile"), "eol")).isEqualTo("lf");
+			assertThat(cache.valueFor(newFile("MANIFEST.MF"), "eol")).isEqualTo("crlf");
+			assertThat(cache.valueFor(newFile("subfolder/MANIFEST.MF"), "eol")).isEqualTo("lf");
 		}
 	}
 
@@ -86,10 +87,10 @@ class GitAttributesTest extends ResourceHarness {
 				"* eol=lf",
 				"*.MF eol=crlf"));
 		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), this::testFiles);
-		Assertions.assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("subfolder/someFile"))).isEqualTo("\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("MANIFEST.MF"))).isEqualTo("\r\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
+		assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\n");
+		assertThat(policy.getEndingFor(newFile("subfolder/someFile"))).isEqualTo("\n");
+		assertThat(policy.getEndingFor(newFile("MANIFEST.MF"))).isEqualTo("\r\n");
+		assertThat(policy.getEndingFor(newFile("subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
 	}
 
 	@Test
@@ -101,7 +102,7 @@ class GitAttributesTest extends ResourceHarness {
 				"autocrlf=true",
 				"eol=lf"));
 		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(rootFolder(), this::testFiles);
-		Assertions.assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\r\n");
+		assertThat(policy.getEndingFor(newFile("someFile"))).isEqualTo("\r\n");
 	}
 
 	@Test
@@ -114,10 +115,10 @@ class GitAttributesTest extends ResourceHarness {
 				"* eol=lf",
 				"*.MF eol=crlf"));
 		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(projectFolder, () -> testFiles("project/"));
-		Assertions.assertThat(policy.getEndingFor(newFile("project/someFile"))).isEqualTo("\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/someFile"))).isEqualTo("\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("project/MANIFEST.MF"))).isEqualTo("\r\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
+		assertThat(policy.getEndingFor(newFile("project/someFile"))).isEqualTo("\n");
+		assertThat(policy.getEndingFor(newFile("project/subfolder/someFile"))).isEqualTo("\n");
+		assertThat(policy.getEndingFor(newFile("project/MANIFEST.MF"))).isEqualTo("\r\n");
+		assertThat(policy.getEndingFor(newFile("project/subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
 	}
 
 	@Test
@@ -136,9 +137,9 @@ class GitAttributesTest extends ResourceHarness {
 				"* eol=lf",
 				"*.MF eol=crlf"));
 		LineEnding.Policy policy = LineEnding.GIT_ATTRIBUTES.createPolicy(projectFolder, () -> testFiles("project/"));
-		Assertions.assertThat(policy.getEndingFor(newFile("project/someFile"))).isEqualTo("\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/someFile"))).isEqualTo("\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("project/MANIFEST.MF"))).isEqualTo("\r\n");
-		Assertions.assertThat(policy.getEndingFor(newFile("project/subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
+		assertThat(policy.getEndingFor(newFile("project/someFile"))).isEqualTo("\n");
+		assertThat(policy.getEndingFor(newFile("project/subfolder/someFile"))).isEqualTo("\n");
+		assertThat(policy.getEndingFor(newFile("project/MANIFEST.MF"))).isEqualTo("\r\n");
+		assertThat(policy.getEndingFor(newFile("project/subfolder/MANIFEST.MF"))).isEqualTo("\r\n");
 	}
 }

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/GitWorkaroundsTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/GitWorkaroundsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.extra;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
@@ -39,7 +40,7 @@ class GitWorkaroundsTest extends ResourceHarness {
 		Git.init().setDirectory(projectFolder).call();
 
 		RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(projectFolder);
-		Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(new File(projectFolder, ".git"));
+		assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(new File(projectFolder, ".git"));
 	}
 
 	@Test
@@ -49,7 +50,7 @@ class GitWorkaroundsTest extends ResourceHarness {
 		Git.init().setDirectory(projectFolder).setGitDir(gitDir).call();
 
 		RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(projectFolder);
-		Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(gitDir);
+		assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(gitDir);
 	}
 
 	@Nested
@@ -87,15 +88,15 @@ class GitWorkaroundsTest extends ResourceHarness {
 			// Test worktree 1
 			{
 				RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(project1Tree);
-				Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(project1GitDir);
-				Assertions.assertThat(repositorySpecificResolver.resolveWithCommonDir(Constants.CONFIG)).isEqualTo(new File(commonGitDir, Constants.CONFIG));
+				assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(project1GitDir);
+				assertThat(repositorySpecificResolver.resolveWithCommonDir(Constants.CONFIG)).isEqualTo(new File(commonGitDir, Constants.CONFIG));
 			}
 
 			// Test worktree 2
 			{
 				RepositorySpecificResolver repositorySpecificResolver = GitWorkarounds.fileRepositoryResolverForProject(project2Tree);
-				Assertions.assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(project2GitDir);
-				Assertions.assertThat(repositorySpecificResolver.resolveWithCommonDir(Constants.CONFIG)).isEqualTo(new File(commonGitDir, Constants.CONFIG));
+				assertThat(repositorySpecificResolver.getGitDir()).isEqualTo(project2GitDir);
+				assertThat(repositorySpecificResolver.resolveWithCommonDir(Constants.CONFIG)).isEqualTo(new File(commonGitDir, Constants.CONFIG));
 			}
 		}
 
@@ -103,20 +104,20 @@ class GitWorkaroundsTest extends ResourceHarness {
 		void perWorktreeConfig() throws IOException {
 			setFile("project.git/config").toLines("[core]", "mySetting = true");
 
-			Assertions.assertThat(getMySetting(project1Tree)).isTrue();
-			Assertions.assertThat(getMySetting(project2Tree)).isTrue();
+			assertThat(getMySetting(project1Tree)).isTrue();
+			assertThat(getMySetting(project2Tree)).isTrue();
 
 			// Override setting for project 1, but don't enable extension yet
 			setFile("project.git/worktrees/project-w1/config.worktree").toLines("[core]", "mySetting = false");
 
-			Assertions.assertThat(getMySetting(project1Tree)).isTrue();
-			Assertions.assertThat(getMySetting(project2Tree)).isTrue();
+			assertThat(getMySetting(project1Tree)).isTrue();
+			assertThat(getMySetting(project2Tree)).isTrue();
 
 			// Enable extension
 			setFile("project.git/config").toLines("[core]", "mySetting = true", "[extensions]", "worktreeConfig = true");
 
-			Assertions.assertThat(getMySetting(project1Tree)).isFalse(); // Should now be overridden by config.worktree
-			Assertions.assertThat(getMySetting(project2Tree)).isTrue();
+			assertThat(getMySetting(project1Tree)).isFalse(); // Should now be overridden by config.worktree
+			assertThat(getMySetting(project2Tree)).isTrue();
 		}
 
 		private boolean getMySetting(File projectDir) {

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepSpecialCaseTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/groovy/GrEclipseFormatterStepSpecialCaseTest.java
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.extra.groovy;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.StepHarness;
@@ -30,7 +31,7 @@ public class GrEclipseFormatterStepSpecialCaseTest {
 	 */
 	@Test
 	public void issue_1657() {
-		Assertions.assertThrows(RuntimeException.class, () -> StepHarness.forStep(GrEclipseFormatterStep.createBuilder(TestProvisioner.mavenCentral()).build())
+		assertThrows(RuntimeException.class, () -> StepHarness.forStep(GrEclipseFormatterStep.createBuilder(TestProvisioner.mavenCentral()).build())
 				.testResourceUnaffected("groovy/greclipse/format/SomeClass.test"));
 	}
 

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtEqualityTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtEqualityTest.java
@@ -15,6 +15,9 @@
  */
 package com.diffplug.spotless.extra.java;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -23,7 +26,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -39,12 +41,12 @@ public class EclipseJdtEqualityTest extends ResourceHarness {
 		var step1 = withSettingsFile(settings1);
 		var step2 = withSettingsFile(settings2);
 
-		Assertions.assertTrue(step1.equals(step2));
-		Assertions.assertTrue(step1.hashCode() == step2.hashCode());
+		assertTrue(step1.equals(step2));
+		assertTrue(step1.hashCode() == step2.hashCode());
 
 		var serialized1 = toBytes(step1);
 		var serialized2 = toBytes(step2);
-		Assertions.assertFalse(Arrays.equals(serialized1, serialized2));
+		assertFalse(Arrays.equals(serialized1, serialized2));
 	}
 
 	private static FormatterStep withSettingsFile(File settingsFile) {

--- a/lib/src/cleanthat/java/com/diffplug/spotless/glue/java/JavaCleanthatRefactorerFunc.java
+++ b/lib/src/cleanthat/java/com/diffplug/spotless/glue/java/JavaCleanthatRefactorerFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.glue.java;
 
+import static java.util.Collections.emptyList;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -48,8 +49,8 @@ public class JavaCleanthatRefactorerFunc implements FormatterFunc.NeedsFile {
 
 	public JavaCleanthatRefactorerFunc(String jdkVersion, List<String> included, List<String> excluded, boolean includeDraft) {
 		this.jdkVersion = jdkVersion == null ? IJdkVersionConstants.JDK_8 : jdkVersion;
-		this.included = included == null ? Collections.emptyList() : included;
-		this.excluded = excluded == null ? Collections.emptyList() : excluded;
+		this.included = included == null ? emptyList() : included;
+		this.excluded = excluded == null ? emptyList() : excluded;
 		this.includeDraft = includeDraft;
 	}
 

--- a/lib/src/compatDiktat1Dot2Dot5/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat1Dot2Dot5Adapter.java
+++ b/lib/src/compatDiktat1Dot2Dot5/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat1Dot2Dot5Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@
  */
 package com.diffplug.spotless.glue.diktat.compat;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -41,7 +43,7 @@ public class DiktatCompat1Dot2Dot5Adapter implements DiktatCompatAdapter {
 		if (configFile != null) {
 			System.setProperty("diktat.config.path", configFile.getAbsolutePath());
 		}
-		this.ruleSets = Collections.singletonList(new DiktatRuleSetProvider().get());
+		this.ruleSets = singletonList(new DiktatRuleSetProvider().get());
 		this.formatterCallback = new FormatterCallback(errors);
 	}
 
@@ -70,7 +72,7 @@ public class DiktatCompat1Dot2Dot5Adapter implements DiktatCompatAdapter {
 				file.getAbsolutePath(),
 				content,
 				ruleSets,
-				Collections.emptyMap(),
+				emptyMap(),
 				formatterCallback,
 				isScript,
 				null,

--- a/lib/src/compatDiktat2Dot0Dot0/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat2Dot0Dot0Adapter.java
+++ b/lib/src/compatDiktat2Dot0Dot0/java/com/diffplug/spotless/glue/diktat/compat/DiktatCompat2Dot0Dot0Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.glue.diktat.compat;
 
+import static java.util.Collections.emptyList;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
@@ -85,7 +86,7 @@ public class DiktatCompat2Dot0Dot0Adapter implements DiktatCompatAdapter {
 
 	private static List<DiktatRuleConfig> readRuleConfigs(File configFile) {
 		if (configFile == null) {
-			return Collections.emptyList();
+			return emptyList();
 		}
 		try (final InputStream configInputStream = new FileInputStream(configFile)) {
 			return DiktatFactoriesKt.getDiktatRuleConfigReader().invoke(configInputStream);

--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -15,13 +15,16 @@
  */
 package com.diffplug.spotless.glue.ktlint.compat;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -91,7 +94,7 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 		Set<RuleProvider> allRuleProviders = ServiceLoader.load(RuleSetProviderV3.class, RuleSetProviderV3.class.getClassLoader())
 				.stream()
 				.flatMap(loader -> loader.get().getRuleProviders().stream())
-				.collect(Collectors.toUnmodifiableSet());
+				.collect(toUnmodifiableSet());
 
 		EditorConfigDefaults editorConfig = EditorConfigDefaults.Companion.load(editorConfigPath, RuleProviderKt.propertyTypes(allRuleProviders));
 		EditorConfigOverride editorConfigOverride;
@@ -100,7 +103,7 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 		} else {
 			editorConfigOverride = createEditorConfigOverride(
 					editorConfig,
-					allRuleProviders.stream().map(RuleProvider::createNewRuleInstance).collect(Collectors.toList()),
+					allRuleProviders.stream().map(RuleProvider::createNewRuleInstance).collect(toList()),
 					editorConfigOverrideMap);
 		}
 
@@ -128,7 +131,7 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 		Map<String, EditorConfigProperty<?>> supportedProperties = Stream
 				.concat(ruleProperties, DEFAULT_EDITOR_CONFIG_PROPERTIES.stream())
 				.distinct()
-				.collect(Collectors.toMap(EditorConfigProperty::getName, property -> property));
+				.collect(toMap(EditorConfigProperty::getName, property -> property));
 
 		// The default style had been changed from intellij_idea to ktlint_official in version 1.0.0
 		boolean isCodeStyleDefinedInEditorConfig = editorConfig.getValue().getSections().stream()

--- a/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
+++ b/lib/src/diktat/java/com/diffplug/spotless/glue/diktat/DiktatFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.glue.diktat;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
-import java.util.stream.Collectors;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.Lint;
@@ -46,7 +47,7 @@ public class DiktatFormatterFunc implements FormatterFunc.NeedsFile {
 		try {
 			return adapter.format(file, unix, isScript);
 		} catch (DiktatReporting.LintException e) {
-			throw Lint.shortcut(e.lints.stream().map(lint -> Lint.atLine(lint.line, lint.ruleId, lint.detail)).collect(Collectors.toList()));
+			throw Lint.shortcut(e.lints.stream().map(lint -> Lint.atLine(lint.line, lint.ruleId, lint.detail)).collect(toList()));
 		}
 	}
 }

--- a/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatFormatterFunc.java
+++ b/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.diffplug.spotless.glue.java;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nonnull;
 
@@ -47,8 +47,8 @@ public class GoogleJavaFormatFormatterFunc implements FormatterFunc {
 	private final boolean reorderImports;
 
 	public GoogleJavaFormatFormatterFunc(@Nonnull String version, @Nonnull String style, boolean reflowStrings, boolean reorderImports, boolean formatJavadoc) {
-		this.version = Objects.requireNonNull(version);
-		this.formatterStyle = Style.valueOf(Objects.requireNonNull(style));
+		this.version = requireNonNull(version);
+		this.formatterStyle = Style.valueOf(requireNonNull(style));
 		this.reflowStrings = reflowStrings;
 		this.reorderImports = reorderImports;
 

--- a/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatRemoveUnusedImporterFormatterFunc.java
+++ b/lib/src/googleJavaFormat/java/com/diffplug/spotless/glue/java/GoogleJavaFormatRemoveUnusedImporterFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.diffplug.spotless.glue.java;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nonnull;
 
@@ -29,7 +29,7 @@ public class GoogleJavaFormatRemoveUnusedImporterFormatterFunc implements Format
 	private final String version;
 
 	public GoogleJavaFormatRemoveUnusedImporterFormatterFunc(@Nonnull String version) {
-		this.version = Objects.requireNonNull(version);
+		this.version = requireNonNull(version);
 	}
 
 	@Override

--- a/lib/src/jackson/java/com/diffplug/spotless/glue/yaml/JacksonYamlFormatterFunc.java
+++ b/lib/src/jackson/java/com/diffplug/spotless/glue/yaml/JacksonYamlFormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ public class JacksonYamlFormatterFunc extends AJacksonFormatterFunc {
 		}
 	}
 
+	@Override
 	protected JsonFactory makeJsonFactory() {
 		YAMLFactoryBuilder yamlFactoryBuilder = new YAMLFactoryBuilder(new YAMLFactory());
 

--- a/lib/src/main/java/com/diffplug/spotless/DelegateFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/DelegateFormatterStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package com.diffplug.spotless;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 /** Superclass of all compound FormatterSteps necessary for {@link com.diffplug.spotless.LazyForwardingEquality#unlazy(java.lang.Object)}. */
 abstract class DelegateFormatterStep implements FormatterStep {
 	protected final FormatterStep delegateStep;
 
 	DelegateFormatterStep(FormatterStep delegateStep) {
-		this.delegateStep = Objects.requireNonNull(delegateStep);
+		this.delegateStep = requireNonNull(delegateStep);
 	}
 
 	@Override

--- a/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
+++ b/lib/src/main/java/com/diffplug/spotless/EncodingErrorMsg.java
@@ -15,13 +15,15 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collection;
 import java.util.Iterator;
@@ -67,7 +69,7 @@ final class EncodingErrorMsg {
 		charBuf = CharBuffer.allocate(Math.min(unrepresentable + 2 * CONTEXT, chars.length()));
 
 		message = new StringBuilder("Encoding error! ");
-		if (charset.equals(StandardCharsets.UTF_8)) {
+		if (charset.equals(UTF_8)) {
 			message.append("Spotless uses UTF-8 by default.");
 		} else {
 			message.append("You configured Spotless to use ").append(charset.name()).append(".");
@@ -89,9 +91,9 @@ final class EncodingErrorMsg {
 		// https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html
 		LinkedHashSet<Charset> encodings = new LinkedHashSet<>();
 		encodings.add(charset); // the encoding we are using
-		encodings.add(StandardCharsets.UTF_8);  // followed by likely encodings
+		encodings.add(UTF_8);  // followed by likely encodings
 		addIfAvailable(encodings, "windows-1252");
-		encodings.add(StandardCharsets.ISO_8859_1);
+		encodings.add(ISO_8859_1);
 		addIfAvailable(encodings, "Shift_JIS");
 		addIfAvailable(encodings, "Big5");
 		addIfAvailable(encodings, "Big5-HKSCS");

--- a/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
+++ b/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,7 +24,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
-import java.util.Objects;
 
 /**
  * This class loader is used to load classes of Spotless features from a search
@@ -56,7 +57,7 @@ class FeatureClassLoader extends URLClassLoader {
 	 */
 	FeatureClassLoader(URL[] urls, ClassLoader buildToolClassLoader) {
 		super(urls, getParentClassLoader());
-		Objects.requireNonNull(buildToolClassLoader);
+		requireNonNull(buildToolClassLoader);
 		this.buildToolClassLoader = buildToolClassLoader;
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/FileSignature.java
+++ b/lib/src/main/java/com/diffplug/spotless/FileSignature.java
@@ -17,6 +17,7 @@ package com.diffplug.spotless;
 
 import static com.diffplug.spotless.MoreIterables.toNullHostileList;
 import static com.diffplug.spotless.MoreIterables.toSortedSet;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Comparator.comparing;
 
 import java.io.File;
@@ -28,7 +29,6 @@ import java.io.Serializable;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -134,7 +134,7 @@ public final class FileSignature implements Serializable {
 
 	/** Returns all of the files in this signature, throwing an exception if there are more or less than 1 file. */
 	public Collection<File> files() {
-		return Collections.unmodifiableList(files);
+		return unmodifiableList(files);
 	}
 
 	/** Returns the only file in this signature, throwing an exception if there are more or less than 1 file. */

--- a/lib/src/main/java/com/diffplug/spotless/FilterByContentPatternFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FilterByContentPatternFormatterStep.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serial;
 import java.util.List;
@@ -30,13 +32,13 @@ final class FilterByContentPatternFormatterStep extends DelegateFormatterStep {
 	FilterByContentPatternFormatterStep(FormatterStep delegateStep, OnMatch onMatch, String contentPattern) {
 		super(delegateStep);
 		this.onMatch = onMatch;
-		this.contentPattern = Pattern.compile(Objects.requireNonNull(contentPattern));
+		this.contentPattern = Pattern.compile(requireNonNull(contentPattern));
 	}
 
 	@Override
 	public @Nullable String format(String raw, File file) throws Exception {
-		Objects.requireNonNull(raw, "raw");
-		Objects.requireNonNull(file, "file");
+		requireNonNull(raw, "raw");
+		requireNonNull(file, "file");
 		if (contentPattern.matcher(raw).find() == (onMatch == OnMatch.INCLUDE)) {
 			return delegateStep.format(raw, file);
 		} else {
@@ -46,8 +48,8 @@ final class FilterByContentPatternFormatterStep extends DelegateFormatterStep {
 
 	@Override
 	public List<Lint> lint(String raw, File file) throws Exception {
-		Objects.requireNonNull(raw, "raw");
-		Objects.requireNonNull(file, "file");
+		requireNonNull(raw, "raw");
+		requireNonNull(file, "file");
 		if (contentPattern.matcher(raw).find() == (onMatch == OnMatch.INCLUDE)) {
 			return delegateStep.lint(raw, file);
 		} else {

--- a/lib/src/main/java/com/diffplug/spotless/FilterByFileFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FilterByFileFormatterStep.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serial;
 import java.util.List;
@@ -27,13 +29,13 @@ final class FilterByFileFormatterStep extends DelegateFormatterStep {
 
 	FilterByFileFormatterStep(FormatterStep delegateStep, SerializableFileFilter filter) {
 		super(delegateStep);
-		this.filter = Objects.requireNonNull(filter);
+		this.filter = requireNonNull(filter);
 	}
 
 	@Override
 	public @Nullable String format(String raw, File file) throws Exception {
-		Objects.requireNonNull(raw, "raw");
-		Objects.requireNonNull(file, "file");
+		requireNonNull(raw, "raw");
+		requireNonNull(file, "file");
 		if (filter.accept(file)) {
 			return delegateStep.format(raw, file);
 		} else {
@@ -43,8 +45,8 @@ final class FilterByFileFormatterStep extends DelegateFormatterStep {
 
 	@Override
 	public List<Lint> lint(String content, File file) throws Exception {
-		Objects.requireNonNull(content, "content");
-		Objects.requireNonNull(file, "file");
+		requireNonNull(content, "content");
+		requireNonNull(file, "file");
 		if (filter.accept(file)) {
 			return delegateStep.lint(content, file);
 		} else {

--- a/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
+++ b/lib/src/main/java/com/diffplug/spotless/ForeignExe.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,20 +50,20 @@ public class ForeignExe implements Serializable {
 	/** The name of the executable, used by "where" (win) and "which" (unix). */
 	public static ForeignExe nameAndVersion(String exeName, String version) {
 		ForeignExe foreign = new ForeignExe();
-		foreign.name = Objects.requireNonNull(exeName);
-		foreign.version = Objects.requireNonNull(version);
+		foreign.name = requireNonNull(exeName);
+		foreign.version = requireNonNull(version);
 		return foreign;
 	}
 
 	/** The flag which causes the exe to print its version (defaults to --version). */
 	public ForeignExe versionFlag(String versionFlag) {
-		this.versionFlag = Objects.requireNonNull(versionFlag);
+		this.versionFlag = requireNonNull(versionFlag);
 		return this;
 	}
 
 	/** A regex which can parse the version out of the output of the {@link #versionFlag(String)} command (defaults to {@code version (\\S*)}) */
 	public ForeignExe versionRegex(Pattern versionRegex) {
-		this.versionRegex = Objects.requireNonNull(versionRegex);
+		this.versionRegex = requireNonNull(versionRegex);
 		return this;
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless;
 
 import static com.diffplug.spotless.LibPreconditions.requireElementsNonNull;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +28,6 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +44,8 @@ public final class Formatter implements Serializable, AutoCloseable {
 	private List<FormatterStep> steps;
 
 	private Formatter(LineEnding.Policy lineEndingsPolicy, Charset encoding, List<FormatterStep> steps) {
-		this.lineEndingsPolicy = Objects.requireNonNull(lineEndingsPolicy, "lineEndingsPolicy");
-		this.encoding = Objects.requireNonNull(encoding, "encoding");
+		this.lineEndingsPolicy = requireNonNull(lineEndingsPolicy, "lineEndingsPolicy");
+		this.encoding = requireNonNull(encoding, "encoding");
 		this.steps = requireElementsNonNull(new ArrayList<>(steps));
 	}
 
@@ -116,8 +116,8 @@ public final class Formatter implements Serializable, AutoCloseable {
 
 	/** Applies the appropriate line endings to the given unix content. */
 	public String computeLineEndings(String unix, File file) {
-		Objects.requireNonNull(unix, "unix");
-		Objects.requireNonNull(file, "file");
+		requireNonNull(unix, "unix");
+		requireNonNull(file, "file");
 
 		String ending = lineEndingsPolicy.getEndingFor(file);
 		if (!ending.equals(LineEnding.UNIX.str())) {
@@ -162,8 +162,8 @@ public final class Formatter implements Serializable, AutoCloseable {
 	 * when the method returns.
 	 */
 	String computeWithLint(String unix, File file, ValuePerStep<Throwable> exceptionPerStep) {
-		Objects.requireNonNull(unix, "unix");
-		Objects.requireNonNull(file, "file");
+		requireNonNull(unix, "unix");
+		requireNonNull(file, "file");
 
 		for (int i = 0; i < steps.size(); i++) {
 			FormatterStep step = steps.get(i);

--- a/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterFunc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A {@code Function<String, String>} which can throw an exception.  Technically, there
@@ -60,8 +61,8 @@ public interface FormatterFunc {
 		 * How the {@code of()} methods below make the correct thing easier to write and safer: https://github.com/diffplug/spotless/commit/18c10f9c93d6f18f753233d0b5f028d5f0961916
 		 */
 		public static Closeable ofDangerous(AutoCloseable closeable, FormatterFunc function) {
-			Objects.requireNonNull(closeable, "closeable");
-			Objects.requireNonNull(function, "function");
+			requireNonNull(closeable, "closeable");
+			requireNonNull(function, "function");
 			return new Closeable() {
 				@Override
 				public void close() {
@@ -95,8 +96,8 @@ public interface FormatterFunc {
 
 		/** Creates a {@link FormatterFunc.Closeable} which uses the given resource to execute the format function. */
 		public static <T extends AutoCloseable> Closeable of(T resource, ResourceFunc<T> function) {
-			Objects.requireNonNull(resource, "resource");
-			Objects.requireNonNull(function, "function");
+			requireNonNull(resource, "resource");
+			requireNonNull(function, "function");
 			return new Closeable() {
 				@Override
 				public void close() {
@@ -126,8 +127,8 @@ public interface FormatterFunc {
 
 		/** Creates a {@link FormatterFunc.Closeable} which uses the given resource to execute the file-dependent format function. */
 		public static <T extends AutoCloseable> Closeable of(T resource, ResourceFuncNeedsFile<T> function) {
-			Objects.requireNonNull(resource, "resource");
-			Objects.requireNonNull(function, "function");
+			requireNonNull(resource, "resource");
+			requireNonNull(function, "function");
 			return new Closeable() {
 				@Override
 				public void close() {

--- a/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterProperties.java
@@ -16,6 +16,10 @@
 package com.diffplug.spotless;
 
 import static com.diffplug.spotless.MoreIterables.toNullHostileList;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toCollection;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -23,14 +27,11 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import javax.xml.XMLConstants;
@@ -61,7 +62,7 @@ public final class FormatterProperties {
 	 *            In case the import of a file fails
 	 */
 	public static FormatterProperties from(File... files) throws IllegalArgumentException {
-		Objects.requireNonNull(files);
+		requireNonNull(files);
 		return from(Arrays.asList(files));
 	}
 
@@ -84,7 +85,7 @@ public final class FormatterProperties {
 		List<String> nonNullElements = toNullHostileList(content);
 		FormatterProperties properties = new FormatterProperties();
 		nonNullElements.forEach(contentElement -> {
-			try (InputStream is = new ByteArrayInputStream(contentElement.getBytes(StandardCharsets.UTF_8))) {
+			try (InputStream is = new ByteArrayInputStream(contentElement.getBytes(UTF_8))) {
 				properties.properties.load(is);
 			} catch (IOException e) {
 				throw new IllegalArgumentException("Unable to load properties: " + contentElement);
@@ -128,7 +129,7 @@ public final class FormatterProperties {
 	 *            In case the import of the file fails
 	 */
 	private void add(final File settingsFile) throws IllegalArgumentException {
-		Objects.requireNonNull(settingsFile);
+		requireNonNull(settingsFile);
 		if (!(settingsFile.isFile() && settingsFile.canRead())) {
 			String msg = "Settings file '%s' does not exist or can not be read.".formatted(settingsFile);
 			throw new IllegalArgumentException(msg);
@@ -182,7 +183,7 @@ public final class FormatterProperties {
 
 			@Override
 			protected Properties executeXmlContent(String content) throws IOException, IllegalArgumentException {
-				return executeWithSupplier(() -> new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+				return executeWithSupplier(() -> new ByteArrayInputStream(content.getBytes(UTF_8)));
 			}
 
 			private Properties executeWithSupplier(Supplier<InputStream> isSupplier) throws IOException, IllegalArgumentException {
@@ -313,7 +314,7 @@ public final class FormatterProperties {
 				}
 				if (profiles.size() > 1) {
 					String message = "Formatter configuration file contains multiple profiles: [";
-					message += profiles.stream().map(XmlParser::getProfileName).collect(Collectors.joining("; "));
+					message += profiles.stream().map(XmlParser::getProfileName).collect(joining("; "));
 					message += "]%n The formatter can only cope with a single profile per configuration file. Please remove the other profiles.";
 					throw new IllegalArgumentException(message);
 				}
@@ -325,7 +326,7 @@ public final class FormatterProperties {
 				return IntStream.range(0, children.getLength())
 						.mapToObj(children::item)
 						.filter(child -> child.getNodeName().equals(nodeName))
-						.collect(Collectors.toCollection(LinkedList::new));
+						.collect(toCollection(LinkedList::new));
 			}
 
 		};

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStep.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.List;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -44,8 +45,7 @@ public interface FormatterStep extends Serializable, AutoCloseable {
 	 *         if the formatter step doesn't have any changes to make
 	 * @throws Exception if the formatter step experiences a problem
 	 */
-	@Nullable
-	String format(String rawUnix, File file) throws Exception;
+	@Nullable String format(String rawUnix, File file) throws Exception;
 
 	/**
 	 * Returns a list of lints against the given file content
@@ -58,8 +58,7 @@ public interface FormatterStep extends Serializable, AutoCloseable {
 	 * @return a list of lints
 	 * @throws Exception if the formatter step experiences a problem
 	 */
-	@Nullable
-	default List<Lint> lint(String content, File file) throws Exception {
+	@Nullable default List<Lint> lint(String content, File file) throws Exception {
 		return List.of();
 	}
 
@@ -164,7 +163,7 @@ public interface FormatterStep extends Serializable, AutoCloseable {
 			String name,
 			State state,
 			SerializedFunction<State, FormatterFunc> stateToFormatter) {
-		Objects.requireNonNull(state, "state");
+		requireNonNull(state, "state");
 		return createLazy(name, () -> state, stateToFormatter);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
+++ b/lib/src/main/java/com/diffplug/spotless/FormatterStepSerializationRoundtrip.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -122,7 +123,7 @@ final class FormatterStepSerializationRoundtrip<RoundtripState extends Serializa
 		}
 
 		public FormatterStep rehydrate() {
-			return original != null ? original : Objects.requireNonNull(cleaned, "how is clean null if this has been serialized?");
+			return original != null ? original : requireNonNull(cleaned, "how is clean null if this has been serialized?");
 		}
 
 		@Override

--- a/lib/src/main/java/com/diffplug/spotless/JarState.java
+++ b/lib/src/main/java/com/diffplug/spotless/JarState.java
@@ -15,6 +15,9 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -25,7 +28,6 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
@@ -113,7 +115,7 @@ public final class JarState implements Serializable {
 
 	/** Provisions the given maven coordinate and its transitive dependencies. */
 	public static JarState from(String mavenCoordinate, Provisioner provisioner) throws IOException {
-		return from(Collections.singletonList(mavenCoordinate), provisioner);
+		return from(singletonList(mavenCoordinate), provisioner);
 	}
 
 	/** Provisions the given maven coordinates and their transitive dependencies. */
@@ -127,8 +129,8 @@ public final class JarState implements Serializable {
 	}
 
 	private static JarState provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates, Provisioner provisioner) throws IOException {
-		Objects.requireNonNull(mavenCoordinates, "mavenCoordinates");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(mavenCoordinates, "mavenCoordinates");
+		requireNonNull(provisioner, "provisioner");
 		Set<File> jars = provisioner.provisionWithTransitives(withTransitives, mavenCoordinates);
 		if (jars.isEmpty()) {
 			throw new NoSuchElementException("Resolved to an empty result: " + String.join(", ", mavenCoordinates));

--- a/lib/src/main/java/com/diffplug/spotless/Jvm.java
+++ b/lib/src/main/java/com/diffplug/spotless/Jvm.java
@@ -15,17 +15,18 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
-import java.util.Objects;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -88,7 +89,7 @@ public final class Jvm {
 		 * @return this
 		 */
 		public Support<V> add(int minimumJvmVersion, V maxFormatterVersion) {
-			Objects.requireNonNull(maxFormatterVersion);
+			requireNonNull(maxFormatterVersion);
 			if (jvm2fmtMaxVersion.put(minimumJvmVersion, maxFormatterVersion) != null) {
 				throw new IllegalArgumentException("Added duplicate entry for JVM %d+.".formatted(minimumJvmVersion));
 			}
@@ -100,7 +101,7 @@ public final class Jvm {
 		}
 
 		public Support<V> addMin(int minimumJvmVersion, V minFormatterVersion) {
-			Objects.requireNonNull(minFormatterVersion);
+			requireNonNull(minFormatterVersion);
 			if (jvm2fmtMinVersion.put(minimumJvmVersion, minFormatterVersion) != null) {
 				throw new IllegalArgumentException("Added duplicate entry for JVM %d+.".formatted(minimumJvmVersion));
 			}
@@ -136,7 +137,7 @@ public final class Jvm {
 		 * @throws IllegalArgumentException if {@code formatterVersion} not supported
 		 */
 		public void assertFormatterSupported(V formatterVersion) {
-			Objects.requireNonNull(formatterVersion);
+			requireNonNull(formatterVersion);
 			String error = buildUnsupportedFormatterMessage(formatterVersion);
 			if (!error.isEmpty()) {
 				throw Lint.atUndefinedLine(LINT_CODE, error).shortcut();
@@ -195,8 +196,8 @@ public final class Jvm {
 		 * @return Wrapped formatter function. Adding hint about later versions to exceptions.
 		 */
 		public FormatterFunc suggestLaterVersionOnError(V formatterVersion, FormatterFunc originalFunc) {
-			Objects.requireNonNull(formatterVersion);
-			Objects.requireNonNull(originalFunc);
+			requireNonNull(formatterVersion);
+			requireNonNull(originalFunc);
 			final String hintUnsupportedProblem = buildUnsupportedFormatterMessage(formatterVersion);
 			final String proposeDifferentFormatter = hintUnsupportedProblem.isEmpty() ? buildUpgradeFormatterMessage(formatterVersion) : hintUnsupportedProblem;
 			return proposeDifferentFormatter.isEmpty() ? originalFunc : new FormatterFunc() {
@@ -253,7 +254,7 @@ public final class Jvm {
 		public String toString() {
 			return "%s alternatives:%n".formatted(fmtName)
 					+ jvm2fmtMaxVersion.entrySet().stream().map(
-							e -> "- Version %s requires JVM %d+".formatted(e.getValue(), e.getKey())).collect(Collectors.joining(System.lineSeparator()));
+							e -> "- Version %s requires JVM %d+".formatted(e.getValue(), e.getKey())).collect(joining(System.lineSeparator()));
 		}
 
 		@SuppressFBWarnings("SE_COMPARATOR_SHOULD_BE_SERIALIZABLE")
@@ -261,8 +262,8 @@ public final class Jvm {
 
 			@Override
 			public int compare(V version0, V version1) {
-				Objects.requireNonNull(version0);
-				Objects.requireNonNull(version1);
+				requireNonNull(version0);
+				requireNonNull(version1);
 				int[] version0Items = convert(version0);
 				int[] version1Items = convert(version1);
 				int numberOfElements = version0Items.length > version1Items.length ? version0Items.length : version1Items.length;
@@ -299,7 +300,7 @@ public final class Jvm {
 	 * @return Empty map of supported formatters
 	 */
 	public static <V> Support<V> support(String formatterName) {
-		Objects.requireNonNull(formatterName);
+		requireNonNull(formatterName);
 		return new Support<>(formatterName);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/LazyForwardingEquality.java
+++ b/lib/src/main/java/com/diffplug/spotless/LazyForwardingEquality.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -24,7 +26,6 @@ import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -73,7 +74,7 @@ public abstract class LazyForwardingEquality<T extends Serializable> implements 
 	// override serialize input
 	@SuppressWarnings("unchecked")
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-		state = (T) Objects.requireNonNull(in.readObject());
+		state = (T) requireNonNull(in.readObject());
 	}
 
 	// override serialize input

--- a/lib/src/main/java/com/diffplug/spotless/LibPreconditions.java
+++ b/lib/src/main/java/com/diffplug/spotless/LibPreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package com.diffplug.spotless;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 final class LibPreconditions {
 	// prevent direct instantiation
 	private LibPreconditions() {}
 
 	static <T, I extends Iterable<T>> I requireElementsNonNull(I elements) {
-		Objects.requireNonNull(elements);
+		requireNonNull(elements);
 		for (Object element : elements) {
-			Objects.requireNonNull(element);
+			requireNonNull(element);
 		}
 		return elements;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/LineEnding.java
+++ b/lib/src/main/java/com/diffplug/spotless/LineEnding.java
@@ -15,6 +15,9 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -22,8 +25,6 @@ import java.io.Reader;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -61,8 +62,8 @@ public enum LineEnding {
 
 	/** Returns a {@link Policy} appropriate for files which are contained within the given rootFolder. */
 	public Policy createPolicy(File projectDir, Supplier<Iterable<File>> toFormat) {
-		Objects.requireNonNull(projectDir, "projectDir");
-		Objects.requireNonNull(toFormat, "toFormat");
+		requireNonNull(projectDir, "projectDir");
+		requireNonNull(toFormat, "toFormat");
 		String gitAttributesMethod;
 		if (this == GIT_ATTRIBUTES) {
 			gitAttributesMethod = "create";
@@ -114,7 +115,7 @@ public enum LineEnding {
         @Override
         public String getEndingFor(File file) {
             // assume US-ASCII encoding (only line ending characters need to be decoded anyways)
-            try (Reader reader = new FileReader(file, StandardCharsets.US_ASCII)) {
+            try (Reader reader = new FileReader(file, US_ASCII)) {
                 return getEndingFor(reader);
             } catch (IOException e) {
                 throw new IllegalArgumentException("Could not determine line ending of file: " + file, e);
@@ -186,7 +187,7 @@ public enum LineEnding {
 
 		/** Returns true iff this file has unix line endings. */
 		public default boolean isUnix(File file) {
-			Objects.requireNonNull(file);
+			requireNonNull(file);
 			String ending = getEndingFor(file);
 			return ending.equals(UNIX.str());
 		}

--- a/lib/src/main/java/com/diffplug/spotless/LintSuppression.java
+++ b/lib/src/main/java/com/diffplug/spotless/LintSuppression.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serial;
 import java.io.Serializable;
@@ -39,7 +41,7 @@ public class LintSuppression implements Serializable {
 		if (path.indexOf('\\') != -1) {
 			throw new IllegalArgumentException("Path must use only unix style path separator `/`, this was " + path);
 		}
-		this.path = Objects.requireNonNull(path);
+		this.path = requireNonNull(path);
 	}
 
 	public String getStep() {
@@ -47,7 +49,7 @@ public class LintSuppression implements Serializable {
 	}
 
 	public void setStep(String step) {
-		this.step = Objects.requireNonNull(step);
+		this.step = requireNonNull(step);
 	}
 
 	public String getShortCode() {
@@ -55,7 +57,7 @@ public class LintSuppression implements Serializable {
 	}
 
 	public void setShortCode(String shortCode) {
-		this.shortCode = Objects.requireNonNull(shortCode);
+		this.shortCode = requireNonNull(shortCode);
 	}
 
 	public boolean suppresses(String relativePath, FormatterStep formatterStep, Lint lint) {

--- a/lib/src/main/java/com/diffplug/spotless/MoreIterables.java
+++ b/lib/src/main/java/com/diffplug/spotless/MoreIterables.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless;
 
 import static com.diffplug.spotless.LibPreconditions.requireElementsNonNull;
+import static java.util.Comparator.naturalOrder;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,7 +41,7 @@ final class MoreIterables {
 
 	/** Sorts "raw" using {@link Comparator#naturalOrder()} and removes duplicates, throwing on null elements. */
 	static <T extends Comparable<T>> List<T> toSortedSet(Iterable<T> raw) {
-		return toSortedSet(raw, Comparator.naturalOrder());
+		return toSortedSet(raw, naturalOrder());
 	}
 
 	/** Sorts "raw" and removes duplicates, throwing on null elements. */

--- a/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
+++ b/lib/src/main/java/com/diffplug/spotless/PaddedCell.java
@@ -16,15 +16,16 @@
 package com.diffplug.spotless;
 
 import static com.diffplug.spotless.LibPreconditions.requireElementsNonNull;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Comparator.comparingInt;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * Models the result of applying a {@link Formatter} on a given {@link File}
@@ -48,8 +49,8 @@ public final class PaddedCell {
 	private final List<String> steps;
 
 	private PaddedCell(File file, Type type, List<String> steps) {
-		this.file = Objects.requireNonNull(file, "file");
-		this.type = Objects.requireNonNull(type, "type");
+		this.file = requireNonNull(file, "file");
+		this.type = requireNonNull(type, "type");
 		// defensive copy
 		this.steps = new ArrayList<>(steps);
 		requireElementsNonNull(this.steps);
@@ -67,7 +68,7 @@ public final class PaddedCell {
 
 	/** Returns the steps it takes to get to the result. */
 	public List<String> steps() {
-		return Collections.unmodifiableList(steps);
+		return unmodifiableList(steps);
 	}
 
 	/**
@@ -81,8 +82,8 @@ public final class PaddedCell {
 	 *
 	 */
 	public static PaddedCell check(Formatter formatter, File file) {
-		Objects.requireNonNull(formatter, "formatter");
-		Objects.requireNonNull(file, "file");
+		requireNonNull(formatter, "formatter");
+		requireNonNull(file, "file");
 		byte[] rawBytes = ThrowingEx.get(() -> Files.readAllBytes(file.toPath()));
 		String raw = new String(rawBytes, formatter.getEncoding());
 		String original = LineEnding.toUnix(raw);
@@ -153,7 +154,7 @@ public final class PaddedCell {
 		// @formatter:off
 		switch (type) {
 		case CONVERGE:	return steps.get(steps.size() - 1);
-		case CYCLE:		return Collections.min(steps, Comparator.comparingInt(String::length).thenComparing(Function.identity()));
+		case CYCLE:		return Collections.min(steps, comparingInt(String::length).thenComparing(identity()));
 		case DIVERGE:	throw new IllegalArgumentException("No canonical form for a diverging result");
 		default:	throw new IllegalArgumentException("Unknown type: " + type);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
+++ b/lib/src/main/java/com/diffplug/spotless/ProcessRunner.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.io.ByteArrayOutputStream;
@@ -23,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -223,11 +223,11 @@ public class ProcessRunner implements AutoCloseable {
 		}
 
 		public String stdOutUtf8() {
-			return new String(stdOut, StandardCharsets.UTF_8);
+			return new String(stdOut, UTF_8);
 		}
 
 		public String stdErrUtf8() {
-			return new String(stdErr, StandardCharsets.UTF_8);
+			return new String(stdErr, UTF_8);
 		}
 
 		/** Returns true if the exit code was not zero. */

--- a/lib/src/main/java/com/diffplug/spotless/SerializableFileFilterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/SerializableFileFilterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 package com.diffplug.spotless;
 
 import static com.diffplug.spotless.MoreIterables.toSortedSet;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 class SerializableFileFilterImpl {
 	static class SkipFilesNamed extends NoLambda.EqualityBasedOnSerialization implements SerializableFileFilter {
@@ -29,7 +29,7 @@ class SerializableFileFilterImpl {
 		private final String[] namesToSkip;
 
 		SkipFilesNamed(String... namesToSkip) {
-			Objects.requireNonNull(namesToSkip);
+			requireNonNull(namesToSkip);
 			List<String> sorted = toSortedSet(Arrays.asList(namesToSkip));
 			this.namesToSkip = sorted.toArray(new String[sorted.size()]);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
+++ b/lib/src/main/java/com/diffplug/spotless/SpotlessCache.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URLClassLoader;
@@ -23,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -43,7 +44,7 @@ public final class SpotlessCache {
 		final int hashCode;
 
 		SerializedKey(Serializable key) {
-			Objects.requireNonNull(key);
+			requireNonNull(key);
 			serialized = LazyForwardingEquality.toBytes(key);
 			hashCode = Arrays.hashCode(serialized);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeExecutableDownloader.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.biome;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
@@ -23,7 +25,6 @@ import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -201,7 +202,7 @@ final class BiomeExecutableDownloader {
 		}
 		try {
 			var actualChecksum = computeChecksum(filePath, CHECKSUM_ALGORITHM);
-			var expectedChecksum = readTextFile(checksumPath, StandardCharsets.ISO_8859_1);
+			var expectedChecksum = readTextFile(checksumPath, ISO_8859_1);
 			LOGGER.debug("Expected checksum: {}, actual checksum: {}", expectedChecksum, actualChecksum);
 			return Objects.equals(expectedChecksum, actualChecksum);
 		} catch (final IOException ignored) {
@@ -363,7 +364,7 @@ final class BiomeExecutableDownloader {
 	private void writeChecksumFile(Path file, Path checksumPath) throws IOException {
 		var checksum = computeChecksum(file, CHECKSUM_ALGORITHM);
 		try (var out = Files.newOutputStream(checksumPath, WRITE_OPTIONS)) {
-			out.write(checksum.getBytes(StandardCharsets.ISO_8859_1));
+			out.write(checksum.getBytes(ISO_8859_1));
 		}
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/biome/BiomeStep.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless.biome;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
@@ -418,7 +419,7 @@ public final class BiomeStep {
 		 *                              for Biome to finish formatting.
 		 */
 		private String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
-			var stdin = input.getBytes(StandardCharsets.UTF_8);
+			var stdin = input.getBytes(UTF_8);
 			var args = buildBiomeCommand(file);
 			if (LOGGER.isDebugEnabled()) {
 				LOGGER.debug("Running Biome command to format code: '{}'", String.join(", ", args));
@@ -428,7 +429,7 @@ public final class BiomeStep {
 			if (!stdErr.isEmpty()) {
 				LOGGER.warn("Biome stderr ouptut for file '{}'\n{}", file, stdErr.trim());
 			}
-			var formatted = runnerResult.assertExitZero(StandardCharsets.UTF_8);
+			var formatted = runnerResult.assertExitZero(UTF_8);
 			// When biome encounters an ignored file, it does not output any formatted code
 			// Ignored files come from (a) the biome.json configuration file and (b) from
 			// a list of hard-coded file names, such as package.json or tsconfig.json.

--- a/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/cpp/ClangFormatStep.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.spotless.cpp;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -116,7 +117,7 @@ public final class ClangFormatStep {
 		EqualityState(String version, @Nullable String style, ForeignExe pathToExe) {
 			this.version = version;
 			this.style = style;
-			this.exe = Objects.requireNonNull(pathToExe);
+			this.exe = requireNonNull(pathToExe);
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
@@ -130,7 +131,7 @@ public final class ClangFormatStep {
 			}
 			final String[] processArgs = args.toArray(new String[args.size() + 1]);
 			processArgs[processArgs.length - 1] = "--assume-filename=" + file.getName();
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), processArgs).assertExitZero(StandardCharsets.UTF_8);
+			return runner.exec(input.getBytes(UTF_8), processArgs).assertExitZero(UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/cpp/CppDefaults.java
+++ b/lib/src/main/java/com/diffplug/spotless/cpp/CppDefaults.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.cpp;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 /** Common utilities for C/C++ */
 public final class CppDefaults {
@@ -37,6 +38,6 @@ public final class CppDefaults {
 			"int8_t", "int16_t", "int32_t", "int64_t",
 			"__int8_t", "__int16_t", "__int32_t", "__int64_t",
 			"uint8_t", "uint16_t", "uint32_t", "uint64_t")
-			.stream().map(s -> "(?<![0-9a-zA-Z]+)" + s.replaceAll("#", "\\\\#").replaceAll(" ", "[\\\\n\\\\s]+") + "[\\*\\s\\n]+").collect(Collectors.joining("|"));
+			.stream().map(s -> "(?<![0-9a-zA-Z]+)" + s.replaceAll("#", "\\\\#").replaceAll(" ", "[\\\\n\\\\s]+") + "[\\*\\s\\n]+").collect(joining("|"));
 
 }

--- a/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -53,7 +54,7 @@ public final class FenceStep {
 	Pattern regex;
 
 	private FenceStep(String name) {
-		this.name = Objects.requireNonNull(name);
+		this.name = requireNonNull(name);
 	}
 
 	/** Defines the opening and closing markers. */
@@ -68,12 +69,12 @@ public final class FenceStep {
 
 	/** Defines the pipe via regex. Must have *exactly one* capturing group. */
 	public FenceStep regex(Pattern regex) {
-		this.regex = Objects.requireNonNull(regex);
+		this.regex = requireNonNull(regex);
 		return this;
 	}
 
 	private void assertRegexSet() {
-		Objects.requireNonNull(regex, "must call regex() or openClose()");
+		requireNonNull(regex, "must call regex() or openClose()");
 	}
 
 	/** Returns a step which will apply the given steps but preserve the content selected by the regex / openClose pair. */
@@ -159,7 +160,7 @@ public final class FenceStep {
 
 		protected Formatter buildFormatter() {
 			return Formatter.builder()
-					.encoding(StandardCharsets.UTF_8) // can be any UTF, doesn't matter
+					.encoding(UTF_8) // can be any UTF, doesn't matter
 					.lineEndingsPolicy(LineEnding.UNIX.createPolicy()) // just internal, won't conflict with user
 					.steps(steps)
 					.build();

--- a/lib/src/main/java/com/diffplug/spotless/generic/IdeaStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/IdeaStep.java
@@ -15,23 +15,24 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.TreeMap;
-import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.CheckForNull;
@@ -65,7 +66,7 @@ public final class IdeaStep {
 	}
 
 	public static IdeaStepBuilder newBuilder(@Nonnull File buildDir) {
-		return new IdeaStepBuilder(Objects.requireNonNull(buildDir));
+		return new IdeaStepBuilder(requireNonNull(buildDir));
 	}
 
 	private static FormatterStep create(IdeaStepBuilder builder) {
@@ -77,7 +78,7 @@ public final class IdeaStep {
 	}
 
 	private State createState() {
-		return new State(Objects.requireNonNull(builder));
+		return new State(requireNonNull(builder));
 	}
 
 	public static final class IdeaStepBuilder {
@@ -92,7 +93,7 @@ public final class IdeaStep {
 		private final File buildDir;
 
 		private IdeaStepBuilder(@Nonnull File buildDir) {
-			this.buildDir = Objects.requireNonNull(buildDir);
+			this.buildDir = requireNonNull(buildDir);
 		}
 
 		public IdeaStepBuilder setUseDefaults(boolean useDefaults) {
@@ -101,7 +102,7 @@ public final class IdeaStep {
 		}
 
 		public IdeaStepBuilder setBinaryPath(@Nonnull String binaryPath) {
-			this.binaryPath = Objects.requireNonNull(binaryPath);
+			this.binaryPath = requireNonNull(binaryPath);
 			return this;
 		}
 
@@ -145,7 +146,7 @@ public final class IdeaStep {
 
 		private State(@Nonnull IdeaStepBuilder builder) {
 			LOGGER.debug("Creating {} state with configuration {}", NAME, builder);
-			this.uniqueBuildFolder = new File(builder.buildDir, UUID.randomUUID().toString());
+			this.uniqueBuildFolder = new File(builder.buildDir, randomUUID().toString());
 			this.withDefaults = builder.useDefaults;
 			this.codeStyleSettingsPath = builder.codeStyleSettingsPath;
 			this.ideaProperties = new TreeMap<>(builder.ideaProperties);
@@ -215,7 +216,7 @@ public final class IdeaStep {
 			// since we cannot directly work with the file, we need to write the unix string to a temporary file
 			File tempFile = Files.createTempFile("spotless", file.getName()).toFile();
 			try {
-				Files.write(tempFile.toPath(), unix.getBytes(StandardCharsets.UTF_8));
+				Files.write(tempFile.toPath(), unix.getBytes(UTF_8));
 				List<String> params = getParams(tempFile);
 
 				Map<String, String> env = createEnv();
@@ -223,7 +224,7 @@ public final class IdeaStep {
 				var result = ideaStepFormatterCleanupResources.runner.exec(null, env, null, params);
 				LOGGER.debug("command finished with exit code: {}", result.exitCode());
 				LOGGER.debug("command finished with stdout: {}",
-						result.assertExitZero(StandardCharsets.UTF_8));
+						result.assertExitZero(UTF_8));
 				return Files.readString(tempFile.toPath());
 			} finally {
 				Files.delete(tempFile.toPath());
@@ -280,7 +281,7 @@ public final class IdeaStep {
 			}
 			builder.add("-charset").add("UTF-8");
 			builder.add(ThrowingEx.get(file::getCanonicalPath));
-			return builder.build().collect(Collectors.toList());
+			return builder.build().collect(toList());
 		}
 
 		private FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/generic/Jsr223Step.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/Jsr223Step.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.script.ScriptEngine;
@@ -43,9 +44,9 @@ public final class Jsr223Step implements Serializable {
 	}
 
 	public static FormatterStep create(String name, @Nullable String dependency, CharSequence engine, CharSequence script, Provisioner provisioner) {
-		Objects.requireNonNull(name, "name");
-		Objects.requireNonNull(engine, "engine");
-		Objects.requireNonNull(script, "script");
+		requireNonNull(name, "name");
+		requireNonNull(engine, "engine");
+		requireNonNull(script, "script");
 		return FormatterStep.create(name,
 				new Jsr223Step(dependency == null ? null : JarState.promise(() -> JarState.from(dependency, provisioner)), engine.toString(), script.toString()),
 				Jsr223Step::equalityState,
@@ -81,7 +82,7 @@ public final class Jsr223Step implements Serializable {
 
 			if (scriptEngine == null) {
 				throw new IllegalArgumentException("Unknown script engine '" + engine + "'. Available engines: "
-						+ scriptEngineManager.getEngineFactories().stream().flatMap(f -> f.getNames().stream()).collect(Collectors.joining(", ")));
+						+ scriptEngineManager.getEngineFactories().stream().flatMap(f -> f.getNames().stream()).collect(joining(", ")));
 			}
 
 			// evaluate script code

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -15,6 +15,10 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.regex.Pattern.MULTILINE;
+import static java.util.regex.Pattern.UNIX_LINES;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -73,10 +77,10 @@ public final class LicenseHeaderStep {
 	private LicenseHeaderStep(@Nullable String name, @Nullable String contentPattern, ThrowingEx.Supplier<String> headerLazy, String delimiter, String yearSeparator, Supplier<YearMode> yearMode, @Nullable String skipLinesMatching) {
 		this.name = sanitizeName(name);
 		this.contentPattern = sanitizePattern(contentPattern);
-		this.headerLazy = Objects.requireNonNull(headerLazy);
-		this.delimiter = Objects.requireNonNull(delimiter);
-		this.yearSeparator = Objects.requireNonNull(yearSeparator);
-		this.yearMode = Objects.requireNonNull(yearMode);
+		this.headerLazy = requireNonNull(headerLazy);
+		this.delimiter = requireNonNull(delimiter);
+		this.yearSeparator = requireNonNull(yearSeparator);
+		this.yearMode = requireNonNull(yearMode);
 		this.skipLinesMatching = sanitizePattern(skipLinesMatching);
 	}
 
@@ -234,7 +238,7 @@ public final class LicenseHeaderStep {
 			if (!licenseHeader.isEmpty() && !licenseHeader.endsWith("\n")) {
 				licenseHeader = licenseHeader + "\n";
 			}
-			this.delimiterPattern = Pattern.compile('^' + delimiter, Pattern.UNIX_LINES | Pattern.MULTILINE);
+			this.delimiterPattern = Pattern.compile('^' + delimiter, UNIX_LINES | MULTILINE);
 			this.skipLinesMatching = skipLinesMatching == null ? null : Pattern.compile(skipLinesMatching);
 			this.hasFileToken = FILENAME_PATTERN.matcher(licenseHeader).find();
 

--- a/lib/src/main/java/com/diffplug/spotless/generic/NativeCmdStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/NativeCmdStep.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterFunc;
@@ -33,8 +34,8 @@ public final class NativeCmdStep {
 	private NativeCmdStep() {}
 
 	public static FormatterStep create(String name, File pathToExe, List<String> arguments) {
-		Objects.requireNonNull(name, "name");
-		Objects.requireNonNull(pathToExe, "pathToExe");
+		requireNonNull(name, "name");
+		requireNonNull(pathToExe, "pathToExe");
 		return FormatterStep.createLazy(name, () -> new State(FileSignature.promise(pathToExe), arguments), State::toRuntime, Runtime::toFunc);
 	}
 
@@ -69,7 +70,7 @@ public final class NativeCmdStep {
 			if (arguments != null) {
 				argumentsWithPathToExe.addAll(arguments);
 			}
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), argumentsWithPathToExe).assertExitZero(StandardCharsets.UTF_8);
+			return runner.exec(input.getBytes(UTF_8), argumentsWithPathToExe).assertExitZero(UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/generic/ReplaceRegexStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/ReplaceRegexStep.java
@@ -15,11 +15,14 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.regex.Pattern.MULTILINE;
+import static java.util.regex.Pattern.UNIX_LINES;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.diffplug.spotless.FormatterFunc;
@@ -31,20 +34,20 @@ public final class ReplaceRegexStep {
 	private ReplaceRegexStep() {}
 
 	public static FormatterStep create(String name, String regex, String replacement) {
-		Objects.requireNonNull(name, "name");
-		Objects.requireNonNull(regex, "regex");
-		Objects.requireNonNull(replacement, "replacement");
+		requireNonNull(name, "name");
+		requireNonNull(regex, "regex");
+		requireNonNull(replacement, "replacement");
 		return FormatterStep.createLazy(name,
-				() -> new State(Pattern.compile(regex, Pattern.UNIX_LINES | Pattern.MULTILINE), replacement),
+				() -> new State(Pattern.compile(regex, UNIX_LINES | MULTILINE), replacement),
 				State::toFormatter);
 	}
 
 	public static FormatterStep lint(String name, String regex, String lintDetail) {
-		Objects.requireNonNull(name, "name");
-		Objects.requireNonNull(regex, "regex");
-		Objects.requireNonNull(lintDetail, "lintDetail");
+		requireNonNull(name, "name");
+		requireNonNull(regex, "regex");
+		requireNonNull(lintDetail, "lintDetail");
 		return FormatterStep.createLazy(name,
-				() -> new LintState(Pattern.compile(regex, Pattern.UNIX_LINES | Pattern.MULTILINE), name, lintDetail),
+				() -> new LintState(Pattern.compile(regex, UNIX_LINES | MULTILINE), name, lintDetail),
 				LintState::toLinter);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/generic/ReplaceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/ReplaceStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serializable;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -26,9 +27,9 @@ public final class ReplaceStep {
 	private ReplaceStep() {}
 
 	public static FormatterStep create(String name, CharSequence target, CharSequence replacement) {
-		Objects.requireNonNull(name, "name");
-		Objects.requireNonNull(target, "target");
-		Objects.requireNonNull(replacement, "replacement");
+		requireNonNull(name, "name");
+		requireNonNull(target, "target");
+		requireNonNull(replacement, "replacement");
 		return FormatterStep.createLazy(name,
 				() -> new State(target, replacement),
 				State::toFormatter);

--- a/lib/src/main/java/com/diffplug/spotless/generic/TestEnvVars.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/TestEnvVars.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -72,7 +73,7 @@ final class TestEnvVars {
 		builder.add(
 				Path.of(System.getProperty("user.dir"), "testenv.properties"));
 		builder.add(
-				Objects.requireNonNull(Path.of(System.getProperty("user.dir")).getParent()).resolve("testenv.properties"));
+				requireNonNull(Path.of(System.getProperty("user.dir")).getParent()).resolve("testenv.properties"));
 		return builder.build();
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/gherkin/GherkinUtilsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/gherkin/GherkinUtilsStep.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless.gherkin;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -47,7 +48,7 @@ public final class GherkinUtilsStep implements Serializable {
 
 	public static FormatterStep create(GherkinUtilsConfig gherkinSimpleConfig,
 			String formatterVersion, Provisioner provisioner) {
-		Objects.requireNonNull(provisioner, "provisioner cannot be null");
+		requireNonNull(provisioner, "provisioner cannot be null");
 		return FormatterStep.create(NAME,
 				new GherkinUtilsStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + formatterVersion, provisioner)), gherkinSimpleConfig),
 				GherkinUtilsStep::equalityState,

--- a/lib/src/main/java/com/diffplug/spotless/go/GofmtFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/go/GofmtFormatStep.java
@@ -15,14 +15,15 @@
  */
 package com.diffplug.spotless.go;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -104,7 +105,7 @@ public final class GofmtFormatStep {
 
 		public EqualityState(String version, ForeignExe goExecutable) {
 			this.version = version;
-			this.exe = Objects.requireNonNull(goExecutable);
+			this.exe = requireNonNull(goExecutable);
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
@@ -116,7 +117,7 @@ public final class GofmtFormatStep {
 			}
 			String pathToGoFmt = goBasePath.resolve("gofmt").toString();
 			processArgs.add(pathToGoFmt);
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), processArgs).assertExitZero(StandardCharsets.UTF_8);
+			return runner.exec(input.getBytes(UTF_8), processArgs).assertExitZero(UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/java/CleanthatJavaStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/CleanthatJavaStep.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.java;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serial;
 import java.io.Serializable;
@@ -22,7 +24,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
 
 import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterFunc;
@@ -111,12 +112,12 @@ public final class CleanthatJavaStep implements Serializable {
 			List<String> excluded,
 			boolean includeDraft,
 			Provisioner provisioner) {
-		Objects.requireNonNull(groupArtifact, "groupArtifact");
+		requireNonNull(groupArtifact, "groupArtifact");
 		if (groupArtifact.chars().filter(ch -> ch == ':').count() != 1) {
 			throw new IllegalArgumentException("groupArtifact must be in the form 'groupId:artifactId'. it was: " + groupArtifact);
 		}
-		Objects.requireNonNull(version, "version");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(version, "version");
+		requireNonNull(provisioner, "provisioner");
 		return FormatterStep.create(stepName,
 				new CleanthatJavaStep(JarState.promise(() -> JarState.from(groupArtifact + ":" + version, provisioner)), version, sourceJdkVersion, included, excluded, includeDraft),
 				CleanthatJavaStep::equalityState,
@@ -136,7 +137,7 @@ public final class CleanthatJavaStep implements Serializable {
 
 	/** Get default formatter version */
 	public static String defaultVersion() {
-		return Objects.requireNonNull(JVM_SUPPORT.getRecommendedFormatterVersion());
+		return requireNonNull(JVM_SUPPORT.getRecommendedFormatterVersion());
 	}
 
 	public static String defaultGroupArtifact() {

--- a/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/FormatAnnotationsStep.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.java;
 
+import static java.util.Collections.emptyList;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -417,7 +418,7 @@ public final class FormatAnnotationsStep implements Serializable {
 	private static final String NAME = "No line break between type annotation and type";
 
 	public static FormatterStep create() {
-		return create(Collections.emptyList(), Collections.emptyList());
+		return create(emptyList(), emptyList());
 	}
 
 	public static FormatterStep create(List<String> addedTypeAnnotations, List<String> removedTypeAnnotations) {

--- a/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.java;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -97,13 +98,13 @@ public final class GoogleJavaFormatStep implements Serializable {
 	}
 
 	private static FormatterStep createInternally(String name, String groupArtifact, String version, String style, Provisioner provisioner, boolean reflowLongStrings, boolean reorderImports, boolean formatJavadoc, boolean removeImports) {
-		Objects.requireNonNull(groupArtifact, "groupArtifact");
+		requireNonNull(groupArtifact, "groupArtifact");
 		if (groupArtifact.chars().filter(ch -> ch == ':').count() != 1) {
 			throw new IllegalArgumentException("groupArtifact must be in the form 'groupId:artifactId'");
 		}
-		Objects.requireNonNull(version, "version");
-		Objects.requireNonNull(style, "style");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(version, "version");
+		requireNonNull(style, "style");
+		requireNonNull(provisioner, "provisioner");
 
 		GoogleJavaFormatStep step = new GoogleJavaFormatStep(JarState.promise(() -> JarState.from(groupArtifact + ":" + version, provisioner)), version, style, reflowLongStrings, reorderImports, formatJavadoc);
 		if (removeImports) {
@@ -131,7 +132,7 @@ public final class GoogleJavaFormatStep implements Serializable {
 
 	/** Get default formatter version */
 	public static String defaultVersion() {
-		return Objects.requireNonNull(JVM_SUPPORT.getRecommendedFormatterVersion());
+		return requireNonNull(JVM_SUPPORT.getRecommendedFormatterVersion());
 	}
 
 	public static String defaultStyle() {

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportOrderStep.java
@@ -16,6 +16,9 @@
 package com.diffplug.spotless.java;
 
 import static com.diffplug.spotless.java.LibJavaPreconditions.requireElementsNonNull;
+import static java.util.Map.Entry.comparingByKey;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,11 +31,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -82,7 +83,7 @@ public final class ImportOrderStep implements Serializable {
 
 	public FormatterStep createFrom(boolean wildcardsLast, boolean semanticSort, Set<String> treatAsPackage,
 			Set<String> treatAsClass, File importsFile) {
-		Objects.requireNonNull(importsFile);
+		requireNonNull(importsFile);
 		return createFrom(wildcardsLast, semanticSort, treatAsPackage, treatAsClass, () -> getImportOrder(importsFile));
 	}
 
@@ -99,9 +100,9 @@ public final class ImportOrderStep implements Serializable {
 			return lines.filter(line -> !line.startsWith("#"))
 					// parse 0=input
 					.map(ImportOrderStep::splitIntoIndexAndName)
-					.sorted(Map.Entry.comparingByKey())
+					.sorted(comparingByKey())
 					.map(Map.Entry::getValue)
-					.collect(Collectors.toCollection(ArrayList::new));
+					.collect(toCollection(ArrayList::new));
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorterImpl.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.java;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -57,7 +58,7 @@ final class ImportSorterImpl {
 			this.subGroups = Stream.of(importOrder.split("\\" + SUBGROUP_SEPARATOR, -1))
 					.map(this::normalizeStatic)
 					.filter(group -> !knownGroupings.contains(group))
-					.collect(Collectors.toList());
+					.collect(toList());
 			knownGroupings.addAll(this.subGroups);
 		}
 
@@ -91,7 +92,7 @@ final class ImportSorterImpl {
 
 	private ImportSorterImpl(List<String> importOrder, boolean wildcardsLast, boolean semanticSort,
 			Set<String> treatAsPackage, Set<String> treatAsClass) {
-		importsGroups = importOrder.stream().filter(Objects::nonNull).map(order -> new ImportsGroup(order, knownGroupings)).collect(Collectors.toList());
+		importsGroups = importOrder.stream().filter(Objects::nonNull).map(order -> new ImportsGroup(order, knownGroupings)).collect(toList());
 		putStaticItemIfNotExists(importsGroups);
 		putCatchAllGroupIfNotExists(importsGroups);
 
@@ -101,7 +102,7 @@ final class ImportSorterImpl {
 			ordering = new LexicographicalOrderingComparator(wildcardsLast);
 		}
 
-		List<String> subgroups = importsGroups.stream().map(ImportsGroup::getSubGroups).flatMap(Collection::stream).collect(Collectors.toList());
+		List<String> subgroups = importsGroups.stream().map(ImportsGroup::getSubGroups).flatMap(Collection::stream).collect(toList());
 		this.allImportOrderItems.addAll(subgroups);
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/java/LibJavaPreconditions.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/LibJavaPreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package com.diffplug.spotless.java;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 final class LibJavaPreconditions {
 	// prevent direct instantiation
 	private LibJavaPreconditions() {}
 
 	static <T, I extends Iterable<T>> I requireElementsNonNull(I elements) {
-		Objects.requireNonNull(elements);
+		requireNonNull(elements);
 		for (Object element : elements) {
-			Objects.requireNonNull(element);
+			requireNonNull(element);
 		}
 		return elements;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/PalantirJavaFormatStep.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.java;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -77,9 +78,9 @@ public final class PalantirJavaFormatStep implements Serializable {
 	 * format style.
 	 */
 	public static FormatterStep create(String version, String style, boolean formatJavadoc, Provisioner provisioner) {
-		Objects.requireNonNull(version, "version");
-		Objects.requireNonNull(style, "style");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(version, "version");
+		requireNonNull(style, "style");
+		requireNonNull(provisioner, "provisioner");
 
 		return FormatterStep.create(NAME,
 				new PalantirJavaFormatStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + version, provisioner)), version, style, formatJavadoc),

--- a/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedImportsStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/RemoveUnusedImportsStep.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.java;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.Provisioner;
@@ -48,7 +49,7 @@ public final class RemoveUnusedImportsStep implements Serializable {
 	}
 
 	public static FormatterStep create(String unusedImportRemover, Provisioner provisioner) {
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(provisioner, "provisioner");
 		switch (unusedImportRemover) {
 		case GJF:
 			return GoogleJavaFormatStep.createRemoveUnusedImportsOnly(provisioner);

--- a/lib/src/main/java/com/diffplug/spotless/json/JacksonConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JacksonConfig.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.spotless.json;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -42,7 +43,7 @@ public class JacksonConfig implements Serializable {
 	protected Map<String, Boolean> featureToToggle = new TreeMap<>(DEFAULT_FEATURE_TOGGLES);
 
 	public Map<String, Boolean> getFeatureToToggle() {
-		return Collections.unmodifiableMap(featureToToggle);
+		return unmodifiableMap(featureToToggle);
 	}
 
 	public void setFeatureToToggle(Map<String, Boolean> featureToToggle) {

--- a/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonConfig.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.json;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.io.Serial;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -34,7 +35,7 @@ public class JacksonJsonConfig extends JacksonConfig {
 	protected boolean spaceBeforeSeparator;
 
 	public Map<String, Boolean> getJsonFeatureToToggle() {
-		return Collections.unmodifiableMap(jsonFeatureToToggle);
+		return unmodifiableMap(jsonFeatureToToggle);
 	}
 
 	/**

--- a/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JacksonJsonStep.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless.json;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -56,7 +57,7 @@ public final class JacksonJsonStep implements Serializable {
 	public static FormatterStep create(JacksonJsonConfig jacksonConfig,
 			String jacksonVersion,
 			Provisioner provisioner) {
-		Objects.requireNonNull(provisioner, "provisioner cannot be null");
+		requireNonNull(provisioner, "provisioner cannot be null");
 		return FormatterStep.create(NAME,
 				new JacksonJsonStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + jacksonVersion, provisioner)), jacksonConfig),
 				JacksonJsonStep::equalityState,

--- a/lib/src/main/java/com/diffplug/spotless/json/JsonPatchStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JsonPatchStep.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.spotless.json;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -54,9 +55,9 @@ public final class JsonPatchStep implements Serializable {
 	}
 
 	public static FormatterStep create(String zjsonPatchVersion, String patchString, Provisioner provisioner) {
-		Objects.requireNonNull(zjsonPatchVersion, "zjsonPatchVersion cannot be null");
-		Objects.requireNonNull(patchString, "patchString cannot be null");
-		Objects.requireNonNull(provisioner, "provisioner cannot be null");
+		requireNonNull(zjsonPatchVersion, "zjsonPatchVersion cannot be null");
+		requireNonNull(patchString, "patchString cannot be null");
+		requireNonNull(provisioner, "provisioner cannot be null");
 		return FormatterStep.create(NAME,
 				new JsonPatchStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + ":" + zjsonPatchVersion, provisioner)), patchString, null),
 				JsonPatchStep::equalityState,
@@ -68,9 +69,9 @@ public final class JsonPatchStep implements Serializable {
 	}
 
 	public static FormatterStep create(String zjsonPatchVersion, List<Map<String, Object>> patch, Provisioner provisioner) {
-		Objects.requireNonNull(zjsonPatchVersion, "zjsonPatchVersion cannot be null");
-		Objects.requireNonNull(patch, "patch cannot be null");
-		Objects.requireNonNull(provisioner, "provisioner cannot be null");
+		requireNonNull(zjsonPatchVersion, "zjsonPatchVersion cannot be null");
+		requireNonNull(patch, "patch cannot be null");
+		requireNonNull(provisioner, "provisioner cannot be null");
 		return FormatterStep.create(NAME,
 				new JsonPatchStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + ":" + zjsonPatchVersion, provisioner)), null, patch),
 				JsonPatchStep::equalityState,

--- a/lib/src/main/java/com/diffplug/spotless/json/JsonSimpleStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/JsonSimpleStep.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.json;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -46,7 +47,7 @@ public final class JsonSimpleStep implements Serializable {
 	}
 
 	public static FormatterStep create(int indent, Provisioner provisioner) {
-		Objects.requireNonNull(provisioner, "provisioner cannot be null");
+		requireNonNull(provisioner, "provisioner cannot be null");
 		return FormatterStep.create(NAME,
 				new JsonSimpleStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + DEFAULT_VERSION, provisioner)), indent),
 				JsonSimpleStep::equalityState,

--- a/lib/src/main/java/com/diffplug/spotless/json/gson/GsonStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/json/gson/GsonStep.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless.json.gson;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -43,7 +44,7 @@ public final class GsonStep implements Serializable {
 	}
 
 	public static FormatterStep create(GsonConfig gsonConfig, Provisioner provisioner) {
-		Objects.requireNonNull(provisioner, "provisioner cannot be null");
+		requireNonNull(provisioner, "provisioner cannot be null");
 		return FormatterStep.create(NAME,
 				new GsonStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATES + ":" + gsonConfig.getVersion(), provisioner)), gsonConfig),
 				GsonStep::equalityState,

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/DiktatStep.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless.kotlin;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -74,8 +75,8 @@ public final class DiktatStep implements Serializable {
 		if (BadSemver.version(versionDiktat) < BadSemver.version(MIN_SUPPORTED_VERSION)) {
 			throw new IllegalStateException("Minimum required Diktat version is " + MIN_SUPPORTED_VERSION + ", you tried " + versionDiktat + " which is too old");
 		}
-		Objects.requireNonNull(versionDiktat, "versionDiktat");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(versionDiktat, "versionDiktat");
+		requireNonNull(provisioner, "provisioner");
 		final String diktatCoordinate;
 		if (BadSemver.version(versionDiktat) >= BadSemver.version(PACKAGE_RELOCATED_VERSION)) {
 			diktatCoordinate = MAVEN_COORDINATE + versionDiktat;

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtLintStep.java
@@ -15,14 +15,16 @@
  */
 package com.diffplug.spotless.kotlin;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -63,7 +65,7 @@ public final class KtLintStep implements Serializable {
 	}
 
 	public static FormatterStep create(String version, Provisioner provisioner) {
-		return create(version, provisioner, null, Collections.emptyMap(), Collections.emptyList());
+		return create(version, provisioner, null, emptyMap(), emptyList());
 	}
 
 	public static FormatterStep create(String version,
@@ -71,8 +73,8 @@ public final class KtLintStep implements Serializable {
 			@Nullable FileSignature editorConfig,
 			Map<String, Object> editorConfigOverride,
 			List<String> customRuleSets) {
-		Objects.requireNonNull(version, "version");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(version, "version");
+		requireNonNull(provisioner, "provisioner");
 		String ktlintCoordinate = (version.startsWith("0.") ? MAVEN_COORDINATE_0_DOT : MAVEN_COORDINATE_1_DOT) + version;
 		Set<String> mavenCoordinates = new HashSet<>(customRuleSets);
 		mavenCoordinates.add(ktlintCoordinate);

--- a/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/kotlin/KtfmtStep.java
@@ -19,13 +19,14 @@ import static com.diffplug.spotless.kotlin.KtfmtStep.Style.DEFAULT;
 import static com.diffplug.spotless.kotlin.KtfmtStep.Style.DROPBOX;
 import static com.diffplug.spotless.kotlin.KtfmtStep.Style.META;
 import static com.diffplug.spotless.kotlin.KtfmtStep.TrailingCommaManagementStrategy.ONLY_ADD;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -60,10 +61,10 @@ public final class KtfmtStep implements Serializable {
 			JarState.Promised jarState,
 			@Nullable Style style,
 			@Nullable KtfmtFormattingOptions options) {
-		this.version = Objects.requireNonNull(version, "version");
+		this.version = requireNonNull(version, "version");
 		this.style = style;
 		this.options = options;
-		this.jarState = Objects.requireNonNull(jarState, "jarState");
+		this.jarState = requireNonNull(jarState, "jarState");
 	}
 
 	/**
@@ -210,8 +211,8 @@ public final class KtfmtStep implements Serializable {
 	 * Creates a step which formats everything - code, import order, and unused imports.
 	 */
 	public static FormatterStep create(String version, Provisioner provisioner, @Nullable Style style, @Nullable KtfmtFormattingOptions options) {
-		Objects.requireNonNull(version, "version");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(version, "version");
+		requireNonNull(provisioner, "provisioner");
 		return FormatterStep.create(NAME,
 				new KtfmtStep(version, JarState.promise(() -> JarState.from(MAVEN_COORDINATE + version, provisioner)), style, options),
 				KtfmtStep::equalityState,
@@ -389,45 +390,45 @@ public final class KtfmtStep implements Serializable {
 			if (options != null) {
 				if (BadSemver.version(version) < BadSemver.version(0, 17)) {
 					formattingOptions = formattingOptions.getClass().getConstructor(int.class, int.class, int.class).newInstance(
-							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)));
+							/* maxWidth = */ requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)));
 				} else if (BadSemver.version(version) < BadSemver.version(0, 19)) {
 					formattingOptions = formattingOptions.getClass().getConstructor(int.class, int.class, int.class, boolean.class, boolean.class).newInstance(
-							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions));
 				} else if (BadSemver.version(version) < BadSemver.version(0, 47)) {
 					Class<?> styleClass = classLoader.loadClass(formattingOptionsClass.getName() + "$Style");
 					formattingOptions = formattingOptions.getClass().getConstructor(styleClass, int.class, int.class, int.class, boolean.class, boolean.class).newInstance(
 							/* style = */ formattingOptionsClass.getMethod("getStyle").invoke(formattingOptions),
-							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions));
 				} else if (BadSemver.version(version) < BadSemver.version(0, 57)) {
 					Class<?> styleClass = classLoader.loadClass(formattingOptionsClass.getName() + "$Style");
 					formattingOptions = formattingOptions.getClass().getConstructor(styleClass, int.class, int.class, int.class, boolean.class, boolean.class, boolean.class).newInstance(
 							/* style = */ formattingOptionsClass.getMethod("getStyle").invoke(formattingOptions),
-							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions),
-							/* manageTrailingCommas = */ Objects.requireNonNullElse(getManageTrailingCommasFrom(options.trailingCommaManagementStrategy), (Boolean) formattingOptionsClass.getMethod("getManageTrailingCommas").invoke(formattingOptions)));
+							/* manageTrailingCommas = */ requireNonNullElse(getManageTrailingCommasFrom(options.trailingCommaManagementStrategy), (Boolean) formattingOptionsClass.getMethod("getManageTrailingCommas").invoke(formattingOptions)));
 				} else {
 					Class<?> styleClass = classLoader.loadClass(formattingOptionsClass.getName() + "$Style");
 					formattingOptions = formattingOptions.getClass().getConstructor(styleClass, int.class, int.class, int.class, boolean.class, boolean.class, TrailingCommaManagementStrategy.class).newInstance(
 							/* style = */ formattingOptionsClass.getMethod("getStyle").invoke(formattingOptions),
-							/* maxWidth = */ Objects.requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
-							/* blockIndent = */ Objects.requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
-							/* continuationIndent = */ Objects.requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
-							/* removeUnusedImports = */ Objects.requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
+							/* maxWidth = */ requireNonNullElse(options.maxWidth, (Integer) formattingOptionsClass.getMethod("getMaxWidth").invoke(formattingOptions)),
+							/* blockIndent = */ requireNonNullElse(options.blockIndent, (Integer) formattingOptionsClass.getMethod("getBlockIndent").invoke(formattingOptions)),
+							/* continuationIndent = */ requireNonNullElse(options.continuationIndent, (Integer) formattingOptionsClass.getMethod("getContinuationIndent").invoke(formattingOptions)),
+							/* removeUnusedImports = */ requireNonNullElse(options.removeUnusedImports, (Boolean) formattingOptionsClass.getMethod("getRemoveUnusedImports").invoke(formattingOptions)),
 							/* debuggingPrintOpsAfterFormatting = */ (Boolean) formattingOptionsClass.getMethod("getDebuggingPrintOpsAfterFormatting").invoke(formattingOptions),
-							/* trailingCommaManagementStrategy */ Objects.requireNonNullElse(options.trailingCommaManagementStrategy, (TrailingCommaManagementStrategy) formattingOptionsClass.getMethod("getTrailingCommaManagementStrategy").invoke(formattingOptions)));
+							/* trailingCommaManagementStrategy */ requireNonNullElse(options.trailingCommaManagementStrategy, (TrailingCommaManagementStrategy) formattingOptionsClass.getMethod("getTrailingCommaManagementStrategy").invoke(formattingOptions)));
 				}
 			}
 

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FlexmarkStep.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.markdown;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -48,8 +49,8 @@ public final class FlexmarkStep implements Serializable {
 
 	/** Creates a formatter step for the given version. */
 	public static FormatterStep create(String version, Provisioner provisioner, FlexmarkConfig config) {
-		Objects.requireNonNull(version, "version");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(version, "version");
+		requireNonNull(provisioner, "provisioner");
 		return FormatterStep.create(NAME,
 				new FlexmarkStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + version, provisioner)), config),
 				FlexmarkStep::equalityState,

--- a/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/FreshMarkStep.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.markdown;
 
 import static com.diffplug.spotless.markdown.LibMarkdownPreconditions.requireKeysAndValuesNonNull;
+import static java.util.Objects.requireNonNull;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -24,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 
@@ -67,9 +67,9 @@ public final class FreshMarkStep implements Serializable {
 
 	/** Creates a formatter step for the given version and settings file. */
 	public static FormatterStep create(String version, Map<String, ?> properties, Provisioner provisioner) {
-		Objects.requireNonNull(version, "version");
-		Objects.requireNonNull(properties, "properties");
-		Objects.requireNonNull(provisioner, "provisioner");
+		requireNonNull(version, "version");
+		requireNonNull(properties, "properties");
+		requireNonNull(provisioner, "provisioner");
 
 		List<String> mavenCoordinates = new ArrayList<>();
 		mavenCoordinates.add(MAVEN_COORDINATE + version);

--- a/lib/src/main/java/com/diffplug/spotless/markdown/LibMarkdownPreconditions.java
+++ b/lib/src/main/java/com/diffplug/spotless/markdown/LibMarkdownPreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,20 @@
  */
 package com.diffplug.spotless.markdown;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Map;
-import java.util.Objects;
 
 final class LibMarkdownPreconditions {
 	// prevent direct instantiation
 	private LibMarkdownPreconditions() {}
 
 	static <K, V> Map<K, V> requireKeysAndValuesNonNull(Map<K, V> map) {
-		Objects.requireNonNull(map);
+		requireNonNull(map);
 		map.forEach((key, value) -> {
 			String errorMessage = key + "=" + value;
-			Objects.requireNonNull(key, errorMessage);
-			Objects.requireNonNull(value, errorMessage);
+			requireNonNull(key, errorMessage);
+			requireNonNull(value, errorMessage);
 		});
 		return map;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/EslintFormatterStep.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 import javax.annotation.Nonnull;
@@ -55,7 +54,7 @@ public final class EslintFormatterStep {
 		dependencies.put("@typescript-eslint/eslint-plugin", "^6.1.0");
 		dependencies.put("@typescript-eslint/parser", "^6.1.0");
 		dependencies.put("typescript", "^5.1.6");
-		dependencies.put("eslint", Objects.requireNonNull(eslintVersion));
+		dependencies.put("eslint", requireNonNull(eslintVersion));
 		return dependencies;
 	}
 

--- a/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/ExclusiveFolderAccess.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -32,7 +33,7 @@ interface ExclusiveFolderAccess {
 	}
 
 	static ExclusiveFolderAccess forFolder(@Nonnull String path) {
-		return new ExclusiveFolderAccessSharedMutex(Objects.requireNonNull(path));
+		return new ExclusiveFolderAccessSharedMutex(requireNonNull(path));
 	}
 
 	void runExclusively(ThrowingEx.Runnable runnable);
@@ -44,7 +45,7 @@ interface ExclusiveFolderAccess {
 		private final String path;
 
 		private ExclusiveFolderAccessSharedMutex(@Nonnull String path) {
-			this.path = Objects.requireNonNull(path);
+			this.path = requireNonNull(path);
 		}
 
 		private Lock getMutex() {

--- a/lib/src/main/java/com/diffplug/spotless/npm/JsonWriter.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/JsonWriter.java
@@ -16,14 +16,14 @@
 package com.diffplug.spotless.npm;
 
 import static com.diffplug.spotless.npm.JsonEscaper.jsonEscape;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.diffplug.spotless.ThrowingEx;
 
@@ -74,7 +74,7 @@ class JsonWriter {
 		final String valueString = valueMap.entrySet()
 				.stream()
 				.map(entry -> "    " + jsonEscape(entry.getKey()) + ": " + jsonEscape(entry.getValue()))
-				.collect(Collectors.joining(",\n"));
+				.collect(joining(",\n"));
 		return "{\n" + valueString + "\n}";
 	}
 
@@ -89,7 +89,7 @@ class JsonWriter {
 			}
 		}
 		try {
-			Files.write(file.toPath(), toJsonString().getBytes(StandardCharsets.UTF_8));
+			Files.write(file.toPath(), toJsonString().getBytes(UTF_8));
 		} catch (IOException e) {
 			throw ThrowingEx.asRuntime(e);
 		}

--- a/lib/src/main/java/com/diffplug/spotless/npm/ListableAdapter.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/ListableAdapter.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
@@ -28,7 +29,7 @@ final class ListableAdapter<T> implements Iterable<T> {
 
 	@SuppressWarnings("unchecked")
 	private ListableAdapter(Object delegate) {
-		Objects.requireNonNull(delegate);
+		requireNonNull(delegate);
 		if (!canAdapt(delegate)) {
 			throw new IllegalArgumentException("Cannot create ListableAdapter from " + delegate.getClass() + ". Use canAdapt() to check first.");
 		}
@@ -52,7 +53,7 @@ final class ListableAdapter<T> implements Iterable<T> {
 	}
 
 	static boolean canAdapt(Object delegate) {
-		Objects.requireNonNull(delegate);
+		requireNonNull(delegate);
 		return delegate instanceof List || delegate.getClass().isArray();
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeApp.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeApp.java
@@ -17,8 +17,7 @@ package com.diffplug.spotless.npm;
 
 import static com.diffplug.spotless.npm.NpmProcessFactory.OnlinePreferrence.PREFER_OFFLINE;
 import static com.diffplug.spotless.npm.NpmProcessFactory.OnlinePreferrence.PREFER_ONLINE;
-
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nonnull;
 
@@ -46,10 +45,10 @@ public class NodeApp {
 	protected final NpmFormatterStepLocations formatterStepLocations;
 
 	public NodeApp(@Nonnull NodeServerLayout nodeServerLayout, @Nonnull NpmConfig npmConfig, @Nonnull NpmFormatterStepLocations formatterStepLocations) {
-		this.nodeServerLayout = Objects.requireNonNull(nodeServerLayout);
-		this.npmConfig = Objects.requireNonNull(npmConfig);
+		this.nodeServerLayout = requireNonNull(nodeServerLayout);
+		this.npmConfig = requireNonNull(npmConfig);
 		this.npmProcessFactory = processFactory(formatterStepLocations);
-		this.formatterStepLocations = Objects.requireNonNull(formatterStepLocations);
+		this.formatterStepLocations = requireNonNull(formatterStepLocations);
 	}
 
 	private static NpmProcessFactory processFactory(NpmFormatterStepLocations formatterStepLocations) {

--- a/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NodeModulesCachingNpmProcessFactory.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
@@ -38,7 +39,7 @@ public final class NodeModulesCachingNpmProcessFactory implements NpmProcessFact
 	private final ShadowCopy shadowCopy;
 
 	private NodeModulesCachingNpmProcessFactory(@Nonnull File cacheDir) {
-		this.cacheDir = Objects.requireNonNull(cacheDir);
+		this.cacheDir = requireNonNull(cacheDir);
 		assertDir(); // throws if cacheDir is not a directory
 		this.shadowCopy = new ShadowCopy(this::assertDir);
 	}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmConfig.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
@@ -34,7 +35,7 @@ class NpmConfig implements Serializable {
 	private final String npmrcContent;
 
 	public NpmConfig(@Nonnull String packageJsonContent, String serveScriptContent, String npmrcContent) {
-		this.packageJsonContent = Objects.requireNonNull(packageJsonContent);
+		this.packageJsonContent = requireNonNull(packageJsonContent);
 		this.serveScriptContent = serveScriptContent;
 		this.npmrcContent = npmrcContent;
 	}

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmFormatterStepStateBase.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.npm;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 
 import java.io.File;
 import java.io.IOException;
@@ -115,7 +116,7 @@ abstract class NpmFormatterStepStateBase implements Serializable {
 			assertNodeServerDirReady();
 			LongRunningProcess server = null;
 			try {
-				final UUID nodeServerInstanceId = UUID.randomUUID();
+				final UUID nodeServerInstanceId = randomUUID();
 				// The npm process will output the randomly selected port of the http server process to 'server-<id>.port' file
 				// so in order to be safe, remove such a file if it exists before starting.
 				final File serverPortFile = new File(this.nodeServerLayout.nodeModulesDir(), "server-%s.port".formatted(nodeServerInstanceId));

--- a/lib/src/main/java/com/diffplug/spotless/npm/NpmResourceHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/NpmResourceHelper.java
@@ -15,6 +15,10 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -27,9 +31,7 @@ import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.diffplug.spotless.ThrowingEx;
@@ -43,11 +45,11 @@ final class NpmResourceHelper {
 	}
 
 	static void writeUtf8StringToFile(File file, String stringToWrite) throws IOException {
-		Files.write(file.toPath(), stringToWrite.getBytes(StandardCharsets.UTF_8));
+		Files.write(file.toPath(), stringToWrite.getBytes(UTF_8));
 	}
 
 	static void writeUtf8StringToOutputStream(String stringToWrite, OutputStream outputStream) throws IOException {
-		final byte[] bytes = stringToWrite.getBytes(StandardCharsets.UTF_8);
+		final byte[] bytes = stringToWrite.getBytes(UTF_8);
 		outputStream.write(bytes);
 	}
 
@@ -62,7 +64,7 @@ final class NpmResourceHelper {
 	static String readUtf8StringFromClasspath(Class<?> clazz, String... resourceNames) {
 		return Arrays.stream(resourceNames)
 				.map(resourceName -> readUtf8StringFromClasspath(clazz, resourceName))
-				.collect(Collectors.joining("\n"));
+				.collect(joining("\n"));
 	}
 
 	static String readUtf8StringFromClasspath(Class<?> clazz, String resourceName) {
@@ -130,7 +132,7 @@ final class NpmResourceHelper {
 	}
 
 	static File copyFileToDirAtSubpath(File file, File targetDir, String relativePath) {
-		Objects.requireNonNull(relativePath);
+		requireNonNull(relativePath);
 		try {
 			// create file pointing to relativePath in targetDir
 			final Path relativeTargetFile = Path.of(targetDir.getAbsolutePath(), relativePath);
@@ -148,13 +150,13 @@ final class NpmResourceHelper {
 	}
 
 	static String md5(String fileContent, String... additionalFileContents) {
-		Objects.requireNonNull(fileContent, "fileContent must not be null");
+		requireNonNull(fileContent, "fileContent must not be null");
 		Stream<String> additionalFileContentStream = Stream.concat(
 				Stream.of(fileContent),
 				Stream.of(additionalFileContents));
 		MessageDigest md = ThrowingEx.get(() -> MessageDigest.getInstance("MD5"));
-		String stringToHash = additionalFileContentStream.collect(Collectors.joining(MD5_STRING_DELIMITER));
-		md.update(stringToHash.getBytes(StandardCharsets.UTF_8));
+		String stringToHash = additionalFileContentStream.collect(joining(MD5_STRING_DELIMITER));
+		md.update(stringToHash.getBytes(UTF_8));
 
 		byte[] digest = md.digest();
 		// convert byte array digest to hex string

--- a/lib/src/main/java/com/diffplug/spotless/npm/PrettierMissingParserException.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/PrettierMissingParserException.java
@@ -15,14 +15,15 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.Serial;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
@@ -82,14 +83,14 @@ class PrettierMissingParserException extends RuntimeException implements Lint.Ha
 		Arrays.asList(".nginx", ".nginxconf").forEach(ext -> plugins.put(ext, "prettier-plugin-nginx"));
 		plugins.put(".sol", "prettier-plugin-solidity");
 
-		EXTENSIONS_TO_PLUGINS = Collections.unmodifiableMap(plugins);
+		EXTENSIONS_TO_PLUGINS = unmodifiableMap(plugins);
 	}
 
 	private final File file;
 
 	public PrettierMissingParserException(@Nonnull File file, Exception cause) {
 		super("Prettier could not infer a parser for file '" + file + "'. Maybe you need to include a prettier plugin in devDependencies?\n\n" + recommendPlugin(file), cause);
-		this.file = Objects.requireNonNull(file);
+		this.file = requireNonNull(file);
 	}
 
 	@Override

--- a/lib/src/main/java/com/diffplug/spotless/npm/TimedLogger.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/TimedLogger.java
@@ -16,9 +16,9 @@
 package com.diffplug.spotless.npm;
 
 import static com.diffplug.spotless.LazyArgLogger.lazy;
+import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -42,7 +42,7 @@ final class TimedLogger {
 	private final Ticker ticker;
 
 	private TimedLogger(@Nonnull Logger logger, Ticker ticker) {
-		this.logger = Objects.requireNonNull(logger);
+		this.logger = requireNonNull(logger);
 		this.ticker = ticker;
 	}
 
@@ -89,10 +89,10 @@ final class TimedLogger {
 		private final long startedAt;
 
 		public Timed(@Nonnull Ticker ticker, @Nonnull String msg, @Nonnull List<Object> params, @Nonnull LogToLevelMethod delegatedLogger) {
-			this.ticker = Objects.requireNonNull(ticker);
-			this.msg = Objects.requireNonNull(msg);
-			this.params = List.copyOf(Objects.requireNonNull(params));
-			this.delegatedLogger = Objects.requireNonNull(delegatedLogger);
+			this.ticker = requireNonNull(ticker);
+			this.msg = requireNonNull(msg);
+			this.params = List.copyOf(requireNonNull(params));
+			this.delegatedLogger = requireNonNull(delegatedLogger);
 			this.startedAt = ticker.read();
 			logStart();
 		}
@@ -183,11 +183,11 @@ final class TimedLogger {
 		private final Object[] args;
 
 		public TimedExec(LogActiveMethod logActiveMethod, LogToLevelMethod logMethod, Ticker ticker, String message, Object... args) {
-			this.logActiveMethod = Objects.requireNonNull(logActiveMethod);
-			this.logMethod = Objects.requireNonNull(logMethod);
-			this.ticker = Objects.requireNonNull(ticker);
-			this.message = Objects.requireNonNull(message);
-			this.args = Objects.requireNonNull(args);
+			this.logActiveMethod = requireNonNull(logActiveMethod);
+			this.logMethod = requireNonNull(logMethod);
+			this.ticker = requireNonNull(ticker);
+			this.message = requireNonNull(message);
+			this.args = requireNonNull(args);
 		}
 
 		public void run(ThrowingEx.Runnable r) {

--- a/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/protobuf/BufStep.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -98,7 +99,7 @@ public final class BufStep {
 
 		State(String version, ForeignExe exeAbsPath) {
 			this.version = version;
-			this.exe = Objects.requireNonNull(exeAbsPath);
+			this.exe = requireNonNull(exeAbsPath);
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
@@ -106,7 +107,7 @@ public final class BufStep {
 				exeAbsPath = exe.confirmVersionAndGetAbsolutePath();
 			}
 			List<String> args = List.of(exeAbsPath, "format", file.getAbsolutePath());
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
+			return runner.exec(input.getBytes(UTF_8), args).assertExitZero(UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/python/BlackStep.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.python;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -96,14 +97,14 @@ public final class BlackStep {
 
 		EqualityState(String version, ForeignExe exeAbsPath) {
 			this.version = version;
-			this.exe = Objects.requireNonNull(exeAbsPath);
+			this.exe = requireNonNull(exeAbsPath);
 		}
 
 		String format(ProcessRunner runner, String input) throws IOException, InterruptedException {
 			if (args == null) {
 				args = new String[]{exe.confirmVersionAndGetAbsolutePath(), "-"};
 			}
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), args).assertExitZero(StandardCharsets.UTF_8);
+			return runner.exec(input.getBytes(UTF_8), args).assertExitZero(UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterFunc.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/RdfFormatterFunc.java
@@ -15,12 +15,14 @@
  */
 package com.diffplug.spotless.rdf;
 
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.LineEnding;
@@ -141,7 +143,7 @@ public class RdfFormatterFunc implements FormatterFunc {
 						throw new RuntimeException(e);
 					}
 				})
-				.collect(Collectors.toList());
+				.collect(toList());
 
 		List<Object> onlyInAfterContent = reflectionHelper.streamGraph(graphAfter)
 				.filter(triple -> {
@@ -151,11 +153,11 @@ public class RdfFormatterFunc implements FormatterFunc {
 						throw new RuntimeException(e);
 					}
 				})
-				.collect(Collectors.toList());
+				.collect(toList());
 		if (!(onlyInBeforeContent.isEmpty() && onlyInAfterContent.isEmpty())) {
 			diffResult = onlyInBeforeContent.stream().map("< %s"::formatted)
-					.collect(Collectors.joining("\n"));
-			diffResult += "\n" + onlyInAfterContent.stream().map("> %s"::formatted).collect(Collectors.joining("\n"));
+					.collect(joining("\n"));
+			diffResult += "\n" + onlyInAfterContent.stream().map("> %s"::formatted).collect(joining("\n"));
 		} else {
 			diffResult = "'before' and 'after' content differs, but we don't know why. This is probably a bug.";
 		}

--- a/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
+++ b/lib/src/main/java/com/diffplug/spotless/rdf/ReflectionHelper.java
@@ -15,6 +15,11 @@
  */
 package com.diffplug.spotless.rdf;
 
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 import java.io.File;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
@@ -31,12 +36,10 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -298,7 +301,7 @@ class ReflectionHelper {
 					throw new RuntimeException(ex);
 				}
 			}).collect(
-					Collectors.toList());
+					toList());
 			if (selectedEnumValueList.isEmpty()) {
 				throw new IllegalArgumentException(
 						"Cannot set config option %s to value %s: value must be one of %s".formatted(
@@ -311,7 +314,7 @@ class ReflectionHelper {
 										throw new RuntimeException(ex);
 									}
 								}).collect(
-										Collectors.joining(",", "[", "]"))));
+										joining(",", "[", "]"))));
 			} else if (selectedEnumValueList.size() > 1) {
 				throw new IllegalArgumentException(
 						"Found more than 1 enum value for name %s, that should never happen".formatted(
@@ -350,7 +353,7 @@ class ReflectionHelper {
 			} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException ex) {
 				throw new RuntimeException(ex);
 			}
-		}).collect(Collectors.toList());
+		}).collect(toList());
 	}
 
 	private Object makeSetOf(Type type, String parameterValueAsString) {
@@ -361,7 +364,7 @@ class ReflectionHelper {
 			} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException ex) {
 				throw new RuntimeException(ex);
 			}
-		}).collect(Collectors.toSet());
+		}).collect(toSet());
 	}
 
 	private Object instantiate(Type type, String stringRepresentation)
@@ -427,7 +430,7 @@ class ReflectionHelper {
 			}
 		}
 		throw new IllegalArgumentException("Unable to find FormattingStyle.KnownPrefix for prefix '%s'. Options are: %s".formatted(stringRepresentation, options.stream().collect(
-				Collectors.joining(",\n\t", "\n\t", "\n"))));
+				joining(",\n\t", "\n\t", "\n"))));
 	}
 
 	private static String[] split(String parameterValueAsString) {
@@ -441,14 +444,14 @@ class ReflectionHelper {
 		Method[] allMethods = TurtleFormatFormattingStyleBuilderClass.getDeclaredMethods();
 		List<Method> methods = Arrays.stream(allMethods).filter(m -> m.getName().equals(optionName))
 				.collect(
-						Collectors.toList());
+						toList());
 		if (methods.isEmpty()) {
 			List<Method> candidates = Arrays.stream(allMethods).filter(m -> m.getParameterCount() == 1)
-					.sorted(Comparator.comparing(Method::getName)).collect(
-							Collectors.toList());
+					.sorted(comparing(Method::getName)).collect(
+							toList());
 			throw new RuntimeException(
 					"Unrecognized configuration parameter name: %s. Candidates are:%n%s".formatted(optionName, candidates.stream().map(Method::getName).collect(
-							Collectors.joining("\n\t", "\t", ""))));
+							joining("\n\t", "\t", ""))));
 		}
 		if (methods.size() > 1) {
 			throw new RuntimeException(
@@ -506,7 +509,7 @@ class ReflectionHelper {
 				while (hasNext(resIterator)) {
 					resources.add(next(resIterator));
 				}
-				resources.sort(Comparator.comparing(x -> {
+				resources.sort(comparing(x -> {
 					try {
 						return (String) x.getClass().getMethod("getURI").invoke(x);
 					} catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {

--- a/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/scala/ScalaFmtStep.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.scala;
 
+import static java.util.Collections.emptySet;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
-import java.util.Collections;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -88,7 +89,7 @@ public final class ScalaFmtStep implements Serializable {
 
 		State(JarState jarState, @Nullable File configFile) throws IOException {
 			this.jarState = jarState;
-			this.configSignature = FileSignature.signAsList(configFile == null ? Collections.emptySet() : Set.of(configFile));
+			this.configSignature = FileSignature.signAsList(configFile == null ? emptySet() : Set.of(configFile));
 		}
 
 		FormatterFunc createFormat() throws Exception {

--- a/lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/shell/ShfmtStep.java
@@ -15,14 +15,15 @@
  */
 package com.diffplug.spotless.shell;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -111,7 +112,7 @@ public final class ShfmtStep {
 
 		EqualityState(String version, ForeignExe pathToExe) {
 			this.version = version;
-			this.exe = Objects.requireNonNull(pathToExe);
+			this.exe = requireNonNull(pathToExe);
 		}
 
 		String format(ProcessRunner runner, String input, File file) throws IOException, InterruptedException {
@@ -123,9 +124,9 @@ public final class ShfmtStep {
 
 			// This will ensure that the next file name is retrieved on every format
 			final List<String> finalArgs = Stream.concat(args.stream(), Stream.of(file.getAbsolutePath()))
-					.collect(Collectors.toList());
+					.collect(toList());
 
-			return runner.exec(input.getBytes(StandardCharsets.UTF_8), finalArgs).assertExitZero(StandardCharsets.UTF_8);
+			return runner.exec(input.getBytes(UTF_8), finalArgs).assertExitZero(UTF_8);
 		}
 
 		FormatterFunc.Closeable toFunc() {

--- a/lib/src/main/java/com/diffplug/spotless/yaml/JacksonYamlConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/yaml/JacksonYamlConfig.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.yaml;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.io.Serial;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ public class JacksonYamlConfig extends JacksonConfig {
 	protected Map<String, Boolean> yamlFeatureToToggle = new LinkedHashMap<>();
 
 	public Map<String, Boolean> getYamlFeatureToToggle() {
-		return Collections.unmodifiableMap(yamlFeatureToToggle);
+		return unmodifiableMap(yamlFeatureToToggle);
 	}
 
 	/**

--- a/lib/src/main/java/com/diffplug/spotless/yaml/JacksonYamlStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/yaml/JacksonYamlStep.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless.yaml;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
@@ -53,8 +54,8 @@ public final class JacksonYamlStep implements Serializable {
 	public static FormatterStep create(JacksonYamlConfig jacksonConfig,
 			String jacksonVersion,
 			Provisioner provisioner) {
-		Objects.requireNonNull(jacksonConfig, "jacksonConfig cannot be null");
-		Objects.requireNonNull(provisioner, "provisioner cannot be null");
+		requireNonNull(jacksonConfig, "jacksonConfig cannot be null");
+		requireNonNull(provisioner, "provisioner cannot be null");
 		return FormatterStep.create(NAME,
 				new JacksonYamlStep(JarState.promise(() -> JarState.from(MAVEN_COORDINATE + jacksonVersion, provisioner)), jacksonConfig),
 				JacksonYamlStep::equalityState,

--- a/lib/src/test/java/com/diffplug/spotless/JarStateTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/JarStateTest.java
@@ -15,6 +15,9 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -25,9 +28,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ class JarStateTest {
 
 	File b;
 
-	Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(name -> name.equals("a") ? a : b).collect(Collectors.toSet());
+	Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(name -> name.equals("a") ? a : b).collect(toSet());
 
 	@BeforeEach
 	void setUp() throws IOException {
@@ -62,7 +63,7 @@ class JarStateTest {
 		JarState state1 = JarState.from(a.getName(), provisioner);
 		JarState state2 = JarState.from(b.getName(), provisioner);
 
-		SoftAssertions.assertSoftly(softly -> {
+		assertSoftly(softly -> {
 			softly.assertThat(state1.getClassLoader()).isNotNull();
 			softly.assertThat(state2.getClassLoader()).isNotNull();
 		});
@@ -75,7 +76,7 @@ class JarStateTest {
 		JarState.setForcedClassLoader(forcedClassLoader);
 		JarState stateB = JarState.from(b.getName(), provisioner);
 
-		SoftAssertions.assertSoftly(softly -> {
+		assertSoftly(softly -> {
 			softly.assertThat(stateA.getClassLoader()).isSameAs(forcedClassLoader);
 			softly.assertThat(stateB.getClassLoader()).isSameAs(forcedClassLoader);
 		});
@@ -91,7 +92,7 @@ class JarStateTest {
 		JarState stateARoundtripSerialized = roundtripSerialize(stateA);
 		JarState stateBRoundtripSerialized = roundtripSerialize(stateB);
 
-		SoftAssertions.assertSoftly(softly -> {
+		assertSoftly(softly -> {
 			softly.assertThat(stateARoundtripSerialized.getClassLoader()).isSameAs(forcedClassLoader);
 			softly.assertThat(stateBRoundtripSerialized.getClassLoader()).isSameAs(forcedClassLoader);
 		});

--- a/lib/src/test/java/com/diffplug/spotless/LineEndingTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/LineEndingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class LineEndingTest {
@@ -44,7 +45,7 @@ class LineEndingTest {
 
 	static void assertLineEnding(String ending, String input) throws IOException {
 		try (Reader reader = new StringReader(input)) {
-			Assertions.assertEquals(ending, LineEnding.PreserveLineEndingPolicy.getEndingFor(reader));
+			assertEquals(ending, LineEnding.PreserveLineEndingPolicy.getEndingFor(reader));
 		}
 	}
 }

--- a/lib/src/test/java/com/diffplug/spotless/LintSuppressionTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/LintSuppressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -39,7 +39,7 @@ public class LintSuppressionTest {
 	private Formatter formatter() {
 		return Formatter.builder()
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
-				.encoding(StandardCharsets.UTF_8)
+				.encoding(UTF_8)
 				.steps(List.of(EndWithNewlineStep.create()))
 				.build();
 	}

--- a/lib/src/test/java/com/diffplug/spotless/RingBufferByteArrayOutputStreamTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/RingBufferByteArrayOutputStreamTest.java
@@ -15,11 +15,12 @@
  */
 package com.diffplug.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,7 +35,7 @@ class RingBufferByteArrayOutputStreamTest {
 	void toStringBehavesNormallyWithinLimit(String name, ByteWriteStrategy writeStrategy) {
 		RingBufferByteArrayOutputStream stream = new RingBufferByteArrayOutputStream(12, 1);
 		writeStrategy.write(stream, bytes);
-		Assertions.assertThat(stream.toString()).isEqualTo("0123456789");
+		assertThat(stream.toString()).isEqualTo("0123456789");
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -42,8 +43,8 @@ class RingBufferByteArrayOutputStreamTest {
 	void toStringBehavesOverwritingOverLimit(String name, ByteWriteStrategy writeStrategy) {
 		RingBufferByteArrayOutputStream stream = new RingBufferByteArrayOutputStream(4, 1);
 		writeStrategy.write(stream, bytes);
-		Assertions.assertThat(stream.toString()).hasSize(4);
-		Assertions.assertThat(stream.toString()).isEqualTo("6789");
+		assertThat(stream.toString()).hasSize(4);
+		assertThat(stream.toString()).isEqualTo("6789");
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -51,7 +52,7 @@ class RingBufferByteArrayOutputStreamTest {
 	void toStringBehavesNormallyAtExactlyLimit(String name, ByteWriteStrategy writeStrategy) {
 		RingBufferByteArrayOutputStream stream = new RingBufferByteArrayOutputStream(bytes.length, 1);
 		writeStrategy.write(stream, bytes);
-		Assertions.assertThat(stream.toString()).isEqualTo("0123456789");
+		assertThat(stream.toString()).isEqualTo("0123456789");
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -59,7 +60,7 @@ class RingBufferByteArrayOutputStreamTest {
 	void toByteArrayBehavesNormallyWithinLimit(String name, ByteWriteStrategy writeStrategy) {
 		RingBufferByteArrayOutputStream stream = new RingBufferByteArrayOutputStream(12, 1);
 		writeStrategy.write(stream, bytes);
-		Assertions.assertThat(stream.toByteArray()).isEqualTo(bytes);
+		assertThat(stream.toByteArray()).isEqualTo(bytes);
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -67,8 +68,8 @@ class RingBufferByteArrayOutputStreamTest {
 	void toByteArrayBehavesOverwritingOverLimit(String name, ByteWriteStrategy writeStrategy) {
 		RingBufferByteArrayOutputStream stream = new RingBufferByteArrayOutputStream(4, 1);
 		writeStrategy.write(stream, bytes);
-		Assertions.assertThat(stream.toByteArray()).hasSize(4);
-		Assertions.assertThat(stream.toByteArray()).isEqualTo(new byte[]{'6', '7', '8', '9'});
+		assertThat(stream.toByteArray()).hasSize(4);
+		assertThat(stream.toByteArray()).isEqualTo(new byte[]{'6', '7', '8', '9'});
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -76,7 +77,7 @@ class RingBufferByteArrayOutputStreamTest {
 	void toByteArrayBehavesOverwritingAtExactlyLimit(String name, ByteWriteStrategy writeStrategy) {
 		RingBufferByteArrayOutputStream stream = new RingBufferByteArrayOutputStream(bytes.length, 1);
 		writeStrategy.write(stream, bytes);
-		Assertions.assertThat(stream.toByteArray()).isEqualTo(bytes);
+		assertThat(stream.toByteArray()).isEqualTo(bytes);
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -86,7 +87,7 @@ class RingBufferByteArrayOutputStreamTest {
 		writeStrategy.write(stream, bytes);
 		ByteArrayOutputStream target = new ByteArrayOutputStream();
 		stream.writeTo(target);
-		Assertions.assertThat(target.toByteArray()).isEqualTo(bytes);
+		assertThat(target.toByteArray()).isEqualTo(bytes);
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -96,8 +97,8 @@ class RingBufferByteArrayOutputStreamTest {
 		writeStrategy.write(stream, bytes);
 		ByteArrayOutputStream target = new ByteArrayOutputStream();
 		stream.writeTo(target);
-		Assertions.assertThat(target.toByteArray()).hasSize(4);
-		Assertions.assertThat(target.toByteArray()).isEqualTo(new byte[]{'6', '7', '8', '9'});
+		assertThat(target.toByteArray()).hasSize(4);
+		assertThat(target.toByteArray()).isEqualTo(new byte[]{'6', '7', '8', '9'});
 	}
 
 	@ParameterizedTest(name = "{index} writeStrategy: {0}")
@@ -107,7 +108,7 @@ class RingBufferByteArrayOutputStreamTest {
 		writeStrategy.write(stream, bytes);
 		ByteArrayOutputStream target = new ByteArrayOutputStream();
 		stream.writeTo(target);
-		Assertions.assertThat(target.toByteArray()).isEqualTo(bytes);
+		assertThat(target.toByteArray()).isEqualTo(bytes);
 	}
 
 	@Test
@@ -116,8 +117,8 @@ class RingBufferByteArrayOutputStreamTest {
 		RingBufferByteArrayOutputStream stream = new RingBufferByteArrayOutputStream(2, 1);
 		stream.write('0');
 		stream.write(new byte[]{'1', '2'}, 0, 2);
-		Assertions.assertThat(stream.toString()).hasSize(2);
-		Assertions.assertThat(stream.toString()).isEqualTo("12");
+		assertThat(stream.toString()).hasSize(2);
+		assertThat(stream.toString()).isEqualTo("12");
 	}
 
 	private static Stream<Arguments> writeStrategies() {

--- a/lib/src/test/java/com/diffplug/spotless/npm/NodeServerLayoutTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/npm/NodeServerLayoutTest.java
@@ -15,11 +15,11 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ class NodeServerLayoutTest extends ResourceHarness {
 	@Test
 	void itCalculatesSameNodeModulesDirForSameContent() throws IOException {
 		File testDir = newFolder("build");
-		String packageJsonContent = prettierPackageJson(Collections.emptyMap());
+		String packageJsonContent = prettierPackageJson(emptyMap());
 		String serveJsContent = "fun main() { console.log('Hello, world!'); }";
 		NodeServerLayout layout1 = new NodeServerLayout(testDir, packageJsonContent, serveJsContent);
 		NodeServerLayout layout2 = new NodeServerLayout(testDir, packageJsonContent, serveJsContent);
@@ -55,7 +55,7 @@ class NodeServerLayoutTest extends ResourceHarness {
 	@Test
 	void itCalculatesDifferentNodeModulesDirForDifferentServeJs() throws IOException {
 		File testDir = newFolder("build");
-		String packageJsonContent = prettierPackageJson(Collections.emptyMap());
+		String packageJsonContent = prettierPackageJson(emptyMap());
 		String serveJsContent1 = "fun main() { console.log('Hello, world!'); }";
 		String serveJsContent2 = "fun main() { console.log('Goodbye, world!'); }";
 

--- a/lib/src/test/java/com/diffplug/spotless/npm/TimedLoggerTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/npm/TimedLoggerTest.java
@@ -18,12 +18,13 @@ package com.diffplug.spotless.npm;
 import static com.diffplug.spotless.npm.TimedLogger.MESSAGE_PREFIX_BEGIN;
 import static com.diffplug.spotless.npm.TimedLogger.MESSAGE_PREFIX_END;
 import static com.diffplug.spotless.npm.TimedLogger.MESSAGE_SUFFIX_TOOK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,14 +116,14 @@ class TimedLoggerTest {
 
 	@Test
 	void itThrowsExceptionsInChecked() {
-		Assertions.assertThatThrownBy(() -> timedLogger.withInfo("This should be logged").runChecked(() -> {
+		assertThatThrownBy(() -> timedLogger.withInfo("This should be logged").runChecked(() -> {
 			throw new Exception("This is an exception");
 		})).isInstanceOf(Exception.class).hasMessage("This is an exception");
 	}
 
 	@Test
 	void itLogsEvenWhenExceptionsAreThrown() {
-		Assertions.assertThatThrownBy(() -> timedLogger.withInfo("This should be logged").run(() -> {
+		assertThatThrownBy(() -> timedLogger.withInfo("This should be logged").run(() -> {
 			testTicker.tickMillis(2);
 			throw new Exception("This is an exception");
 		})).isInstanceOf(RuntimeException.class)
@@ -141,7 +142,7 @@ class TimedLoggerTest {
 			return "This is the result";
 		});
 
-		Assertions.assertThat(result).isEqualTo("This is the result");
+		assertThat(result).isEqualTo("This is the result");
 
 		testLogger.assertEvents(2);
 		testLogger.assertHasEventWithMessageAndArguments(MESSAGE_PREFIX_BEGIN);
@@ -192,16 +193,16 @@ class TimedLoggerTest {
 		}
 
 		public void assertNoEvents() {
-			Assertions.assertThat(getEvents()).isEmpty();
+			assertThat(getEvents()).isEmpty();
 		}
 
 		public void assertEvents(int eventCount) {
-			Assertions.assertThat(getEvents()).hasSize(eventCount);
+			assertThat(getEvents()).hasSize(eventCount);
 		}
 
 		public void assertHasEventWithMessageAndArguments(String message, Object... arguments) {
 
-			Assertions.assertThat(getEvents()).haveAtLeastOne(new Condition<>(event -> {
+			assertThat(getEvents()).haveAtLeastOne(new Condition<>(event -> {
 				if (!event.msg().contains(message)) {
 					return false;
 				}

--- a/lib/src/testCompatCleanthat2Dot1/java/com/diffplug/spotless/glue/java/JavaCleanthatRefactorerFuncTest.java
+++ b/lib/src/testCompatCleanthat2Dot1/java/com/diffplug/spotless/glue/java/JavaCleanthatRefactorerFuncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.glue.java;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 import eu.solven.cleanthat.engine.java.refactorer.JavaRefactorer;
@@ -23,6 +24,6 @@ import eu.solven.cleanthat.engine.java.refactorer.JavaRefactorer;
 public class JavaCleanthatRefactorerFuncTest {
 	@Test
 	public void testMutatorsDetection() {
-		Assertions.assertThat(JavaRefactorer.getAllIncluded()).isNotEmpty();
+		assertThat(JavaRefactorer.getAllIncluded()).isNotEmpty();
 	}
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/Antlr4Extension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/Antlr4Extension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import javax.inject.Inject;
 
@@ -44,7 +44,7 @@ public class Antlr4Extension extends FormatExtension implements HasBuiltinDelimi
 		private final String version;
 
 		Antlr4FormatterConfig(String version) {
-			this.version = Objects.requireNonNull(version);
+			this.version = requireNonNull(version);
 			addStep(createStep());
 		}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseGroovyExtension.java
@@ -16,10 +16,10 @@
 package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
+import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.gradle.api.Project;
 
@@ -38,7 +38,7 @@ public abstract class BaseGroovyExtension extends FormatExtension {
 	}
 
 	public void importOrderFile(Object importOrderFile) {
-		Objects.requireNonNull(importOrderFile);
+		requireNonNull(importOrderFile);
 		addStep(ImportOrderStep.forGroovy().createFrom(getProject().file(importOrderFile)));
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseKotlinExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/BaseKotlinExtension.java
@@ -15,12 +15,14 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
@@ -53,7 +55,7 @@ public abstract class BaseKotlinExtension extends FormatExtension {
 
 	/** Adds the specified version of <a href="https://github.com/pinterest/ktlint">ktlint</a>. */
 	public KtlintConfig ktlint(String version) throws IOException {
-		return new KtlintConfig(version, Collections.emptyMap(), Collections.emptyList());
+		return new KtlintConfig(version, emptyMap(), emptyList());
 	}
 
 	/** Uses the <a href="https://github.com/facebook/ktfmt">ktfmt</a> jar to format source code. */
@@ -76,7 +78,7 @@ public abstract class BaseKotlinExtension extends FormatExtension {
 		private FileSignature config;
 
 		private DiktatConfig(String version) {
-			Objects.requireNonNull(version, "version");
+			requireNonNull(version, "version");
 			this.version = version;
 			addStep(createStep());
 		}
@@ -104,8 +106,8 @@ public abstract class BaseKotlinExtension extends FormatExtension {
 		private KtfmtStep.KtfmtFormattingOptions options;
 
 		private KtfmtConfig(String version) {
-			Objects.requireNonNull(version);
-			this.version = Objects.requireNonNull(version);
+			requireNonNull(version);
+			this.version = requireNonNull(version);
 			addStep(createStep());
 		}
 
@@ -159,7 +161,7 @@ public abstract class BaseKotlinExtension extends FormatExtension {
 				String version,
 				Map<String, Object> editorConfigOverride,
 				List<String> customRuleSets) throws IOException {
-			Objects.requireNonNull(version);
+			requireNonNull(version);
 			File defaultEditorConfig = getProject().getRootProject().file(".editorconfig");
 			FileSignature editorConfigPath = defaultEditorConfig.exists() ? FileSignature.signAsList(defaultEditorConfig) : null;
 			this.version = version;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FlexmarkExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FlexmarkExtension.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -55,7 +56,7 @@ public class FlexmarkExtension extends FormatExtension {
 		private final FlexmarkConfig config = new FlexmarkConfig();
 
 		FlexmarkFormatterConfig(String version) {
-			this.version = Objects.requireNonNull(version);
+			this.version = requireNonNull(version);
 			addStep(createStep());
 		}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FreshMarkExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
+import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 import javax.inject.Inject;
@@ -42,7 +42,7 @@ public class FreshMarkExtension extends FormatExtension {
 	}
 
 	public void properties(Action<Map<String, Object>> action) {
-		propertyActions.add(Objects.requireNonNull(action));
+		propertyActions.add(requireNonNull(action));
 	}
 
 	public void propertiesFile(Object... files) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -16,6 +16,7 @@
 package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.PluginGradlePreconditions.requireElementsNonNull;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -24,7 +25,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -69,7 +69,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	}
 
 	public ImportOrderConfig importOrderFile(Object importOrderFile) {
-		Objects.requireNonNull(importOrderFile);
+		requireNonNull(importOrderFile);
 		return new ImportOrderConfig(getProject().file(importOrderFile));
 	}
 
@@ -179,7 +179,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	 * for a workaround for using snapshot versions.
 	 */
 	public GoogleJavaFormatConfig googleJavaFormat(String version) {
-		Objects.requireNonNull(version);
+		requireNonNull(version);
 		return new GoogleJavaFormatConfig(version);
 	}
 
@@ -192,20 +192,20 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		boolean formatJavadoc = true;
 
 		GoogleJavaFormatConfig(String version) {
-			this.version = Objects.requireNonNull(version);
+			this.version = requireNonNull(version);
 			this.groupArtifact = GoogleJavaFormatStep.defaultGroupArtifact();
 			this.style = GoogleJavaFormatStep.defaultStyle();
 			addStep(createStep());
 		}
 
 		public GoogleJavaFormatConfig groupArtifact(String groupArtifact) {
-			this.groupArtifact = Objects.requireNonNull(groupArtifact);
+			this.groupArtifact = requireNonNull(groupArtifact);
 			replaceStep(createStep());
 			return this;
 		}
 
 		public GoogleJavaFormatConfig style(String style) {
-			this.style = Objects.requireNonNull(style);
+			this.style = requireNonNull(style);
 			replaceStep(createStep());
 			return this;
 		}
@@ -264,7 +264,7 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	 * for a workaround for using snapshot versions.
 	 */
 	public PalantirJavaFormatConfig palantirJavaFormat(String version) {
-		Objects.requireNonNull(version);
+		requireNonNull(version);
 		return new PalantirJavaFormatConfig(version);
 	}
 
@@ -274,13 +274,13 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		boolean formatJavadoc;
 
 		PalantirJavaFormatConfig(String version) {
-			this.version = Objects.requireNonNull(version);
+			this.version = requireNonNull(version);
 			this.style = PalantirJavaFormatStep.defaultStyle();
 			addStep(createStep());
 		}
 
 		public PalantirJavaFormatConfig style(String style) {
-			this.style = Objects.requireNonNull(style);
+			this.style = requireNonNull(style);
 			replaceStep(createStep());
 			return this;
 		}
@@ -391,14 +391,14 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		}
 
 		public FormatAnnotationsConfig addTypeAnnotation(String simpleName) {
-			Objects.requireNonNull(simpleName);
+			requireNonNull(simpleName);
 			addedTypeAnnotations.add(simpleName);
 			replaceStep(createStep());
 			return this;
 		}
 
 		public FormatAnnotationsConfig removeTypeAnnotation(String simpleName) {
-			Objects.requireNonNull(simpleName);
+			requireNonNull(simpleName);
 			removedTypeAnnotations.add(simpleName);
 			replaceStep(createStep());
 			return this;
@@ -434,21 +434,21 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 		}
 
 		public CleanthatJavaConfig groupArtifact(String groupArtifact) {
-			Objects.requireNonNull(groupArtifact);
+			requireNonNull(groupArtifact);
 			this.groupArtifact = groupArtifact;
 			replaceStep(createStep());
 			return this;
 		}
 
 		public CleanthatJavaConfig version(String version) {
-			Objects.requireNonNull(version);
+			requireNonNull(version);
 			this.version = version;
 			replaceStep(createStep());
 			return this;
 		}
 
 		public CleanthatJavaConfig sourceCompatibility(String jdkVersion) {
-			Objects.requireNonNull(jdkVersion);
+			requireNonNull(jdkVersion);
 			this.sourceJdk = jdkVersion;
 			replaceStep(createStep());
 			return this;

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PluginGradlePreconditions.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PluginGradlePreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 final class PluginGradlePreconditions {
 	// prevent direct instantiation
@@ -23,17 +23,17 @@ final class PluginGradlePreconditions {
 
 	@SafeVarargs
 	static <T> T[] requireElementsNonNull(T... elements) {
-		Objects.requireNonNull(elements);
+		requireNonNull(elements);
 		for (T element : elements) {
-			Objects.requireNonNull(element);
+			requireNonNull(element);
 		}
 		return elements;
 	}
 
 	static <T, I extends Iterable<T>> I requireElementsNonNull(I elements) {
-		Objects.requireNonNull(elements);
+		requireNonNull(elements);
 		for (Object element : elements) {
-			Objects.requireNonNull(element);
+			requireNonNull(element);
 		}
 		return elements;
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PomExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/PomExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import javax.inject.Inject;
 
@@ -46,7 +46,7 @@ public class PomExtension extends FormatExtension {
 	}
 
 	public SortPomGradleConfig sortPom(String version) {
-		Objects.requireNonNull(version);
+		requireNonNull(version);
 		return new SortPomGradleConfig(version);
 	}
 
@@ -59,7 +59,7 @@ public class PomExtension extends FormatExtension {
 
 		SortPomGradleConfig(String version) {
 			this();
-			cfg.version = Objects.requireNonNull(version);
+			cfg.version = requireNonNull(version);
 		}
 
 		public SortPomGradleConfig encoding(String encoding) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ProtobufExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ProtobufExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 package com.diffplug.gradle.spotless;
 
 import static com.diffplug.spotless.protobuf.ProtobufConstants.LICENSE_HEADER_DELIMITER;
-
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import javax.inject.Inject;
 
@@ -53,7 +52,7 @@ public class ProtobufExtension extends FormatExtension implements HasBuiltinDeli
 
 	/** Adds the specified version of <a href="https://buf.build/">buf</a>. */
 	public BufFormatExtension buf(String version) {
-		Objects.requireNonNull(version);
+		requireNonNull(version);
 		return new BufFormatExtension(version);
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -88,7 +89,7 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 	@TaskAction
 	public void trivialFunction() throws IOException {
 		Files.createParentDirs(unitOutput);
-		Files.write(Integer.toString(1), unitOutput, StandardCharsets.UTF_8);
+		Files.write(Integer.toString(1), unitOutput, UTF_8);
 	}
 
 	// this field is stupid, but we need it, see https://github.com/diffplug/spotless/issues/1260

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ScalaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ScalaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
-import java.util.Objects;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -44,24 +45,22 @@ public class ScalaExtension extends FormatExtension implements JvmLang {
 
 	public class ScalaFmtConfig {
 		final String version;
-		@Nullable
-		String scalaMajorVersion;
-		@Nullable
-		Object configFile;
+		@Nullable String scalaMajorVersion;
+		@Nullable Object configFile;
 
 		ScalaFmtConfig(String version) {
-			this.version = Objects.requireNonNull(version);
+			this.version = requireNonNull(version);
 			addStep(createStep());
 		}
 
 		public ScalaFmtConfig configFile(Object configFile) {
-			this.configFile = Objects.requireNonNull(configFile);
+			this.configFile = requireNonNull(configFile);
 			replaceStep(createStep());
 			return this;
 		}
 
 		public ScalaFmtConfig scalaMajorVersion(String scalaMajorVersion) {
-			this.scalaMajorVersion = Objects.requireNonNull(scalaMajorVersion);
+			this.scalaMajorVersion = requireNonNull(scalaMajorVersion);
 			replaceStep(createStep());
 			return this;
 		}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ShellExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/ShellExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import javax.inject.Inject;
 
@@ -43,7 +43,7 @@ public class ShellExtension extends FormatExtension {
 
 	/** Adds the specified version of <a href="https://github.com/mvdan/sh">shfmt</a>. */
 	public ShfmtExtension shfmt(String version) {
-		Objects.requireNonNull(version);
+		requireNonNull(version);
 		return new ShfmtExtension(version);
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -15,10 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -73,7 +73,7 @@ public abstract class SpotlessExtension {
 		this.lineEndings = requireNonNull(lineEndings);
 	}
 
-	Charset encoding = StandardCharsets.UTF_8;
+	Charset encoding = UTF_8;
 
 	/** Returns the encoding to use. */
 	public Charset getEncoding() {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTask.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.gradle.api.DefaultTask;
@@ -58,7 +59,7 @@ public abstract class SpotlessTask extends DefaultTask {
 	}
 
 	public void setEncoding(String encoding) {
-		this.encoding = Objects.requireNonNull(encoding);
+		this.encoding = requireNonNull(encoding);
 	}
 
 	protected Provider<LineEnding.Policy> lineEndingsPolicy = null;
@@ -127,7 +128,7 @@ public abstract class SpotlessTask extends DefaultTask {
 	protected List<LintSuppression> lintSuppressions = new ArrayList<>();
 
 	public void setLintSuppressions(List<LintSuppression> lintSuppressions) {
-		this.lintSuppressions = Objects.requireNonNull(lintSuppressions);
+		this.lintSuppressions = requireNonNull(lintSuppressions);
 	}
 
 	@Input

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Collections.synchronizedMap;
+
 import java.io.File;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -54,9 +55,9 @@ import com.diffplug.spotless.Provisioner;
  * apply already did).
  */
 public abstract class SpotlessTaskService implements BuildService<BuildServiceParameters.None>, AutoCloseable, OperationCompletionListener {
-	private final Map<String, SpotlessApply> apply = Collections.synchronizedMap(new HashMap<>());
-	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
-	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
+	private final Map<String, SpotlessApply> apply = synchronizedMap(new HashMap<>());
+	private final Map<String, SpotlessTask> source = synchronizedMap(new HashMap<>());
+	private final Map<String, Provisioner> provisioner = synchronizedMap(new HashMap<>());
 
 	@Nullable GradleProvisioner.DedupingProvisioner predeclaredProvisioner;
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TypescriptExtension.java
@@ -15,12 +15,11 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 import javax.annotation.Nullable;
@@ -70,7 +69,7 @@ public class TypescriptExtension extends FormatExtension {
 
 	public class TypescriptFormatExtension extends NpmStepConfig<TypescriptFormatExtension> {
 
-		private Map<String, Object> config = Collections.emptyMap();
+		private Map<String, Object> config = emptyMap();
 
 		@Nullable TsConfigFileType configFileType = null;
 
@@ -80,7 +79,7 @@ public class TypescriptExtension extends FormatExtension {
 
 		TypescriptFormatExtension(Map<String, String> devDependencies) {
 			super(getProject(), TypescriptExtension.this::replaceStep);
-			this.devDependencies = Objects.requireNonNull(devDependencies);
+			this.devDependencies = requireNonNull(devDependencies);
 		}
 
 		public TypescriptFormatExtension config(final Map<String, Object> config) {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigAvoidanceTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/ConfigAvoidanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ConfigAvoidanceTest extends GradleIntegrationHarness {
@@ -52,8 +53,8 @@ class ConfigAvoidanceTest extends GradleIntegrationHarness {
 		setFile("src/main/java/test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
 
 		String help = gradleRunner().withArguments("help").build().getOutput();
-		Assertions.assertThat(help).doesNotContain("Canary was configured");
+		assertThat(help).doesNotContain("Canary was configured");
 		String check = gradleRunner().withArguments("check").buildAndFail().getOutput();
-		Assertions.assertThat(check).contains("Canary was configured", "Canary ran", "Execution failed for task ':spotlessJavaCheck'");
+		assertThat(check).contains("Canary was configured", "Canary ran", "Execution failed for task ':spotlessJavaCheck'");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/DiffMessageFormatterTest.java
@@ -15,14 +15,15 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildServiceParameters;
@@ -63,7 +64,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 			return project.getTasks().register("spotless" + SpotlessPlugin.capitalize(name), SpotlessTaskImpl.class, task -> {
 				task.init(taskService);
 				task.setLineEndingsPolicy(project.provider(LineEnding.UNIX::createPolicy));
-				task.setTarget(Collections.singletonList(file));
+				task.setTarget(singletonList(file));
 			});
 		}
 
@@ -106,11 +107,11 @@ class DiffMessageFormatterTest extends ResourceHarness {
 
 		String firstLine = "The following files had format violations:\n";
 		String lastLine = "\n" + EXPECTED_RUN_SPOTLESS_APPLY_SUGGESTION;
-		Assertions.assertThat(msg).startsWith(firstLine).endsWith(lastLine);
+		assertThat(msg).startsWith(firstLine).endsWith(lastLine);
 
 		String middle = msg.substring(firstLine.length(), msg.length() - lastLine.length());
 		String expectedMessage = StringPrinter.buildStringFromLines(expectedLines);
-		Assertions.assertThat(middle).isEqualTo(expectedMessage.substring(0, expectedMessage.length() - 1));
+		assertThat(middle).isEqualTo(expectedMessage.substring(0, expectedMessage.length() - 1));
 	}
 
 	static final String EXPECTED_RUN_SPOTLESS_APPLY_SUGGESTION = FileSignature.machineIsWin()
@@ -141,7 +142,7 @@ class DiffMessageFormatterTest extends ResourceHarness {
 
 		String firstLine = "The following files had format violations:\n";
 		String lastLine = "\n" + customMessage;
-		Assertions.assertThat(msg).startsWith(firstLine).endsWith(lastLine);
+		assertThat(msg).startsWith(firstLine).endsWith(lastLine);
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FilePermissionsTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FilePermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.io.IOException;
@@ -23,7 +24,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 
 import org.assertj.core.api.AbstractStringAssert;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -55,6 +55,6 @@ class FilePermissionsTest extends GradleIntegrationHarness {
 	}
 
 	private AbstractStringAssert<?> assertPermissions(Path path) throws IOException {
-		return Assertions.assertThat(PosixFilePermissions.toString(Files.getPosixFilePermissions(path)));
+		return assertThat(PosixFilePermissions.toString(Files.getPosixFilePermissions(path)));
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FileTreeTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/FileTreeTest.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ class FileTreeTest extends ResourceHarness {
 		File someFile = setFile("someFolder/someFile").toContent("");
 		File someFolder = someFile.getParentFile();
 		fileTree.exclude(someFolder.getAbsolutePath());
-		Assertions.assertThat(fileTree).containsExactlyInAnyOrder(someFile);
+		assertThat(fileTree).containsExactlyInAnyOrder(someFile);
 	}
 
 	@Test
@@ -51,6 +52,6 @@ class FileTreeTest extends ResourceHarness {
 		File someFile = setFile("someFolder/someFile").toContent("");
 		File someFolder = someFile.getParentFile();
 		fileTree.exclude(LintSuppression.relativizeAsUnix(rootFolder(), someFolder));
-		Assertions.assertThat(fileTree).containsExactlyInAnyOrder();
+		assertThat(fileTree).containsExactlyInAnyOrder();
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GitRatchetGradleTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GitRatchetGradleTest.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.Date;
-import java.util.Objects;
 import java.util.TimeZone;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoFilepatternException;
@@ -197,9 +198,9 @@ class GitRatchetGradleTest extends GradleIntegrationHarness {
 			ObjectId cleanFolder = TreeWalk.forPath(git.getRepository(), "clean", baseline.getTree()).getObjectId(0);
 			ObjectId dirtyFolder = TreeWalk.forPath(git.getRepository(), "dirty", baseline.getTree()).getObjectId(0);
 
-			Assertions.assertThat(baseline.getTree().toObjectId()).isEqualTo(ObjectId.fromString(BASELINE_ROOT));
-			Assertions.assertThat(cleanFolder).isEqualTo(ObjectId.fromString(BASELINE_CLEAN));
-			Assertions.assertThat(dirtyFolder).isEqualTo(ObjectId.fromString(BASELINE_DIRTY));
+			assertThat(baseline.getTree().toObjectId()).isEqualTo(ObjectId.fromString(BASELINE_ROOT));
+			assertThat(cleanFolder).isEqualTo(ObjectId.fromString(BASELINE_CLEAN));
+			assertThat(dirtyFolder).isEqualTo(ObjectId.fromString(BASELINE_DIRTY));
 
 			assertPass("spotlessCheck")
 					.outcome(":spotlessCheck", TaskOutcome.SUCCESS)
@@ -231,7 +232,7 @@ class GitRatchetGradleTest extends GradleIntegrationHarness {
 					.outcome(":added:spotlessMisc", TaskOutcome.UP_TO_DATE);
 
 			RevCommit next = addAndCommit(git);
-			Assertions.assertThat(next.getTree().toObjectId()).isNotEqualTo(baseline.getTree().toObjectId());
+			assertThat(next.getTree().toObjectId()).isNotEqualTo(baseline.getTree().toObjectId());
 			// if we commit to main (the baseline), then tasks will be out of date only because the baseline changed
 			// TO REPEAAT:
 			// - everything was up-to-date
@@ -240,8 +241,8 @@ class GitRatchetGradleTest extends GradleIntegrationHarness {
 
 			ObjectId nextCleanFolder = TreeWalk.forPath(git.getRepository(), "clean", next.getTree()).getObjectId(0);
 			ObjectId nextDirtyFolder = TreeWalk.forPath(git.getRepository(), "dirty", next.getTree()).getObjectId(0);
-			Assertions.assertThat(nextCleanFolder).isEqualTo(cleanFolder);    // the baseline for 'clean' didn't change
-			Assertions.assertThat(nextDirtyFolder).isNotEqualTo(dirtyFolder); // only the baseline for dirty
+			assertThat(nextCleanFolder).isEqualTo(cleanFolder);    // the baseline for 'clean' didn't change
+			assertThat(nextDirtyFolder).isNotEqualTo(dirtyFolder); // only the baseline for dirty
 
 			// check will still pass, but the tasks are all out of date
 			assertPass("spotlessCheck")
@@ -256,14 +257,14 @@ class GitRatchetGradleTest extends GradleIntegrationHarness {
 		BuildResult result;
 
 		BuildResultAssertion(BuildResult result) {
-			this.result = Objects.requireNonNull(result);
+			this.result = requireNonNull(result);
 		}
 
 		public BuildResultAssertion outcome(String taskPath, TaskOutcome expected) {
 			TaskOutcome actual = result.getTasks().stream()
 					.filter(task -> task.getPath().equals(taskPath))
 					.findAny().get().getOutcome();
-			Assertions.assertThat(actual).isEqualTo(expected);
+			assertThat(actual).isEqualTo(expected);
 			return this;
 		}
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleIncrementalResolutionTest.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -25,7 +26,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.assertj.core.api.AbstractStringAssert;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.Errors;
@@ -130,7 +130,7 @@ class GradleIncrementalResolutionTest extends GradleIntegrationHarness {
 
 	private AbstractStringAssert<?> checkRanAgainstNoneButError() throws IOException {
 		String console = taskRanAgainst("spotlessCheck");
-		return Assertions.assertThat(console);
+		return assertThat(console);
 	}
 
 	private String taskRanAgainst(String task, String... ranAgainst) throws IOException {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IdeHookTest.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
@@ -57,13 +58,13 @@ class IdeHookTest extends GradleIntegrationHarness {
 				"  }",
 				"}");
 		dirty = new File(rootFolder(), "DIRTY.md");
-		Files.write("ABC".getBytes(StandardCharsets.UTF_8), dirty);
+		Files.write("ABC".getBytes(UTF_8), dirty);
 		clean = new File(rootFolder(), "CLEAN.md");
-		Files.write("abc".getBytes(StandardCharsets.UTF_8), clean);
+		Files.write("abc".getBytes(UTF_8), clean);
 		diverge = new File(rootFolder(), "DIVERGE.md");
-		Files.write("ABC".getBytes(StandardCharsets.UTF_8), diverge);
+		Files.write("ABC".getBytes(UTF_8), diverge);
 		outofbounds = new File(rootFolder(), "OUTOFBOUNDS.md");
-		Files.write("ABC".getBytes(StandardCharsets.UTF_8), outofbounds);
+		Files.write("ABC".getBytes(UTF_8), outofbounds);
 	}
 
 	private static Stream<Boolean> configurationCacheProvider() {
@@ -106,39 +107,39 @@ class IdeHookTest extends GradleIntegrationHarness {
 	@MethodSource("configurationCacheProvider")
 	void dirty(boolean configurationCache) throws IOException {
 		runWith(configurationCache, "spotlessApply", "--quiet", "-PspotlessIdeHook=" + dirty.getAbsolutePath(), "-PspotlessIdeHookUseStdOut");
-		Assertions.assertThat(output).isEqualTo("abc");
-		Assertions.assertThat(error).startsWith("IS DIRTY");
+		assertThat(output).isEqualTo("abc");
+		assertThat(error).startsWith("IS DIRTY");
 	}
 
 	@ParameterizedTest
 	@MethodSource("configurationCacheProvider")
 	void clean(boolean configurationCache) throws IOException {
 		runWith(configurationCache, "spotlessApply", "--quiet", "-PspotlessIdeHook=" + clean.getAbsolutePath(), "-PspotlessIdeHookUseStdOut");
-		Assertions.assertThat(output).isEmpty();
-		Assertions.assertThat(error).startsWith("IS CLEAN");
+		assertThat(output).isEmpty();
+		assertThat(error).startsWith("IS CLEAN");
 	}
 
 	@ParameterizedTest
 	@MethodSource("configurationCacheProvider")
 	void diverge(boolean configurationCache) throws IOException {
 		runWith(configurationCache, "spotlessApply", "--quiet", "-PspotlessIdeHook=" + diverge.getAbsolutePath(), "-PspotlessIdeHookUseStdOut");
-		Assertions.assertThat(output).isEmpty();
-		Assertions.assertThat(error).startsWith("DID NOT CONVERGE");
+		assertThat(output).isEmpty();
+		assertThat(error).startsWith("DID NOT CONVERGE");
 	}
 
 	@ParameterizedTest
 	@MethodSource("configurationCacheProvider")
 	void outofbounds(boolean configurationCache) throws IOException {
 		runWith(configurationCache, "spotlessApply", "--quiet", "-PspotlessIdeHook=" + outofbounds.getAbsolutePath(), "-PspotlessIdeHookUseStdOut");
-		Assertions.assertThat(output).isEmpty();
-		Assertions.assertThat(error).isEmpty();
+		assertThat(output).isEmpty();
+		assertThat(error).isEmpty();
 	}
 
 	@ParameterizedTest
 	@MethodSource("configurationCacheProvider")
 	void notAbsolute(boolean configurationCache) throws IOException {
 		runWith(configurationCache, "spotlessApply", "--quiet", "-PspotlessIdeHook=build.gradle", "-PspotlessIdeHookUseStdOut");
-		Assertions.assertThat(output).isEmpty();
-		Assertions.assertThat(error).contains("Argument passed to spotlessIdeHook must be an absolute path");
+		assertThat(output).isEmpty();
+		assertThat(error).contains("Argument passed to spotlessIdeHook must be an absolute path");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavascriptExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavascriptExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -126,7 +127,7 @@ class JavascriptExtensionTest extends GradleIntegrationHarness {
 					"}");
 			setFile("test.js").toResource("npm/eslint/javascript/styleguide/standard/javascript-es6.dirty");
 			BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").buildAndFail();
-			Assertions.assertThat(spotlessApply.getOutput()).contains("ESLint must be configured");
+			assertThat(spotlessApply.getOutput()).contains("ESLint must be configured");
 		}
 
 		@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectAfterEvaluate.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectAfterEvaluate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Reproduces https://github.com/diffplug/spotless/issues/506 */
@@ -34,6 +35,6 @@ class MultiProjectAfterEvaluate extends GradleIntegrationHarness {
 						"repositories { mavenCentral() }",
 						"spotless { java { googleJavaFormat() } }");
 		String output = gradleRunner().withArguments("spotlessApply", "--warning-mode", "all").build().getOutput().replace("\r\n", "\n");
-		Assertions.assertThat(output).doesNotContain("Using method Project#afterEvaluate(Action) when the project is already evaluated has been deprecated.");
+		assertThat(output).doesNotContain("Using method Project#afterEvaluate(Action) when the project is already evaluated has been deprecated.");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.StringPrinter;
@@ -87,7 +88,7 @@ class MultiProjectTest extends GradleIntegrationHarness {
 				"}",
 				"spotless { predeclareDeps() }");
 		createNSubprojects();
-		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
+		assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
 				.contains("Add a step with [com.google.googlejavaformat:google-java-format:1.17.0] into the `spotlessPredeclare` block in the root project.");
 	}
 
@@ -133,7 +134,7 @@ class MultiProjectTest extends GradleIntegrationHarness {
 				"}",
 				"spotless { predeclareDepsFromBuildscript() }");
 		createNSubprojects();
-		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
+		assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
 				.contains("Could not find method spotlessPredeclare() for arguments");
 	}
 
@@ -148,7 +149,7 @@ class MultiProjectTest extends GradleIntegrationHarness {
 				" java { googleJavaFormat('1.17.0') }",
 				"}");
 		createNSubprojects();
-		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
+		assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
 				.contains("Could not find method spotlessPredeclare() for arguments");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmInstallCacheIntegrationTests.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmInstallCacheIntegrationTests.java
@@ -16,12 +16,12 @@
 package com.diffplug.gradle.spotless;
 
 import static com.diffplug.gradle.spotless.FormatExtension.NpmStepConfig.SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -51,7 +51,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir1 = newFolder("npm-prettier-1");
 		File cacheDir = DEFAULT_DIR_FOR_NPM_INSTALL_CACHE_DO_NEVER_WRITE_TO_THIS;
 		BuildResult result = runPhpPrettierOnDir(dir1, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.doesNotContain("Using cached node_modules for")
 				.contains("Caching node_modules for ")
 				.contains(Path.of(dir1.getAbsolutePath(), "build", SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME).toString());
@@ -63,17 +63,17 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir1 = newFolder("npm-prettier-1");
 		File cacheDir = newFolder("npm-prettier-cache");
 		BuildResult result = runPhpPrettierOnDir(dir1, cacheDir);
-		Assertions.assertThat(result.getOutput()).doesNotContainPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
+		assertThat(result.getOutput()).doesNotContainPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 		File dir2 = newFolder("npm-prettier-2");
 		BuildResult result2 = runPhpPrettierOnDir(dir2, cacheDir);
-		Assertions.assertThat(result2.getOutput()).containsPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
+		assertThat(result2.getOutput()).containsPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 	}
 
 	@Test
 	void prettierDoesNotCacheNodeModulesIfNotExplicitlyEnabled() throws IOException {
 		File dir2 = newFolder("npm-prettier-1");
 		BuildResult result = runPhpPrettierOnDir(dir2, null);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.doesNotContainPattern("Using cached node_modules for .*")
 				.doesNotContainPattern("Caching node_modules for .*");
 	}
@@ -84,7 +84,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir1 = newFolder("npm-prettier-global-1");
 		File cacheDir = pertainingCacheDir;
 		BuildResult result = runPhpPrettierOnDir(dir1, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.doesNotContainPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E")
 				.containsPattern("Caching node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 	}
@@ -95,7 +95,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir2 = newFolder("npm-prettier-global-2");
 		File cacheDir = pertainingCacheDir;
 		BuildResult result = runPhpPrettierOnDir(dir2, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.containsPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E")
 				.doesNotContainPattern("Caching node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 	}
@@ -122,7 +122,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 				"}");
 		setFile(baseDir + "/php-example.php").toResource("npm/prettier/plugins/php.dirty");
 		final BuildResult spotlessApply = gradleRunner().withProjectDir(projDir).withArguments("--stacktrace", "--info", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile(baseDir + "/php-example.php").sameAsResource("npm/prettier/plugins/php.clean");
 		return spotlessApply;
 	}
@@ -133,7 +133,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir1 = newFolder("npm-tsfmt-global-1");
 		File cacheDir = pertainingCacheDir;
 		BuildResult result = runTsfmtOnDir(dir1, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.doesNotContainPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E")
 				.containsPattern("Caching node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 	}
@@ -144,7 +144,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir2 = newFolder("npm-tsfmt-global-2");
 		File cacheDir = pertainingCacheDir;
 		BuildResult result = runTsfmtOnDir(dir2, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.containsPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E")
 				.doesNotContainPattern("Caching node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 	}
@@ -153,7 +153,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 	void tsfmtDoesNotCacheNodeModulesIfNotExplicitlyEnabled() throws IOException {
 		File dir2 = newFolder("npm-tsfmt-1");
 		BuildResult result = runTsfmtOnDir(dir2, null);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.doesNotContainPattern("Using cached node_modules for .*")
 				.doesNotContainPattern("Caching node_modules for .*");
 	}
@@ -187,7 +187,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir1 = newFolder("npm-eslint-global-1");
 		File cacheDir = pertainingCacheDir;
 		BuildResult result = runEslintOnDir(dir1, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.doesNotContainPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E")
 				.containsPattern("Caching node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 	}
@@ -198,7 +198,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir2 = newFolder("npm-eslint-global-2");
 		File cacheDir = pertainingCacheDir;
 		BuildResult result = runEslintOnDir(dir2, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.containsPattern("Using cached node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E")
 				.doesNotContainPattern("Caching node_modules for .*\\Q" + cacheDir.getAbsolutePath() + "\\E");
 	}
@@ -208,7 +208,7 @@ class NpmInstallCacheIntegrationTests extends GradleIntegrationHarness {
 		File dir2 = newFolder("npm-eslint-1");
 		File cacheDir = null;
 		BuildResult result = runEslintOnDir(dir2, cacheDir);
-		Assertions.assertThat(result.getOutput())
+		assertThat(result.getOutput())
 				.doesNotContainPattern("Using cached node_modules for .*")
 				.doesNotContainPattern("Caching node_modules for .*");
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest.java
@@ -15,7 +15,8 @@
  */
 package com.diffplug.gradle.spotless;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +59,7 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 			gradleRunner().withArguments("nodeSetup", "npmSetup").build();
 			// then run spotless using that node installation
 			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 		} catch (Exception e) {
 			printContents();
@@ -78,7 +79,7 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 			setFile("build.gradle").toResource("com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_1.gradle");
 			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 		} catch (Exception e) {
 			printContents();
@@ -92,7 +93,7 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 			setFile("build.gradle").toResource("com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_2.gradle");
 			setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 		} catch (Exception e) {
 			printContents();
@@ -131,7 +132,7 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 			gradleRunner().withArguments("nodeSetup", "npmSetup").build();
 			// then run spotless using that node installation
 			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 		} catch (Exception e) {
 			printContents();
@@ -170,7 +171,7 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 			gradleRunner().withArguments("nodeSetup", "npmSetup").build();
 			// then run spotless using that node installation
 			final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-			Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+			assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 		} catch (Exception e) {
 			printContents();
@@ -183,7 +184,7 @@ class NpmTestsWithoutNpmInstallationTest extends GradleIntegrationHarness {
 		setFile("build.gradle").toResource("com/diffplug/gradle/spotless/NpmTestsWithoutNpmInstallationTest_gradle_node_plugin_example_1.gradle");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "--configuration-cache", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PaddedCellTaskTest.java
@@ -15,19 +15,20 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.tasks.TaskProvider;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.StringPrinter;
@@ -70,7 +71,7 @@ class PaddedCellTaskTest extends ResourceHarness {
 				task.init(taskService);
 				task.setSteps(List.of(step));
 				task.setLineEndingsPolicy(project.provider(LineEnding.UNIX::createPolicy));
-				task.setTarget(Collections.singletonList(file));
+				task.setTarget(singletonList(file));
 			});
 		}
 
@@ -203,9 +204,9 @@ class PaddedCellTaskTest extends ResourceHarness {
 
 	private void assertFolderContents(String subfolderName, String... files) throws IOException {
 		File subfolder = new File(rootFolder(), subfolderName);
-		Assertions.assertTrue(subfolder.isDirectory());
+		assertTrue(subfolder.isDirectory());
 		String asList = String.join("\n", Arrays.asList(files));
-		Assertions.assertEquals(StringPrinter.buildStringFromLines(files).trim(), asList);
+		assertEquals(StringPrinter.buildStringFromLines(files).trim(), asList);
 	}
 
 	@Test
@@ -232,6 +233,6 @@ class PaddedCellTaskTest extends ResourceHarness {
 	private void assertFailureMessage(Bundle bundle, String... expectedOutput) {
 		String msg = bundle.checkFailureMsg();
 		String expected = StringPrinter.buildStringFromLines(expectedOutput).trim();
-		Assertions.assertEquals(expected, msg);
+		assertEquals(expected, msg);
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/PrettierIntegrationTest.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -51,7 +52,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
@@ -78,7 +79,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessCheckFailsGracefully = gradleRunner().withArguments("--stacktrace", "spotlessCheck").buildAndFail();
-		Assertions.assertThat(spotlessCheckFailsGracefully.getOutput()).contains("> The following files had format violations:");
+		assertThat(spotlessCheckFailsGracefully.getOutput()).contains("> The following files had format violations:");
 
 		gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
 		gradleRunner().withArguments("--stacktrace", "spotlessCheck").build();
@@ -101,7 +102,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		if (PRETTIER_VERSION_2.equals(prettierVersion)) {
 			assertFile("test.ts").sameAsResource("npm/prettier/config/typescript.configfile_prettier_2.clean");
 		} else if (PRETTIER_VERSION_3.equals(prettierVersion)) {
@@ -125,7 +126,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("dirty.json").toResource("npm/prettier/filename/dirty.json");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile("dirty.json").sameAsResource("npm/prettier/filename/clean.json");
 	}
 
@@ -160,7 +161,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("JavaTest.java").toResource("npm/prettier/plugins/java-test.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile("JavaTest.java").sameAsResource("npm/prettier/plugins/java-test.clean");
 	}
 
@@ -190,7 +191,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("JavaTest.java").toResource("npm/prettier/plugins/java-test.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile("JavaTest.java").sameAsResource("npm/prettier/plugins/java-test.clean");
 	}
 
@@ -214,8 +215,8 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("JavaTest.java").toResource("npm/prettier/plugins/java-test.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").buildAndFail();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("Could not infer a parser");
-		Assertions.assertThat(spotlessApply.getOutput()).contains("prettier-plugin-java");
+		assertThat(spotlessApply.getOutput()).contains("Could not infer a parser");
+		assertThat(spotlessApply.getOutput()).contains("prettier-plugin-java");
 	}
 
 	@ParameterizedTest(name = "{index}: usePhpCommunityPlugin with prettier {0}")
@@ -249,7 +250,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("php-example.php").toResource("npm/prettier/plugins/php.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile("php-example.php").sameAsResource("npm/prettier/plugins/php.clean");
 	}
 
@@ -306,9 +307,9 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 		setFile("php-example.php").toResource("npm/prettier/plugins/php.dirty");
 		setFile("JavaTest.java").toResource("npm/prettier/plugins/java-test.dirty");
 		final BuildResult spotlessApply = gradleRunner().forwardOutput().withArguments("--stacktrace", "--info", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		final BuildResult spotlessApply2 = gradleRunner().forwardOutput().withArguments("--stacktrace", "--info", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply2.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply2.getOutput()).contains("BUILD SUCCESSFUL");
 		assertFile("php-example.php").sameAsResource("npm/prettier/plugins/php.clean");
 		assertFile("JavaTest.java").sameAsResource("npm/prettier/plugins/java-test.clean");
 	}
@@ -337,7 +338,7 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").buildAndFail();
-		Assertions.assertThat(spotlessApply.getOutput()).containsPattern("Running npm command.*npm install.* failed with exit code: 1");
+		assertThat(spotlessApply.getOutput()).containsPattern("Running npm command.*npm install.* failed with exit code: 1");
 	}
 
 	@ParameterizedTest(name = "{index}: verifyCleanAndSpotlessWorks with prettier {0}")
@@ -359,9 +360,9 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "clean", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		final BuildResult spotlessApply2 = gradleRunner().withArguments("--stacktrace", "clean", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply2.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply2.getOutput()).contains("BUILD SUCCESSFUL");
 	}
 
 	@ParameterizedTest(name = "{index}: verifyCleanAndSpotlessWithNpmInstallCacheWorks with prettier {0}")
@@ -383,9 +384,9 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "clean", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply.getOutput()).contains("BUILD SUCCESSFUL");
 		final BuildResult spotlessApply2 = gradleRunner().withArguments("--stacktrace", "clean", "spotlessApply").build();
-		Assertions.assertThat(spotlessApply2.getOutput()).contains("BUILD SUCCESSFUL");
+		assertThat(spotlessApply2.getOutput()).contains("BUILD SUCCESSFUL");
 	}
 
 	@ParameterizedTest(name = "{index}: autodetectNpmrcFileConfig with prettier {0}")
@@ -412,6 +413,6 @@ class PrettierIntegrationTest extends GradleIntegrationHarness {
 				"}");
 		setFile("test.ts").toResource("npm/prettier/config/typescript.dirty");
 		final BuildResult spotlessApply = gradleRunner().withArguments("--stacktrace", "spotlessApply").buildAndFail();
-		Assertions.assertThat(spotlessApply.getOutput()).containsPattern("Running npm command.*npm install.* failed with exit code: 1");
+		assertThat(spotlessApply.getOutput()).containsPattern("Running npm command.*npm install.* failed with exit code: 1");
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
@@ -42,7 +43,7 @@ class RegisterDependenciesTaskTest extends GradleIntegrationHarness {
 
 		setFile("gradle.properties").toLines();
 		String newestSupported = gradleRunner().withArguments("spotlessCheck").build().getOutput();
-		Assertions.assertThat(newestSupported.replace("\r", ""))
+		assertThat(newestSupported.replace("\r", ""))
 				.startsWith(
 						"> Task :spotlessInternalRegisterDependencies\n")
 				.contains(

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPluginRedirectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPluginRedirectTest.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.base.StringPrinter;
@@ -29,7 +30,7 @@ class SpotlessPluginRedirectTest extends GradleIntegrationHarness {
 				"plugins {",
 				"    id 'com.diffplug.gradle.spotless'",
 				"}");
-		Assertions.assertThat(gradleRunner().buildAndFail().getOutput().replace("\r", ""))
+		assertThat(gradleRunner().buildAndFail().getOutput().replace("\r", ""))
 				.contains(StringPrinter.buildStringFromLines(
 						"   > We have moved from 'com.diffplug.gradle.spotless'",
 						"                     to 'com.diffplug.spotless'",

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessTaskImplTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessTaskImplTest.java
@@ -15,32 +15,36 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.nio.file.Path;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.logging.Logger;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import com.diffplug.spotless.Formatter;
 
 public class SpotlessTaskImplTest {
 	@Test
 	public void testThrowsMessageContainsFilename() throws Exception {
-		SpotlessTaskImpl task = Mockito.mock(Mockito.CALLS_REAL_METHODS);
-		Mockito.when(task.getLogger()).thenReturn(Mockito.mock(Logger.class));
+		SpotlessTaskImpl task = mock(CALLS_REAL_METHODS);
+		when(task.getLogger()).thenReturn(mock(Logger.class));
 
 		File projectDir = Path.of("unitTests", "projectDir").toFile();
-		DirectoryProperty projectDirProperty = Mockito.mock(Mockito.RETURNS_DEEP_STUBS);
-		Mockito.when(projectDirProperty.get().getAsFile()).thenReturn(projectDir);
+		DirectoryProperty projectDirProperty = mock(RETURNS_DEEP_STUBS);
+		when(projectDirProperty.get().getAsFile()).thenReturn(projectDir);
 
-		Mockito.when(task.getProjectDir()).thenReturn(projectDirProperty);
+		when(task.getProjectDir()).thenReturn(projectDirProperty);
 
 		File input = Path.of("unitTests", "projectDir", "someInput").toFile();
-		Formatter formatter = Mockito.mock();
+		Formatter formatter = mock();
 
-		Assertions.assertThatThrownBy(() -> task.processInputFile(null, formatter, input, "someInput")).hasMessageContaining(input.toString());
+		assertThatThrownBy(() -> task.processInputFile(null, formatter, input, "someInput")).hasMessageContaining(input.toString());
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/UpToDateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package com.diffplug.gradle.spotless;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
@@ -88,8 +89,8 @@ class UpToDateTest extends GradleIntegrationHarness {
 		// the format task is UP-TO-DATE (same inputs), but the apply tasks will run again
 		pauseForFilesystem();
 		BuildResult buildResult = gradleRunner().withArguments("spotlessApply").build();
-		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.UP_TO_DATE)).containsExactly(":spotlessInternalRegisterDependencies", ":spotlessMisc");
-		Assertions.assertThat(buildResult.taskPaths(TaskOutcome.SUCCESS)).containsExactly(":spotlessMiscApply", ":spotlessApply");
+		assertThat(buildResult.taskPaths(TaskOutcome.UP_TO_DATE)).containsExactly(":spotlessInternalRegisterDependencies", ":spotlessMisc");
+		assertThat(buildResult.taskPaths(TaskOutcome.SUCCESS)).containsExactly(":spotlessMiscApply", ":spotlessApply");
 		assertFile("README.md").hasContent("abc");
 
 		// and it'll take two more runs to get to fully UP-TO-DATE

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -17,14 +17,15 @@ package com.diffplug.spotless.maven;
 
 import static com.diffplug.common.base.Strings.isNullOrEmpty;
 import static com.diffplug.spotless.generic.LicenseHeaderStep.SPOTLESS_SET_LICENSE_HEADER_YEARS_FROM_GIT_HISTORY;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -35,7 +36,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -145,7 +145,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	private LicenseHeader licenseHeader;
 
 	@Parameter
-	private List<Format> formats = Collections.emptyList();
+	private List<Format> formats = emptyList();
 
 	@Parameter
 	private Css css;
@@ -315,7 +315,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 			final String[] includePatterns = this.filePatterns.split(",");
 			final List<Pattern> compiledIncludePatterns = Arrays.stream(includePatterns)
 					.map(Pattern::compile)
-					.collect(Collectors.toList());
+					.collect(toList());
 			final Predicate<File> shouldInclude = file -> compiledIncludePatterns
 					.stream()
 					.anyMatch(filePattern -> filePattern.matcher(file.getAbsolutePath())
@@ -365,7 +365,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		return StreamSupport.stream(patterns.spliterator(), true)
 				.map(pattern -> pattern.replace('/', File.separatorChar))
 				.map(pattern -> pattern.replace('\\', File.separatorChar))
-				.collect(Collectors.toSet());
+				.collect(toSet());
 	}
 
 	private static String withTrailingSeparator(String path) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/ArtifactResolver.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.maven;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -22,7 +23,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import org.apache.maven.plugin.logging.Log;
@@ -50,10 +50,10 @@ public class ArtifactResolver {
 
 	public ArtifactResolver(RepositorySystem repositorySystem, RepositorySystemSession session,
 			List<RemoteRepository> repositories, Log log) {
-		this.repositorySystem = Objects.requireNonNull(repositorySystem);
-		this.session = Objects.requireNonNull(session);
-		this.repositories = Objects.requireNonNull(repositories);
-		this.log = Objects.requireNonNull(log);
+		this.repositorySystem = requireNonNull(repositorySystem);
+		this.session = requireNonNull(session);
+		this.repositories = requireNonNull(repositories);
+		this.log = requireNonNull(log);
 	}
 
 	/**

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FileLocator.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FileLocator.java
@@ -17,6 +17,7 @@ package com.diffplug.spotless.maven;
 
 import static com.diffplug.common.base.Strings.isNullOrEmpty;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -25,7 +26,6 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
-import java.util.Objects;
 
 import org.codehaus.plexus.resource.ResourceManager;
 import org.codehaus.plexus.resource.loader.FileResourceCreationException;
@@ -42,9 +42,9 @@ public class FileLocator {
 	private final File dataDir;
 
 	public FileLocator(ResourceManager resourceManager, File baseDir, File buildDir) {
-		this.resourceManager = Objects.requireNonNull(resourceManager);
-		this.baseDir = Objects.requireNonNull(baseDir);
-		this.buildDir = Objects.requireNonNull(buildDir);
+		this.resourceManager = requireNonNull(resourceManager);
+		this.baseDir = requireNonNull(baseDir);
+		this.buildDir = requireNonNull(buildDir);
 		this.dataDir = findDataDir();
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -17,6 +17,8 @@ package com.diffplug.spotless.maven;
 
 import static com.diffplug.spotless.maven.AbstractSpotlessMojo.RATCHETFROM_NONE;
 import static java.util.Collections.emptySet;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -26,7 +28,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -96,7 +97,7 @@ public abstract class FormatterFactory {
 		List<FormatterStep> formatterSteps = factories.stream()
 				.filter(Objects::nonNull) // all unrecognized steps from XML config appear as nulls in the list
 				.map(factory -> factory.newFormatterStep(stepConfig))
-				.collect(Collectors.toCollection(ArrayList::new));
+				.collect(toCollection(ArrayList::new));
 		if (toggle != null) {
 			List<FormatterStep> formatterStepsBeforeToggle = formatterSteps;
 			formatterSteps = List.of(toggle.createFence().preserveWithin(formatterStepsBeforeToggle));
@@ -162,7 +163,7 @@ public abstract class FormatterFactory {
 	}
 
 	protected final void addStepFactory(FormatterStepFactory stepFactory) {
-		Objects.requireNonNull(stepFactory);
+		requireNonNull(stepFactory);
 		stepFactories.add(stepFactory);
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/GitRatchetMaven.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/GitRatchetMaven.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless.maven;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.eclipse.jgit.lib.IndexDiff;
 import org.eclipse.jgit.lib.ObjectId;
@@ -93,6 +94,6 @@ final class GitRatchetMaven extends GitRatchet<File> {
 
 		return dirtyPaths.stream()
 				.map(path -> baseDirPath.relativize(Path.of(workTreePath, path)).toString())
-				.collect(Collectors.toList());
+				.collect(toList());
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/Cpp.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/cpp/Cpp.java
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.cpp;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -33,7 +34,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
 public class Cpp extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	public void addEclipseCdt(EclipseCdt eclipse) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/css/Css.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/css/Css.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.css;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -28,7 +29,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Css extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Format.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Format.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.generic;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -32,7 +33,7 @@ public class Format extends FormatterFactory {
 
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Prettier.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/Prettier.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.maven.generic;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.io.File;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -22,7 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -97,7 +98,7 @@ public class Prettier extends AbstractNpmFormatterStepFactory {
 						}
 						return entry;
 					})
-					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
+					.collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
 		} else {
 			configInline = null;
 		}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/gherkin/Gherkin.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/gherkin/Gherkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.gherkin;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -28,7 +29,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Gherkin extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/go/Go.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/go/Go.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.go;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -25,7 +26,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Go extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/FormatAnnotations.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/FormatAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.diffplug.spotless.maven.java;
 
-import java.util.Collections;
+import static java.util.Collections.emptyList;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.java.FormatAnnotationsStep;
@@ -27,6 +27,6 @@ public class FormatAnnotations implements FormatterStepFactory {
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		// TODO: Permit customization in Maven build files.
-		return FormatAnnotationsStep.create(Collections.emptyList(), Collections.emptyList());
+		return FormatAnnotationsStep.create(emptyList(), emptyList());
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/javascript/Javascript.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/javascript/Javascript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.javascript;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -30,7 +31,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Javascript extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/JacksonJson.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/JacksonJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.json;
 
-import java.util.Collections;
+import static java.util.Collections.emptyMap;
+
 import java.util.Map;
 
 import org.apache.maven.plugins.annotations.Parameter;
@@ -39,10 +40,10 @@ public class JacksonJson implements FormatterStepFactory {
 	private boolean spaceBeforeSeparator = new JacksonJsonConfig().isSpaceBeforeSeparator();
 
 	@Parameter
-	private Map<String, Boolean> features = Collections.emptyMap();
+	private Map<String, Boolean> features = emptyMap();
 
 	@Parameter
-	private Map<String, Boolean> jsonFeatures = Collections.emptyMap();
+	private Map<String, Boolean> jsonFeatures = emptyMap();
 
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/json/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.json;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -30,7 +31,7 @@ public class Json extends FormatterFactory {
 
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Ktlint.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/kotlin/Ktlint.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.maven.kotlin;
 
+import static java.util.Collections.emptyList;
+
 import java.io.File;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +57,7 @@ public class Ktlint implements FormatterStepFactory {
 			editorConfigOverride = new HashMap<>();
 		}
 		if (customRuleSets == null) {
-			customRuleSets = Collections.emptyList();
+			customRuleSets = emptyList();
 		}
 		return KtLintStep.create(
 				ktlintVersion,

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/markdown/Markdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.markdown;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -32,7 +33,7 @@ import com.diffplug.spotless.maven.generic.LicenseHeader;
 public class Markdown extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/npm/AbstractNpmFormatterStepFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/npm/AbstractNpmFormatterStepFactory.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.maven.npm;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.util.AbstractMap;
@@ -24,7 +26,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -93,6 +94,6 @@ public abstract class AbstractNpmFormatterStepFactory implements FormatterStepFa
 		return devDependencyProperties.stringPropertyNames()
 				.stream()
 				.map(name -> new AbstractMap.SimpleEntry<>(name, devDependencyProperties.getProperty(name)))
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+				.collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/python/Python.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/python/Python.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.python;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -33,7 +34,7 @@ public class Python extends FormatterFactory {
 
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/rdf/Rdf.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/rdf/Rdf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 DiffPlug
+ * Copyright 2024-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.rdf;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -25,7 +26,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Rdf extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/sql/Sql.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/sql/Sql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 DiffPlug
+ * Copyright 2020-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.sql;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -30,7 +31,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Sql extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/typescript/Typescript.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/typescript/Typescript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.typescript;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -30,7 +31,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Typescript extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/yaml/JacksonYaml.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/yaml/JacksonYaml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.yaml;
 
-import java.util.Collections;
+import static java.util.Collections.emptyMap;
+
 import java.util.Map;
 
 import org.apache.maven.plugins.annotations.Parameter;
@@ -36,10 +37,10 @@ public class JacksonYaml implements FormatterStepFactory {
 	private String version = JacksonYamlStep.defaultVersion();
 
 	@Parameter
-	private Map<String, Boolean> features = Collections.emptyMap();
+	private Map<String, Boolean> features = emptyMap();
 
 	@Parameter
-	private Map<String, Boolean> yamlFeatures = Collections.emptyMap();
+	private Map<String, Boolean> yamlFeatures = emptyMap();
 
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig stepConfig) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/yaml/Yaml.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/yaml/Yaml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.yaml;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -28,7 +29,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Yaml extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/IdeHookTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/IdeHookTest.java
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.maven;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -62,28 +63,28 @@ class IdeHookTest extends MavenIntegrationHarness {
 	@Test
 	void dirty() throws IOException, InterruptedException {
 		runWith("spotless:apply", "--quiet", "-DspotlessIdeHook=\"" + dirty.getAbsolutePath() + "\"", "-DspotlessIdeHookUseStdOut=true");
-		Assertions.assertThat(output).isEqualTo("Mars");
-		Assertions.assertThat(error).startsWith("IS DIRTY");
+		assertThat(output).isEqualTo("Mars");
+		assertThat(error).startsWith("IS DIRTY");
 	}
 
 	@Test
 	void clean() throws IOException, InterruptedException {
 		runWith("spotless:apply", "--quiet", "-DspotlessIdeHook=" + clean.getAbsolutePath(), "-DspotlessIdeHookUseStdOut=true");
-		Assertions.assertThat(output).isEmpty();
-		Assertions.assertThat(error).startsWith("IS CLEAN");
+		assertThat(output).isEmpty();
+		assertThat(error).startsWith("IS CLEAN");
 	}
 
 	@Test
 	void outofbounds() throws IOException, InterruptedException {
 		runWith("spotless:apply", "--quiet", "-DspotlessIdeHook=" + outofbounds.getAbsolutePath(), "-DspotlessIdeHookUseStdOut=true");
-		Assertions.assertThat(output).isEmpty();
-		Assertions.assertThat(error).isEmpty();
+		assertThat(output).isEmpty();
+		assertThat(error).isEmpty();
 	}
 
 	@Test
 	void notAbsolute() throws IOException, InterruptedException {
 		runWith("spotless:apply", "--quiet", "-DspotlessIdeHook=\"pom.xml\"", "-DspotlessIdeHookUseStdOut=true");
-		Assertions.assertThat(output).isEmpty();
-		Assertions.assertThat(error).contains("Argument passed to spotlessIdeHook must be an absolute path");
+		assertThat(output).isEmpty();
+		assertThat(error).contains("Argument passed to spotlessIdeHook must be an absolute path");
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -16,7 +16,9 @@
 package com.diffplug.spotless.maven;
 
 import static com.diffplug.common.base.Strings.isNullOrEmpty;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -25,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -33,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -272,7 +272,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 
 	protected String createPomXmlContent(String pomTemplate, Map<String, Object> params) throws IOException {
 		URL url = MavenIntegrationHarness.class.getResource(pomTemplate);
-		try (BufferedReader reader = Resources.asCharSource(url, StandardCharsets.UTF_8).openBufferedStream()) {
+		try (BufferedReader reader = Resources.asCharSource(url, UTF_8).openBufferedStream()) {
 			Mustache mustache = mustacheFactory.compile(reader, "pom");
 			StringWriter writer = new StringWriter();
 			mustache.execute(writer, params);
@@ -361,7 +361,7 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		String concatenatedError = result.stdOutUtf8().lines()
 				.map(line -> line.startsWith(ERROR_PREFIX) ? line.substring(ERROR_PREFIX.length()) : null)
 				.filter(Objects::nonNull)
-				.collect(Collectors.joining("\n"));
+				.collect(joining("\n"));
 
 		String sanitizedVersion = concatenatedError.replaceFirst("com\\.diffplug\\.spotless:spotless-maven-plugin:([^:]+):", "com.diffplug.spotless:spotless-maven-plugin:VERSION:");
 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenRunner.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenRunner.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.maven;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -22,8 +24,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.diffplug.spotless.Jvm;
@@ -47,12 +47,12 @@ public final class MavenRunner {
 	private ProcessRunner runner;
 
 	public MavenRunner withProjectDir(File projectDir) {
-		this.projectDir = Objects.requireNonNull(projectDir);
+		this.projectDir = requireNonNull(projectDir);
 		return this;
 	}
 
 	public MavenRunner withArguments(String... args) {
-		this.args = Objects.requireNonNull(args);
+		this.args = requireNonNull(args);
 		return this;
 	}
 
@@ -83,17 +83,17 @@ public final class MavenRunner {
 			// add system properties as environment variables as MAVEN_OPTS or append if already there
 			String sysProps = systemProperties.entrySet().stream()
 					.map(entry -> "-D%s=%s".formatted(entry.getKey(), entry.getValue()))
-					.collect(Collectors.joining(" "));
+					.collect(joining(" "));
 			String mavenOpts = Stream.of(env.getOrDefault("MAVEN_OPTS", ""), sysProps)
-					.collect(Collectors.joining(" "));
+					.collect(joining(" "));
 			env.put("MAVEN_OPTS", mavenOpts.trim());
 		}
 		return env;
 	}
 
 	private ProcessRunner.Result run() throws IOException, InterruptedException {
-		Objects.requireNonNull(projectDir, "Need to call withProjectDir() first");
-		Objects.requireNonNull(args, "Need to call withArguments() first");
+		requireNonNull(projectDir, "Need to call withProjectDir() first");
+		requireNonNull(args, "Need to call withArguments() first");
 		// run Maven with the given args in the given directory
 		String argsString = "-e " + String.join(" ", Arrays.asList(args));
 		return runner.shellWinUnix(projectDir, calculateEnvironment(), "mvnw " + argsString, "./mvnw " + argsString);

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/incremental/PluginFingerprintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 package com.diffplug.spotless.maven.incremental;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.model.Model;
@@ -126,7 +126,7 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		spotlessPlugin.setVersion("1.2.3");
 		project.getBuild().addPlugin(spotlessPlugin);
 
-		PluginFingerprint fingerprint = PluginFingerprint.from(project, Collections.emptyList());
+		PluginFingerprint fingerprint = PluginFingerprint.from(project, emptyList());
 
 		assertThat(fingerprint).isNotNull();
 	}
@@ -143,7 +143,7 @@ class PluginFingerprintTest extends MavenIntegrationHarness {
 		pluginManagement.addPlugin(spotlessPlugin);
 		project.getBuild().setPluginManagement(pluginManagement);
 
-		PluginFingerprint fingerprint = PluginFingerprint.from(project, Collections.emptyList());
+		PluginFingerprint fingerprint = PluginFingerprint.from(project, emptyList());
 
 		assertThat(fingerprint).isNotNull();
 	}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/java/CleanthatJavaRefactorerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 DiffPlug
+ * Copyright 2022-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.java;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
@@ -104,7 +105,7 @@ class CleanthatJavaRefactorerTest extends MavenIntegrationHarness {
 		String path = "src/main/java/test.java";
 		setFile(path).toResource("java/cleanthat/" + dirtyPath);
 		// .withRemoteDebug(21654)
-		Assertions.assertThat(mavenRunner().withArguments("spotless:apply").runNoError().stdOutUtf8()).doesNotContain("[ERROR]");
+		assertThat(mavenRunner().withArguments("spotless:apply").runNoError().stdOutUtf8()).doesNotContain("[ERROR]");
 		assertFile(path).sameAsResource("java/cleanthat/" + cleanPath);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -15,7 +15,8 @@
  */
 package com.diffplug.spotless.maven.kotlin;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.ProcessRunner;
@@ -92,7 +93,7 @@ class KtlintTest extends MavenIntegrationHarness {
 				</ktlint>""");
 		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/listScreen.dirty");
 		ProcessRunner.Result result = mavenRunner().withArguments("spotless:check").runHasError();
-		Assertions.assertThat(result.toString()).contains("Composable functions that return Unit should start with an uppercase letter.");
+		assertThat(result.toString()).contains("Composable functions that return Unit should start with an uppercase letter.");
 	}
 
 	private void checkKtlintOfficialStyle() throws Exception {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmStepsWithNpmInstallCacheTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/npm/NpmStepsWithNpmInstallCacheTest.java
@@ -16,6 +16,7 @@
 package com.diffplug.spotless.maven.npm;
 
 import static com.diffplug.spotless.maven.npm.AbstractNpmFormatterStepFactory.SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +48,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <configFile>.prettierrc.yml</configFile>",
 				"</prettier>");
 		Result result = run("typescript", suffix);
-		Assertions.assertThat(result.stdOutUtf8()).doesNotContain("Caching node_modules for").doesNotContain("Using cached node_modules for");
+		assertThat(result.stdOutUtf8()).doesNotContain("Caching node_modules for").doesNotContain("Using cached node_modules for");
 	}
 
 	@Test
@@ -61,7 +61,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <npmInstallCache>true</npmInstallCache>",
 				"</prettier>");
 		Result result = run("typescript", suffix);
-		Assertions.assertThat(result.stdOutUtf8())
+		assertThat(result.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME)
 				.doesNotContain("Using cached node_modules for");
@@ -78,7 +78,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <npmInstallCache>true</npmInstallCache>",
 				"</prettier>");
 		Result result1 = run("typescript", suffix);
-		Assertions.assertThat(result1.stdOutUtf8())
+		assertThat(result1.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME)
 				.doesNotContain("Using cached node_modules for");
@@ -87,7 +87,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 		recursiveDelete(Path.of(rootFolder().getAbsolutePath(), "target"), SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME);
 
 		Result result2 = run("typescript", suffix);
-		Assertions.assertThat(result2.stdOutUtf8())
+		assertThat(result2.stdOutUtf8())
 				.doesNotContain("Caching node_modules for")
 				.contains(SPOTLESS_NPM_INSTALL_CACHE_DEFAULT_NAME)
 				.contains("Using cached node_modules for");
@@ -104,7 +104,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <npmInstallCache>" + cacheDir.getAbsolutePath() + "</npmInstallCache>",
 				"</prettier>");
 		Result result = run("typescript", suffix);
-		Assertions.assertThat(result.stdOutUtf8())
+		assertThat(result.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(Path.of(cacheDir.getAbsolutePath()).toAbsolutePath().toString())
 				.doesNotContain("Using cached node_modules for");
@@ -122,7 +122,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 				"  <npmInstallCache>" + cacheDir.getAbsolutePath() + "</npmInstallCache>",
 				"</prettier>");
 		Result result1 = run("typescript", suffix);
-		Assertions.assertThat(result1.stdOutUtf8())
+		assertThat(result1.stdOutUtf8())
 				.contains("Caching node_modules for")
 				.contains(Path.of(cacheDir.getAbsolutePath()).toAbsolutePath().toString())
 				.doesNotContain("Using cached node_modules for");
@@ -131,7 +131,7 @@ public class NpmStepsWithNpmInstallCacheTest extends MavenIntegrationHarness {
 		recursiveDelete(Path.of(rootFolder().getAbsolutePath(), "target"), null);
 
 		Result result2 = run("typescript", suffix);
-		Assertions.assertThat(result2.stdOutUtf8())
+		assertThat(result2.stdOutUtf8())
 				.doesNotContain("Caching node_modules for")
 				.contains(Path.of(cacheDir.getAbsolutePath()).toAbsolutePath().toString())
 				.contains("Using cached node_modules for");

--- a/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/ResourceHarness.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
@@ -24,7 +25,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -92,7 +92,7 @@ public class ResourceHarness {
 					throw new RuntimeException("Resource not found in classpath: '%s' - did you mean '/%1$s'?".formatted(path));
 				}
 			}
-			try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+			try (BufferedReader br = new BufferedReader(new InputStreamReader(in, UTF_8))) {
 				String resource;
 				while ((resource = br.readLine()) != null) {
 					filenames.add(resource);
@@ -107,7 +107,7 @@ public class ResourceHarness {
 	}
 
 	public String read(String path) throws IOException {
-		return read(newFile(path).toPath(), StandardCharsets.UTF_8);
+		return read(newFile(path).toPath(), UTF_8);
 	}
 
 	public String read(Path path, Charset encoding) throws IOException {
@@ -127,7 +127,7 @@ public class ResourceHarness {
 	public static String getTestResource(String filename) {
 		Optional<URL> resourceUrl = getTestResourceUrl(filename);
 		if (resourceUrl.isPresent()) {
-			return ThrowingEx.get(() -> LineEnding.toUnix(Resources.toString(resourceUrl.orElseThrow(), StandardCharsets.UTF_8)));
+			return ThrowingEx.get(() -> LineEnding.toUnix(Resources.toString(resourceUrl.orElseThrow(), UTF_8)));
 		}
 		throw new IllegalArgumentException("No such resource " + filename);
 	}
@@ -164,7 +164,7 @@ public class ResourceHarness {
 		String name = lastSlash >= 0 ? filename.substring(lastSlash) : filename;
 		File file = newFile(name);
 		file.getParentFile().mkdirs();
-		ThrowingEx.run(() -> Files.write(file.toPath(), fileContentsProcessor.apply(getTestResource(filename)).getBytes(StandardCharsets.UTF_8)));
+		ThrowingEx.run(() -> Files.write(file.toPath(), fileContentsProcessor.apply(getTestResource(filename)).getBytes(UTF_8)));
 		return file;
 	}
 
@@ -186,11 +186,11 @@ public class ResourceHarness {
 		}
 
 		public void hasContent(String expected) {
-			hasContent(expected, StandardCharsets.UTF_8);
+			hasContent(expected, UTF_8);
 		}
 
 		public void hasDifferentContent(String expected) {
-			hasDifferentContent(expected, StandardCharsets.UTF_8);
+			hasDifferentContent(expected, UTF_8);
 		}
 
 		public void hasContent(String expected, Charset charset) {
@@ -236,7 +236,7 @@ public class ResourceHarness {
 		}
 
 		public File toContent(String content) {
-			return toContent(content, StandardCharsets.UTF_8);
+			return toContent(content, UTF_8);
 		}
 
 		public File toContent(String content, Charset charset) {
@@ -245,7 +245,7 @@ public class ResourceHarness {
 		}
 
 		public File toResource(String path) {
-			ThrowingEx.run(() -> Files.write(file.toPath(), getTestResource(path).getBytes(StandardCharsets.UTF_8)));
+			ThrowingEx.run(() -> Files.write(file.toPath(), getTestResource(path).getBytes(UTF_8)));
 			return file;
 		}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarness.java
@@ -15,10 +15,10 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import com.diffplug.selfie.Selfie;
@@ -40,7 +40,7 @@ public final class StepHarness extends StepHarnessBase {
 		return forFormatter(Formatter.builder()
 				.steps(Arrays.asList(steps))
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
-				.encoding(StandardCharsets.UTF_8)
+				.encoding(UTF_8)
 				.build());
 	}
 
@@ -53,7 +53,7 @@ public final class StepHarness extends StepHarnessBase {
 		return new StepHarness(Formatter.builder()
 				.steps(Arrays.asList(step))
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
-				.encoding(StandardCharsets.UTF_8)
+				.encoding(UTF_8)
 				.build(), RoundTrip.DONT_ROUNDTRIP);
 	}
 

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,8 @@
  */
 package com.diffplug.spotless;
 
-import java.util.Objects;
-
-import org.assertj.core.api.Assertions;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class StepHarnessBase implements AutoCloseable {
 	enum RoundTrip {
@@ -28,12 +27,12 @@ class StepHarnessBase implements AutoCloseable {
 
 	protected StepHarnessBase(Formatter formatter, RoundTrip roundTrip) {
 		if (roundTrip == RoundTrip.DONT_ROUNDTRIP) {
-			this.formatter = Objects.requireNonNull(formatter);
+			this.formatter = requireNonNull(formatter);
 			return;
 		}
 		Formatter roundTripped = SerializableEqualityTester.reserialize(formatter);
 		if (roundTrip == RoundTrip.ASSERT_EQUAL) {
-			Assertions.assertThat(roundTripped).isEqualTo(formatter);
+			assertThat(roundTripped).isEqualTo(formatter);
 		}
 		this.formatter = roundTripped;
 	}

--- a/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
+++ b/testlib/src/main/java/com/diffplug/spotless/StepHarnessWithFile.java
@@ -15,13 +15,13 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Objects;
 
 import com.diffplug.selfie.StringSelfie;
 
@@ -31,15 +31,15 @@ public final class StepHarnessWithFile extends StepHarnessBase {
 
 	private StepHarnessWithFile(ResourceHarness harness, Formatter formatter, RoundTrip roundTrip) {
 		super(formatter, roundTrip);
-		this.harness = Objects.requireNonNull(harness);
+		this.harness = requireNonNull(harness);
 	}
 
 	/** Creates a harness for testing steps which do depend on the file. */
 	public static StepHarnessWithFile forStep(ResourceHarness harness, FormatterStep step) {
 		return forFormatter(harness, Formatter.builder()
-				.encoding(StandardCharsets.UTF_8)
+				.encoding(UTF_8)
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
-				.steps(Collections.singletonList(step))
+				.steps(singletonList(step))
 				.build());
 	}
 

--- a/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
+++ b/testlib/src/main/java/com/diffplug/spotless/TestProvisioner.java
@@ -15,12 +15,13 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Comparator.reverseOrder;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -86,7 +87,7 @@ public class TestProvisioner {
 				// delete the temp dir
 				try {
 					java.nio.file.Files.walk(tempDir.toPath())
-							.sorted(Comparator.reverseOrder())
+							.sorted(reverseOrder())
 							.map(Path::toFile)
 							.forEach(File::delete);
 				} catch (IOException e) {

--- a/testlib/src/main/java/com/diffplug/spotless/npm/EslintStyleGuide.java
+++ b/testlib/src/main/java/com/diffplug/spotless/npm/EslintStyleGuide.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -110,13 +111,13 @@ public enum EslintStyleGuide {
 	public String asGradleMapStringMergedWith(Map<String, String> devDependencies) {
 		return mergedWith(devDependencies).entrySet().stream()
 				.map(entry -> "'" + entry.getKey() + "': '" + entry.getValue() + "'")
-				.collect(Collectors.joining(", ", "[", "]"));
+				.collect(joining(", ", "[", "]"));
 	}
 
 	public String asMavenXmlStringMergedWith(Map<String, String> devDependencies) {
 		return mergedWith(devDependencies).entrySet().stream()
 				.map(entry -> "<property><name>%s</name><value>%s</value></property>".formatted(entry.getKey(), entry.getValue()))
-				.collect(Collectors.joining("", "<devDependencyProperties>", "</devDependencyProperties>"));
+				.collect(joining("", "<devDependencyProperties>", "</devDependencyProperties>"));
 	}
 
 }

--- a/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/EncodingErrorMsgTest.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nullable;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class EncodingErrorMsgTest {
@@ -49,9 +50,9 @@ class EncodingErrorMsgTest {
 
 	private void cp1252asUtf8(String test, @Nullable String expectedMessage) throws UnsupportedEncodingException {
 		byte[] cp1252 = test.getBytes("cp1252");
-		String asUTF = new String(cp1252, StandardCharsets.UTF_8);
-		String actualMessage = EncodingErrorMsg.msg(asUTF, cp1252, StandardCharsets.UTF_8);
-		Assertions.assertThat(actualMessage).isEqualTo(expectedMessage);
+		String asUTF = new String(cp1252, UTF_8);
+		String actualMessage = EncodingErrorMsg.msg(asUTF, cp1252, UTF_8);
+		assertThat(actualMessage).isEqualTo(expectedMessage);
 	}
 
 	@Test
@@ -86,17 +87,17 @@ class EncodingErrorMsgTest {
 	}
 
 	private void utf8asCP1252(String test, @Nullable String expectedMessage) throws UnsupportedEncodingException {
-		byte[] utf8 = test.getBytes(StandardCharsets.UTF_8);
+		byte[] utf8 = test.getBytes(UTF_8);
 		String asCp1252 = new String(utf8, "cp1252");
 		String actualMessage = EncodingErrorMsg.msg(asCp1252, utf8, Charset.forName("cp1252"));
-		Assertions.assertThat(actualMessage).isEqualTo(expectedMessage);
+		assertThat(actualMessage).isEqualTo(expectedMessage);
 	}
 
 	@Test
 	void canUseUnrepresentableOnPurpose() throws UnsupportedEncodingException {
 		String pathologic = new String(new char[]{EncodingErrorMsg.UNREPRESENTABLE});
-		byte[] pathologicBytes = pathologic.getBytes(StandardCharsets.UTF_8);
-		String pathologicMsg = EncodingErrorMsg.msg(pathologic, pathologicBytes, StandardCharsets.UTF_8);
-		Assertions.assertThat(pathologicMsg).isNull();
+		byte[] pathologicBytes = pathologic.getBytes(UTF_8);
+		String pathologicMsg = EncodingErrorMsg.msg(pathologic, pathologicBytes, UTF_8);
+		assertThat(pathologicMsg).isNull();
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FileSignatureTest.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.Collections.shuffle;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
@@ -23,10 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 
@@ -65,7 +64,7 @@ class FileSignatureTest extends ResourceHarness {
 		File dir = new File(rootFolder(), "dir");
 		List<File> files = getTestFiles(INPUT_PATHS);
 		files.add(dir);
-		Collections.shuffle(files);
+		shuffle(files);
 		assertThatThrownBy(() -> FileSignature.signAsList(files))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
@@ -87,6 +86,6 @@ class FileSignatureTest extends ResourceHarness {
 	@EnabledOnOs(WINDOWS)
 	void windowsRoot() {
 		String subpath = FileSignature.subpath("S://", "S:/build.gradle");
-		Assertions.assertThat(subpath).isEqualTo("build.gradle");
+		assertThat(subpath).isEqualTo("build.gradle");
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterPropertiesTest.java
@@ -15,7 +15,9 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -25,10 +27,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class FormatterPropertiesTest extends ResourceHarness {
@@ -50,15 +50,15 @@ class FormatterPropertiesTest extends ResourceHarness {
 	};
 
 	private List<String> validPropertiesResources() {
-		return List.of(VALID_SETTINGS_RESOURCES).stream().filter(it -> !it.endsWith(".xml")).collect(Collectors.toList());
+		return List.of(VALID_SETTINGS_RESOURCES).stream().filter(it -> !it.endsWith(".xml")).collect(toList());
 	}
 
 	private List<String> validXmlResources() {
-		return List.of(VALID_SETTINGS_RESOURCES).stream().filter(it -> it.endsWith(".xml")).collect(Collectors.toList());
+		return List.of(VALID_SETTINGS_RESOURCES).stream().filter(it -> it.endsWith(".xml")).collect(toList());
 	}
 
 	private List<String> invalidXmlResources() {
-		return List.of(INVALID_SETTINGS_RESOURCES).stream().filter(it -> it.endsWith(".xml")).collect(Collectors.toList());
+		return List.of(INVALID_SETTINGS_RESOURCES).stream().filter(it -> it.endsWith(".xml")).collect(toList());
 	}
 
 	private static final String[] VALID_VALUES = {
@@ -181,7 +181,7 @@ class FormatterPropertiesTest extends ResourceHarness {
 		String filePath = FileSignature.pathUnixToNative("does/not/exist.properties");
 		try {
 			FormatterProperties.from(new File(filePath));
-			Assertions.fail("Should have thrown");
+			fail("Should have thrown");
 		} catch (IllegalArgumentException ex) {
 			assertThat(ex.getMessage())
 					.as("IllegalArgumentException does not contain path of non-existing file.").contains(filePath);

--- a/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/FormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
  */
 package com.diffplug.spotless;
 
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.generic.EndWithNewlineStep;
@@ -28,9 +30,9 @@ import com.diffplug.spotless.generic.EndWithNewlineStep;
 class FormatterTest {
 	@Test
 	void toUnix() {
-		Assertions.assertEquals("1\n2\n3", LineEnding.toUnix("1\n2\n3"));
-		Assertions.assertEquals("1\n2\n3", LineEnding.toUnix("1\r2\r3"));
-		Assertions.assertEquals("1\n2\n3", LineEnding.toUnix("1\r\n2\r\n3"));
+		assertEquals("1\n2\n3", LineEnding.toUnix("1\n2\n3"));
+		assertEquals("1\n2\n3", LineEnding.toUnix("1\r2\r3"));
+		assertEquals("1\n2\n3", LineEnding.toUnix("1\r\n2\r\n3"));
 	}
 
 	// Formatter normally needs to be closed, but no resources will be leaked in this special case
@@ -38,7 +40,7 @@ class FormatterTest {
 	void equality() {
 		new SerializableEqualityTester() {
 			private LineEnding.Policy lineEndingsPolicy = LineEnding.UNIX.createPolicy();
-			private Charset encoding = StandardCharsets.UTF_8;
+			private Charset encoding = UTF_8;
 			private List<FormatterStep> steps = new ArrayList<>();
 
 			@Override
@@ -48,7 +50,7 @@ class FormatterTest {
 				lineEndingsPolicy = LineEnding.WINDOWS.createPolicy();
 				api.areDifferentThan();
 
-				encoding = StandardCharsets.UTF_16;
+				encoding = UTF_16;
 				api.areDifferentThan();
 
 				steps.add(EndWithNewlineStep.create());

--- a/testlib/src/test/java/com/diffplug/spotless/PaddedCellTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/PaddedCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package com.diffplug.spotless;
 import static com.diffplug.spotless.PaddedCell.Type.CONVERGE;
 import static com.diffplug.spotless.PaddedCell.Type.CYCLE;
 import static com.diffplug.spotless.PaddedCell.Type.DIVERGE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -50,23 +51,23 @@ class PaddedCellTest {
 		formatterSteps.add(NeverUpToDateStep.create("step", step));
 		try (Formatter formatter = Formatter.builder()
 				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
-				.encoding(StandardCharsets.UTF_8)
+				.encoding(UTF_8)
 				.steps(formatterSteps).build()) {
 
 			File file = new File(rootFolder, "input");
-			Files.write(file.toPath(), input.getBytes(StandardCharsets.UTF_8));
+			Files.write(file.toPath(), input.getBytes(UTF_8));
 
 			PaddedCell result = PaddedCell.check(formatter, file);
-			Assertions.assertEquals(misbehaved, result.misbehaved());
-			Assertions.assertEquals(expectedOutputType, result.type());
+			assertEquals(misbehaved, result.misbehaved());
+			assertEquals(expectedOutputType, result.type());
 
 			String actual = String.join(",", result.steps());
-			Assertions.assertEquals(expectedSteps, actual);
+			assertEquals(expectedSteps, actual);
 
 			if (canonical == null) {
-				Assertions.assertThrows(IllegalArgumentException.class, result::canonical);
+				assertThrows(IllegalArgumentException.class, result::canonical);
 			} else {
-				Assertions.assertEquals(canonical, result.canonical());
+				assertEquals(canonical, result.canonical());
 			}
 		}
 	}
@@ -121,7 +122,7 @@ class PaddedCellTest {
 				Collections.rotate(unordered, 1);
 				PaddedCell result = CYCLE.create(rootFolder, unordered);
 				// make sure the canonical result is always the appropriate one
-				Assertions.assertEquals(canonical, result.canonical());
+				assertEquals(canonical, result.canonical());
 			}
 		};
 		// alphabetic

--- a/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/ProvisionerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,23 @@
  */
 package com.diffplug.spotless;
 
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ProvisionerTest {
 	@Test
 	void testManipulation() {
-		Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(File::new).collect(Collectors.toSet());
-		Assertions.assertThat(provisioner.provisionWithTransitives(true, "a"))
+		Provisioner provisioner = (withTransitives, deps) -> deps.stream().map(File::new).collect(toSet());
+		assertThat(provisioner.provisionWithTransitives(true, "a"))
 				.containsExactlyInAnyOrder(new File("a"));
-		Assertions.assertThat(provisioner.provisionWithTransitives(true, "a", "a"))
+		assertThat(provisioner.provisionWithTransitives(true, "a", "a"))
 				.containsExactlyInAnyOrder(new File("a"));
-		Assertions.assertThat(provisioner.provisionWithTransitives(true, Arrays.asList("a", "a")))
+		assertThat(provisioner.provisionWithTransitives(true, Arrays.asList("a", "a")))
 				.containsExactlyInAnyOrder(new File("a"));
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/generic/IdeaStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/IdeaStepTest.java
@@ -15,10 +15,12 @@
  */
 package com.diffplug.spotless.generic;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.jupiter.api.Assertions;
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.common.io.Files;
@@ -36,19 +38,19 @@ class IdeaStepTest extends ResourceHarness {
 
 		String name = step.getName();
 
-		Assertions.assertEquals("IDEA", name);
+		assertEquals("IDEA", name);
 	}
 
 	@Test
 	void notFormattings() throws Exception {
 		File cleanFile = newFile("clean.java");
 		String cleanJava = ResourceHarness.getTestResource("java/idea/full.clean.java");
-		Files.write(cleanJava, cleanFile, StandardCharsets.UTF_8);
+		Files.write(cleanJava, cleanFile, UTF_8);
 		FormatterStep step = IdeaStep.newBuilder(buildDir()).setUseDefaults(true).build();
 
 		var result = step.format(cleanJava, cleanFile);
 
-		Assertions.assertEquals(cleanJava, result,
+		assertEquals(cleanJava, result,
 				"formatting was applied to clean file");
 	}
 
@@ -56,12 +58,12 @@ class IdeaStepTest extends ResourceHarness {
 	void formattings() throws Exception {
 		File dirtyFile = newFile("dirty.java");
 		String dirtyJava = ResourceHarness.getTestResource("java/idea/full.dirty.java");
-		Files.write(dirtyJava, dirtyFile, StandardCharsets.UTF_8);
+		Files.write(dirtyJava, dirtyFile, UTF_8);
 		FormatterStep step = IdeaStep.newBuilder(buildDir()).setUseDefaults(true).build();
 
 		var result = step.format(dirtyJava, dirtyFile);
 
-		Assertions.assertNotEquals(dirtyJava, result,
+		assertNotEquals(dirtyJava, result,
 				"files were not changed after reformat");
 	}
 
@@ -69,12 +71,12 @@ class IdeaStepTest extends ResourceHarness {
 	void formattingsWorkWithDefaultParameters() throws Exception {
 		File dirtyFile = newFile("dirty.java");
 		String dirtyJava = ResourceHarness.getTestResource("java/idea/full.dirty.java");
-		Files.write(dirtyJava, dirtyFile, StandardCharsets.UTF_8);
+		Files.write(dirtyJava, dirtyFile, UTF_8);
 		FormatterStep step = IdeaStep.newBuilder(buildDir()).build();
 
 		var result = step.format(dirtyJava, dirtyFile);
 
-		Assertions.assertNotEquals(dirtyJava, result,
+		assertNotEquals(dirtyJava, result,
 				"files were not changed after reformat");
 	}
 
@@ -82,12 +84,12 @@ class IdeaStepTest extends ResourceHarness {
 	void formattingsWithoutDefaultDoesNothing() throws Exception {
 		File dirtyFile = newFile("dirty.java");
 		String dirtyJava = ResourceHarness.getTestResource("java/idea/full.dirty.java");
-		Files.write(dirtyJava, dirtyFile, StandardCharsets.UTF_8);
+		Files.write(dirtyJava, dirtyFile, UTF_8);
 		FormatterStep step = IdeaStep.newBuilder(buildDir()).setUseDefaults(false).build();
 
 		var result = step.format(dirtyJava, dirtyFile);
 
-		Assertions.assertEquals(dirtyJava, result,
+		assertEquals(dirtyJava, result,
 				"files were changed after reformat");
 	}
 
@@ -95,12 +97,12 @@ class IdeaStepTest extends ResourceHarness {
 	void configureFile() throws Exception {
 		File cleanFile = newFile("clean.java");
 		String cleanJava = ResourceHarness.getTestResource("java/idea/full.clean.java");
-		Files.write(cleanJava, cleanFile, StandardCharsets.UTF_8);
+		Files.write(cleanJava, cleanFile, UTF_8);
 		FormatterStep step = IdeaStep.newBuilder(buildDir()).setUseDefaults(true).build();
 
 		var result = step.format(cleanJava, cleanFile);
 
-		Assertions.assertEquals(cleanJava, result,
+		assertEquals(cleanJava, result,
 				"formatting was applied to clean file");
 	}
 

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -15,13 +15,15 @@
  */
 package com.diffplug.spotless.generic;
 
+import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.time.ZoneOffset;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -185,9 +187,9 @@ class LicenseHeaderStepTest extends ResourceHarness {
 	void efficient() throws Throwable {
 		FormatterStep step = LicenseHeaderStep.headerDelimiter("LicenseHeader\n", "contentstart").build();
 		String alreadyCorrect = "LicenseHeader\ncontentstart";
-		Assertions.assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
+		assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
 		// If no change is required, it should return the exact same string for efficiency reasons
-		Assertions.assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));
+		assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));
 	}
 
 	@Test
@@ -195,8 +197,8 @@ class LicenseHeaderStepTest extends ResourceHarness {
 		// The sanitizer should add a \n
 		FormatterStep step = LicenseHeaderStep.headerDelimiter("LicenseHeader", "contentstart").build();
 		String alreadyCorrect = "LicenseHeader\ncontentstart";
-		Assertions.assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
-		Assertions.assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));
+		assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
+		assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));
 	}
 
 	@Test
@@ -204,8 +206,8 @@ class LicenseHeaderStepTest extends ResourceHarness {
 		// if the user wants extra lines after the header, we shouldn't clobber them
 		FormatterStep step = LicenseHeaderStep.headerDelimiter("LicenseHeader\n\n", "contentstart").build();
 		String alreadyCorrect = "LicenseHeader\n\ncontentstart";
-		Assertions.assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
-		Assertions.assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));
+		assertEquals(alreadyCorrect, step.format(alreadyCorrect, new File("")));
+		assertSame(alreadyCorrect, step.format(alreadyCorrect, new File("")));
 	}
 
 	@Test
@@ -250,7 +252,7 @@ class LicenseHeaderStepTest extends ResourceHarness {
 
 	@Test
 	void should_update_year_for_license_with_address() throws Throwable {
-		int currentYear = LocalDate.now(ZoneOffset.UTC).getYear();
+		int currentYear = LocalDate.now(UTC).getYear();
 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(licenceWithAddress()), PACKAGE_).withYearMode(YearMode.UPDATE_TO_TODAY).build();
 		StepHarness.forStep(step).test(
 				hasHeader(licenceWithAddress().replace("$YEAR", "2015")),

--- a/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/kotlin/DiktatStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 DiffPlug
+ * Copyright 2021-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 package com.diffplug.spotless.kotlin;
 
 import static com.diffplug.spotless.FileSignature.signAsList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FileSignature;
@@ -49,12 +51,12 @@ class DiktatStepTest extends ResourceHarness {
 
 	@Test
 	void notSupportedVersion() {
-		final IllegalStateException notSupportedException = Assertions.assertThrows(IllegalStateException.class,
+		final IllegalStateException notSupportedException = assertThrows(IllegalStateException.class,
 				() -> DiktatStep.create("1.1.0", TestProvisioner.mavenCentral()));
-		Assertions.assertTrue(
+		assertTrue(
 				notSupportedException.getMessage().contains("Minimum required Diktat version is 1.2.1, you tried 1.1.0 which is too old"));
 
-		Assertions.assertDoesNotThrow(() -> DiktatStep.create("1.2.1", TestProvisioner.mavenCentral()));
-		Assertions.assertDoesNotThrow(() -> DiktatStep.create("2.0.0", TestProvisioner.mavenCentral()));
+		assertDoesNotThrow(() -> DiktatStep.create("1.2.1", TestProvisioner.mavenCentral()));
+		assertDoesNotThrow(() -> DiktatStep.create("2.0.0", TestProvisioner.mavenCentral()));
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/npm/NpmFormatterStepCommonTests.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/NpmFormatterStepCommonTests.java
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Collections.emptyList;
+
 import java.io.File;
-import java.util.Collections;
 
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.ThrowingEx;
@@ -24,7 +25,7 @@ import com.diffplug.spotless.ThrowingEx;
 public abstract class NpmFormatterStepCommonTests extends ResourceHarness {
 
 	protected NpmPathResolver npmPathResolver() {
-		return new NpmPathResolver(npmExecutable(), nodeExecutable(), npmrc(), Collections.emptyList());
+		return new NpmPathResolver(npmExecutable(), nodeExecutable(), npmrc(), emptyList());
 	}
 
 	private File npmExecutable() {

--- a/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/PrettierFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.util.Collections.emptyMap;
+
 import java.io.File;
-import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Nested;
@@ -118,7 +119,7 @@ class PrettierFormatterStepTest extends NpmFormatterStepCommonTests {
 					buildDir(),
 					null,
 					npmPathResolver(),
-					new PrettierConfig(null, Collections.emptyMap()));
+					new PrettierConfig(null, emptyMap()));
 
 			try (StepHarnessWithFile stepHarness = StepHarnessWithFile.forStep(this, formatterStep)) {
 				stepHarness.testResource("test.json", dirtyFile, cleanFile);

--- a/testlib/src/test/java/com/diffplug/spotless/npm/ShadowCopyTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/ShadowCopyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 DiffPlug
+ * Copyright 2023-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,18 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +53,7 @@ class ShadowCopyTest extends ResourceHarness {
 		File folderWithRandomFile = newFolderWithRandomFile();
 		shadowCopy.addEntry("someEntry", folderWithRandomFile);
 		File shadowCopyFile = shadowCopy.getEntry("someEntry", folderWithRandomFile.getName());
-		Assertions.assertThat(shadowCopyFile.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
+		assertThat(shadowCopyFile.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
 		assertAllFilesAreEqualButNotSameAbsolutePath(folderWithRandomFile, shadowCopyFile);
 	}
 
@@ -64,8 +65,8 @@ class ShadowCopyTest extends ResourceHarness {
 		shadowCopy.addEntry("someOtherEntry", folderWithRandomFile2);
 		File shadowCopyFile = shadowCopy.getEntry("someEntry", folderWithRandomFile.getName());
 		File shadowCopyFile2 = shadowCopy.getEntry("someOtherEntry", folderWithRandomFile2.getName());
-		Assertions.assertThat(shadowCopyFile.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
-		Assertions.assertThat(shadowCopyFile2.listFiles()).hasSize(folderWithRandomFile2.listFiles().length);
+		assertThat(shadowCopyFile.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
+		assertThat(shadowCopyFile2.listFiles()).hasSize(folderWithRandomFile2.listFiles().length);
 		assertAllFilesAreEqualButNotSameAbsolutePath(folderWithRandomFile, shadowCopyFile);
 		assertAllFilesAreEqualButNotSameAbsolutePath(folderWithRandomFile2, shadowCopyFile2);
 	}
@@ -76,7 +77,7 @@ class ShadowCopyTest extends ResourceHarness {
 		shadowCopy.addEntry("someEntry", folderWithRandomFile);
 		shadowCopy.addEntry("someEntry", folderWithRandomFile);
 		File shadowCopyFile = shadowCopy.getEntry("someEntry", folderWithRandomFile.getName());
-		Assertions.assertThat(shadowCopyFile.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
+		assertThat(shadowCopyFile.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
 		assertAllFilesAreEqualButNotSameAbsolutePath(folderWithRandomFile, shadowCopyFile);
 	}
 
@@ -92,8 +93,8 @@ class ShadowCopyTest extends ResourceHarness {
 
 		// now check that they are different
 		File shadowCopy = this.shadowCopy.getEntry("someEntry", folderWithRandomFile.getName());
-		Assertions.assertThat(shadowCopy.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
-		Assertions.assertThat(shadowCopy.listFiles()[0].getName()).isNotEqualTo(folderWithRandomFile.listFiles()[0].getName());
+		assertThat(shadowCopy.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
+		assertThat(shadowCopy.listFiles()[0].getName()).isNotEqualTo(folderWithRandomFile.listFiles()[0].getName());
 	}
 
 	@Test
@@ -103,7 +104,7 @@ class ShadowCopyTest extends ResourceHarness {
 		File copiedFolder = newFolder("copyDest");
 		File copiedEntry = shadowCopy.copyEntryInto("someEntry", folderWithRandomFile.getName(), copiedFolder);
 
-		Assertions.assertThat(copiedEntry.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
+		assertThat(copiedEntry.listFiles()).hasSize(folderWithRandomFile.listFiles().length);
 		assertAllFilesAreEqualButNotSameAbsolutePath(folderWithRandomFile, copiedEntry);
 	}
 
@@ -115,7 +116,7 @@ class ShadowCopyTest extends ResourceHarness {
 		File copiedEntry = shadowCopy.copyEntryInto("someEntry", folderWithRandomFile.getName(), copiedFolder);
 
 		File shadowCopyFile = shadowCopy.getEntry("someEntry", folderWithRandomFile.getName());
-		Assertions.assertThat(shadowCopyFile.listFiles()).hasSize(copiedEntry.listFiles().length);
+		assertThat(shadowCopyFile.listFiles()).hasSize(copiedEntry.listFiles().length);
 		assertAllFilesAreEqualButNotSameAbsolutePath(copiedEntry, shadowCopyFile);
 	}
 
@@ -123,13 +124,13 @@ class ShadowCopyTest extends ResourceHarness {
 	void anAddedEntryExistsAfterAdding() throws IOException {
 		File folderWithRandomFile = newFolderWithRandomFile();
 		shadowCopy.addEntry("someEntry", folderWithRandomFile);
-		Assertions.assertThat(shadowCopy.entryExists("someEntry", folderWithRandomFile.getName())).isTrue();
+		assertThat(shadowCopy.entryExists("someEntry", folderWithRandomFile.getName())).isTrue();
 	}
 
 	@Test
 	void aEntryThatHasNotBeenAddedDoesNotExist() throws IOException {
 		File folderWithRandomFile = newFolderWithRandomFile();
-		Assertions.assertThat(shadowCopy.entryExists("someEntry", folderWithRandomFile.getName())).isFalse();
+		assertThat(shadowCopy.entryExists("someEntry", folderWithRandomFile.getName())).isFalse();
 	}
 
 	private void assertAllFilesAreEqualButNotSameAbsolutePath(File expected, File actual) {
@@ -141,8 +142,8 @@ class ShadowCopyTest extends ResourceHarness {
 	}
 
 	private void assertDirectoryIsEqualButNotSameAbsolutePath(File expected, File actual) {
-		Assertions.assertThat(actual.getAbsolutePath()).as("absolute path should be different").isNotEqualTo(expected.getAbsolutePath());
-		Assertions.assertThat(actual.listFiles()).as("folder should have same amount of files").hasSize(expected.listFiles().length);
+		assertThat(actual.getAbsolutePath()).as("absolute path should be different").isNotEqualTo(expected.getAbsolutePath());
+		assertThat(actual.listFiles()).as("folder should have same amount of files").hasSize(expected.listFiles().length);
 		List<File> actualContent = filesInAlphabeticalOrder(actual);
 		List<File> expectedContent = filesInAlphabeticalOrder(expected);
 
@@ -156,14 +157,14 @@ class ShadowCopyTest extends ResourceHarness {
 			throw new IllegalArgumentException("folder must be a directory");
 		}
 		return Arrays.stream(folder.listFiles())
-				.sorted(Comparator.comparing(File::getName).thenComparing(File::getAbsolutePath))
-				.collect(Collectors.toList());
+				.sorted(comparing(File::getName).thenComparing(File::getAbsolutePath))
+				.collect(toList());
 	}
 
 	private void assertFileIsEqualButNotSameAbsolutePath(File expected, File actual) {
-		Assertions.assertThat(actual).as("Files have same name").hasName(expected.getName());
-		Assertions.assertThat(actual.getAbsolutePath()).as("absolute path is different").isNotEqualTo(expected.getAbsolutePath());
-		Assertions.assertThat(actual).as("files have same content").hasSameTextualContentAs(expected, StandardCharsets.UTF_8);
+		assertThat(actual).as("Files have same name").hasName(expected.getName());
+		assertThat(actual.getAbsolutePath()).as("absolute path is different").isNotEqualTo(expected.getAbsolutePath());
+		assertThat(actual).as("files have same content").hasSameTextualContentAs(expected, UTF_8);
 	}
 
 	private File newFolderWithRandomFile() throws IOException {
@@ -174,7 +175,7 @@ class ShadowCopyTest extends ResourceHarness {
 	}
 
 	private void writeRandomStringOfLengthToFile(File file, int length) throws IOException {
-		Files.write(file.toPath(), randomStringOfLength(length).getBytes(StandardCharsets.UTF_8));
+		Files.write(file.toPath(), randomStringOfLength(length).getBytes(UTF_8));
 	}
 
 	private String randomStringOfLength(int length) {

--- a/testlib/src/test/java/com/diffplug/spotless/npm/TsFmtFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/npm/TsFmtFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  */
 package com.diffplug.spotless.npm;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ class TsFmtFormatterStepTest {
 			// some config options expect to see at least one file in the baseDir, so let's write one there
 			File srcDir = new File(rootFolder(), "src/main/typescript");
 			Files.createDirectories(srcDir.toPath());
-			Files.write(new File(srcDir, configFileNameWithoutExtension + ".ts").toPath(), getTestResource(dirtyFile).getBytes(StandardCharsets.UTF_8));
+			Files.write(new File(srcDir, configFileNameWithoutExtension + ".ts").toPath(), getTestResource(dirtyFile).getBytes(UTF_8));
 
 			final FormatterStep formatterStep = TsFmtFormatterStep.create(
 					TsFmtFormatterStep.defaultDevDependencies(),
@@ -62,7 +63,7 @@ class TsFmtFormatterStepTest {
 					null,
 					npmPathResolver(),
 					TypedTsFmtConfigFile.named(configFileNameWithoutExtension, configFile),
-					Collections.emptyMap());
+					emptyMap());
 
 			try (StepHarness stepHarness = StepHarness.forStep(formatterStep)) {
 				stepHarness.testResource(dirtyFile, cleanFile);

--- a/testlib/src/test/java/com/diffplug/spotless/rdf/RdfFormatterTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/rdf/RdfFormatterTest.java
@@ -15,13 +15,14 @@
  */
 package com.diffplug.spotless.rdf;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -92,16 +93,16 @@ public class RdfFormatterTest extends ResourceHarness {
 		List<Path> inputs = listTestResources(beforeDir)
 				.stream()
 				.map(s -> Path.of(beforeDir, s))
-				.collect(Collectors.toList());
+				.collect(toList());
 		List<Path> outputs = listTestResources(afterDir)
 				.stream()
 				.map(s -> Path.of(afterDir, s))
-				.collect(Collectors.toList());
+				.collect(toList());
 		List<Path> missingOutputs = inputs
 				.stream()
 				.filter(in -> outputs
 						.stream().noneMatch(out -> out.getFileName().equals(in.getFileName())))
-				.collect(Collectors.toList());
+				.collect(toList());
 		if (!missingOutputs.isEmpty()) {
 			throw new IllegalStateException("'after' directory %s is missing files corresponding to these 'before' files: %s".formatted(beforeDir, missingOutputs));
 		}
@@ -109,7 +110,7 @@ public class RdfFormatterTest extends ResourceHarness {
 				.stream()
 				.filter(o -> inputs
 						.stream().noneMatch(in -> in.getFileName().equals(o.getFileName())))
-				.collect(Collectors.toList());
+				.collect(toList());
 		if (!missingInputs.isEmpty()) {
 			throw new IllegalStateException("'before' directory %s is missing files corresponding to these 'after' files: %s".formatted(afterDir, missingInputs));
 		}

--- a/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/scala/ScalaFmtStepTest.java
@@ -15,9 +15,10 @@
  */
 package com.diffplug.spotless.scala;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -57,7 +58,7 @@ class ScalaFmtStepTest extends ResourceHarness {
 	@Test
 	void behaviorConfigFileVersionDoesnotMatchLibrary() {
 		FormatterStep step = ScalaFmtStep.create("3.0.0", TestProvisioner.mavenCentral(), createTestFile("scala/scalafmt/scalafmt.conf"));
-		Assertions.assertThatThrownBy(() -> step.format("", new File(""))).cause().message().contains("Spotless is using 3.0.0 but the config file declares 3.8.1. Both must match. Update the version declared in the plugin's settings and/or the config file.");
+		assertThatThrownBy(() -> step.format("", new File(""))).cause().message().contains("Spotless is using 3.0.0 but the config file declares 3.8.1. Both must match. Update the version declared in the plugin's settings and/or the config file.");
 	}
 
 	@Test
@@ -92,6 +93,6 @@ class ScalaFmtStepTest extends ResourceHarness {
 	void invalidConfiguration() {
 		File invalidConfFile = createTestFile("scala/scalafmt/scalafmt.invalid.conf");
 		Provisioner provisioner = TestProvisioner.mavenCentral();
-		Assertions.assertThatThrownBy(() -> ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile).format("", new File(""))).cause().message().contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
+		assertThatThrownBy(() -> ScalaFmtStep.create("3.0.0", provisioner, invalidConfFile).format("", new File(""))).cause().message().contains("found option 'invalidScalaFmtConfigField' which wasn't expected");
 	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/sql/DBeaverSQLFormatterStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 package com.diffplug.spotless.sql;
 
+import static java.util.Collections.emptySet;
+
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ class DBeaverSQLFormatterStepTest extends ResourceHarness {
 
 	@Test
 	void behavior() {
-		FormatterStep step = DBeaverSQLFormatterStep.create(Collections.emptySet());
+		FormatterStep step = DBeaverSQLFormatterStep.create(emptySet());
 		StepHarness.forStep(step)
 				.testResource("sql/dbeaver/full.dirty", "sql/dbeaver/full.clean")
 				.testResource("sql/dbeaver/V1_initial.sql.dirty", "sql/dbeaver/V1_initial.sql.clean")


### PR DESCRIPTION
tryout reduce warnings for:

- https://github.com/diffplug/spotless/issues/2745
- https://github.com/diffplug/spotless/pull/2758
- https://github.com/diffplug/spotless/pull/2744
- https://github.com/diffplug/spotless/issues/2743

try fixing: 139 warnings 


<img width="532" height="454" alt="image" src="https://github.com/user-attachments/assets/93cea9b0-d61c-4d4a-98b3-3b7954bcde8f" />


Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
