### PR TITLE
[fix] `ConcurrentModificationException` in `expandWildcardImports`

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -7,6 +7,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [8.2.1] - 2026-01-27
 ### Fixed
 - Fix OutOfMemoryError and slow configuration phase in large multi-project builds when using Eclipse-based formatters (Eclipse JDT, GrEclipse, Eclipse CDT) by implementing P2 dependency caching. ([#2788](https://github.com/diffplug/spotless/issues/2788))
+- `removeSemicolons()` should not be applied to multiline strings in groovy #2780 ([#2792](https://github.com/diffplug/spotless/issues/2792))
+- [fix] `ConcurrentModificationException` in `expandWildcardImports` ([#2830](https://github.com/diffplug/spotless/issues/2830))
 
 ## [8.2.0] - 2026-01-22
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,7 +6,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [3.2.1] - 2026-01-27
 ### Fixed
+- Fix OutOfMemoryError and slow configuration phase in large multi-project builds when using Eclipse-based formatters (Eclipse JDT, GrEclipse, Eclipse CDT) by implementing P2 dependency caching. ([#2788](https://github.com/diffplug/spotless/issues/2788))
 - `removeSemicolons()` should not be applied to multiline strings in groovy #2780 ([#2792](https://github.com/diffplug/spotless/issues/2792))
+- [fix] `ConcurrentModificationException` in `expandWildcardImports` ([#2830](https://github.com/diffplug/spotless/issues/2830))
 
 ## [3.2.0] - 2026-01-22
 ### Added

--- a/testlib/src/test/java/com/diffplug/spotless/java/ExpandWildcardImportsStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ExpandWildcardImportsStepTest.java
@@ -15,15 +15,26 @@
  */
 package com.diffplug.spotless.java;
 
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
+import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.StepHarnessWithFile;
 import com.diffplug.spotless.TestProvisioner;
 
@@ -39,4 +50,150 @@ public class ExpandWildcardImportsStepTest extends ResourceHarness {
 		StepHarnessWithFile.forStep(this, step).testResource("java/expandwildcardimports/JavaClassWithWildcardsUnformatted.test", "java/expandwildcardimports/JavaClassWithWildcardsFormatted.test");
 	}
 
+	@Test
+	void expandWildcardImports_concurrentAccess() throws Exception {
+		// Test concurrent access to the formatter step
+		newFile("src/foo/bar/baz/").mkdirs();
+		Files.write(newFile("src/foo/bar/AnotherClassInSamePackage.java").toPath(), getTestResource("java/expandwildcardimports/AnotherClassInSamePackage.test").getBytes(StandardCharsets.UTF_8));
+		Files.write(newFile("src/foo/bar/baz/AnotherImportedClass.java").toPath(), getTestResource("java/expandwildcardimports/AnotherImportedClass.test").getBytes(StandardCharsets.UTF_8));
+		File dummyJar = new File(ResourceHarness.class.getResource("/java/expandwildcardimports/example-lib.jar").toURI());
+
+		// Create the step once
+		FormatterStep step = ExpandWildcardImportsStep.create(
+				Collections.synchronizedSet(new HashSet<>(Set.of(newFile("src"), dummyJar))),
+				TestProvisioner.mavenCentral());
+
+		String testInput = getTestResource("java/expandwildcardimports/JavaClassWithWildcardsUnformatted.test");
+		String expectedOutput = getTestResource("java/expandwildcardimports/JavaClassWithWildcardsFormatted.test");
+
+		// Test with multiple threads
+		int threadCount = 10;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		AtomicInteger successCount = new AtomicInteger(0);
+
+		for (int i = 0; i < threadCount; i++) {
+			executor.submit(() -> {
+				try {
+					StepHarness harness = StepHarness.forStep(step);
+					harness.test(testInput, expectedOutput);
+					successCount.incrementAndGet();
+				} catch (Exception e) {
+					e.printStackTrace();
+					throw new RuntimeException(e);
+				}
+			});
+		}
+
+		executor.shutdown();
+		executor.awaitTermination(30, TimeUnit.SECONDS);
+
+		// All threads should succeed
+		assertEquals(threadCount, successCount.get(), "All concurrent accesses should succeed");
+	}
+
+	@Test
+	void expandWildcardImports_withMutableClasspath() throws Exception {
+		// Test with a classpath that could be modified concurrently
+		newFile("src/foo/bar/baz/").mkdirs();
+		Files.write(newFile("src/foo/bar/AnotherClassInSamePackage.java").toPath(), getTestResource("java/expandwildcardimports/AnotherClassInSamePackage.test").getBytes(StandardCharsets.UTF_8));
+		Files.write(newFile("src/foo/bar/baz/AnotherImportedClass.java").toPath(), getTestResource("java/expandwildcardimports/AnotherImportedClass.test").getBytes(StandardCharsets.UTF_8));
+		File dummyJar = new File(ResourceHarness.class.getResource("/java/expandwildcardimports/example-lib.jar").toURI());
+
+		// Use thread-safe collections for classpath
+		Set<File> classpath = ConcurrentHashMap.newKeySet();
+		classpath.add(newFile("src"));
+		classpath.add(dummyJar);
+
+		FormatterStep step = ExpandWildcardImportsStep.create(classpath, TestProvisioner.mavenCentral());
+
+		String testInput = getTestResource("java/expandwildcardimports/JavaClassWithWildcardsUnformatted.test");
+		String expectedOutput = getTestResource("java/expandwildcardimports/JavaClassWithWildcardsFormatted.test");
+
+		StepHarness.forStep(step).test(testInput, expectedOutput);
+
+		// Test that we can modify the original classpath without affecting the step
+		// (the step should have taken a defensive copy)
+		classpath.clear();
+		classpath.add(newFile("different/path"));
+
+		// The step should still work with its original classpath
+		StepHarness.forStep(step).test(testInput, expectedOutput);
+	}
+
+	@Test
+	void expandWildcardImports_emptyClasspath() throws Exception {
+		// Test with empty classpath
+		FormatterStep step = ExpandWildcardImportsStep.create(Collections.emptySet(), TestProvisioner.mavenCentral());
+
+		// Even with empty classpath, Java standard library imports should still be expanded
+		String simpleCode = """
+				package test;
+
+				import java.util.*;
+
+				public class Test {
+					private List<String> items;
+				}
+				""";
+
+		String expectedOutput = """
+				package test;
+
+				import java.util.List;
+
+				public class Test {
+					private List<String> items;
+				}
+				""";
+
+		// The step should still expand java.util.* to java.util.List
+		StepHarness.forStep(step).test(simpleCode, expectedOutput);
+	}
+
+	@Test
+	void expandWildcardImports_nullSafety() throws Exception {
+		// Test null safety
+		try {
+			ExpandWildcardImportsStep.create(null, TestProvisioner.mavenCentral());
+			fail("Should throw NullPointerException for null classpath");
+		} catch (NullPointerException e) {
+			// Expected
+		}
+
+		try {
+			ExpandWildcardImportsStep.create(Set.of(newFile("src")), null);
+			fail("Should throw NullPointerException for null provisioner");
+		} catch (NullPointerException e) {
+			// Expected
+		}
+	}
+
+	@Test
+	void expandWildcardImports_withLargeClasspath() throws Exception {
+		// Test with a large classpath to ensure no performance issues
+		newFile("src/foo/bar/baz/").mkdirs();
+		Files.write(newFile("src/foo/bar/AnotherClassInSamePackage.java").toPath(), getTestResource("java/expandwildcardimports/AnotherClassInSamePackage.test").getBytes(StandardCharsets.UTF_8));
+		Files.write(newFile("src/foo/bar/baz/AnotherImportedClass.java").toPath(), getTestResource("java/expandwildcardimports/AnotherImportedClass.test").getBytes(StandardCharsets.UTF_8));
+		File dummyJar = new File(ResourceHarness.class.getResource("/java/expandwildcardimports/example-lib.jar").toURI());
+
+		// Create a large classpath
+		Set<File> largeClasspath = ConcurrentHashMap.newKeySet();
+		largeClasspath.add(newFile("src"));
+		largeClasspath.add(dummyJar);
+
+		// Add many dummy directories
+		for (int i = 0; i < 100; i++) {
+			File dummyDir = newFile("dummy/dir/" + i + "/");
+			dummyDir.mkdirs();
+			largeClasspath.add(dummyDir);
+		}
+
+		FormatterStep step = ExpandWildcardImportsStep.create(largeClasspath, TestProvisioner.mavenCentral());
+
+		String testInput = getTestResource("java/expandwildcardimports/JavaClassWithWildcardsUnformatted.test");
+		String expectedOutput = getTestResource("java/expandwildcardimports/JavaClassWithWildcardsFormatted.test");
+
+		// Should handle large classpaths without issues
+		StepHarness.forStep(step).test(testInput, expectedOutput);
+	}
 }


### PR DESCRIPTION
### [fix] `ConcurrentModificationException` in `expandWildcardImports`


- https://github.com/diffplug/spotless/issues/2830