### PR TITLE
Fix wildcard import expansion for JDK XML types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 - Add `javaparserVersion` option to the Cleanthat step, allowing callers to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
+- Fix `expandWildcardImports` failing on JDK XML types such as `org.xml.sax.InputSource`. ([#2921](https://github.com/diffplug/spotless/pull/2921))
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 

--- a/lib/src/javaParser/java/com/diffplug/spotless/glue/javaparser/ExpandWildcardsFormatterFunc.java
+++ b/lib/src/javaParser/java/com/diffplug/spotless/glue/javaparser/ExpandWildcardsFormatterFunc.java
@@ -70,7 +70,7 @@ public class ExpandWildcardsFormatterFunc implements FormatterFunc.NeedsFile {
 		this.parser = new JavaParser();
 
 		CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
-		combinedTypeSolver.add(new ReflectionTypeSolver());
+		combinedTypeSolver.add(new ReflectionTypeSolver(ReflectionTypeSolver.JCL_ONLY));
 		for (File element : typeSolverClasspath) {
 			if (element.isFile()) {
 				combinedTypeSolver.add(new JarTypeSolver(element));

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
 ### Changes
+- Fix `expandWildcardImports` failing on JDK XML types such as `org.xml.sax.InputSource`. ([#2921](https://github.com/diffplug/spotless/pull/2921))
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Added
 - Add `<javaparserVersion>` option to `<cleanthat>`, allowing users to override the JavaParser version pulled in transitively by Cleanthat. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 ### Changes
+- Fix `expandWildcardImports` failing on JDK XML types such as `org.xml.sax.InputSource`. ([#2921](https://github.com/diffplug/spotless/pull/2921))
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))
 

--- a/testlib/src/test/java/com/diffplug/spotless/java/ExpandWildcardImportsStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ExpandWildcardImportsStepTest.java
@@ -151,6 +151,39 @@ public class ExpandWildcardImportsStepTest extends ResourceHarness {
 	}
 
 	@Test
+	void expandWildcardImports_resolvesJdkXmlTypes() throws Exception {
+		FormatterStep step = ExpandWildcardImportsStep.create(Collections.emptySet(), TestProvisioner.mavenCentral());
+
+		String simpleCode = """
+				package test;
+
+				import java.io.*;
+				import org.xml.sax.InputSource;
+
+				public class Test {
+					InputSource inputSource(String value) {
+						return new InputSource(new StringReader(value));
+					}
+				}
+				""";
+
+		String expectedOutput = """
+				package test;
+
+				import java.io.StringReader;
+				import org.xml.sax.InputSource;
+
+				public class Test {
+					InputSource inputSource(String value) {
+						return new InputSource(new StringReader(value));
+					}
+				}
+				""";
+
+		StepHarness.forStep(step).test(simpleCode, expectedOutput);
+	}
+
+	@Test
 	void expandWildcardImports_nullSafety() throws Exception {
 		// Test null safety
 		try {


### PR DESCRIPTION
## Summary

This fixes `expandWildcardImports()` for JDK classes outside the `java.*` and `javax.*` package prefixes, such as `org.xml.sax.InputSource`.

`expandWildcardImports()` uses JavaParser symbol resolution to inspect the whole compilation unit before replacing wildcard imports. The default `ReflectionTypeSolver` only covers `java.*` and `javax.*`, so JDK XML types e.g. in `org.xml.sax.*` could fail with an `UnsolvedSymbolException`.

## Changes

- Use `ReflectionTypeSolver.JCL_ONLY` for the reflection type solver.
- Add a regression test with `org.xml.sax.InputSource` and a `java.io.*` wildcard import.

## Test

```bash
./gradlew :testlib:test --tests com.diffplug.spotless.java.ExpandWildcardImportsStepTest --no-daemon --no-configuration-cache --console=plain
```
