### PR TITLE
Remove maxLineLength from versionCatalog step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 - `forbidWildcardImports` and `forbidModuleImports` now detect imports that have leading whitespace (indentation/tabs). ([#2939](https://github.com/diffplug/spotless/pull/2939))
+- `versionCatalog` step no longer splits long inline tables across multiple lines — Gradle's TOML 1.0 parser cannot read multi-line inline tables. The `maxLineLength` option has been removed. ([#2948](https://github.com/diffplug/spotless/issues/2948))
 ### Changes
 - `Formatter` no longer recomputes line-ending normalization (`LineEnding.toUnix`) a second time for every formatter step that changes content, removing redundant O(n) work from the core formatting loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 

--- a/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
@@ -33,7 +33,6 @@ public final class VersionCatalogStep {
 	private VersionCatalogStep() {}
 
 	private static final String NAME = "versionCatalog";
-	private static final int DEFAULT_MAX_LINE_LENGTH = 120;
 
 	private static final List<String> TABLE_ORDER = Arrays.asList(
 			"[versions]",
@@ -45,20 +44,16 @@ public final class VersionCatalogStep {
 	private static final Pattern ENTRY_LINE = Pattern.compile("^([^=]+)=(.+)$");
 
 	public static FormatterStep create() {
-		return create(false, DEFAULT_MAX_LINE_LENGTH);
+		return create(false);
 	}
 
 	public static FormatterStep create(boolean stripQuotedKeys) {
-		return create(stripQuotedKeys, DEFAULT_MAX_LINE_LENGTH);
-	}
-
-	public static FormatterStep create(boolean stripQuotedKeys, int maxLineLength) {
 		return FormatterStep.createLazy(NAME,
-				() -> new State(stripQuotedKeys, maxLineLength),
+				() -> new State(stripQuotedKeys),
 				State::toFormatter);
 	}
 
-	static String format(String raw, boolean stripQuotedKeys, int maxLineLength) {
+	static String format(String raw, boolean stripQuotedKeys) {
 		if (raw.trim().isEmpty()) {
 			return raw;
 		}
@@ -95,8 +90,7 @@ public final class VersionCatalogStep {
 			result.append(header).append('\n');
 
 			for (Entry entry : entries) {
-				String formatted = formatEntry(entry.content, stripQuotedKeys);
-				entry.formatted = applyLineLength(formatted, maxLineLength);
+				entry.formatted = formatEntry(entry.content, stripQuotedKeys);
 			}
 			Collections.sort(entries, Comparator.comparing(Entry::sortKey));
 
@@ -191,8 +185,7 @@ public final class VersionCatalogStep {
 	}
 
 	private static String extractKey(String formattedEntry) {
-		String firstLine = formattedEntry.contains("\n") ? formattedEntry.substring(0, formattedEntry.indexOf('\n')) : formattedEntry;
-		Matcher matcher = ENTRY_LINE.matcher(firstLine);
+		Matcher matcher = ENTRY_LINE.matcher(formattedEntry);
 		if (!matcher.matches()) {
 			return formattedEntry;
 		}
@@ -229,52 +222,6 @@ public final class VersionCatalogStep {
 			return key + " = " + value + " " + inlineComment;
 		}
 		return key + " = " + value;
-	}
-
-	private static String applyLineLength(String formattedEntry, int maxLineLength) {
-		if (maxLineLength <= 0) {
-			return formattedEntry;
-		}
-
-		String inlineComment = extractInlineComment(formattedEntry);
-		String entryWithoutComment = inlineComment != null
-				? formattedEntry.substring(0, formattedEntry.length() - inlineComment.length()).trim()
-				: formattedEntry;
-
-		Matcher matcher = ENTRY_LINE.matcher(entryWithoutComment);
-		if (!matcher.matches()) {
-			return formattedEntry;
-		}
-
-		String key = matcher.group(1).trim();
-		String value = matcher.group(2).trim();
-		String commentSuffix = inlineComment != null ? " " + inlineComment : "";
-
-		if (value.startsWith("{") && value.endsWith("}")) {
-			if (formattedEntry.length() > maxLineLength) {
-				return splitInlineTable(key, value, commentSuffix);
-			}
-			return formattedEntry;
-		}
-
-		return formattedEntry;
-	}
-
-	private static String splitInlineTable(String key, String value, String commentSuffix) {
-		String inner = value.substring(1, value.length() - 1).trim();
-		String[] pairs = splitTopLevel(inner, ',');
-
-		StringBuilder result = new StringBuilder();
-		result.append(key).append(" = {").append(commentSuffix).append('\n');
-		for (int i = 0; i < pairs.length; i++) {
-			String pair = pairs[i].trim();
-			if (pair.isEmpty()) {
-				continue;
-			}
-			result.append("  ").append(pair).append(',').append('\n');
-		}
-		result.append('}');
-		return result.toString();
 	}
 
 	private static String extractInlineComment(String valueAndComment) {
@@ -398,18 +345,16 @@ public final class VersionCatalogStep {
 	}
 
 	private static final class State implements Serializable {
-		private static final long serialVersionUID = 2L;
+		private static final long serialVersionUID = 3L;
 
 		private final boolean stripQuotedKeys;
-		private final int maxLineLength;
 
-		State(boolean stripQuotedKeys, int maxLineLength) {
+		State(boolean stripQuotedKeys) {
 			this.stripQuotedKeys = stripQuotedKeys;
-			this.maxLineLength = maxLineLength;
 		}
 
 		FormatterFunc toFormatter() {
-			return raw -> format(raw, stripQuotedKeys, maxLineLength);
+			return raw -> format(raw, stripQuotedKeys);
 		}
 	}
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 - `forbidWildcardImports` and `forbidModuleImports` now detect imports that have leading whitespace (indentation/tabs). ([#2939](https://github.com/diffplug/spotless/pull/2939))
+- `versionCatalog()` no longer splits long inline tables across multiple lines — Gradle's TOML 1.0 parser cannot read multi-line inline tables. The `maxLineLength` option has been removed. ([#2948](https://github.com/diffplug/spotless/issues/2948))
 ### Changes
 - Improved formatting performance by eliminating redundant per-step line-ending normalization in the core formatter loop. ([#2934](https://github.com/diffplug/spotless/pull/2934))
 

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TomlExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/TomlExtension.java
@@ -42,7 +42,6 @@ public class TomlExtension extends FormatExtension {
 
 	public class VersionCatalogConfig {
 		private boolean stripQuotedKeys;
-		private int maxLineLength = 120;
 
 		public VersionCatalogConfig() {
 			this.stripQuotedKeys = false;
@@ -54,13 +53,8 @@ public class TomlExtension extends FormatExtension {
 			replaceStep(createStep());
 		}
 
-		public void maxLineLength(int maxLineLength) {
-			this.maxLineLength = maxLineLength;
-			replaceStep(createStep());
-		}
-
 		private FormatterStep createStep() {
-			return VersionCatalogStep.create(stripQuotedKeys, maxLineLength);
+			return VersionCatalogStep.create(stripQuotedKeys);
 		}
 	}
 }

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
+- `<versionCatalog>` no longer splits long inline tables across multiple lines — Gradle's TOML 1.0 parser cannot read multi-line inline tables. The `maxLineLength` option has been removed. ([#2948](https://github.com/diffplug/spotless/issues/2948))
 - `spotless:apply` no longer aborts on the first file with lints; it now formats all files and reports a single aggregated lint failure across every file, matching the Gradle plugin's behavior. ([#2937](https://github.com/diffplug/spotless/pull/2937))
 - `forbidWildcardImports` and `forbidModuleImports` now detect imports that have leading whitespace (indentation/tabs). ([#2939](https://github.com/diffplug/spotless/pull/2939))
 ### Changes

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/toml/VersionCatalog.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/toml/VersionCatalog.java
@@ -27,11 +27,8 @@ public class VersionCatalog implements FormatterStepFactory {
 	@Parameter
 	private boolean stripQuotedKeys;
 
-	@Parameter
-	private int maxLineLength = 120;
-
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
-		return VersionCatalogStep.create(stripQuotedKeys, maxLineLength);
+		return VersionCatalogStep.create(stripQuotedKeys);
 	}
 }

--- a/testlib/src/main/resources/toml/versionCatalogClean.toml
+++ b/testlib/src/main/resources/toml/versionCatalogClean.toml
@@ -10,10 +10,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
-testcontainers-junit-jupiter = {
-  module = "org.testcontainers:testcontainers-junit-jupiter",
-  version.ref = "testcontainers",
-}
+testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 
 [bundles]

--- a/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
@@ -155,46 +155,27 @@ class VersionCatalogStepTest {
 	}
 
 	@Test
-	void longLineSplitsInlineTable() throws Exception {
-		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create(false, 40));
-		harness.test(
-				"[libraries]\nfoo = { module = \"org.example:foo-bar\", version.ref = \"fooBar\" }\n",
-				"[libraries]\nfoo = {\n  module = \"org.example:foo-bar\",\n  version.ref = \"fooBar\",\n}\n");
-	}
-
-	@Test
-	void shortLineStaysSingleLine() throws Exception {
-		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create(false, 200));
-		harness.test(
-				"[libraries]\nfoo = {module=\"org:foo\",version.ref=\"bar\"}\n",
-				"[libraries]\nfoo = { module = \"org:foo\", version.ref = \"bar\" }\n");
-	}
-
-	@Test
-	void splitLineIdempotent() throws Exception {
-		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create(false, 40));
+	void longLineStaysSingleLine() throws Exception {
+		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create());
 		harness.testUnaffected(
-				"[libraries]\nfoo = {\n  module = \"org.example:foo-bar\",\n  version.ref = \"fooBar\",\n}\n");
+				"[libraries]\nfoo = { module = \"org.example:foo-bar-baz-qux\", version.ref = \"fooBarBazQux\" }\n");
 	}
 
 	@Test
 	void equality() throws Exception {
 		new SerializableEqualityTester() {
 			boolean stripQuotedKeys;
-			int maxLineLength = 120;
 
 			@Override
 			protected void setupTest(API api) {
 				api.areDifferentThan();
 				stripQuotedKeys = true;
 				api.areDifferentThan();
-				maxLineLength = 80;
-				api.areDifferentThan();
 			}
 
 			@Override
 			protected FormatterStep create() {
-				return VersionCatalogStep.create(stripQuotedKeys, maxLineLength);
+				return VersionCatalogStep.create(stripQuotedKeys);
 			}
 		}.testEquals();
 	}


### PR DESCRIPTION
## Summary

- Remove the `maxLineLength` option from the `versionCatalog` step — it produced multi-line inline tables (TOML 1.1 syntax) that Gradle's TOML 1.0 parser cannot read, breaking the build after `spotlessApply`
- Multi-line inline tables in input are still collapsed to single lines
- Clean up across Gradle plugin, Maven plugin, and test fixtures

Fixes #2948