### PR TITLE
Fix flaky P2 test failures caused by parallel fork lock contention

### DIFF
--- a/lib-extra/build.gradle
+++ b/lib-extra/build.gradle
@@ -70,6 +70,9 @@ def jar = tasks.named('jar', Jar) {
 tasks.withType(Test).configureEach {
 	dependsOn jar
 	classpath += jar.get().outputs.files
+	// P2 tests use a process-level file lock; parallel forks race for it.
+	// In-JVM synchronization in TestP2Provisioner is enough, so one fork is sufficient.
+	maxParallelForks = 1
 }
 
 apply plugin: 'dev.equo.p2deps'


### PR DESCRIPTION
This PR aims to fix Fix flaky P2 test failures.

**Context**

`lib-extra:test` runs with `maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2)`.

Each Gradle test fork is a separate JVM. When multiple forks simultaneously call `model.query()`, they race for a process-level file lock causing one of the 2 forks to get an IllegalStateException (P2 operation already in progress).

`TestP2Provisioner` already has sync mechanism, but that only works within one JVM and not across multiple forks.

**Fix**

Override `maxParallelForks = 1` in `lib-extra/build.gradle`. One fork is enough because the `TestP2Provisioner` synch handles thread safety within one JVM, and its disk cache ensures P2 deps are provisioned once and reused across all test classes.

I don't expect meaningful slowdown since with 2 forks the parallel gain was already lost to lock failures and `testRetry` reschedules. Also, I expect this to make the pipeline more stable.