### PR TITLE
Remove rewrite from our CI checks. It can still be optionally run intermittently.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Spotless ✨
         run: ./gradlew spotlessCheck
-      - name: Rewrite ♻️
-        run: ./gradlew rewriteDryRun
       - name: assemble testClasses
         run: ./gradlew assemble testClasses
   build:
@@ -68,10 +66,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: build (maven-only)
         if: matrix.kind == 'maven'
-        run: ./gradlew :plugin-maven:build -x spotlessCheck -x rewriteDryRun
+        run: ./gradlew :plugin-maven:build -x spotlessCheck
       - name: build (everything-but-maven)
         if: matrix.kind == 'gradle'
-        run: ./gradlew build -x spotlessCheck -x rewriteDryRun -PSPOTLESS_EXCLUDE_MAVEN=true
+        run: ./gradlew build -x spotlessCheck -PSPOTLESS_EXCLUDE_MAVEN=true
       - name: test npm
         if: matrix.kind == 'npm'
         run: ./gradlew testNpm

--- a/gradle/rewrite.gradle
+++ b/gradle/rewrite.gradle
@@ -1,3 +1,6 @@
+if (!project.hasProperty('rewrite')) {
+	return
+}
 apply plugin: 'org.openrewrite.rewrite'
 rewrite {
 	activeRecipe('com.diffplug.spotless.openrewrite.SanityCheck')


### PR DESCRIPTION
I have found it difficult to work on this project since we introduced rewrite. On my M4 Macbook Air, `rewriteRun` takes about 2 minutes to complete. I just went through and tried to merge some excellent PRs. It tended to be the case that CI failed because of rewrite, and the nits were so small that they were not worth the try-again loop of CI. some examples:

- https://github.com/diffplug/spotless/pull/2805/changes/46f913ca0450e8f9a5468cbb5909e397e23ca952
- https://github.com/diffplug/spotless/pull/2796/changes/37891c42f3ed0286908697cd726c1cc5f3e6f6a3
- https://github.com/diffplug/spotless/pull/2774/changes/edb626995692d6d920ee534845009d271a6821a6

In every case, it was a real but tiny improvement, but it took ~10 minutes of my time including context switches. I can just push that back onto the PR authors, but that's even more work because they have to wait for me to push "run CI".

If we merge this PR, it is still possible to run rewrite like so:

```
./gradlew rewriteRun -Prewrite=true
```

I think the cleanup that rewrite does is real, but I think it needs the following improvements to be "production ready"

- it needs to not clutter the build log so much (look at CI for the commit previous to the commits above, it's very hard to tell what the problem is or how to fix it)
- it needs to be at least 10x faster
- it needs to make it more clear to the user what the problem is and how to autofix
- it needs a central version policy, this is too many independent versions
  - https://github.com/diffplug/spotless/blob/e8267b7fd33760e252ab4c674f9bc987862af83b/gradle/rewrite.gradle#L23-L28
 
I am open to something like a monthly chron job, where it `rewriteRun` gets run automatically once a month and opens a PR with the changes. But right now the cost / benefit is out of whack.