### PR TITLE
fix idea tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           download_link=$(curl https://data.services.jetbrains.com/products/releases\?code\=IIC\&latest\=true\&type\=release | jq -r '.IIC[0].downloads.linux.link')
           curl --location "$download_link" -o idea.tar.gz
           tar -xf idea.tar.gz
-          cd idea-IC*
+          cd idea-IU*
           export PATH=${PATH}:$(pwd)/bin
           cd ..
           ./gradlew testIdea


### PR DESCRIPTION
From https://blog.jetbrains.com/idea/2025/12/intellij-idea-unified-release/:

> [...] starting from this release (2025.3), there is one IntelliJ IDEA, replacing the separate IntelliJ IDEA Community Edition and IntelliJ IDEA Ultimate [...] 

That's why the paths changes inside the archive.