### PR TITLE
Fix JDBI named bind params being uppercased and losing spaces in DBeaver SQL formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Preserve case of JDBI named bind params that collide with SQL keywords (e.g. `:limit`, `:offset`) in the DBeaver SQL formatter.
 
 ## [4.5.0] - 2026-03-18
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/sql/dbeaver/SQLTokenizedFormatter.java
@@ -95,9 +95,13 @@ public class SQLTokenizedFormatter {
 		}
 
 		final KeywordCase keywordCase = formatterCfg.getKeywordCase();
-		for (FormatterToken anArgList : argList) {
-			token = anArgList;
+		for (int index = 0; index < argList.size(); index++) {
+			token = argList.get(index);
 			if (token.getType() == TokenType.KEYWORD) {
+				// Do not transform case for JDBI named bind params (e.g. :limit, :offset)
+				if (index > 0 && isEmbeddedToken(argList.get(index - 1))) {
+					continue;
+				}
 				token.setString(keywordCase.transform(token.getString()));
 			}
 		}
@@ -323,8 +327,10 @@ public class SQLTokenizedFormatter {
 					continue;
 				}
 				if (token.getType() == TokenType.SYMBOL && isEmbeddedToken(token)
+						&& (!":".equals(token.getString()) || prev.getType() == TokenType.SYMBOL)
 						|| prev.getType() == TokenType.SYMBOL && isEmbeddedToken(prev)) {
-					// Do not insert spaces around colons
+					// Do not insert spaces around embedded tokens (colons, dots),
+					// except before JDBI named bind params (e.g. :limit) preceded by a keyword or name
 					continue;
 				}
 				if (token.getType() == TokenType.SYMBOL && prev.getType() == TokenType.SYMBOL) {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Preserve case of JDBI named bind params that collide with SQL keywords (e.g. `:limit`, `:offset`) in the DBeaver SQL formatter.
 
 ## [8.4.0] - 2026-03-18
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+* Preserve case of JDBI named bind params that collide with SQL keywords (e.g. `:limit`, `:offset`) in the DBeaver SQL formatter.
 
 ## [3.4.0] - 2026-03-18
 ### Added

--- a/testlib/src/main/resources/sql/dbeaver/jdbi-params.clean
+++ b/testlib/src/main/resources/sql/dbeaver/jdbi-params.clean
@@ -5,3 +5,10 @@ FROM
     WHERE
         id IN(<ids>)
         AND user_id =:user_id;
+
+SELECT
+    *
+FROM
+    TABLE
+    WHERE
+        id =:id LIMIT :limit OFFSET :offset;

--- a/testlib/src/main/resources/sql/dbeaver/jdbi-params.dirty
+++ b/testlib/src/main/resources/sql/dbeaver/jdbi-params.dirty
@@ -1,1 +1,2 @@
 SELECT * FROM table WHERE id IN (<ids>) AND user_id = :user_id;
+SELECT * FROM table WHERE id = :id LIMIT :limit OFFSET :offset;


### PR DESCRIPTION
## Problem

When using JDBI named bind params that collide with SQL keywords (e.g. `:limit`, `:offset`, `:set`), the DBeaver SQL formatter would incorrectly uppercase them (`:limit` → `:LIMIT`) and strip the space before them (`LIMIT :limit` → `LIMIT:limit`). Both of these break the resulting SQL.

## Changes

- **Keyword case**: When applying keyword case transformation, skip any `KEYWORD` token that is immediately preceded by a `:` symbol — it's a JDBI named bind param, not a SQL keyword.
- **Spacing**: When inserting spaces between tokens, allow a space before `:` when it is preceded by a keyword or name token. Spaces before `:` are still suppressed when preceded by a symbol (e.g. `=:param` remains unchanged).

## Test

Extended the existing `jdbi-params` test resource with a query using `:limit` and `:offset` to cover both fixes.