### PR TITLE
Bump tabletest-formatter 1.0.1 -> 1.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+- Bump default `tabletest-formatter` version `1.0.1` -> `1.1.1`, now works with Java 17+.
 
 ## [4.4.0] - 2026-03-02
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ ktfmt = "com.facebook:ktfmt:0.61"
 palantir-java-format = "com.palantir.javaformat:palantir-java-format:1.1.0"
 scalafmt-core = "org.scalameta:scalafmt-core_2.13:3.8.1"
 sortpom-sorter = "com.github.ekryd.sortpom:sortpom-sorter:4.0.0"
-tabletest-formatter-core = "org.tabletest:tabletest-formatter-core:1.0.1"
+tabletest-formatter-core = "org.tabletest:tabletest-formatter-core:1.1.1"
 zjsonpatch = "com.flipkart.zjsonpatch:zjsonpatch:0.4.16"
 
 rewrite-recipe-migrate-java = "org.openrewrite.recipe:rewrite-migrate-java:3.28.0"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -24,12 +24,9 @@ def NEEDS_GLUE = [
 	'palantirJavaFormat',
 	'scalafmt',
 	'sortPom',
+	'tableTestFormatter',
 	'zjsonPatch',
 ]
-// tableTestFormatter requires Java 21+
-if (JavaVersion.current() >= JavaVersion.VERSION_21) {
-	NEEDS_GLUE << 'tableTestFormatter'
-}
 
 for (glue in NEEDS_GLUE) {
 	sourceSets.register(glue) {
@@ -125,10 +122,8 @@ dependencies {
 	// sortPom
 	sortPomCompileOnly libs.sortpom.sorter
 	sortPomCompileOnly libs.slf4j.api
-	// tableTestFormatter (Java 21+ only)
-	if (JavaVersion.current() >= JavaVersion.VERSION_21) {
-		tableTestFormatterCompileOnly libs.tabletest.formatter.core
-	}
+	// tableTestFormatter
+	tableTestFormatterCompileOnly libs.tabletest.formatter.core
 	// zjsonPatch
 	zjsonPatchCompileOnly libs.zjsonpatch
 }

--- a/lib/src/main/java/com/diffplug/spotless/java/TableTestFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/TableTestFormatterStep.java
@@ -34,7 +34,7 @@ public final class TableTestFormatterStep implements Serializable {
 	private static final long serialVersionUID = 1L;
 	private static final String NAME = "tableTestFormatter";
 	private static final String MAVEN_COORDINATE = "org.tabletest:tabletest-formatter-core:";
-	private static final String DEFAULT_VERSION = "1.0.1";
+	private static final String DEFAULT_VERSION = "1.1.1";
 
 	private final JarState.Promised jarState;
 	private final String version;

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changes
+- Bump default `tabletest-formatter` version `1.0.1` -> `1.1.1`, now works with Java 17+.
 
 ## [8.3.0] - 2026-03-02
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -439,7 +439,7 @@ spotless {
   java {
     tableTestFormatter()
     // optional: you can specify a specific version
-    tableTestFormatter('1.0.1')
+    tableTestFormatter('1.1.1')
 ```
 
 <a name="applying-to-groovy-source"></a>
@@ -616,7 +616,7 @@ spotless {
   kotlin {
     tableTestFormatter()
     // optional: you can specify a specific version
-    tableTestFormatter('1.0.1')
+    tableTestFormatter('1.1.1')
 ```
 
 <a name="applying-scalafmt-to-scala-files"></a>

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+- Bump default `tabletest-formatter` version `1.0.1` -> `1.1.1`, now works with Java 17+.
 
 ## [3.3.0] - 2026-03-02
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -407,7 +407,7 @@ These mechanisms already exist for the Gradle plugin.
 
 ```xml
 <tableTestFormatter>
-  <version>1.0.1</version> <!-- optional -->
+  <version>1.1.1</version> <!-- optional -->
 </tableTestFormatter>
 ```
 
@@ -543,7 +543,7 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 
 ```xml
 <tableTestFormatter>
-  <version>1.0.1</version> <!-- optional -->
+  <version>1.1.1</version> <!-- optional -->
 </tableTestFormatter>
 ```
 

--- a/testlib/src/test/java/com/diffplug/spotless/java/TableTestFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/TableTestFormatterStepTest.java
@@ -15,10 +15,7 @@
  */
 package com.diffplug.spotless.java;
 
-import static org.junit.jupiter.api.condition.JRE.JAVA_21;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
@@ -28,10 +25,9 @@ import com.diffplug.spotless.TestProvisioner;
 
 class TableTestFormatterStepTest extends ResourceHarness {
 
-	private static final String VERSION = "1.0.1";
+	private static final String VERSION = "1.1.1";
 
 	@Test
-	@EnabledForJreRange(min = JAVA_21)
 	void behavior() {
 		FormatterStep step = TableTestFormatterStep.create(VERSION, TestProvisioner.mavenCentral());
 		try (StepHarnessWithFile harness = StepHarnessWithFile.forStep(this, step)) {
@@ -40,7 +36,6 @@ class TableTestFormatterStepTest extends ResourceHarness {
 	}
 
 	@Test
-	@EnabledForJreRange(min = JAVA_21)
 	void equality() {
 		new SerializableEqualityTester() {
 			String version = VERSION;


### PR DESCRIPTION
## Summary
- Bump default `tabletest-formatter` version from `1.0.1` to `1.1.1`
- Remove Java 21+ restriction — the library now supports Java 17+, matching spotless's own minimum requirement
- Update version references in READMEs and changelogs

## Test plan
- [x] `./gradlew :testlib:test --tests '*TableTestFormatterStepTest*'` passes on Java 17
- [ ] CI build passes