### PR TITLE
[fix] `NPE` due to workingTreeIterator being null for git ignored files. #911

### DIFF
--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/GitRatchet.java
@@ -96,7 +96,7 @@ public abstract class GitRatchet<Project> implements AutoCloseable {
 				DirCacheIterator dirCacheIterator = treeWalk.getTree(INDEX, DirCacheIterator.class);
 				WorkingTreeIterator workingTreeIterator = treeWalk.getTree(WORKDIR, WorkingTreeIterator.class);
 
-				boolean hasTree = treeIterator != null;
+				boolean hasTree = treeIterator != null && workingTreeIterator != null;
 				boolean hasDirCache = dirCacheIterator != null;
 
 				if (!hasTree) {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 - Add the ability to specify a wildcard version (`*`) for external formatter executables. ([#2757](https://github.com/diffplug/spotless/issues/2757))
+### Fixed
+- [fix] `NPE` due to workingTreeIterator being null for git ignored files. #911 ([#2771](https://github.com/diffplug/spotless/issues/2771))
 ### Changes
 * Bump default `ktlint` version to latest `1.7.1` -> `1.8.0`. ([2763](https://github.com/diffplug/spotless/pull/2763))
 * Bump default `gherkin-utils` version to latest `9.2.0` -> `10.0.0`. ([#2619](https://github.com/diffplug/spotless/pull/2619))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 - Add the ability to specify a wildcard version (`*`) for external formatter executables. ([#2757](https://github.com/diffplug/spotless/issues/2757))
+### Fixed
+- [fix] `NPE` due to workingTreeIterator being null for git ignored files. #911 ([#2771](https://github.com/diffplug/spotless/issues/2771))
 ### Changes
 * Bump default `ktlint` version to latest `1.7.1` -> `1.8.0`. ([2763](https://github.com/diffplug/spotless/pull/2763))
 * Bump default `gherkin-utils` version to latest `9.2.0` -> `10.0.0`. ([#2619](https://github.com/diffplug/spotless/pull/2619))


### PR DESCRIPTION
tryout fixing:

- https://github.com/diffplug/spotless/issues/911
- https://github.com/diffplug/spotless/pull/2770

crediting @Gene-R-Pool for the solution. I was able to test this issue and fix as well.





tc:


before:

<html>
<body>

100% (1/1) | 57% (4/7) | 67% (50/74) | 44% (15/34)
-- | -- | -- | --



</body>
</html> 



after:

<html>
<body>

100% (1/1) | 57% (4/7) | 70% (52/74) | 61% (22/36)
-- | -- | -- | --



</body>
</html> 
