### PR TITLE
Bump default Eclipse JDT from 4.35 to 4.39

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `javaparserVersion` option to the Cleanthat step, allowing callers to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 
 ## [4.5.0] - 2026-03-18
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `javaparserVersion` option to the Cleanthat step, allowing callers to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
+- Bump `eclipse-jdt` default version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+
 
 ## [4.5.0] - 2026-03-18
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,6 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump `eclipse-jdt` default version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
 
-
 ## [4.5.0] - 2026-03-18
 ### Added
 - Add `tableTest` format type for standalone `.table` files. ([#2880](https://github.com/diffplug/spotless/pull/2880))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `javaparserVersion` option to the Cleanthat step, allowing callers to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump `eclipse-jdt` default version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
 
 ## [4.5.0] - 2026-03-18
 ### Added

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -35,7 +35,7 @@ public final class EclipseJdtFormatterStep {
 	private EclipseJdtFormatterStep() {}
 
 	private static final String NAME = "eclipse jdt formatter";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(17, "4.35");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(17, "4.40");
 
 	public static String defaultVersion() {
 		return JVM_SUPPORT.getRecommendedFormatterVersion();

--- a/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
+++ b/lib-extra/src/main/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStep.java
@@ -35,7 +35,7 @@ public final class EclipseJdtFormatterStep {
 	private EclipseJdtFormatterStep() {}
 
 	private static final String NAME = "eclipse jdt formatter";
-	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(17, "4.40");
+	private static final Jvm.Support<String> JVM_SUPPORT = Jvm.<String> support(NAME).add(17, "4.39");
 
 	public static String defaultVersion() {
 		return JVM_SUPPORT.getRecommendedFormatterVersion();

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -10,7 +10,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 
 ## [8.4.0] - 2026-03-18
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -10,8 +10,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump `eclipse-jdt` default version from `4.35` to `4.40`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
-
+- Bump `eclipse-jdt` default version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
 
 ## [8.4.0] - 2026-03-18
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -10,6 +10,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
+- Bump `eclipse-jdt` default version from `4.35` to `4.40`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+
 
 ## [8.4.0] - 2026-03-18
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -10,7 +10,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump `eclipse-jdt` default version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
 
 ## [8.4.0] - 2026-03-18
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,7 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `<javaparserVersion>` option to `<cleanthat>`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump `eclipse-jdt` default version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
 
 ## [3.4.0] - 2026-03-18
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,7 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `<javaparserVersion>` option to `<cleanthat>`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump `eclipse-jdt` default version from `4.35` to `4.40`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+- Bump `eclipse-jdt` default version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
 
 ## [3.4.0] - 2026-03-18
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,7 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `<javaparserVersion>` option to `<cleanthat>`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
-- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
+- Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 
 ## [3.4.0] - 2026-03-18
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `<javaparserVersion>` option to `<cleanthat>`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
+- Bump `eclipse-jdt` default version from `4.35` to `4.40`. ([#2902](https://github.com/diffplug/spotless/pull/2902))
 
 ## [3.4.0] - 2026-03-18
 ### Added


### PR DESCRIPTION
## Problem
I noticed that VSCode's "Language support for Java" formatter was formatting some things differently than Spotless (when pointing to the same eclipse formatter XML file. Spotless is at 4.35, looks like VSCode embeds: `~./vscode-server/extensions/redhat.java-1.54.0/server/plugins/org.eclipse.jdt.core_3.46.0.v20260409-1507.jar` JDT 3.46.0 (which I _think_ corresponds to 4.39?).

It turns out this doesn't actually fix what I'm seeing (setting the version locally doesn't fix it), but I figured the default version should still be updated.

## Fix
Bump the Spotless Eclipse JDT version.

## Refs
- https://github.com/diffplug/spotless/pull/2179
- https://github.com/diffplug/spotless/pull/1939
- https://download.eclipse.org/eclipse/updates/4.39/