### PR TITLE
Add `Scheduled Cleanup 🧹`

### DIFF
--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -1,0 +1,29 @@
+name: Scheduled Cleanup 🧹
+on:
+  schedule:
+    - cron: '0 16 * * 3'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  sanity:
+    name: Sanity 🦢
+    runs-on: ubuntu-latest
+    env:
+      buildcacheuser: ${{ secrets.BUILDCACHE_USER }}
+      buildcachepass: ${{ secrets.BUILDCACHE_PASS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Gradle Setup 🐘
+        uses: gradle/actions/setup-gradle@v5
+      - name: Error Prone 🚧️
+        run: ./gradlew assemble -Derror-prone=true
+      - name: OpenRewrite ☑️ # 4m 55s (2 min compile, 3 min rewrite)
+        run: ./gradlew rewriteDryRun

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ apply from: rootProject.file('gradle/java-publish.gradle')
 apply from: rootProject.file('gradle/changelog.gradle')
 apply from: rootProject.file('gradle/rewrite.gradle')
 allprojects {
+	apply from: rootProject.file('gradle/error-prone.gradle')
 	apply from: rootProject.file('gradle/spotless.gradle')
 }
 apply from: rootProject.file('gradle/spotless-freshmark.gradle')

--- a/gradle/error-prone.gradle
+++ b/gradle/error-prone.gradle
@@ -4,11 +4,10 @@ apply plugin: 'net.ltgt.errorprone'
 
 tasks.withType(JavaCompile).configureEach {
 	options.errorprone {
+		getenv('error-prone')?.toBoolean() ? enable() : disable()
 		disableAllWarnings = true // https://github.com/diffplug/spotless/issues/2745 https://github.com/google/error-prone/issues/5365
 		disable(
-				// consider fix, or reasoning.
 				'AnnotateFormatMethod', // We don`t want to use ErrorProne's annotations.
-				'DoNotCallSuggester', // We don`t want to use ErrorProne's annotations.
 				'FunctionalInterfaceMethodChanged',
 				'ImmutableEnumChecker', // We don`t want to use ErrorProne's annotations.
 				'InlineMeSuggester', // We don`t want to use ErrorProne's annotations.
@@ -26,17 +25,7 @@ tasks.withType(JavaCompile).configureEach {
 		// bug: this only happens when the file is dirty.
 		// might be an up2date (caching) issue, as file is currently in corrupt state.
 		// ForbidGradleInternal(import
-		excludedPaths.set(
-				'.*/GradleIntegrationHarness.java|'+
-				'.*/SelfTest.java'
-				)
-		if (!getenv().containsKey('CI') && getenv('IN_PLACE')?.toBoolean()) {
-			errorproneArgs.addAll(
-					'-XepPatchLocation:IN_PLACE',
-					'-XepPatchChecks:' +
-					'MissingOverride'
-					)
-		}
+		excludedPaths.set('.*/GradleIntegrationHarness.java')
 	}
 }
 

--- a/gradle/rewrite.gradle
+++ b/gradle/rewrite.gradle
@@ -1,6 +1,3 @@
-if (!project.hasProperty('rewrite')) {
-	return
-}
 apply plugin: 'org.openrewrite.rewrite'
 rewrite {
 	activeRecipe('com.diffplug.spotless.openrewrite.SanityCheck')
@@ -24,8 +21,7 @@ rewrite {
 	failOnDryRunResults = true
 }
 dependencies {
-	rewrite('org.openrewrite.recipe:rewrite-migrate-java:3.22.0')
-	rewrite('org.openrewrite.recipe:rewrite-rewrite:0.16.0')
-	rewrite('org.openrewrite.recipe:rewrite-static-analysis:2.22.0')
-	rewrite('org.openrewrite.recipe:rewrite-third-party:0.31.2')
+	rewrite('org.openrewrite.recipe:rewrite-migrate-java:3.26.0')
+	rewrite('org.openrewrite.recipe:rewrite-static-analysis:2.26.0')
+	rewrite('org.openrewrite.recipe:rewrite-third-party:0.34.0')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=0d585f69da091fc5b2beced877feab55a3064d43b8a1d46aeb07996b0915e0e0
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lib-extra/src/test/java/com/diffplug/spotless/TestP2Provisioner.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/TestP2Provisioner.java
@@ -118,10 +118,12 @@ public class TestP2Provisioner {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o)
+			if (this == o) {
 				return true;
-			if (o == null || getClass() != o.getClass())
+			}
+			if (o == null || getClass() != o.getClass()) {
 				return false;
+			}
 			CacheKey cacheKey = (CacheKey) o;
 			return useMavenCentral == cacheKey.useMavenCentral &&
 					Objects.equals(p2Repos, cacheKey.p2Repos) &&

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/FormatExtension.java
@@ -64,6 +64,7 @@ import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.SerializedFunction;
 import com.diffplug.spotless.cpp.ClangFormatStep;
 import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
+import com.diffplug.spotless.extra.P2Provisioner;
 import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
 import com.diffplug.spotless.generic.EndWithNewlineStep;
 import com.diffplug.spotless.generic.FenceStep;
@@ -97,7 +98,7 @@ public class FormatExtension {
 		return spotless.getRegisterDependenciesTask().getTaskService().get().provisionerFor(spotless);
 	}
 
-	protected final com.diffplug.spotless.extra.P2Provisioner p2Provisioner() {
+	protected final P2Provisioner p2Provisioner() {
 		return spotless.getRegisterDependenciesTask().getTaskService().get().p2ProvisionerFor(spotless);
 	}
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -256,7 +256,7 @@ final class GradleProvisioner {
 		private record P2Request(
 				List<String> p2Repos,
 				List<String> installList,
-				java.util.Set<String> filterNames, // Filter names (Filter objects aren't easily comparable)
+				Set<String> filterNames, // Filter names (Filter objects aren't easily comparable)
 				List<String> pureMaven,
 				boolean useMavenCentral,
 				@Nullable File cacheDirectory) {}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleProvisionerTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/GradleProvisionerTest.java
@@ -172,35 +172,35 @@ class GradleProvisionerTest {
 
 		static Stream<Arguments> cacheMissScenarios() {
 			return Stream.of(
-					Arguments.of("different P2 repo", (Function<P2ModelWrapper, P2ModelWrapper>) (m) -> createMockModel(
+					Arguments.of("different P2 repo", (Function<P2ModelWrapper, P2ModelWrapper>) m -> createMockModel(
 							List.of("https://download.eclipse.org/eclipse/updates/4.27/"),
 							List.of("org.eclipse.jdt.core"),
 							Set.of(),
 							List.of(),
 							true,
 							null), null),
-					Arguments.of("different install list", (Function<P2ModelWrapper, P2ModelWrapper>) (m) -> createMockModel(
+					Arguments.of("different install list", (Function<P2ModelWrapper, P2ModelWrapper>) m -> createMockModel(
 							List.of("https://download.eclipse.org/eclipse/updates/4.26/"),
 							List.of("org.eclipse.jdt.core", "org.eclipse.jdt.ui"),
 							Set.of(),
 							List.of(),
 							true,
 							null), null),
-					Arguments.of("different filters", (Function<P2ModelWrapper, P2ModelWrapper>) (m) -> createMockModel(
+					Arguments.of("different filters", (Function<P2ModelWrapper, P2ModelWrapper>) m -> createMockModel(
 							List.of("https://download.eclipse.org/eclipse/updates/4.26/"),
 							List.of("org.eclipse.jdt.core"),
 							Set.of("osgiFilter1"),
 							List.of(),
 							true,
 							null), null),
-					Arguments.of("different pure maven", (Function<P2ModelWrapper, P2ModelWrapper>) (m) -> createMockModel(
+					Arguments.of("different pure maven", (Function<P2ModelWrapper, P2ModelWrapper>) m -> createMockModel(
 							List.of("https://download.eclipse.org/eclipse/updates/4.26/"),
 							List.of("org.eclipse.jdt.core"),
 							Set.of(),
 							List.of("com.google:guava:32.0.0-jre"),
 							true,
 							null), null),
-					Arguments.of("different useMavenCentral", (Function<P2ModelWrapper, P2ModelWrapper>) (m) -> createMockModel(
+					Arguments.of("different useMavenCentral", (Function<P2ModelWrapper, P2ModelWrapper>) m -> createMockModel(
 							List.of("https://download.eclipse.org/eclipse/updates/4.26/"),
 							List.of("org.eclipse.jdt.core"),
 							Set.of(),

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -42,7 +42,7 @@ recipeList:
   - tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes
   - tech.picnic.errorprone.refasterrules.CharSequenceRulesRecipes
   - tech.picnic.errorprone.refasterrules.ClassRulesRecipes
-  - tech.picnic.errorprone.refasterrules.CollectionRulesRecipes
+  # tech.picnic.errorprone.refasterrules.CollectionRulesRecipes # needs UpgradeToJava21
   - tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes
   - tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
   - tech.picnic.errorprone.refasterrules.FileRulesRecipes


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
