### PR TITLE
Fix for illegal mutation issue with `predeclareDeps`

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 - Add `tableTest` format type for standalone `.table` files.
+### Fixed
+- Fix illegal mutation when using predeclared dependencies.
 ### Changes
 - Bump default `tabletest-formatter` version `1.0.1` -> `1.1.1`, now works with Java 17+.
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
@@ -33,6 +33,7 @@ public class SpotlessExtensionPredeclare extends SpotlessExtension {
 		this.registerDependenciesTask = findRegisterDepsTask().get();
 		SpotlessTaskService taskService = getSpotlessTaskService().get();
 		taskService.isUsingPredeclared = true;
+		taskService.registerDependenciesTask = registerDependenciesTask;
 		taskService.predeclaredProvisioner = policy.dedupingProvisioner(project);
 		taskService.predeclaredP2Provisioner = policy.dedupingP2Provisioner(project);
 		project.afterEvaluate(unused -> toSetup.forEach((name, formatExtension) -> {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionPredeclare.java
@@ -32,7 +32,6 @@ public class SpotlessExtensionPredeclare extends SpotlessExtension {
 		super(project);
 		this.registerDependenciesTask = findRegisterDepsTask().get();
 		SpotlessTaskService taskService = getSpotlessTaskService().get();
-		taskService.isUsingPredeclared = true;
 		taskService.registerDependenciesTask = registerDependenciesTask;
 		taskService.predeclaredProvisioner = policy.dedupingProvisioner(project);
 		taskService.predeclaredP2Provisioner = policy.dedupingP2Provisioner(project);

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -64,6 +64,7 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 
 	@Nullable GradleProvisioner.DedupingProvisioner predeclaredProvisioner;
 	@Nullable GradleProvisioner.DedupingP2Provisioner predeclaredP2Provisioner;
+	@Nullable RegisterDependenciesTask registerDependenciesTask;
 
 	Provisioner provisionerFor(SpotlessExtension spotless) {
 		if (spotless instanceof SpotlessExtensionPredeclare) {
@@ -134,7 +135,9 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 			return;
 		}
 
-		project.getRootProject().getTasks().withType(RegisterDependenciesTask.class, registerTask -> registerTask.hookSubprojectTask(task));
+		if (registerDependenciesTask != null) {
+			registerDependenciesTask.hookSubprojectTask(task);
+		}
 	}
 
 	public static Provider<SpotlessTaskService> registerIfAbsent(Project project, String suffix) {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessTaskService.java
@@ -56,7 +56,6 @@ import com.diffplug.spotless.extra.P2Provisioner;
  * apply already did).
  */
 public abstract class SpotlessTaskService implements BuildService<BuildServiceParameters.None>, AutoCloseable, OperationCompletionListener {
-	protected boolean isUsingPredeclared;
 	private final Map<String, SpotlessApply> apply = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, SpotlessTask> source = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, Provisioner> provisioner = Collections.synchronizedMap(new HashMap<>());
@@ -130,11 +129,6 @@ public abstract class SpotlessTaskService implements BuildService<BuildServicePa
 	}
 
 	public void hookSubprojectTask(Project project, SpotlessTask task) {
-		// This check allows isolated projects support by not accessing the root project tasks unless really needed
-		if (!isUsingPredeclared) {
-			return;
-		}
-
 		if (registerDependenciesTask != null) {
 			registerDependenciesTask.hookSubprojectTask(task);
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IsolatedProjectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/IsolatedProjectTest.java
@@ -17,7 +17,6 @@ package com.diffplug.gradle.spotless;
 
 import java.io.IOException;
 
-import org.assertj.core.api.Assertions;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
@@ -85,7 +84,7 @@ class IsolatedProjectTest extends GradleIntegrationHarness {
 	}
 
 	@Test
-	void predeclaredIsUnsupported() throws IOException {
+	void predeclaredIsSupported() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
 				"    id 'com.diffplug.spotless'",
@@ -96,7 +95,6 @@ class IsolatedProjectTest extends GradleIntegrationHarness {
 				" kotlin { ktlint() }",
 				"}");
 		createNSubprojects();
-		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
-				.containsAnyOf("Cannot access project", "cannot access 'Project.tasks'");
+		gradleRunner().withArguments("spotlessApply").build();
 	}
 }

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/MultiProjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,36 @@ class MultiProjectTest extends GradleIntegrationHarness {
 		createNSubprojects();
 		Assertions.assertThat(gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput())
 				.contains("Could not find method spotlessPredeclare() for arguments");
+	}
+
+	@Test
+	public void predeclaredDepsRegression() throws IOException {
+		setFile("settings.gradle").toContent("include 'sub'");
+		setFile("build.gradle").toLines(
+				"plugins { id 'com.diffplug.spotless' }",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    predeclareDeps()",
+				"    java {",
+				"        target file('test.java')",
+				"        googleJavaFormat('1.17.0')",
+				"    }",
+				"}",
+				"spotlessPredeclare {",
+				"    java { googleJavaFormat('1.17.0') }",
+				"}");
+		setFile("test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		setFile("sub/build.gradle").toLines(
+				"plugins { id 'com.diffplug.spotless' }",
+				"repositories { mavenCentral() }",
+				"spotless {",
+				"    java {",
+				"        target file('test.java')",
+				"        googleJavaFormat('1.17.0')",
+				"    }",
+				"}");
+		setFile("sub/test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		gradleRunner().withGradleVersion("8.14").withArguments("spotlessApply").build();
 	}
 
 	@Test


### PR DESCRIPTION
## Fix `IllegalMutationException` when root project uses `predeclareDeps()` with format tasks

Fixes
* #2885 

Introduced by
* #2854

### Problem

PR #2854 ("Partially support isolated projects") refactored `SpotlessTaskService.hookSubprojectTask` to look up the `RegisterDependenciesTask` dynamically via the task container rather than holding a direct reference. The call used `withType(Class, Action)`:

```java
project.getRootProject().getTasks()
  .withType(RegisterDependenciesTask.class, task -> task.hookSubprojectTask(task));
```

On Gradle 8.14.x (unsure about the exact version this behavior was introduced), this throws `IllegalMutationException` when all the following are true:

1. The root project calls `predeclareDeps()`
2. The root project also configures its own spotless format tasks (e.g. java, `groovyGradle`)
3. A spotless task on the root project is being realized

During root project task realization, Gradle activates its mutation guard on the root task container.
The `configure` callback calls `FormatExtension.setupTask()` then `hookSubprojectTask()` then `project.getRootProject().getTasks().withType(Class, Action)` on that same guarded container which Gradle forbids.

Switching to `withType(Class).configureEach(Action)` does not help either as Gradle also considers `configureEach` a mutating registration in this context.

**Fix**

Since `RegisterDependenciesTask` is the task that must run before all projects, this fix assumes it can be safely referenced by the main spotless service. So the fix stores the `RegisterDependenciesTask` reference directly in `SpotlessTaskService` at configuration time (when `SpotlessExtensionPredeclare` is constructed and `isUsingPredeclared()` is set). Then `hookSubprojectTask` uses that reference directly, with no task container lookup during task realization.

```java
// SpotlessExtensionPredeclare constructor
taskService.registerDependenciesTask = this.registerDependenciesTask;

// hookSubprojectTask — no task container query
if (registerDependenciesTask != null) {
    registerDependenciesTask.hookSubprojectTask(task);
}
```

The `RegisterDependenciesTask` reference is already computed eagerly in `SpotlessExtensionPredeclare` (via `findRegisterDepsTask().get()`), so no new eagerness is introduced.

Note that `IsolatedProjectTest.predeclaredIsUnsupported()` (introduced in #2854) expected a build failure that no longer occurs because this fix` 

**Verification**

Added `MultiProjectTest.predeclaredDepsRegression()` that reproduces the exact trigger conditions and runs against Gradle 8.14.