### PR TITLE
Use Collator when sorting Eclipse JDT members

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 - Add `javaparserVersion` option to the Cleanthat step, allowing callers to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
+- Use Eclipse JDT's collator-based comparison when sorting Java members to better match Eclipse save actions. ([#2920](https://github.com/diffplug/spotless/pull/2920))
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 

--- a/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/DefaultJavaElementComparator.java
+++ b/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/DefaultJavaElementComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 DiffPlug
+ * Copyright 2024-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/DefaultJavaElementComparator.java
+++ b/lib-extra/src/jdt/java/com/diffplug/spotless/extra/glue/jdt/DefaultJavaElementComparator.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.extra.glue.jdt;
 
+import java.text.Collator;
 import java.util.Comparator;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -61,6 +62,7 @@ class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 	private final int[] memberCategoryOffsets;
 	private final boolean sortByVisibility;
 	private final int[] visibilityOffsets;
+	private final Collator collator;
 
 	static DefaultJavaElementComparator of(
 			boolean doNotSortFields,
@@ -95,6 +97,7 @@ class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 		this.memberCategoryOffsets = memberCategoryOffsets;
 		this.sortByVisibility = sortByVisibility;
 		this.visibilityOffsets = visibilityOffsets;
+		this.collator = Collator.getInstance();
 	}
 
 	@SuppressFBWarnings(value = "SF_SWITCH_NO_DEFAULT", justification = "we only accept valid tokens in the order string, otherwise we fall back to default value")
@@ -271,7 +274,7 @@ class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 			String name2 = method2.getName().getIdentifier();
 
 			// method declarations (constructors) are sorted by name
-			int cmp = name1.compareTo(name2);
+			int cmp = collator.compare(name1, name2);
 			if (cmp != 0) {
 				return cmp;
 			}
@@ -286,7 +289,7 @@ class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 			for (int i = 0; i < len; i++) {
 				SingleVariableDeclaration param1 = parameters1.get(i);
 				SingleVariableDeclaration param2 = parameters2.get(i);
-				cmp = buildSignature(param1.getType()).compareTo(buildSignature(param2.getType()));
+				cmp = collator.compare(buildSignature(param1.getType()), buildSignature(param2.getType()));
 				if (cmp != 0) {
 					return cmp;
 				}
@@ -377,7 +380,7 @@ class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 	}
 
 	private int compareNames(BodyDeclaration bodyDeclaration1, BodyDeclaration bodyDeclaration2, String name1, String name2) {
-		int cmp = name1.compareTo(name2);
+		int cmp = collator.compare(name1, name2);
 		if (cmp != 0) {
 			return cmp;
 		}

--- a/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepSpecialCaseTest.java
+++ b/lib-extra/src/test/java/com/diffplug/spotless/extra/java/EclipseJdtFormatterStepSpecialCaseTest.java
@@ -107,4 +107,12 @@ class EclipseJdtFormatterStepSpecialCaseTest {
 		StepHarness.forStep(builder.build())
 				.testResource("java/eclipse/SortExample.localEnabledTrue.test", "java/eclipse/SortExample.localEnabledTrue.clean");
 	}
+
+	@Test
+	void sort_members_uses_collator() {
+		EclipseJdtFormatterStep.Builder builder = EclipseJdtFormatterStep.createBuilder(TestProvisioner.mavenCentral(), TestP2Provisioner.defaultProvisioner());
+		builder.sortMembersEnabled(true);
+		StepHarness.forStep(builder.build())
+				.testResource("java/eclipse/SortExample.collator.test", "java/eclipse/SortExample.collator.clean");
+	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
 ### Changes
+- Use Eclipse JDT's collator-based comparison when sorting Java members to better match Eclipse save actions. ([#2920](https://github.com/diffplug/spotless/pull/2920))
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 - Add `<javaparserVersion>` option to `<cleanthat>`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
+- Use Eclipse JDT's collator-based comparison when sorting Java members to better match Eclipse save actions. ([#2920](https://github.com/diffplug/spotless/pull/2920))
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 

--- a/testlib/src/main/resources/java/eclipse/SortExample.collator.clean
+++ b/testlib/src/main/resources/java/eclipse/SortExample.collator.clean
@@ -1,0 +1,15 @@
+package com.diffplug.spotless.extra.glue.jdt;
+
+public class SortExample {
+	private static void mab() {
+	}
+
+	private static void mAc() {
+	}
+
+	private static void mp(String a, String b, int a) {
+	}
+
+	private static void mp(String a, String b, String p) {
+	}
+}

--- a/testlib/src/main/resources/java/eclipse/SortExample.collator.test
+++ b/testlib/src/main/resources/java/eclipse/SortExample.collator.test
@@ -1,0 +1,15 @@
+package com.diffplug.spotless.extra.glue.jdt;
+
+public class SortExample {
+	private static void mAc() {
+	}
+
+	private static void mab() {
+	}
+
+	private static void mp(String a, String b, String p) {
+	}
+
+	private static void mp(String a, String b, int a) {
+	}
+}


### PR DESCRIPTION
## Summary

This updates the Eclipse JDT member sorting comparator to use `java.text.Collator` when comparing member names and parameter type signatures.

The Eclipse JDT UI implementation uses a collator for these comparisons. Spotless used `String.compareTo`, which can produce a different member order than Eclipse save actions for names that differ by case or locale-sensitive collation.

## Motivation

Our team primarily works with Eclipse, but some developers now use VS Code for smaller edits. We use Spotless to make the command line and non-Eclipse editing workflow follow the same formatting rules as Eclipse save actions.

Without this patch, member sorting can differ deterministically between Eclipse and Spotless in edge cases. That creates a "ping pong" scenario where method positions shift depending on which editor or formatter was used last.

Using the same collator-based comparison as Eclipse avoids that difference and makes Spotless member sorting match Eclipse more closely.

## Changes

- Use `Collator` in `DefaultJavaElementComparator`.
- Apply it to method name comparison.
- Apply it to parameter type signature comparison.
- Add a regression fixture that exposes the ordering difference.

## Test

```bash
./gradlew :lib-extra:test --tests com.diffplug.spotless.extra.java.EclipseJdtFormatterStepSpecialCaseTest --no-daemon --no-configuration-cache --console=plain
```