### PR TITLE
Fix: importOrder() with single catch-all group strips blank lines added by greclipse(), causing non-idempotent formatting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 - Add `javaparserVersion` option to the Cleanthat step, allowing callers to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
+### Fixed
+- Fix non-idempotent formatting when `importOrder()` is combined with `greclipse()`: a single catch-all group no longer strips blank lines that `greclipse()` independently inserted between import groups. ([#2914](https://github.com/diffplug/spotless/pull/2914))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/ImportSorter.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Vojtech Krasa
@@ -91,6 +92,15 @@ final class ImportSorter {
 
 		List<String> sortedImports = ImportSorterImpl.sort(imports, importsOrder, wildcardsLast, semanticSort,
 				treatAsPackage, treatAsClass, lineFormat);
+		boolean sortedHasNoBlanks = sortedImports.stream().noneMatch(N::equals);
+		if (sortedHasNoBlanks && firstImportLine > 0) {
+			List<String> originalFormatted = imports.stream()
+					.map(i -> lineFormat.formatted(i) + N)
+					.collect(Collectors.toList());
+			if (sortedImports.equals(originalFormatted)) {
+				return raw;
+			}
+		}
 		return applyImportsToDocument(raw, firstImportLine, lastImportLine, sortedImports);
 	}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -8,6 +8,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Add `javaparserVersion(...)` to `cleanthat`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Fixed
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
+- Fix non-idempotent formatting when `importOrder()` is combined with `greclipse()`: a single catch-all group no longer strips blank lines that `greclipse()` independently inserted between import groups. ([#2914](https://github.com/diffplug/spotless/pull/2914))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 - Add `<javaparserVersion>` option to `<cleanthat>`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
+### Fixed
+- Fix non-idempotent formatting when `importOrder()` is combined with `greclipse()`: a single catch-all group no longer strips blank lines that `greclipse()` independently inserted between import groups. ([#2914](https://github.com/diffplug/spotless/pull/2914))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))

--- a/testlib/src/main/resources/java/importsorter/GroovyCodeSortedImportsNoBlankLines.test
+++ b/testlib/src/main/resources/java/importsorter/GroovyCodeSortedImportsNoBlankLines.test
@@ -1,0 +1,6 @@
+import java.lang.Runnable
+import java.lang.Thread
+import org.dooda.Didoo
+
+public class NotDeletedByFormatter {
+}

--- a/testlib/src/main/resources/java/importsorter/GroovyCodeSortedImportsWithBlankLines.test
+++ b/testlib/src/main/resources/java/importsorter/GroovyCodeSortedImportsWithBlankLines.test
@@ -1,0 +1,7 @@
+import java.lang.Runnable
+import java.lang.Thread
+
+import org.dooda.Didoo
+
+public class NotDeletedByFormatter {
+}

--- a/testlib/src/main/resources/java/importsorter/GroovyCodeUnsortedImportsWithBlankLines.test
+++ b/testlib/src/main/resources/java/importsorter/GroovyCodeUnsortedImportsWithBlankLines.test
@@ -1,0 +1,7 @@
+import org.dooda.Didoo
+
+import java.lang.Thread
+import java.lang.Runnable
+
+public class NotDeletedByFormatter {
+}

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ImportOrderStepTest.java
@@ -117,12 +117,24 @@ class ImportOrderStepTest extends ResourceHarness {
 	}
 
 	@Test
-	void doesntThrowIfImportOrderIsntSerializable() {
+	void groovyImportsPreservesBlankLinesBetweenGroups() {
+		FormatterStep step = ImportOrderStep.forGroovy().createFrom();
+		StepHarness.forStep(step).testResourceUnaffected("java/importsorter/GroovyCodeSortedImportsWithBlankLines.test");
+	}
+
+	@Test
+	void groovySortImportsStripsInterleavedBlankLines() {
+		FormatterStep step = ImportOrderStep.forGroovy().createFrom();
+		StepHarness.forStep(step).testResource("java/importsorter/GroovyCodeUnsortedImportsWithBlankLines.test", "java/importsorter/GroovyCodeSortedImportsNoBlankLines.test");
+	}
+
+	@Test
+	void doesntThrowIfImportOrderIsNotSerializable() {
 		ImportOrderStep.forJava().createFrom("java", "javax", "org", "\\#com");
 	}
 
 	@Test
-	void equality() throws Exception {
+	void equality() {
 		new SerializableEqualityTester() {
 			String[] imports = {};
 


### PR DESCRIPTION
## Summary

- `importOrder()` with no explicit groups (single catch-all) unconditionally replaced the entire import block, stripping any blank lines that a prior step like `greclipse()` had independently inserted between import groups.
- This created an infinite cycle: `greclipse()` adds blank lines → `importOrder()` strips them → `greclipse()` re-adds them → repeat (GitHub issue #899).
- Fix: when the sorted output contains no blank-line separators (single catch-all group) and the imports are already in the correct order, return the raw input unchanged, preserving any blank lines already present.

## Test plan

- `groovyImportsPreservesBlankLinesBetweenGroups` — asserts that `importOrder()` with no args leaves an already-sorted Groovy import block with blank lines untouched.
- `groovySortImportsStripsInterleavedBlankLines` — asserts that sorting still works when imports are out of order; interleaved blank lines are removed as a side effect of the rewrite.

Fixes #899 