### PR TITLE
Avoids recomputing LineEnding.toUnix in Formatter step loop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 - `LicenseHeaderStep` in `SET_FROM_GIT` year mode no longer invokes `git log` through `bash -c` / `cmd /c`, eliminating a shell-injection vector when processing repositories that contain files whose names include shell metacharacters.
+### Changes
+- `Formatter` no longer recomputes line-ending normalization (`LineEnding.toUnix`) a second time for every formatter step that changes content, removing redundant O(n) work from the core formatting loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [4.6.0] - 2026-05-14
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,12 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+- `Formatter` no longer recomputes line-ending normalization (`LineEnding.toUnix`) a second time for every formatter step that changes content, removing redundant O(n) work from the core formatting loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [4.6.1] - 2026-05-15
 ### Fixed
 - `LicenseHeaderStep` in `SET_FROM_GIT` year mode no longer invokes `git log` through `bash -c` / `cmd /c`, eliminating a shell-injection vector when processing repositories that contain files whose names include shell metacharacters.
-### Changes
-- `Formatter` no longer recomputes line-ending normalization (`LineEnding.toUnix`) a second time for every formatter step that changes content, removing redundant O(n) work from the core formatting loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [4.6.0] - 2026-05-14
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/Formatter.java
+++ b/lib/src/main/java/com/diffplug/spotless/Formatter.java
@@ -182,7 +182,7 @@ public final class Formatter implements Serializable, AutoCloseable {
 						storeForStep = LintState.formatStepCausedNoChange();
 					} else {
 						storeForStep = null;
-						unix = LineEnding.toUnix(formatted);
+						unix = clean;
 					}
 				}
 			} catch (Throwable e) {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 - `licenseHeader` with `setLicenseHeaderYearsFromGitHistory()` no longer runs `git log` through a shell, eliminating a shell-injection vector when formatting files whose names contain shell metacharacters.
+### Changes
+- Improved formatting performance by eliminating redundant per-step line-ending normalization in the core formatter loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [8.5.0] - 2026-05-14
 ### Added

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,12 +3,12 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changes
+- Improved formatting performance by eliminating redundant per-step line-ending normalization in the core formatter loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [8.5.1] - 2026-05-15
 ### Fixed
 - `licenseHeader` with `setLicenseHeaderYearsFromGitHistory()` no longer runs `git log` through a shell, eliminating a shell-injection vector when formatting files whose names contain shell metacharacters.
-### Changes
-- Improved formatting performance by eliminating redundant per-step line-ending normalization in the core formatter loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [8.5.0] - 2026-05-14
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 - `<licenseHeader>` with `<yearMode>SET_FROM_GIT</yearMode>` no longer runs `git log` through a shell, eliminating a shell-injection vector when formatting files whose names contain shell metacharacters.
 - Bump transitive `plexus-utils` `4.0.2` -> `4.0.3` to address [CVE-2025-67030](https://github.com/advisories/GHSA-6fmv-xxpf-w3cw). ([#2919](https://github.com/diffplug/spotless/issues/2919))
+### Changes
+- Improved formatting performance by eliminating redundant per-step line-ending normalization in the core formatter loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [3.5.0] - 2026-05-14
 ### Added

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,13 +3,13 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+- Improved formatting performance by eliminating redundant per-step line-ending normalization in the core formatter loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [3.5.1] - 2026-05-15
 ### Fixed
 - `<licenseHeader>` with `<yearMode>SET_FROM_GIT</yearMode>` no longer runs `git log` through a shell, eliminating a shell-injection vector when formatting files whose names contain shell metacharacters.
 - Bump transitive `plexus-utils` `4.0.2` -> `4.0.3` to address [CVE-2025-67030](https://github.com/advisories/GHSA-6fmv-xxpf-w3cw). ([#2919](https://github.com/diffplug/spotless/issues/2919))
-### Changes
-- Improved formatting performance by eliminating redundant per-step line-ending normalization in the core formatter loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 
 ## [3.5.0] - 2026-05-14
 ### Added


### PR DESCRIPTION
In the core format loop, when a formatting step changes a file's content, the code used to normalize line endings to Unix twice in a row on the same content: once to compare, then again one more time to store.  The loop runs once per step, per file. `toUnix` scans the whole file. This PR fixes it to reuse the first result instead of computing it a second time, with no changes in the behavior.

