### PR TITLE
[rewrite] remove unused `JavaSecurityBestPractices`

### DIFF
--- a/gradle/rewrite.gradle
+++ b/gradle/rewrite.gradle
@@ -21,7 +21,6 @@ rewrite {
 	failOnDryRunResults = true
 }
 dependencies {
-	rewrite('org.openrewrite.recipe:rewrite-java-security:3.22.0')
 	rewrite('org.openrewrite.recipe:rewrite-migrate-java:3.22.0')
 	rewrite('org.openrewrite.recipe:rewrite-rewrite:0.16.0')
 	rewrite('org.openrewrite.recipe:rewrite-static-analysis:2.22.0')

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -20,7 +20,6 @@ recipeList:
   - org.openrewrite.java.migrate.util.SequencedCollection
   - org.openrewrite.java.recipes.JavaRecipeBestPractices
   - org.openrewrite.java.recipes.RecipeTestingBestPractices
-  - org.openrewrite.java.security.JavaSecurityBestPractices
   - org.openrewrite.staticanalysis.BufferedWriterCreationRecipes
   - org.openrewrite.staticanalysis.CommonStaticAnalysis
   - org.openrewrite.staticanalysis.EqualsAvoidsNull


### PR DESCRIPTION
currently obsolete, as can only be used via CLI. We dont have this.

- https://docs.openrewrite.org/recipes/java/security/javasecuritybestpractices#usage