### PR TITLE
Fix shell-injection in LicenseHeaderStep SET_FROM_GIT mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- `LicenseHeaderStep` in `SET_FROM_GIT` year mode no longer invokes `git log` through `bash -c` / `cmd /c`, eliminating a shell-injection vector when processing repositories that contain files whose names include shell metacharacters.
 
 ## [4.6.0] - 2026-05-14
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -34,7 +35,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.LineEnding;
@@ -420,14 +420,14 @@ public final class LicenseHeaderStep {
 
 			String oldYear;
 			try {
-				oldYear = parseYear("git log --follow --find-renames=40% --diff-filter=A", file);
+				oldYear = parseYear(Arrays.asList("git", "log", "--follow", "--find-renames=40%", "--diff-filter=A"), file);
 			} catch (IllegalArgumentException e) {
 				// Ideally, git log would always find the commit where it was added.
 				// For some reason, that is sometimes not possible - in that case,
 				// we'll settle for just the most recent, even if it was just a modification.
-				oldYear = parseYear("git log --follow --find-renames=40% --reverse", file);
+				oldYear = parseYear(Arrays.asList("git", "log", "--follow", "--find-renames=40%", "--reverse"), file);
 			}
-			String newYear = parseYear("git log --max-count=1", file);
+			String newYear = parseYear(Arrays.asList("git", "log", "--max-count=1"), file);
 			String yearRange;
 			if (oldYear.equals(newYear)) {
 				yearRange = oldYear;
@@ -450,14 +450,12 @@ public final class LicenseHeaderStep {
 			return FILENAME_PATTERN.matcher(header).replaceAll(file.getName()) + content;
 		}
 
-		private static String parseYear(String cmd, File file) throws IOException {
-			String fullCmd = cmd + " -- " + file.getAbsolutePath();
-			ProcessBuilder builder = new ProcessBuilder().directory(file.getParentFile());
-			if (FileSignature.machineIsWin()) {
-				builder.command("cmd", "/c", fullCmd);
-			} else {
-				builder.command("bash", "-c", fullCmd);
-			}
+		private static String parseYear(List<String> cmd, File file) throws IOException {
+			List<String> fullCmd = new ArrayList<>(cmd.size() + 2);
+			fullCmd.addAll(cmd);
+			fullCmd.add("--");
+			fullCmd.add(file.getAbsolutePath());
+			ProcessBuilder builder = new ProcessBuilder().directory(file.getParentFile()).command(fullCmd);
 			Process process = builder.start();
 			String output = drain(process.getInputStream());
 			String error = drain(process.getErrorStream());

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+- `licenseHeader` with `setLicenseHeaderYearsFromGitHistory()` no longer runs `git log` through a shell, eliminating a shell-injection vector when formatting files whose names contain shell metacharacters.
 
 ## [8.5.0] - 2026-05-14
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- `<licenseHeader>` with `<yearMode>SET_FROM_GIT</yearMode>` no longer runs `git log` through a shell, eliminating a shell-injection vector when formatting files whose names contain shell metacharacters.
 
 ## [3.5.0] - 2026-05-14
 ### Added


### PR DESCRIPTION
## Summary
- `LicenseHeaderStep.parseYear()` was concatenating `file.getAbsolutePath()` into a shell string and running it via `bash -c` / `cmd /c`. A file in a processed repository whose name contained shell metacharacters (e.g. `` foo`whoami`.java ``, `foo;rm -rf ~.java`, Windows `foo&calc.exe.java`) could execute arbitrary commands as the user running Spotless — a real risk on dev workstations and CI workers that run `spotlessApply` / `spotless:apply` against untrusted repos in `SET_FROM_GIT` year mode.
- Fix: invoke `git` directly via `ProcessBuilder` with an explicit argument list. No shell, no concatenation, no per-OS branch. The `--` separator is preserved so paths starting with `-` aren't interpreted as flags.
- Side benefit: paths with spaces — which were silently broken under the old `bash -c` form because the shell would word-split them — now work correctly.

## Test plan
- [x] `./gradlew :lib:compileJava` (verified locally)
- [x] `./gradlew :testlib:test --tests '*LicenseHeader*'` passes
- [x] Manual: run `spotlessApply` against a repo containing a file with shell metacharacters in its name and confirm no command execution