### PR TITLE
Fix predeclare from buildscript in gradle 9.x

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -9,6 +9,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 - Fix `tableTestFormatter` editorconfig cache not honoring `.editorconfig` changes across Gradle daemon runs due to a shared static `EditorConfigProvider`. ([#2893](https://github.com/diffplug/spotless/pull/2893))
 - Fix non-idempotent formatting when `importOrder()` is combined with `greclipse()`: a single catch-all group no longer strips blank lines that `greclipse()` independently inserted between import groups. ([#2914](https://github.com/diffplug/spotless/pull/2914))
+- Fix `predeclareDepsFromBuildscript()` on Gradle 9 by avoiding mutation of the root buildscript configuration container. ([#2929](https://github.com/diffplug/spotless/pull/2929), fixes [#2599](https://github.com/diffplug/spotless/issues/2599))
 ### Changes
 - Bump default `cleanthat` version `2.24` -> `2.25`. ([#2903](https://github.com/diffplug/spotless/pull/2903))
 - Bump default `eclipse-jdt` version from `4.35` to `4.39`. ([#2912](https://github.com/diffplug/spotless/pull/2912))

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/GradleProvisioner.java
@@ -29,6 +29,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
@@ -122,12 +123,14 @@ final class GradleProvisioner {
 	private static Provisioner forConfigurationContainer(Project project, ConfigurationContainer configurations, DependencyHandler dependencies) {
 		return (withTransitives, mavenCoords) -> {
 			try {
-				Configuration config = configurations.create("spotless"
-						+ new Request(withTransitives, mavenCoords).hashCode());
-				mavenCoords.stream()
+				Request request = new Request(withTransitives, mavenCoords);
+				Dependency[] deps = mavenCoords.stream()
 						.map(dependencies::create)
-						.forEach(config.getDependencies()::add);
-				config.setDescription(mavenCoords.toString());
+						.toArray(Dependency[]::new);
+				// Detached configurations avoid mutating the target configuration container, which Gradle 9 forbids
+				// for the root buildscript container during task execution. See https://github.com/diffplug/spotless/issues/2599.
+				Configuration config = configurations.detachedConfiguration(deps);
+				config.setDescription("Spotless internal dependency resolution for " + request);
 				config.setTransitive(withTransitives);
 				config.setCanBeConsumed(false);
 				config.setVisible(false);

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPredeclareIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPredeclareIntegrationTest.java
@@ -509,6 +509,82 @@ class SpotlessPredeclareIntegrationTest extends GradleIntegrationHarness {
 	}
 
 	@Nested
+	class Gradle9Compatibility {
+		@Test
+		void issue2599_Gradle951_FailsWhenPredeclareUsesBuildscriptRepositories() throws IOException {
+			setFile("build.gradle.kts").toContent("""
+					buildscript {
+					    repositories { mavenCentral() }
+					}
+					plugins {
+					    id("com.diffplug.spotless")
+					}
+					spotless {
+					    predeclareDepsFromBuildscript()
+					}
+					spotlessPredeclare {
+					    kotlin { ktfmt("0.56") }
+					}
+					spotless {
+					    kotlin {
+					        target("src/**/*.kt")
+					        ktfmt("0.56")
+					    }
+					}
+					""");
+			setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktfmt/basic.dirty");
+
+			BuildResult result = gradleRunner()
+					.withGradleVersion("9.5.1")
+					.withArguments("spotlessApply", "--stacktrace")
+					.buildAndFail();
+
+			assertThat(result.getOutput())
+					.contains("Execution failed for task ':spotlessInternalRegisterDependencies'")
+					.contains("Cannot mutate configuration container for buildscript")
+					.contains("Configurations cannot be added or removed from the buildscript configuration container.");
+		}
+
+		@Test
+		void gradle951CanUsePredeclareWithProjectRepositories() throws IOException {
+			setFile("build.gradle.kts").toContent("""
+					plugins {
+					    id("com.diffplug.spotless")
+					}
+					repositories { mavenCentral() }
+					spotless {
+					    predeclareDeps()
+					}
+					spotlessPredeclare {
+					    kotlin { ktfmt("0.56") }
+					}
+					spotless {
+					    kotlin {
+					        target("src/**/*.kt")
+					        ktfmt("0.56")
+					    }
+					}
+					""");
+			setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktfmt/basic.dirty");
+
+			BuildResult withoutConfigurationCache = gradleRunner()
+					.withGradleVersion("9.5.1")
+					.withArguments("spotlessApply", "--stacktrace")
+					.build();
+			assertThat(withoutConfigurationCache.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktfmt/basic.clean");
+
+			setFile("src/main/kotlin/basic.kt").toResource("kotlin/ktfmt/basic.dirty");
+			BuildResult withConfigurationCache = gradleRunner()
+					.withGradleVersion("9.5.1")
+					.withArguments("spotlessApply", "--configuration-cache", "--stacktrace")
+					.build();
+			assertThat(withConfigurationCache.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktfmt/basic.clean");
+		}
+	}
+
+	@Nested
 	class EdgeCases {
 		@Test
 		void predeclareRequiresPredeclareDepsCall() throws IOException {

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPredeclareIntegrationTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/SpotlessPredeclareIntegrationTest.java
@@ -511,8 +511,10 @@ class SpotlessPredeclareIntegrationTest extends GradleIntegrationHarness {
 	@Nested
 	class Gradle9Compatibility {
 		@Test
-		void issue2599_Gradle951_FailsWhenPredeclareUsesBuildscriptRepositories() throws IOException {
+		void issue2599_Gradle951_CanUsePredeclareDepsFromBuildscript() throws IOException {
 			setFile("build.gradle.kts").toContent("""
+					import com.diffplug.gradle.spotless.SpotlessExtensionPredeclare
+
 					buildscript {
 					    repositories { mavenCentral() }
 					}
@@ -522,7 +524,7 @@ class SpotlessPredeclareIntegrationTest extends GradleIntegrationHarness {
 					spotless {
 					    predeclareDepsFromBuildscript()
 					}
-					spotlessPredeclare {
+					configure<SpotlessExtensionPredeclare> {
 					    kotlin { ktfmt("0.56") }
 					}
 					spotless {
@@ -537,17 +539,17 @@ class SpotlessPredeclareIntegrationTest extends GradleIntegrationHarness {
 			BuildResult result = gradleRunner()
 					.withGradleVersion("9.5.1")
 					.withArguments("spotlessApply", "--stacktrace")
-					.buildAndFail();
+					.build();
 
-			assertThat(result.getOutput())
-					.contains("Execution failed for task ':spotlessInternalRegisterDependencies'")
-					.contains("Cannot mutate configuration container for buildscript")
-					.contains("Configurations cannot be added or removed from the buildscript configuration container.");
+			assertThat(result.getOutput()).contains("BUILD SUCCESSFUL");
+			assertFile("src/main/kotlin/basic.kt").sameAsResource("kotlin/ktfmt/basic.clean");
 		}
 
 		@Test
 		void gradle951CanUsePredeclareWithProjectRepositories() throws IOException {
 			setFile("build.gradle.kts").toContent("""
+					import com.diffplug.gradle.spotless.SpotlessExtensionPredeclare
+
 					plugins {
 					    id("com.diffplug.spotless")
 					}
@@ -555,7 +557,7 @@ class SpotlessPredeclareIntegrationTest extends GradleIntegrationHarness {
 					spotless {
 					    predeclareDeps()
 					}
-					spotlessPredeclare {
+					configure<SpotlessExtensionPredeclare> {
 					    kotlin { ktfmt("0.56") }
 					}
 					spotless {


### PR DESCRIPTION
Gradle 9 rejects mutating the root `buildscript` configuration container during task execution. This breaks `predeclareDepsFromBuildscript()` because Spotless resolved formatter dependencies by calling `ConfigurationContainer.create(...)` from `:spotlessInternalRegisterDependencies`.

This commit makes spotless resolve the formatter dependencies with a detached configurations instead.

They are not added to the target configuration container, so they avoid the Gradle 9 mutation guard while still using the repositories from the same configuration context.

Also adds a Gradle 9.5.1 integration test for the legacy `predeclareDepsFromBuildscript()` path.

https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations

https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ConfigurationContainer.html#detachedConfiguration-org.gradle.api.artifacts.Dependency...-

Fixes #2599
