### PR TITLE
Integrate adocfmt for AsciiDoc formatting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+- Add support for AsciiDoc formatting via `adocfmt`. (#TODO-PR-LINK)
 ### Fixed
 - Support `ktfmt` 0.63 and use its new builder API for formatting options to better avoid future breaking changes.
 ### Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Added
-- Add support for AsciiDoc formatting via `adocfmt`. (#TODO-PR-LINK)
+- Add support for AsciiDoc formatting via `adocfmt`. ([#2960](https://github.com/diffplug/spotless/pull/2960))
 ### Fixed
 - Support `ktfmt` 0.63 and use its new builder API for formatting options to better avoid future breaking changes.
 ### Changes

--- a/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.asciidoc;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+
+public class AdocfmtConfig implements Serializable {
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	public boolean normalizeSetextHeadings = false;
+	public boolean collapseConsecutiveBlankLines = true;
+	public boolean oneSentencePerLine = false;
+	public boolean normalizeBlockDelimiters = true;
+	public boolean removeTrailingHeaderEqualsSign = true;
+	public boolean titleCase = false;
+	public boolean removeTrailingWhitespace = true;
+	public boolean normalizeListBullets = false;
+	public boolean normalizeOrderedListMarkers = false;
+	public boolean ensureHeadingBlankLines = true;
+	public boolean ensureSourceDelimiters = false;
+
+	public AdocfmtConfig() {}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof AdocfmtConfig other))
+			return false;
+		return normalizeSetextHeadings == other.normalizeSetextHeadings
+				&& collapseConsecutiveBlankLines == other.collapseConsecutiveBlankLines
+				&& oneSentencePerLine == other.oneSentencePerLine
+				&& normalizeBlockDelimiters == other.normalizeBlockDelimiters
+				&& removeTrailingHeaderEqualsSign == other.removeTrailingHeaderEqualsSign
+				&& titleCase == other.titleCase
+				&& removeTrailingWhitespace == other.removeTrailingWhitespace
+				&& normalizeListBullets == other.normalizeListBullets
+				&& normalizeOrderedListMarkers == other.normalizeOrderedListMarkers
+				&& ensureHeadingBlankLines == other.ensureHeadingBlankLines
+				&& ensureSourceDelimiters == other.ensureSourceDelimiters;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(normalizeSetextHeadings, collapseConsecutiveBlankLines, oneSentencePerLine,
+				normalizeBlockDelimiters, removeTrailingHeaderEqualsSign, titleCase, removeTrailingWhitespace,
+				normalizeListBullets, normalizeOrderedListMarkers, ensureHeadingBlankLines, ensureSourceDelimiters);
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtStep.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.asciidoc;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import com.diffplug.spotless.FormatterFunc;
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.JarState;
+import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.ThrowingEx;
+
+public final class AdocfmtStep implements Serializable {
+	@Serial
+	private static final long serialVersionUID = 1L;
+	private static final String DEFAULT_VERSION = "0.1.2";
+	private static final String NAME = "adocfmt";
+	private static final String MAVEN_COORDINATE = "org.drjekyll:adocfmt:";
+
+	private final String version;
+	private final AdocfmtConfig config;
+	private final JarState.Promised jarState;
+
+	private AdocfmtStep(String version, AdocfmtConfig config, JarState.Promised jarState) {
+		this.version = version;
+		this.config = config;
+		this.jarState = jarState;
+	}
+
+	public static FormatterStep create(Provisioner provisioner) {
+		return create(defaultVersion(), provisioner);
+	}
+
+	public static FormatterStep create(String version, Provisioner provisioner) {
+		return create(version, provisioner, new AdocfmtConfig());
+	}
+
+	public static FormatterStep create(String version, Provisioner provisioner, AdocfmtConfig config) {
+		Objects.requireNonNull(version, "version");
+		Objects.requireNonNull(provisioner, "provisioner");
+		Objects.requireNonNull(config, "config");
+		return FormatterStep.create(NAME,
+				new AdocfmtStep(version, config, JarState.promise(() -> JarState.from(MAVEN_COORDINATE + version, provisioner))),
+				AdocfmtStep::equalityState,
+				State::createFormat);
+	}
+
+	public static String defaultVersion() {
+		return DEFAULT_VERSION;
+	}
+
+	private State equalityState() {
+		return new State(version, config, jarState.get());
+	}
+
+	private static final class State implements Serializable {
+		@Serial
+		private static final long serialVersionUID = 1L;
+		private final String version;
+		private final AdocfmtConfig config;
+		private final JarState jarState;
+
+		State(String version, AdocfmtConfig config, JarState jarState) {
+			this.version = version;
+			this.config = config;
+			this.jarState = jarState;
+		}
+
+		FormatterFunc createFormat() throws Exception {
+			final ClassLoader classLoader = jarState.getClassLoader();
+			final Class<?> formatterClass = classLoader.loadClass("org.drjekyll.adocfmt.AsciidocFormatter");
+			final Class<?> configClass = classLoader.loadClass("org.drjekyll.adocfmt.AsciidocFormatterConfig");
+			final Method builderMethod = configClass.getMethod("builder");
+			Object builder = builderMethod.invoke(null);
+			final Class<?> builderClass = builder.getClass();
+			builder = builderClass.getMethod("normalizeSetextHeadings", boolean.class).invoke(builder, config.normalizeSetextHeadings);
+			builder = builderClass.getMethod("collapseConsecutiveBlankLines", boolean.class).invoke(builder, config.collapseConsecutiveBlankLines);
+			builder = builderClass.getMethod("oneSentencePerLine", boolean.class).invoke(builder, config.oneSentencePerLine);
+			builder = builderClass.getMethod("normalizeBlockDelimiters", boolean.class).invoke(builder, config.normalizeBlockDelimiters);
+			builder = builderClass.getMethod("removeTrailingHeaderEqualsSign", boolean.class).invoke(builder, config.removeTrailingHeaderEqualsSign);
+			builder = builderClass.getMethod("titleCase", boolean.class).invoke(builder, config.titleCase);
+			builder = builderClass.getMethod("removeTrailingWhitespace", boolean.class).invoke(builder, config.removeTrailingWhitespace);
+			builder = builderClass.getMethod("normalizeListBullets", boolean.class).invoke(builder, config.normalizeListBullets);
+			builder = builderClass.getMethod("normalizeOrderedListMarkers", boolean.class).invoke(builder, config.normalizeOrderedListMarkers);
+			builder = builderClass.getMethod("ensureHeadingBlankLines", boolean.class).invoke(builder, config.ensureHeadingBlankLines);
+			builder = builderClass.getMethod("ensureSourceDelimiters", boolean.class).invoke(builder, config.ensureSourceDelimiters);
+			final Object adocfmtConfig = builderClass.getMethod("build").invoke(builder);
+
+			final Object formatter = formatterClass.getConstructor(configClass).newInstance(adocfmtConfig);
+			final Method formatMethod = formatterClass.getMethod("format", String.class);
+			return input -> {
+				try {
+					return (String) formatMethod.invoke(formatter, input);
+				} catch (InvocationTargetException e) {
+					throw ThrowingEx.unwrapCause(e);
+				}
+			};
+		}
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtStep.java
@@ -30,7 +30,7 @@ import com.diffplug.spotless.ThrowingEx;
 public final class AdocfmtStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
-	private static final String DEFAULT_VERSION = "0.1.2";
+	private static final String DEFAULT_VERSION = "0.2.0";
 	private static final String NAME = "adocfmt";
 	private static final String MAVEN_COORDINATE = "org.drjekyll:adocfmt:";
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Added
-- Add support for AsciiDoc formatting via `adocfmt`. (#TODO-PR-LINK)
+- Add support for AsciiDoc formatting via `adocfmt`. ([#2960](https://github.com/diffplug/spotless/pull/2960))
 ### Fixed
 - Prevent build caches from interfering when executing under the `-PspotlessIdeHook` mode. ([#2365](https://github.com/diffplug/spotless/issues/2365))
 ### Changes

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Added
+- Add support for AsciiDoc formatting via `adocfmt`. (#TODO-PR-LINK)
 ### Fixed
 - Prevent build caches from interfering when executing under the `-PspotlessIdeHook` mode. ([#2365](https://github.com/diffplug/spotless/issues/2365))
 ### Changes

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -60,6 +60,7 @@ Spotless supports all of Gradle's built-in performance features (incremental bui
   - [Groovy](#groovy) ([eclipse groovy](#eclipse-groovy))
   - [Kotlin](#kotlin) ([ktfmt](#ktfmt), [ktlint](#ktlint), [diktat](#diktat), [tabletest-formatter](#tabletest-formatter-1), [prettier](#prettier))
   - [Scala](#scala) ([scalafmt](#scalafmt))
+  - [Asciidoc](#asciidoc) ([adocfmt](#adocfmt))
   - [C/C++](#cc) ([clang-format](#clang-format), [eclipse cdt](#eclipse-cdt))
   - [Protobuf](#protobuf) ([buf](#buf), [clang-format](#clang-format))
   - [Python](#python) ([black](#black))
@@ -829,6 +830,40 @@ spotless {
 ```gradle
 antlr4formatter('1.2.1') // version is optional
 ```
+
+## Asciidoc
+
+`com.diffplug.gradle.spotless.AsciidocExtension` [javadoc](https://javadoc.io/doc/com.diffplug.spotless/spotless-plugin-gradle/8.6.0/com/diffplug/gradle/spotless/AsciidocExtension.html), [code](https://github.com/diffplug/spotless/blob/main/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java)
+
+```gradle
+spotless {
+  asciidoc {
+    target '**/*.adoc', '**/*.asciidoc', '**/*.asc' // default value, you can change if you want
+    adocfmt() // has its own section below
+  }
+}
+```
+
+### adocfmt
+
+[homepage](https://github.com/dheid/adocfmt). [available versions](https://search.maven.org/artifact/org.drjekyll/adocfmt).
+
+```gradle
+adocfmt('0.1.2') // version is optional
+  .normalizeSetextHeadings(false)       // convert === underlines to ATX == (default: false)
+  .collapseConsecutiveBlankLines(true)  // max 1 blank line (default: true)
+  .oneSentencePerLine(false)            // each sentence on its own line (default: false)
+  .normalizeBlockDelimiters(true)       // exactly 4 characters (e.g. ----) (default: true)
+  .removeTrailingHeaderEqualsSign(true) // == Title == -> == Title (default: true)
+  .titleCase(false)                     // Title Case headings (default: false)
+  .removeTrailingWhitespace(true)       // trim end of line (default: true)
+  .normalizeListBullets(false)          // - -> * (default: false)
+  .normalizeOrderedListMarkers(false)   // 1. -> . (default: false)
+  .ensureHeadingBlankLines(true)        // blank line before/after headings (default: true)
+  .ensureSourceDelimiters(false)        // wrap [source] in ---- (default: false)
+```
+
+Options default to `true` or `false` as shown above. This formatter is designed to help you maintain a clean, consistent AsciiDoc structure. Surface-altering options like `oneSentencePerLine` and `normalizeSetextHeadings` default to `false` so that zero-config formatting is conservative; opt in explicitly if you want those transforms.
 
 <a name="sql-dbeaver"></a>
 <a name="applying-dbeaver-to-sql-scripts"></a>

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -838,7 +838,8 @@ antlr4formatter('1.2.1') // version is optional
 ```gradle
 spotless {
   asciidoc {
-    target '**/*.adoc', '**/*.asciidoc' // default value, you can change if you want
+    target 'src/docs/**/*.adoc' // you have to set the target manually
+
     adocfmt() // has its own section below
   }
 }
@@ -849,7 +850,7 @@ spotless {
 [homepage](https://github.com/dheid/adocfmt). [available versions](https://search.maven.org/artifact/org.drjekyll/adocfmt).
 
 ```gradle
-adocfmt('0.1.2') // version is optional
+adocfmt('0.2.0') // version is optional
   .normalizeSetextHeadings(false)       // convert === underlines to ATX == (default: false)
   .collapseConsecutiveBlankLines(true)  // max 1 blank line (default: true)
   .oneSentencePerLine(false)            // each sentence on its own line (default: false)

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -838,7 +838,7 @@ antlr4formatter('1.2.1') // version is optional
 ```gradle
 spotless {
   asciidoc {
-    target '**/*.adoc', '**/*.asciidoc', '**/*.asc' // default value, you can change if you want
+    target '**/*.adoc', '**/*.asciidoc' // default value, you can change if you want
     adocfmt() // has its own section below
   }
 }

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
@@ -15,8 +15,6 @@
  */
 package com.diffplug.gradle.spotless;
 
-import java.util.List;
-
 import javax.inject.Inject;
 
 import com.diffplug.spotless.asciidoc.AdocfmtConfig;
@@ -117,7 +115,7 @@ public class AsciidocExtension extends FormatExtension {
 	@Override
 	protected void setupTask(SpotlessTask task) {
 		if (target == null) {
-			target = parseTarget(List.of("**/*.adoc", "**/*.asciidoc"));
+			throw noDefaultTargetException();
 		}
 		super.setupTask(task);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
@@ -117,7 +117,7 @@ public class AsciidocExtension extends FormatExtension {
 	@Override
 	protected void setupTask(SpotlessTask task) {
 		if (target == null) {
-			target = parseTarget(List.of("**/*.adoc", "**/*.asciidoc", "**/*.asc"));
+			target = parseTarget(List.of("**/*.adoc", "**/*.asciidoc"));
 		}
 		super.setupTask(task);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import com.diffplug.spotless.asciidoc.AdocfmtConfig;
+import com.diffplug.spotless.asciidoc.AdocfmtStep;
+
+public class AsciidocExtension extends FormatExtension {
+	static final String NAME = "asciidoc";
+
+	@Inject
+	public AsciidocExtension(SpotlessExtension spotless) {
+		super(spotless);
+	}
+
+	public AdocfmtFormatterConfig adocfmt() {
+		return adocfmt(AdocfmtStep.defaultVersion());
+	}
+
+	public AdocfmtFormatterConfig adocfmt(String version) {
+		return new AdocfmtFormatterConfig(version);
+	}
+
+	public class AdocfmtFormatterConfig {
+		private final String version;
+		private final AdocfmtConfig config = new AdocfmtConfig();
+
+		AdocfmtFormatterConfig(String version) {
+			this.version = version;
+			addStep(AdocfmtStep.create(version, provisioner(), config));
+		}
+
+		public AdocfmtFormatterConfig normalizeSetextHeadings(boolean normalizeSetextHeadings) {
+			config.normalizeSetextHeadings = normalizeSetextHeadings;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig collapseConsecutiveBlankLines(boolean collapseConsecutiveBlankLines) {
+			config.collapseConsecutiveBlankLines = collapseConsecutiveBlankLines;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig oneSentencePerLine(boolean oneSentencePerLine) {
+			config.oneSentencePerLine = oneSentencePerLine;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig normalizeBlockDelimiters(boolean normalizeBlockDelimiters) {
+			config.normalizeBlockDelimiters = normalizeBlockDelimiters;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig removeTrailingHeaderEqualsSign(boolean removeTrailingHeaderEqualsSign) {
+			config.removeTrailingHeaderEqualsSign = removeTrailingHeaderEqualsSign;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig titleCase(boolean titleCase) {
+			config.titleCase = titleCase;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig removeTrailingWhitespace(boolean removeTrailingWhitespace) {
+			config.removeTrailingWhitespace = removeTrailingWhitespace;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig normalizeListBullets(boolean normalizeListBullets) {
+			config.normalizeListBullets = normalizeListBullets;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig normalizeOrderedListMarkers(boolean normalizeOrderedListMarkers) {
+			config.normalizeOrderedListMarkers = normalizeOrderedListMarkers;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig ensureHeadingBlankLines(boolean ensureHeadingBlankLines) {
+			config.ensureHeadingBlankLines = ensureHeadingBlankLines;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig ensureSourceDelimiters(boolean ensureSourceDelimiters) {
+			config.ensureSourceDelimiters = ensureSourceDelimiters;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+	}
+
+	@Override
+	protected void setupTask(SpotlessTask task) {
+		if (target == null) {
+			target = parseTarget(List.of("**/*.adoc", "**/*.asciidoc", "**/*.asc"));
+		}
+		super.setupTask(task);
+	}
+}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -228,7 +228,7 @@ public abstract class SpotlessExtension {
 		format(YamlExtension.NAME, YamlExtension.class, closure);
 	}
 
-	/** Configures the special gherkin-specific extension. */
+	/** Configures the special Gherkin-specific extension. */
 	public void gherkin(Action<GherkinExtension> closure) {
 		requireNonNull(closure);
 		format(GherkinExtension.NAME, GherkinExtension.class, closure);
@@ -241,7 +241,6 @@ public abstract class SpotlessExtension {
 	}
 
 	public void toml(Action<TomlExtension> closure) {
-
 		requireNonNull(closure);
 		format(TomlExtension.NAME, TomlExtension.class, closure);
 	}

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtension.java
@@ -228,13 +228,20 @@ public abstract class SpotlessExtension {
 		format(YamlExtension.NAME, YamlExtension.class, closure);
 	}
 
-	/** Configures the special Gherkin-specific extension. */
+	/** Configures the special gherkin-specific extension. */
 	public void gherkin(Action<GherkinExtension> closure) {
 		requireNonNull(closure);
 		format(GherkinExtension.NAME, GherkinExtension.class, closure);
 	}
 
+	/** Configures the special asciidoc-specific extension. */
+	public void asciidoc(Action<AsciidocExtension> closure) {
+		requireNonNull(closure);
+		format(AsciidocExtension.NAME, AsciidocExtension.class, closure);
+	}
+
 	public void toml(Action<TomlExtension> closure) {
+
 		requireNonNull(closure);
 		format(TomlExtension.NAME, TomlExtension.class, closure);
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/AsciidocExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/AsciidocExtensionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+class AsciidocExtensionTest extends GradleIntegrationHarness {
+	@Test
+	void integration() throws IOException {
+		setFile("build.gradle")
+				.toContent(
+						"""
+								plugins {
+								    id 'com.diffplug.spotless'
+								}
+								repositories { mavenCentral() }
+								spotless {
+								    asciidoc {
+								        target 'test.adoc'
+										adocfmt('0.1.2')
+										  .normalizeSetextHeadings(true)
+										  .collapseConsecutiveBlankLines(true)
+										  .oneSentencePerLine(true)
+										  .normalizeBlockDelimiters(true)
+										  .removeTrailingHeaderEqualsSign(true)
+										  .titleCase(true)
+										  .removeTrailingWhitespace(true)
+										  .normalizeListBullets(true)
+										  .normalizeOrderedListMarkers(true)
+										  .ensureHeadingBlankLines(true)
+										  .ensureSourceDelimiters(true)
+								    }
+								}
+								""");
+		setFile("test.adoc").toResource("asciidoc/adocfmt/dirty.adoc");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("test.adoc").sameAsResource("asciidoc/adocfmt/clean_all_options.adoc");
+	}
+}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/AsciidocExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/AsciidocExtensionTest.java
@@ -17,9 +17,29 @@ package com.diffplug.gradle.spotless;
 
 import java.io.IOException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class AsciidocExtensionTest extends GradleIntegrationHarness {
+	@Test
+	void missingTargetFails() throws IOException {
+		setFile("build.gradle").toContent(
+				"""
+						plugins {
+						    id 'com.diffplug.spotless'
+						}
+						repositories { mavenCentral() }
+						spotless {
+						    asciidoc {
+						        adocfmt('0.2.0')
+						    }
+						}
+						""");
+		String output = gradleRunner().withArguments("spotlessApply").buildAndFail().getOutput();
+		Assertions.assertThat(output).contains("no target set");
+		Assertions.assertThat(output).contains("asciidoc");
+	}
+
 	@Test
 	void integration() throws IOException {
 		setFile("build.gradle")
@@ -32,7 +52,7 @@ class AsciidocExtensionTest extends GradleIntegrationHarness {
 								spotless {
 								    asciidoc {
 								        target 'test.adoc'
-										adocfmt('0.1.2')
+										adocfmt('0.2.0')
 										  .normalizeSetextHeadings(true)
 										  .collapseConsecutiveBlankLines(true)
 										  .oneSentencePerLine(true)

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Added
+- Add support for AsciiDoc formatting via `adocfmt`. (#TODO-PR-LINK)
+
 ## [3.6.0] - 2026-05-27
 ### Added
 - Add `<cacheDirectory>` to `<eclipse>`, `<greclipse>`, and `<eclipseCdt>` for the Equo/Solstice P2 cache. ([#2944](https://github.com/diffplug/spotless/pull/2944))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Added
-- Add support for AsciiDoc formatting via `adocfmt`. (#TODO-PR-LINK)
+- Add support for AsciiDoc formatting via `adocfmt`. ([#2960](https://github.com/diffplug/spotless/pull/2960))
 
 ## [3.6.0] - 2026-05-27
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -712,10 +712,8 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 ```xml
 <configuration>
   <asciidoc>
-    <!-- These are the defaults, you can override if you want -->
-    <includes>
-      <include>**/*.adoc</include>
-      <include>**/*.asciidoc</include>
+    <includes> <!-- You have to set the target manually -->
+      <include>src/docs/**/*.adoc</include>
     </includes>
 
     <adocfmt /> <!-- has its own section below -->
@@ -729,7 +727,7 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 
 ```xml
 <adocfmt>
-  <version>0.1.2</version> <!-- optional -->
+  <version>0.2.0</version> <!-- optional -->
   <normalizeSetextHeadings>true</normalizeSetextHeadings>       <!-- convert === underlines to ATX == (default: true) -->
   <collapseConsecutiveBlankLines>true</collapseConsecutiveBlankLines> <!-- max 1 blank line (default: true) -->
   <oneSentencePerLine>true</oneSentencePerLine>            <!-- each sentence on its own line (default: true) -->

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -716,7 +716,6 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
     <includes>
       <include>**/*.adoc</include>
       <include>**/*.asciidoc</include>
-      <include>**/*.asc</include>
     </includes>
 
     <adocfmt /> <!-- has its own section below -->

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -44,6 +44,7 @@ user@machine repo % mvn spotless:check
   - [Groovy](#groovy) ([eclipse groovy](#eclipse-groovy))
   - [Kotlin](#kotlin) ([ktfmt](#ktfmt), [ktlint](#ktlint), [diktat](#diktat), [tabletest-formatter](#tabletest-formatter-1), [prettier](#prettier))
   - [Scala](#scala) ([scalafmt](#scalafmt))
+  - [Asciidoc](#asciidoc) ([adocfmt](#adocfmt))
   - [C/C++](#cc) ([eclipse cdt](#eclipse-cdt), [clang-format](#clang-format))
   - [Python](#python) ([black](#black))
   - [Antlr4](#antlr4) ([antlr4formatter](#antlr4formatter))
@@ -703,6 +704,48 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
   <version>1.2.1</version> <!-- optional -->
 </antlr4Formatter>
 ```
+
+## Asciidoc
+
+[code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Asciidoc.java). [available steps](https://github.com/diffplug/spotless/tree/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc).
+
+```xml
+<configuration>
+  <asciidoc>
+    <!-- These are the defaults, you can override if you want -->
+    <includes>
+      <include>**/*.adoc</include>
+      <include>**/*.asciidoc</include>
+      <include>**/*.asc</include>
+    </includes>
+
+    <adocfmt /> <!-- has its own section below -->
+  </asciidoc>
+</configuration>
+```
+
+### adocfmt
+
+[homepage](https://github.com/dheid/adocfmt). [available versions](https://search.maven.org/artifact/org.drjekyll/adocfmt). [code](https://github.com/diffplug/spotless/blob/main/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Adocfmt.java).
+
+```xml
+<adocfmt>
+  <version>0.1.2</version> <!-- optional -->
+  <normalizeSetextHeadings>true</normalizeSetextHeadings>       <!-- convert === underlines to ATX == (default: true) -->
+  <collapseConsecutiveBlankLines>true</collapseConsecutiveBlankLines> <!-- max 1 blank line (default: true) -->
+  <oneSentencePerLine>true</oneSentencePerLine>            <!-- each sentence on its own line (default: true) -->
+  <normalizeBlockDelimiters>true</normalizeBlockDelimiters>      <!-- exactly 4 characters (e.g. ----) (default: true) -->
+  <removeTrailingHeaderEqualsSign>true</removeTrailingHeaderEqualsSign> <!-- == Title == -> == Title (default: true) -->
+  <titleCase>false</titleCase>                     <!-- Title Case headings (default: false) -->
+  <removeTrailingWhitespace>true</removeTrailingWhitespace>      <!-- trim end of line (default: true) -->
+  <normalizeListBullets>false</normalizeListBullets>          <!-- - -> * (default: false) -->
+  <normalizeOrderedListMarkers>false</normalizeOrderedListMarkers>   <!-- 1. -> . (default: false) -->
+  <ensureHeadingBlankLines>true</ensureHeadingBlankLines>       <!-- blank line before/after headings (default: true) -->
+  <ensureSourceDelimiters>false</ensureSourceDelimiters>        <!-- wrap [source] in ---- (default: false) -->
+</adocfmt>
+```
+
+Options default to `true` or `false` as shown above. This formatter is opinionated and designed to help you maintain a clean, consistent AsciiDoc structure. For example, `<oneSentencePerLine>` is a highly recommended practice in the AsciiDoc community for better version control diffs.
 
 ## SQL
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -63,6 +63,7 @@ import com.diffplug.spotless.LintSuppression;
 import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.extra.P2Provisioner;
 import com.diffplug.spotless.maven.antlr4.Antlr4;
+import com.diffplug.spotless.maven.asciidoc.Asciidoc;
 import com.diffplug.spotless.maven.cpp.Cpp;
 import com.diffplug.spotless.maven.css.Css;
 import com.diffplug.spotless.maven.generic.Format;
@@ -181,6 +182,9 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 
 	@Parameter
 	private Antlr4 antlr4;
+
+	@Parameter
+	private Asciidoc asciidoc;
 
 	@Parameter
 	private Pom pom;
@@ -453,7 +457,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	}
 
 	private List<FormatterFactory> getFormatterFactories() {
-		return Stream.concat(formats.stream(), Stream.of(groovy, java, scala, kotlin, cpp, css, typescript, javascript, antlr4, pom, sql, python, markdown, json, shell, yaml, gherkin, go, rdf, protobuf, tableTest, toml))
+		return Stream.concat(formats.stream(), Stream.of(groovy, java, scala, kotlin, asciidoc, cpp, css, typescript, javascript, antlr4, pom, sql, python, markdown, json, shell, yaml, gherkin, go, rdf, protobuf, tableTest, toml))
 				.filter(Objects::nonNull)
 				.map(factory -> factory.init(repositorySystemSession))
 				.collect(toList());

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Adocfmt.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Adocfmt.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.asciidoc;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.asciidoc.AdocfmtConfig;
+import com.diffplug.spotless.asciidoc.AdocfmtStep;
+import com.diffplug.spotless.maven.FormatterStepConfig;
+import com.diffplug.spotless.maven.FormatterStepFactory;
+
+public class Adocfmt implements FormatterStepFactory {
+	@Parameter
+	private String version;
+
+	@Parameter
+	private Boolean normalizeSetextHeadings;
+
+	@Parameter
+	private Boolean collapseConsecutiveBlankLines;
+
+	@Parameter
+	private Boolean oneSentencePerLine;
+
+	@Parameter
+	private Boolean normalizeBlockDelimiters;
+
+	@Parameter
+	private Boolean removeTrailingHeaderEqualsSign;
+
+	@Parameter
+	private Boolean titleCase;
+
+	@Parameter
+	private Boolean removeTrailingWhitespace;
+
+	@Parameter
+	private Boolean normalizeListBullets;
+
+	@Parameter
+	private Boolean normalizeOrderedListMarkers;
+
+	@Parameter
+	private Boolean ensureHeadingBlankLines;
+
+	@Parameter
+	private Boolean ensureSourceDelimiters;
+
+	@Override
+	public FormatterStep newFormatterStep(FormatterStepConfig config) {
+		String version = this.version != null ? this.version : AdocfmtStep.defaultVersion();
+		AdocfmtConfig adocfmtConfig = new AdocfmtConfig();
+		if (normalizeSetextHeadings != null)
+			adocfmtConfig.normalizeSetextHeadings = normalizeSetextHeadings;
+		if (collapseConsecutiveBlankLines != null)
+			adocfmtConfig.collapseConsecutiveBlankLines = collapseConsecutiveBlankLines;
+		if (oneSentencePerLine != null)
+			adocfmtConfig.oneSentencePerLine = oneSentencePerLine;
+		if (normalizeBlockDelimiters != null)
+			adocfmtConfig.normalizeBlockDelimiters = normalizeBlockDelimiters;
+		if (removeTrailingHeaderEqualsSign != null)
+			adocfmtConfig.removeTrailingHeaderEqualsSign = removeTrailingHeaderEqualsSign;
+		if (titleCase != null)
+			adocfmtConfig.titleCase = titleCase;
+		if (removeTrailingWhitespace != null)
+			adocfmtConfig.removeTrailingWhitespace = removeTrailingWhitespace;
+		if (normalizeListBullets != null)
+			adocfmtConfig.normalizeListBullets = normalizeListBullets;
+		if (normalizeOrderedListMarkers != null)
+			adocfmtConfig.normalizeOrderedListMarkers = normalizeOrderedListMarkers;
+		if (ensureHeadingBlankLines != null)
+			adocfmtConfig.ensureHeadingBlankLines = ensureHeadingBlankLines;
+		if (ensureSourceDelimiters != null)
+			adocfmtConfig.ensureSourceDelimiters = ensureSourceDelimiters;
+		return AdocfmtStep.create(version, config.getProvisioner(), adocfmtConfig);
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Asciidoc.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Asciidoc.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.asciidoc;
+
+import java.util.Set;
+
+import org.apache.maven.project.MavenProject;
+
+import com.diffplug.spotless.maven.FormatterFactory;
+
+public class Asciidoc extends FormatterFactory {
+	@Override
+	public Set<String> defaultIncludes(MavenProject project) {
+		return Set.of("**/*.adoc", "**/*.asciidoc", "**/*.asc");
+	}
+
+	@Override
+	public String licenseHeaderDelimiter() {
+		return null;
+	}
+
+	public void addAdocfmt(Adocfmt adocfmt) {
+		addStepFactory(adocfmt);
+	}
+}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Asciidoc.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Asciidoc.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.spotless.maven.asciidoc;
 
+import java.util.Collections;
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
@@ -24,7 +25,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Asciidoc extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Set.of("**/*.adoc", "**/*.asciidoc");
+		return Collections.emptySet();
 	}
 
 	@Override

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Asciidoc.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Asciidoc.java
@@ -24,7 +24,7 @@ import com.diffplug.spotless.maven.FormatterFactory;
 public class Asciidoc extends FormatterFactory {
 	@Override
 	public Set<String> defaultIncludes(MavenProject project) {
-		return Set.of("**/*.adoc", "**/*.asciidoc", "**/*.asc");
+		return Set.of("**/*.adoc", "**/*.asciidoc");
 	}
 
 	@Override

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/MavenIntegrationHarness.java
@@ -125,6 +125,10 @@ public class MavenIntegrationHarness extends ResourceHarness {
 		writePom(groupWithSteps("antlr4", steps));
 	}
 
+	protected void writePomWithAsciidocSteps(String... steps) throws IOException {
+		writePom(groupWithSteps("asciidoc", including("**/*.adoc"), steps));
+	}
+
 	protected void writePomWithGroovySteps(String... steps) throws IOException {
 		writePom(groupWithSteps("groovy", steps));
 	}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/asciidoc/AdocfmtMavenTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/asciidoc/AdocfmtMavenTest.java
@@ -15,17 +15,30 @@
  */
 package com.diffplug.spotless.maven.asciidoc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
+import com.diffplug.spotless.ProcessRunner;
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
 
 public class AdocfmtMavenTest extends MavenIntegrationHarness {
+	@Test
+	public void missingIncludesFails() throws Exception {
+		writePom(groupWithSteps("asciidoc",
+				"<adocfmt>",
+				"  <version>0.2.0</version>",
+				"</adocfmt>"));
+		ProcessRunner.Result result = mavenRunner().withArguments("spotless:apply").runHasError();
+		assertThat(result.stdOutUtf8()).contains("You must specify some files to include");
+	}
+
 	@Test
 	public void testAdocfmt() throws Exception {
 		writePomWithAsciidocSteps(
 				"""
 						<adocfmt>
-						  <version>0.1.2</version> <!-- optional -->
+						  <version>0.2.0</version> <!-- optional -->
 						  <normalizeSetextHeadings>true</normalizeSetextHeadings>
 						  <collapseConsecutiveBlankLines>true</collapseConsecutiveBlankLines>
 						  <oneSentencePerLine>true</oneSentencePerLine>

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/asciidoc/AdocfmtMavenTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/asciidoc/AdocfmtMavenTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.maven.asciidoc;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.maven.MavenIntegrationHarness;
+
+public class AdocfmtMavenTest extends MavenIntegrationHarness {
+	@Test
+	public void testAdocfmt() throws Exception {
+		writePomWithAsciidocSteps(
+				"""
+						<adocfmt>
+						  <version>0.1.2</version> <!-- optional -->
+						  <normalizeSetextHeadings>true</normalizeSetextHeadings>
+						  <collapseConsecutiveBlankLines>true</collapseConsecutiveBlankLines>
+						  <oneSentencePerLine>true</oneSentencePerLine>
+						  <normalizeBlockDelimiters>true</normalizeBlockDelimiters>
+						  <removeTrailingHeaderEqualsSign>true</removeTrailingHeaderEqualsSign>
+						  <titleCase>true</titleCase>
+						  <removeTrailingWhitespace>true</removeTrailingWhitespace>
+						  <normalizeListBullets>true</normalizeListBullets>
+						  <normalizeOrderedListMarkers>true</normalizeOrderedListMarkers>
+						  <ensureHeadingBlankLines>true</ensureHeadingBlankLines>
+						  <ensureSourceDelimiters>true</ensureSourceDelimiters>
+						</adocfmt>
+						""");
+
+		setFile("test.adoc").toResource("asciidoc/adocfmt/dirty.adoc");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile("test.adoc").sameAsResource("asciidoc/adocfmt/clean_all_options.adoc");
+	}
+}

--- a/testlib/src/main/resources/asciidoc/adocfmt/clean_all_options.adoc
+++ b/testlib/src/main/resources/asciidoc/adocfmt/clean_all_options.adoc
@@ -1,0 +1,255 @@
+= Asciidoctor Demo
+////
+Big ol' comment
+
+sittin' right 'tween this here title 'n header metadata
+////
+Dan Allen <thedoc@asciidoctor.org>
+:description: A demo of Asciidoctor. This document \
+              exercises numerous features of AsciiDoc \
+              to test Asciidoctor compliance.
+:library: Asciidoctor
+:idprefix:
+:numbered:
+:imagesdir: images
+:experimental:
+//:toc: macro
+:toc: preamble
+:toc-title: pass:[<h3>Contents</h3>]
+:css-signature: demo
+//:max-width: 800px
+//:doctype: book
+//:sectids!:
+ifdef::env-github[]
+:note-caption: :information_source:
+:tip-caption: :bulb:
+endif::[]
+
+This is a demonstration of {library} {asciidoctor-version}.
+And this is the preamble of this document.
+
+[[purpose]]
+.Purpose
+****
+This document exercises many of the features of AsciiDoc to test the {library} implementation.
+****
+
+TIP: If you want the HTML to have the familiar AsciiDoc Python style, load the asciidoc.css stylesheet using the CLI option `-a stylesheet=asciidoc.css`.
+
+== First Steps with AsciiDoc
+
+.Inline Markup
+* underlines around a phrase place _emphasis_
+* astericks around a phrase make the text *bold*
+* double astericks around one or more **l**etters in a word make those letters bold
+* double underscore around a __sub__string in a word emphasizes that substring
+* use carrots around characters to make them ^super^script
+* use tildes around characters to make them ~sub~script
+ifdef::basebackend-html[* to pass through +++<b>HTML</b>+++ directly, surround the text with triple plus]
+ifdef::basebackend-docbook[* to pass through +++<constant>XML</constant>+++ directly, surround the text with triple plus]
+
+// separate two adjacent lists using a line comment (only the leading // is required)
+
+- characters can be escaped using a {backslash}
+* for instance, you can escape a quote inside emphasized text like _Here\'s Johnny!_
+- you can safely use reserved XML characters like <, > and &, which are escaped when converting
+- force a space{sp}between inline elements using the \{sp} attribute
+- hold text together with an intrinsic non-breaking{nbsp}space attribute, \{nbsp}
+- handle words with unicode characters like in the name Gregory Romé
+- claim your copyright (C), registered trademark (R) or trademark (TM)
+- select menu:View[Zoom > Reset] to reset the zoom
+
+You can write text http://example.com[with inline links], optionally{sp}using an explicit link:http://example.com[link prefix].
+In either case, the link can have a http://example.com?foo=bar&lang=en[query string].
+
+If you want to break a line +
+just end it in a {plus} sign +
+and continue typing on the next line.
+
+=== Lists Upon Lists
+
+.Adjacent Lists
+* this list
+* should join
+
+* to have
+* four items
+
+ifdef::env-github[]
+++++
+<a name="ordered"></a>
+++++
+endif::env-github[]
+
+[[ordered]]
+.Ordered Lists
+. These items
+. will be auto-numbered
+.. and can be nested
+. A numbered list can nest
+* unordered
+* list
+* items
+
+.Statement
+I swear I left it in _Guy\'s_ car.
+Let\'s go look for it.
+
+[[defs]]
+term::
+definition line two
+[[another_term]]another term::
+
+  another definition, which can be literal (indented) or regular paragraph
+
+This should be a standalone paragraph, not grabbed by the definition list.
+
+[[nested]]
+* first level
+written on two lines
+* first level
++
+....
+with this literal text
+....
+
+* first level
+
+ with more literal text
+
+** second level
+*** third level
+- fourth level
+* back to +
+first level
+
+// this is just a comment
+
+Let's make a horizontal rule...
+
+'''
+
+then take a break.
+
+////
+We'll be right with you...
+
+after this brief interruption.
+////
+
+== ...And We're Back!
+
+Do you want to see a image:tiger.png[Tiger,50]?
+
+Do you feel safer with the tiger in a box?
+
+.Tiger in a Box
+image::tiger.png[]
+
+Fancy some math?
+
+pass:[$$\sum_{i=1}^N (f_i)^2$$]
+
+We'd like to include content, but for now the best we can do is link to it.
+
+include::include.adoc[]
+
+.Asciidoctor Usage Example. The Listing Should Contain 5 Lines.
+[,ruby]
+----
+require 'asciidoctor'
+
+doc = Asciidoctor.load '*This* is http://asciidoc.org[AsciiDoc]!', header_footer: true
+
+puts doc.convert
+----
+
+// TODO: Use ifdef to show output according to current backend
+.Output of Asciidoctor Usage Example
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="generator" content="Asciidoctor 0.1.4">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Untitled</title>
+<link rel="stylesheet" href="./asciidoctor.css">
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="paragraph">
+<p><strong>This</strong> is <a href="http://asciidoc.org">AsciiDoc</a>!</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2014-01-28 20:11:37 MST
+</div>
+</div>
+</body>
+</html>
+```
+
+=== Block Quotes and "`Smart`" Ones
+
+____
+AsciiDoc is _so_ *powerful*!
+____
+
+This verse comes to mind.
+
+[verse]
+La la la
+
+Here's another quote:
+
+[quote, Sir Arthur Conan Doyle, The Adventures of Sherlock Holmes]
+____
+When you have eliminated all which is impossible, then whatever remains,
+however improbable, must be the truth.
+____
+
+"`Get moving!`" he shouted.
+
+== Getting Literal [[literally]]
+
+ Want to get literal? Just prefix a line with a space (just 1 space will do).
+
+....
+I'll join that party, too.
+....
+
+We forgot to mention in <<ordered>> that you can change the numbering style.
+
+.. first item (yeah!)
+.. second item, looking `so mono`
+.. third item, `mono` it is!
+
+// This attribute line will get reattached to the next block
+// despite being followed by a trailing blank line
+[id='wrapup']
+
+== Wrap-up
+
+NOTE: AsciiDoc is quite cool, you should try it!
+
+[TIP]
+.Info
+====
+Go to this URL to learn more about it:
+
+* http://asciidoc.org
+
+Or you could return to the xref:first-steps-with-asciidoc[] or <<purpose,Purpose>>.
+====
+
+Here's a reference to the definition of <<another_term>>, in case you forgot it.
+
+[NOTE]
+One more thing.
+Happy documenting!
+
+[[google]]When all else fails, head over to <http://google.com>.

--- a/testlib/src/main/resources/asciidoc/adocfmt/clean_complex.adoc
+++ b/testlib/src/main/resources/asciidoc/adocfmt/clean_complex.adoc
@@ -1,0 +1,258 @@
+Asciidoctor Demo
+================
+////
+Big ol' comment
+
+sittin' right 'tween this here title 'n header metadata
+////
+Dan Allen <thedoc@asciidoctor.org>
+:description: A demo of Asciidoctor. This document \
+              exercises numerous features of AsciiDoc \
+              to test Asciidoctor compliance.
+:library: Asciidoctor
+:idprefix:
+:numbered:
+:imagesdir: images
+:experimental:
+//:toc: macro
+:toc: preamble
+:toc-title: pass:[<h3>Contents</h3>]
+:css-signature: demo
+//:max-width: 800px
+//:doctype: book
+//:sectids!:
+ifdef::env-github[]
+:note-caption: :information_source:
+:tip-caption: :bulb:
+endif::[]
+
+This is a demonstration of {library} {asciidoctor-version}.
+And this is the preamble of this document.
+
+[[purpose]]
+.Purpose
+****
+This document exercises many of the features of AsciiDoc to test the {library} implementation.
+****
+
+TIP: If you want the HTML to have the familiar AsciiDoc Python style, load the asciidoc.css stylesheet using the CLI option `-a stylesheet=asciidoc.css`.
+
+== First Steps with AsciiDoc
+
+.Inline markup
+* underlines around a phrase place _emphasis_
+* astericks around a phrase make the text *bold*
+* double astericks around one or more **l**etters in a word make those letters bold
+* double underscore around a __sub__string in a word emphasizes that substring
+* use carrots around characters to make them ^super^script
+* use tildes around characters to make them ~sub~script
+ifdef::basebackend-html[* to pass through +++<b>HTML</b>+++ directly, surround the text with triple plus]
+ifdef::basebackend-docbook[* to pass through +++<constant>XML</constant>+++ directly, surround the text with triple plus]
+
+// separate two adjacent lists using a line comment (only the leading // is required)
+
+- characters can be escaped using a {backslash}
+* for instance, you can escape a quote inside emphasized text like _Here\'s Johnny!_
+- you can safely use reserved XML characters like <, > and &, which are escaped when converting
+- force a space{sp}between inline elements using the \{sp} attribute
+- hold text together with an intrinsic non-breaking{nbsp}space attribute, \{nbsp}
+- handle words with unicode characters like in the name Gregory Romé
+- claim your copyright (C), registered trademark (R) or trademark (TM)
+- select menu:View[Zoom > Reset] to reset the zoom
+
+You can write text http://example.com[with inline links], optionally{sp}using
+an explicit link:http://example.com[link prefix]. In either case, the link can
+have a http://example.com?foo=bar&lang=en[query string].
+
+If you want to break a line +
+just end it in a {plus} sign +
+and continue typing on the next line.
+
+=== Lists Upon Lists
+
+.Adjacent lists
+* this list
+* should join
+
+* to have
+* four items
+
+ifdef::env-github[]
+++++
+<a name="ordered"></a>
+++++
+endif::env-github[]
+
+[[ordered]]
+.Ordered lists
+. These items
+. will be auto-numbered
+.. and can be nested
+. A numbered list can nest
+* unordered
+* list
+* items
+
+.Statement
+I swear I left it in _Guy\'s_ car. Let\'s go look for it.
+
+[[defs]]
+term::
+definition
+line two
+[[another_term]]another term::
+
+  another definition, which can be literal (indented) or regular paragraph
+
+This should be a standalone paragraph, not grabbed by the definition list.
+
+[[nested]]
+* first level
+written on two lines
+* first level
++
+....
+with this literal text
+....
+
+* first level
+
+ with more literal text
+
+** second level
+*** third level
+- fourth level
+* back to +
+first level
+
+// this is just a comment
+
+Let's make a horizontal rule...
+
+'''
+
+then take a break.
+
+////
+We'll be right with you...
+
+after this brief interruption.
+////
+
+== ...and we're back!
+
+Do you want to see a image:tiger.png[Tiger,50]?
+
+Do you feel safer with the tiger in a box?
+
+.Tiger in a box
+image::tiger.png[]
+
+Fancy some math?
+
+pass:[$$\sum_{i=1}^N (f_i)^2$$]
+
+We'd like to include content, but for now the best we can do is link to it.
+
+include::include.adoc[]
+
+.Asciidoctor usage example. The listing should contain 5 lines.
+[,ruby]
+----
+require 'asciidoctor'
+
+doc = Asciidoctor.load '*This* is http://asciidoc.org[AsciiDoc]!', header_footer: true
+
+puts doc.convert
+----
+
+// TODO: Use ifdef to show output according to current backend
+.Output of Asciidoctor usage example
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="generator" content="Asciidoctor 0.1.4">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Untitled</title>
+<link rel="stylesheet" href="./asciidoctor.css">
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="paragraph">
+<p><strong>This</strong> is <a href="http://asciidoc.org">AsciiDoc</a>!</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2014-01-28 20:11:37 MST
+</div>
+</div>
+</body>
+</html>
+```
+
+=== Block Quotes and "`Smart`" Ones
+
+____
+AsciiDoc is _so_ *powerful*!
+____
+
+This verse comes to mind.
+
+[verse]
+La la la
+
+Here's another quote:
+
+[quote, Sir Arthur Conan Doyle, The Adventures of Sherlock Holmes]
+____
+When you have eliminated all which is impossible, then whatever remains,
+however improbable, must be the truth.
+____
+
+"`Get moving!`" he shouted.
+
+Getting Literal [[literally]]
+-----------------------------
+
+ Want to get literal? Just prefix a line with a space (just 1 space will do).
+
+....
+I'll join that party, too.
+....
+
+We forgot to mention in <<ordered>> that you can change the numbering style.
+
+.. first item (yeah!)
+.. second item, looking `so mono`
+.. third item, `mono` it is!
+
+// This attribute line will get reattached to the next block
+// despite being followed by a trailing blank line
+[id='wrapup']
+
+Wrap-up
+-------
+
+NOTE: AsciiDoc is quite cool, you should try it!
+
+[TIP]
+.Info
+====
+Go to this URL to learn more about it:
+
+* http://asciidoc.org
+
+Or you could return to the xref:first-steps-with-asciidoc[] or <<purpose,Purpose>>.
+====
+
+Here's a reference to the definition of <<another_term>>, in case you forgot it.
+
+[NOTE]
+One more thing. Happy documenting!
+
+[[google]]When all else fails, head over to <http://google.com>.

--- a/testlib/src/main/resources/asciidoc/adocfmt/clean_custom.adoc
+++ b/testlib/src/main/resources/asciidoc/adocfmt/clean_custom.adoc
@@ -1,0 +1,255 @@
+Asciidoctor Demo
+================
+////
+Big ol' comment
+
+sittin' right 'tween this here title 'n header metadata
+////
+Dan Allen <thedoc@asciidoctor.org>
+:description: A demo of Asciidoctor. This document \
+              exercises numerous features of AsciiDoc \
+              to test Asciidoctor compliance.
+:library: Asciidoctor
+:idprefix:
+:numbered:
+:imagesdir: images
+:experimental:
+//:toc: macro
+:toc: preamble
+:toc-title: pass:[<h3>Contents</h3>]
+:css-signature: demo
+//:max-width: 800px
+//:doctype: book
+//:sectids!:
+ifdef::env-github[]
+:note-caption: :information_source:
+:tip-caption: :bulb:
+endif::[]
+
+This is a demonstration of {library} {asciidoctor-version}.
+And this is the preamble of this document.
+
+[[purpose]]
+.Purpose
+****
+This document exercises many of the features of AsciiDoc to test the {library} implementation.
+****
+
+TIP: If you want the HTML to have the familiar AsciiDoc Python style, load the asciidoc.css stylesheet using the CLI option `-a stylesheet=asciidoc.css`.
+
+== First Steps with AsciiDoc
+.Inline markup
+* underlines around a phrase place _emphasis_
+* astericks around a phrase make the text *bold*
+* double astericks around one or more **l**etters in a word make those letters bold
+* double underscore around a __sub__string in a word emphasizes that substring
+* use carrots around characters to make them ^super^script
+* use tildes around characters to make them ~sub~script
+ifdef::basebackend-html[* to pass through +++<b>HTML</b>+++ directly, surround the text with triple plus]
+ifdef::basebackend-docbook[* to pass through +++<constant>XML</constant>+++ directly, surround the text with triple plus]
+
+// separate two adjacent lists using a line comment (only the leading // is required)
+
+- characters can be escaped using a {backslash}
+* for instance, you can escape a quote inside emphasized text like _Here\'s Johnny!_
+- you can safely use reserved XML characters like <, > and &, which are escaped when converting
+- force a space{sp}between inline elements using the \{sp} attribute
+- hold text together with an intrinsic non-breaking{nbsp}space attribute, \{nbsp}
+- handle words with unicode characters like in the name Gregory Romé
+- claim your copyright (C), registered trademark (R) or trademark (TM)
+- select menu:View[Zoom > Reset] to reset the zoom
+
+You can write text http://example.com[with inline links], optionally{sp}using
+an explicit link:http://example.com[link prefix]. In either case, the link can
+have a http://example.com?foo=bar&lang=en[query string].
+
+If you want to break a line +
+just end it in a {plus} sign +
+and continue typing on the next line.
+
+=== Lists Upon Lists
+.Adjacent lists
+* this list
+* should join
+
+* to have
+* four items
+
+ifdef::env-github[]
+++++
+<a name="ordered"></a>
+++++
+endif::env-github[]
+
+[[ordered]]
+.Ordered lists
+. These items
+. will be auto-numbered
+.. and can be nested
+. A numbered list can nest
+* unordered
+* list
+* items
+
+.Statement
+I swear I left it in _Guy\'s_ car. Let\'s go look for it.
+
+[[defs]]
+term::
+definition
+line two
+[[another_term]]another term::
+
+  another definition, which can be literal (indented) or regular paragraph
+
+This should be a standalone paragraph, not grabbed by the definition list.
+
+[[nested]]
+* first level
+written on two lines
+* first level
++
+....
+with this literal text
+....
+
+* first level
+
+ with more literal text
+
+** second level
+*** third level
+- fourth level
+* back to +
+first level
+
+// this is just a comment
+
+Let's make a horizontal rule...
+
+'''
+
+then take a break.
+
+////
+We'll be right with you...
+
+after this brief interruption.
+////
+
+== ...and we're back!
+
+Do you want to see a image:tiger.png[Tiger,50]?
+
+Do you feel safer with the tiger in a box?
+
+.Tiger in a box
+image::tiger.png[]
+
+Fancy some math?
+
+pass:[$$\sum_{i=1}^N (f_i)^2$$]
+
+We'd like to include content, but for now the best we can do is link to it.
+
+include::include.adoc[]
+
+.Asciidoctor usage example. The listing should contain 5 lines.
+[,ruby]
+----
+require 'asciidoctor'
+
+doc = Asciidoctor.load '*This* is http://asciidoc.org[AsciiDoc]!', header_footer: true
+
+puts doc.convert
+----
+
+// TODO: Use ifdef to show output according to current backend
+.Output of Asciidoctor usage example
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="generator" content="Asciidoctor 0.1.4">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Untitled</title>
+<link rel="stylesheet" href="./asciidoctor.css">
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="paragraph">
+<p><strong>This</strong> is <a href="http://asciidoc.org">AsciiDoc</a>!</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2014-01-28 20:11:37 MST
+</div>
+</div>
+</body>
+</html>
+```
+
+=== Block Quotes and "`Smart`" Ones
+
+____
+AsciiDoc is _so_ *powerful*!
+____
+
+This verse comes to mind.
+
+[verse]
+La la la
+
+Here's another quote:
+
+[quote, Sir Arthur Conan Doyle, The Adventures of Sherlock Holmes]
+____
+When you have eliminated all which is impossible, then whatever remains,
+however improbable, must be the truth.
+____
+
+"`Get moving!`" he shouted.
+
+Getting Literal [[literally]]
+-----------------------------
+
+ Want to get literal? Just prefix a line with a space (just 1 space will do).
+
+....
+I'll join that party, too.
+....
+
+We forgot to mention in <<ordered>> that you can change the numbering style.
+
+.. first item (yeah!)
+.. second item, looking `so mono`
+.. third item, `mono` it is!
+
+// This attribute line will get reattached to the next block
+// despite being followed by a trailing blank line
+[id='wrapup']
+
+Wrap-up
+-------
+NOTE: AsciiDoc is quite cool, you should try it!
+
+[TIP]
+.Info
+====
+Go to this URL to learn more about it:
+
+* http://asciidoc.org
+
+Or you could return to the xref:first-steps-with-asciidoc[] or <<purpose,Purpose>>.
+====
+
+Here's a reference to the definition of <<another_term>>, in case you forgot it.
+
+[NOTE]
+One more thing. Happy documenting!
+
+[[google]]When all else fails, head over to <http://google.com>.

--- a/testlib/src/main/resources/asciidoc/adocfmt/clean_minimal.adoc
+++ b/testlib/src/main/resources/asciidoc/adocfmt/clean_minimal.adoc
@@ -1,0 +1,258 @@
+Asciidoctor Demo
+================
+////
+Big ol' comment
+
+sittin' right 'tween this here title 'n header metadata
+////
+Dan Allen <thedoc@asciidoctor.org>
+:description: A demo of Asciidoctor. This document \
+              exercises numerous features of AsciiDoc \
+              to test Asciidoctor compliance.
+:library: Asciidoctor
+:idprefix:
+:numbered:
+:imagesdir: images
+:experimental:
+//:toc: macro
+:toc: preamble
+:toc-title: pass:[<h3>Contents</h3>]
+:css-signature: demo
+//:max-width: 800px
+//:doctype: book
+//:sectids!:
+ifdef::env-github[]
+:note-caption: :information_source:
+:tip-caption: :bulb:
+endif::[]
+
+This is a demonstration of {library} {asciidoctor-version}.
+And this is the preamble of this document.
+
+[[purpose]]
+.Purpose
+****
+This document exercises many of the features of AsciiDoc to test the {library} implementation.
+****
+
+TIP: If you want the HTML to have the familiar AsciiDoc Python style, load the asciidoc.css stylesheet using the CLI option `-a stylesheet=asciidoc.css`.
+
+== First Steps with AsciiDoc
+
+.Inline markup
+* underlines around a phrase place _emphasis_
+* astericks around a phrase make the text *bold*
+* double astericks around one or more **l**etters in a word make those letters bold
+* double underscore around a __sub__string in a word emphasizes that substring
+* use carrots around characters to make them ^super^script
+* use tildes around characters to make them ~sub~script
+ifdef::basebackend-html[* to pass through +++<b>HTML</b>+++ directly, surround the text with triple plus]
+ifdef::basebackend-docbook[* to pass through +++<constant>XML</constant>+++ directly, surround the text with triple plus]
+
+// separate two adjacent lists using a line comment (only the leading // is required)
+
+- characters can be escaped using a {backslash}
+* for instance, you can escape a quote inside emphasized text like _Here\'s Johnny!_
+- you can safely use reserved XML characters like <, > and &, which are escaped when converting
+- force a space{sp}between inline elements using the \{sp} attribute
+- hold text together with an intrinsic non-breaking{nbsp}space attribute, \{nbsp}
+- handle words with unicode characters like in the name Gregory Romé
+- claim your copyright (C), registered trademark (R) or trademark (TM)
+- select menu:View[Zoom > Reset] to reset the zoom
+
+You can write text http://example.com[with inline links], optionally{sp}using
+an explicit link:http://example.com[link prefix]. In either case, the link can
+have a http://example.com?foo=bar&lang=en[query string].
+
+If you want to break a line +
+just end it in a {plus} sign +
+and continue typing on the next line.
+
+=== Lists Upon Lists
+
+.Adjacent lists
+* this list
+* should join
+
+* to have
+* four items
+
+ifdef::env-github[]
+++++
+<a name="ordered"></a>
+++++
+endif::env-github[]
+
+[[ordered]]
+.Ordered lists
+. These items
+. will be auto-numbered
+.. and can be nested
+. A numbered list can nest
+* unordered
+* list
+* items
+
+.Statement
+I swear I left it in _Guy\'s_ car. Let\'s go look for it.
+
+[[defs]]
+term::
+definition
+line two
+[[another_term]]another term::
+
+  another definition, which can be literal (indented) or regular paragraph
+
+This should be a standalone paragraph, not grabbed by the definition list.
+
+[[nested]]
+* first level
+written on two lines
+* first level
++
+....
+with this literal text
+....
+
+* first level
+
+ with more literal text
+
+** second level
+*** third level
+- fourth level
+* back to +
+first level
+
+// this is just a comment
+
+Let's make a horizontal rule...
+
+'''
+
+then take a break.
+
+////
+We'll be right with you...
+
+after this brief interruption.
+////
+
+== ...and we're back!
+
+Do you want to see a image:tiger.png[Tiger,50]?
+
+Do you feel safer with the tiger in a box?
+
+.Tiger in a box
+image::tiger.png[]
+
+Fancy some math?
+
+pass:[$$\sum_{i=1}^N (f_i)^2$$]
+
+We'd like to include content, but for now the best we can do is link to it.
+
+include::include.adoc[]
+
+.Asciidoctor usage example. The listing should contain 5 lines.
+[,ruby]
+----
+require 'asciidoctor'
+
+doc = Asciidoctor.load '*This* is http://asciidoc.org[AsciiDoc]!', header_footer: true
+
+puts doc.convert
+----
+
+// TODO: Use ifdef to show output according to current backend
+.Output of Asciidoctor usage example
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="generator" content="Asciidoctor 0.1.4">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Untitled</title>
+<link rel="stylesheet" href="./asciidoctor.css">
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="paragraph">
+<p><strong>This</strong> is <a href="http://asciidoc.org">AsciiDoc</a>!</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2014-01-28 20:11:37 MST
+</div>
+</div>
+</body>
+</html>
+```
+
+=== Block Quotes and "`Smart`" Ones
+
+____
+AsciiDoc is _so_ *powerful*!
+____
+
+This verse comes to mind.
+
+[verse]
+La la la
+
+Here's another quote:
+
+[quote, Sir Arthur Conan Doyle, The Adventures of Sherlock Holmes]
+____
+When you have eliminated all which is impossible, then whatever remains,
+however improbable, must be the truth.
+____
+
+"`Get moving!`" he shouted.
+
+Getting Literal [[literally]]
+-----------------------------
+
+ Want to get literal? Just prefix a line with a space (just 1 space will do).
+
+....
+I'll join that party, too.
+....
+
+We forgot to mention in <<ordered>> that you can change the numbering style.
+
+.. first item (yeah!)
+.. second item, looking `so mono`
+.. third item, `mono` it is!
+
+// This attribute line will get reattached to the next block
+// despite being followed by a trailing blank line
+[id='wrapup']
+
+Wrap-up
+-------
+
+NOTE: AsciiDoc is quite cool, you should try it!
+
+[TIP]
+.Info
+====
+Go to this URL to learn more about it:
+
+* http://asciidoc.org
+
+Or you could return to the xref:first-steps-with-asciidoc[] or <<purpose,Purpose>>.
+====
+
+Here's a reference to the definition of <<another_term>>, in case you forgot it.
+
+[NOTE]
+One more thing. Happy documenting!
+
+[[google]]When all else fails, head over to <http://google.com>.

--- a/testlib/src/main/resources/asciidoc/adocfmt/dirty.adoc
+++ b/testlib/src/main/resources/asciidoc/adocfmt/dirty.adoc
@@ -1,0 +1,256 @@
+Asciidoctor Demo
+================
+////
+Big ol' comment
+
+sittin' right 'tween this here title 'n header metadata
+////
+Dan Allen <thedoc@asciidoctor.org>
+:description: A demo of Asciidoctor. This document \
+              exercises numerous features of AsciiDoc \
+              to test Asciidoctor compliance.
+:library: Asciidoctor
+:idprefix:
+:numbered:
+:imagesdir: images
+:experimental:
+//:toc: macro
+:toc: preamble
+:toc-title: pass:[<h3>Contents</h3>]
+:css-signature: demo
+//:max-width: 800px
+//:doctype: book
+//:sectids!:
+ifdef::env-github[]
+:note-caption: :information_source:
+:tip-caption: :bulb:
+endif::[]
+
+This is a demonstration of {library} {asciidoctor-version}.
+And this is the preamble of this document.
+
+[[purpose]]
+.Purpose
+****
+This document exercises many of the features of AsciiDoc to test the {library} implementation.
+****
+
+TIP: If you want the HTML to have the familiar AsciiDoc Python style, load the asciidoc.css stylesheet using the CLI option `-a stylesheet=asciidoc.css`.
+
+== First Steps with AsciiDoc
+.Inline markup
+* underlines around a phrase place _emphasis_
+* astericks around a phrase make the text *bold*
+* double astericks around one or more **l**etters in a word make those letters bold
+* double underscore around a __sub__string in a word emphasizes that substring
+* use carrots around characters to make them ^super^script
+* use tildes around characters to make them ~sub~script
+ifdef::basebackend-html[* to pass through +++<b>HTML</b>+++ directly, surround the text with triple plus]
+ifdef::basebackend-docbook[* to pass through +++<constant>XML</constant>+++ directly, surround the text with triple plus]
+
+// separate two adjacent lists using a line comment (only the leading // is required)
+
+- characters can be escaped using a {backslash}
+* for instance, you can escape a quote inside emphasized text like _Here\'s Johnny!_
+- you can safely use reserved XML characters like <, > and &, which are escaped when converting
+- force a space{sp}between inline elements using the \{sp} attribute
+- hold text together with an intrinsic non-breaking{nbsp}space attribute, \{nbsp}
+- handle words with unicode characters like in the name Gregory Romé
+- claim your copyright (C), registered trademark (R) or trademark (TM)
+- select menu:View[Zoom > Reset] to reset the zoom
+
+You can write text http://example.com[with inline links], optionally{sp}using
+an explicit link:http://example.com[link prefix]. In either case, the link can
+have a http://example.com?foo=bar&lang=en[query string].
+
+If you want to break a line +
+just end it in a {plus} sign +
+and continue typing on the next line.
+
+=== Lists Upon Lists
+.Adjacent lists
+* this list
+* should join
+
+* to have
+* four items
+
+ifdef::env-github[]
+++++
+<a name="ordered"></a>
+++++
+endif::env-github[]
+
+[[ordered]]
+.Ordered lists
+. These items
+. will be auto-numbered
+.. and can be nested
+. A numbered list can nest
+* unordered
+* list
+* items
+
+.Statement
+I swear I left it in _Guy\'s_ car. Let\'s go look for it.
+
+[[defs]]
+term::
+definition
+line two
+[[another_term]]another term::
+
+  another definition, which can be literal (indented) or regular paragraph
+
+This should be a standalone paragraph, not grabbed by the definition list.
+
+[[nested]]
+* first level
+written on two lines
+* first level
++
+....
+with this literal text
+....
+
+* first level
+
+ with more literal text
+
+** second level
+*** third level
+- fourth level
+* back to +
+first level
+
+// this is just a comment
+
+Let's make a horizontal rule...
+
+'''
+
+then take a break.
+
+////
+We'll be right with you...
+
+after this brief interruption.
+////
+
+== ...and we're back!
+
+Do you want to see a image:tiger.png[Tiger,50]?
+
+Do you feel safer with the tiger in a box?
+
+.Tiger in a box
+image::tiger.png[]
+
+Fancy some math?
+
+pass:[$$\sum_{i=1}^N (f_i)^2$$]
+
+We'd like to include content, but for now the best we can do is link to it.
+
+include::include.adoc[]
+
+.Asciidoctor usage example. The listing should contain 5 lines.
+[,ruby]
+----
+require 'asciidoctor'
+
+doc = Asciidoctor.load '*This* is http://asciidoc.org[AsciiDoc]!', header_footer: true
+
+puts doc.convert
+----
+
+// TODO: Use ifdef to show output according to current backend
+.Output of Asciidoctor usage example
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="generator" content="Asciidoctor 0.1.4">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Untitled</title>
+<link rel="stylesheet" href="./asciidoctor.css">
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="paragraph">
+<p><strong>This</strong> is <a href="http://asciidoc.org">AsciiDoc</a>!</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2014-01-28 20:11:37 MST
+</div>
+</div>
+</body>
+</html>
+```
+
+=== Block Quotes and "`Smart`" Ones
+
+
+____
+AsciiDoc is _so_ *powerful*!
+____
+
+This verse comes to mind.
+
+[verse]
+La la la
+
+Here's another quote:
+
+[quote, Sir Arthur Conan Doyle, The Adventures of Sherlock Holmes]
+____
+When you have eliminated all which is impossible, then whatever remains,
+however improbable, must be the truth.
+____
+
+"`Get moving!`" he shouted.
+
+Getting Literal [[literally]]
+-----------------------------
+
+ Want to get literal? Just prefix a line with a space (just 1 space will do).
+
+....
+I'll join that party, too.
+....
+
+We forgot to mention in <<ordered>> that you can change the numbering style.
+
+.. first item (yeah!)
+.. second item, looking `so mono`
+.. third item, `mono` it is!
+
+// This attribute line will get reattached to the next block
+// despite being followed by a trailing blank line
+[id='wrapup']
+
+Wrap-up
+-------
+NOTE: AsciiDoc is quite cool, you should try it!
+
+[TIP]
+.Info
+=====
+Go to this URL to learn more about it:
+
+* http://asciidoc.org
+
+Or you could return to the xref:first-steps-with-asciidoc[] or <<purpose,Purpose>>.
+=====
+
+Here's a reference to the definition of <<another_term>>, in case you forgot it.
+
+[NOTE]
+One more thing. Happy documenting!
+
+[[google]]When all else fails, head over to <http://google.com>.

--- a/testlib/src/test/java/com/diffplug/spotless/asciidoc/AdocfmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/asciidoc/AdocfmtStepTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.asciidoc;
+
+import org.junit.jupiter.api.Test;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.ResourceHarness;
+import com.diffplug.spotless.SerializableEqualityTester;
+import com.diffplug.spotless.StepHarness;
+import com.diffplug.spotless.TestProvisioner;
+
+class AdocfmtStepTest extends ResourceHarness {
+	@Test
+	void behavior() {
+		FormatterStep step = AdocfmtStep.create(TestProvisioner.mavenCentral());
+		StepHarness.forStep(step).testResource("asciidoc/adocfmt/dirty.adoc", "asciidoc/adocfmt/clean_minimal.adoc");
+	}
+
+	@Test
+	void complexBehavior() {
+		AdocfmtConfig config = new AdocfmtConfig();
+		config.normalizeListBullets = true;
+		config.normalizeOrderedListMarkers = true;
+		config.ensureSourceDelimiters = true;
+		FormatterStep step = AdocfmtStep.create(AdocfmtStep.defaultVersion(), TestProvisioner.mavenCentral(), config);
+		StepHarness.forStep(step).testResource("asciidoc/adocfmt/dirty.adoc", "asciidoc/adocfmt/clean_complex.adoc");
+	}
+
+	@Test
+	void customConfigBehavior() {
+		AdocfmtConfig config = new AdocfmtConfig();
+		config.ensureHeadingBlankLines = false;
+
+		FormatterStep step = AdocfmtStep.create(AdocfmtStep.defaultVersion(), TestProvisioner.mavenCentral(), config);
+
+		StepHarness.forStep(step).testResource("asciidoc/adocfmt/dirty.adoc", "asciidoc/adocfmt/clean_custom.adoc");
+	}
+
+	@Test
+	void equality() {
+		new SerializableEqualityTester() {
+			// fields drive create(); never mutate a config object after passing it to create()
+			boolean titleCase = false;
+			boolean normalizeListBullets = false;
+
+			@Override
+			protected void setupTest(API api) {
+				// default config == same
+				api.areDifferentThan();
+				// change one config option -> different
+				titleCase = true;
+				api.areDifferentThan();
+				// change another config option -> different
+				titleCase = false;
+				normalizeListBullets = true;
+				api.areDifferentThan();
+			}
+
+			@Override
+			protected FormatterStep create() {
+				AdocfmtConfig config = new AdocfmtConfig();
+				config.titleCase = titleCase;
+				config.normalizeListBullets = normalizeListBullets;
+				return AdocfmtStep.create(AdocfmtStep.defaultVersion(), TestProvisioner.mavenCentral(), config);
+			}
+		}.testEquals();
+	}
+}


### PR DESCRIPTION
Hi @nedtwigg, this is a fresh PR for AsciiDoc support, following up on the earlier
one that we closed.

I took your feedback to heart: the formatting logic now lives in its own library,
`org.drjekyll:adocfmt:0.2.0`, published on Maven Central. This PR therefore
contains only the thin glue code, an `AdocfmtStep` in `lib` that resolves the
library via `JarState` and reflection (the same approach as `KtfmtStep` and
`GoogleJavaFormatStep`), plus the Gradle and Maven wiring. The implementation and
the harness are fully decoupled now, and `lib` gains no new compile dependency.

Thanks again for the patience and the clear guidance earlier. It led to a much
better result.