### PR TITLE
Fix #2940 - Parse standard git year output in LicenseHeaderStep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Fixed
 - Support `ktfmt` 0.63 and use its new builder API for formatting options to better avoid future breaking changes.
+- Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
+
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))
 

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -349,8 +349,8 @@ public final class LicenseHeaderStep {
 			}
 		}
 
-		private static final Pattern YYYY = Pattern.compile("[0-9]{4}");
-
+		private static final Pattern YYYY = Pattern.compile("\\d{4}");
+		
 		/** Calculates the year to inject. */
 		private String calculateYearExact(String parsedYear) {
 			if (parsedYear.equals(yearToday)) {
@@ -418,19 +418,27 @@ public final class LicenseHeaderStep {
 				throw new IllegalArgumentException("Unable to find delimiter regex " + delimiterPattern);
 			}
 
-			String oldYear;
-			try {
-				oldYear = parseYear(Arrays.asList("git", "log", "--follow", "--find-renames=40%", "--diff-filter=A"), file);
-			} catch (IllegalArgumentException e) {
-				// Ideally, git log would always find the commit where it was added.
-				// For some reason, that is sometimes not possible - in that case,
-				// we'll settle for just the most recent, even if it was just a modification.
-				oldYear = parseYear(Arrays.asList("git", "log", "--follow", "--find-renames=40%", "--reverse"), file);
-			}
-			String newYear = parseYear(Arrays.asList("git", "log", "--max-count=1"), file);
-			String yearRange;
-			if (oldYear.equals(newYear)) {
-				yearRange = oldYear;
+            String oldYear;
+            try {
+              List<String> cmd = new ArrayList<>(Arrays.asList("git", "log", "--diff-filter=A"));
+              cmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
+              oldYear = parseYear(cmd, file);
+            } catch (IllegalArgumentException e) {
+              // Ideally, git log would always find the commit where it was added.
+              // For some reason, that is sometimes not possible - in that case,
+              // we'll settle for just the most recent, even if it was just a modification.
+              List<String> cmd = new ArrayList<>(Arrays.asList("git", "log", "--reverse"));
+              cmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
+              oldYear = parseYear(cmd, file);
+            }
+
+			List<String> newYearCmd = new ArrayList<>(Arrays.asList("git", "log", "--max-count=1"));
+            newYearCmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
+
+			String newYear = parseYear(newYearCmd, file);
+            String yearRange;
+            if (oldYear.equals(newYear)) {
+              yearRange = oldYear;
 			} else {
 				yearRange = oldYear + yearSepOrFull + newYear;
 			}
@@ -462,7 +470,7 @@ public final class LicenseHeaderStep {
 			if (!error.isEmpty()) {
 				throw new IllegalArgumentException("Error for command '" + fullCmd + "':\n" + error);
 			}
-			Matcher matcher = FIND_YEAR.matcher(output);
+			Matcher matcher = FIND_YEAR.matcher(output.trim());
 			if (matcher.find()) {
 				return matcher.group(1);
 			} else {
@@ -470,7 +478,14 @@ public final class LicenseHeaderStep {
 			}
 		}
 
-		private static final Pattern FIND_YEAR = Pattern.compile("Date:   .* ([0-9]{4}) ");
+        // Default git log options to find the commit year.
+        // --follow             - Continue listing the history of a file beyond renames.
+        // --find-renames=40%   - Detect renames with a similarity threshold of 40%.
+        // --format=%cd         - Output the committer date using the format specified by --date.
+        // --date=format:%Y     - Format the date as a 4-digit year only.
+        private static final List<String> GIT_LOG_DEFAULT_OPTIONS = Arrays.asList("--follow", "--find-renames=40%", "--format=%cd", "--date=format:%Y");
+
+		private static final Pattern FIND_YEAR = Pattern.compile("^(\\d{4})?");
 
 		@SuppressFBWarnings("DM_DEFAULT_ENCODING")
 		private static String drain(InputStream stream) throws IOException {

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -350,7 +350,7 @@ public final class LicenseHeaderStep {
 		}
 
 		private static final Pattern YYYY = Pattern.compile("\\d{4}");
-		
+
 		/** Calculates the year to inject. */
 		private String calculateYearExact(String parsedYear) {
 			if (parsedYear.equals(yearToday)) {
@@ -408,6 +408,13 @@ public final class LicenseHeaderStep {
 			}
 		}
 
+		// Default git log options to find the commit year.
+		// --follow             - Continue listing the history of a file beyond renames.
+		// --find-renames=40%   - Detect renames with a similarity threshold of 40%.
+		// --format=%cd         - Output the committer date using the format specified by --date.
+		// --date=format:%Y     - Format the date as a 4-digit year only.
+		private static final List<String> GIT_LOG_DEFAULT_OPTIONS = Arrays.asList("--follow", "--find-renames=40%", "--format=%cd", "--date=format:%Y");
+
 		/** Sets copyright years on the given file by finding the oldest and most recent commits throughout git history. */
 		private String setLicenseHeaderYearsFromGitHistory(String raw, File file) throws IOException {
 			if (yearToday == null) {
@@ -418,27 +425,26 @@ public final class LicenseHeaderStep {
 				throw new IllegalArgumentException("Unable to find delimiter regex " + delimiterPattern);
 			}
 
-            String oldYear;
-            try {
-              List<String> cmd = new ArrayList<>(Arrays.asList("git", "log", "--diff-filter=A"));
-              cmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
-              oldYear = parseYear(cmd, file);
-            } catch (IllegalArgumentException e) {
-              // Ideally, git log would always find the commit where it was added.
-              // For some reason, that is sometimes not possible - in that case,
-              // we'll settle for just the most recent, even if it was just a modification.
-              List<String> cmd = new ArrayList<>(Arrays.asList("git", "log", "--reverse"));
-              cmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
-              oldYear = parseYear(cmd, file);
-            }
+			String oldYear;
+			try {
+				List<String> cmd = new ArrayList<>(Arrays.asList("git", "log", "--diff-filter=A"));
+				cmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
+				oldYear = parseYear(cmd, file);
+			} catch (IllegalArgumentException e) {
+				// Ideally, git log would always find the commit where it was added.
+				// For some reason, that is sometimes not possible - in that case,
+				// we'll settle for just the most recent, even if it was just a modification.
+				List<String> cmd = new ArrayList<>(Arrays.asList("git", "log", "--reverse"));
+				cmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
+				oldYear = parseYear(cmd, file);
+			}
 
 			List<String> newYearCmd = new ArrayList<>(Arrays.asList("git", "log", "--max-count=1"));
-            newYearCmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
-
+			newYearCmd.addAll(GIT_LOG_DEFAULT_OPTIONS);
 			String newYear = parseYear(newYearCmd, file);
-            String yearRange;
-            if (oldYear.equals(newYear)) {
-              yearRange = oldYear;
+			String yearRange;
+			if (oldYear.equals(newYear)) {
+				yearRange = oldYear;
 			} else {
 				yearRange = oldYear + yearSepOrFull + newYear;
 			}
@@ -477,13 +483,6 @@ public final class LicenseHeaderStep {
 				throw new IllegalArgumentException("Unable to parse date from command '" + fullCmd + "':\n" + output);
 			}
 		}
-
-        // Default git log options to find the commit year.
-        // --follow             - Continue listing the history of a file beyond renames.
-        // --find-renames=40%   - Detect renames with a similarity threshold of 40%.
-        // --format=%cd         - Output the committer date using the format specified by --date.
-        // --date=format:%Y     - Format the date as a 4-digit year only.
-        private static final List<String> GIT_LOG_DEFAULT_OPTIONS = Arrays.asList("--follow", "--find-renames=40%", "--format=%cd", "--date=format:%Y");
 
 		private static final Pattern FIND_YEAR = Pattern.compile("^(\\d{4})?");
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -6,6 +6,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ### Fixed
 - Prevent build caches from interfering when executing under the `-PspotlessIdeHook` mode. ([#2365](https://github.com/diffplug/spotless/issues/2365))
+- Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
+
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
 
 ## [3.6.0] - 2026-05-27
 ### Added

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -317,22 +317,22 @@ class LicenseHeaderStepTest extends ResourceHarness {
 	void should_setFromGit_year_when_singleCommit() throws Exception {
 		try (Git git = Git.init().setDirectory(rootFolder()).call()) {
 			// Single commit: added once, so old/new year must be equal.
- 			setFile("Foo.java").toContent("package foo; // v1\n");
- 			git.add()
-				.addFilepattern("Foo.java")
-				.call();
- 			git.commit()
-				.setMessage("add")
-				.setAuthor("Test User", "test@example.com")
-				.setCommitter("Test User", "test@example.com")
-				.call();
+			setFile("Foo.java").toContent("package foo; // v1\n");
+			git.add()
+					.addFilepattern("Foo.java")
+					.call();
+			git.commit()
+					.setMessage("add")
+					.setAuthor("Test User", "test@example.com")
+					.setCommitter("Test User", "test@example.com")
+					.call();
 		}
 
- 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_)
- 				.withYearMode(YearMode.SET_FROM_GIT)
- 				.build();
+		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_)
+				.withYearMode(YearMode.SET_FROM_GIT)
+				.build();
 
- 		StepHarnessWithFile.forStep(this, step)
+		StepHarnessWithFile.forStep(this, step)
 				.test("Foo.java", getTestResource(FILE_NO_LICENSE), hasHeaderYear(currentYear()));
- 	}
+	}
 }

--- a/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/LicenseHeaderStepTest.java
@@ -21,9 +21,11 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 
+import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.diffplug.spotless.ClearGitConfig;
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.SerializableEqualityTester;
@@ -309,4 +311,28 @@ class LicenseHeaderStepTest extends ResourceHarness {
 		StepHarness.forStep(step)
 				.test(ResourceHarness.getTestResource("license/module-info.test"), header + ResourceHarness.getTestResource("license/module-info.test"));
 	}
+
+	@Test
+	@ClearGitConfig
+	void should_setFromGit_year_when_singleCommit() throws Exception {
+		try (Git git = Git.init().setDirectory(rootFolder()).call()) {
+			// Single commit: added once, so old/new year must be equal.
+ 			setFile("Foo.java").toContent("package foo; // v1\n");
+ 			git.add()
+				.addFilepattern("Foo.java")
+				.call();
+ 			git.commit()
+				.setMessage("add")
+				.setAuthor("Test User", "test@example.com")
+				.setCommitter("Test User", "test@example.com")
+				.call();
+		}
+
+ 		FormatterStep step = LicenseHeaderStep.headerDelimiter(header(HEADER_WITH_$YEAR), PACKAGE_)
+ 				.withYearMode(YearMode.SET_FROM_GIT)
+ 				.build();
+
+ 		StepHarnessWithFile.forStep(this, step)
+				.test("Foo.java", getTestResource(FILE_NO_LICENSE), hasHeaderYear(currentYear()));
+ 	}
 }


### PR DESCRIPTION
## Summary

Parse standard git year output in `LicenseHeaderStep` when setting license header years from git history.

## Changes

- extract shared default `git log` arguments for year lookup
- request year-only output from git via `--format=%cd --date=format:%Y`
- trim git output before parsing
- simplify year parsing regex