### PR TITLE
Fix lint handling inside toggle fences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
+- `FenceStep.preserveWithin` now forwards lints from nested steps while still suppressing lints inside preserved blocks. ([#2962](https://github.com/diffplug/spotless/pull/2962))
 - Support `ktfmt` 0.63 and use its new builder API for formatting options to better avoid future breaking changes.
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))

--- a/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 DiffPlug
+ * Copyright 2020-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/FenceStep.java
@@ -231,6 +231,72 @@ public final class FenceStep {
 		}
 
 		@Override
+		public List<Lint> lint(String content, File file) throws Exception {
+			if (kind == Kind.APPLY) {
+				return List.of();
+			}
+			List<LineRange> preservedRanges = preservedLineRanges(content);
+			List<Lint> lints = new ArrayList<>();
+			for (FormatterStep step : steps) {
+				List<Lint> lintsForStep = step.lint(content, file);
+				if (lintsForStep == null) {
+					continue;
+				}
+				for (Lint lint : lintsForStep) {
+					if (!isPreserved(preservedRanges, lint)) {
+						lints.add(lint);
+					}
+				}
+			}
+			return lints;
+		}
+
+		private static boolean isPreserved(List<LineRange> preservedRanges, Lint lint) {
+			for (LineRange range : preservedRanges) {
+				if (range.intersects(lint)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private List<LineRange> preservedLineRanges(String content) {
+			List<LineRange> ranges = new ArrayList<>();
+			Matcher matcher = regex.matcher(content);
+			while (matcher.find()) {
+				int start = matcher.start(1);
+				int endExclusive = matcher.end(1);
+				int end = endExclusive == start ? start : endExclusive - 1;
+				ranges.add(new LineRange(lineAt(content, start), lineAt(content, end)));
+			}
+			return ranges;
+		}
+
+		private static int lineAt(String content, int offset) {
+			int line = 1;
+			for (int i = 0; i < offset; ++i) {
+				if (content.charAt(i) == '\n') {
+					++line;
+				}
+			}
+			return line;
+		}
+
+		private static final class LineRange {
+			private final int start;
+			private final int end;
+
+			private LineRange(int start, int end) {
+				this.start = start;
+				this.end = end;
+			}
+
+			boolean intersects(Lint lint) {
+				return start <= lint.getLineEnd() && lint.getLineStart() <= end;
+			}
+		}
+
+		@Override
 		public void close() {
 			if (formatter != null) {
 				formatter.close();

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
+- `toggleOffOn` no longer disables lint-only steps such as `forbidWildcardImports`. ([#2962](https://github.com/diffplug/spotless/pull/2962))
 - Prevent build caches from interfering when executing under the `-PspotlessIdeHook` mode. ([#2365](https://github.com/diffplug/spotless/issues/2365))
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- `<toggleOffOn>` no longer disables lint-only steps such as `<forbidWildcardImports>`. ([#2962](https://github.com/diffplug/spotless/pull/2962))
 
 ## [3.6.0] - 2026-05-27
 ### Added

--- a/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 DiffPlug
+ * Copyright 2020-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/generic/FenceStepTest.java
@@ -26,6 +26,7 @@ import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.ResourceHarness;
 import com.diffplug.spotless.StepHarness;
 import com.diffplug.spotless.StepHarnessWithFile;
+import com.diffplug.spotless.java.ForbidWildcardImportsStep;
 
 class FenceStepTest extends ResourceHarness {
 	@Test
@@ -92,6 +93,21 @@ class FenceStepTest extends ResourceHarness {
 				"D E F",
 				"spotless:on",
 				"G H I")).toBe("L1-6 fence(fenceRemoved) An intermediate step removed a match of spotless:off spotless:on");
+	}
+
+	@Test
+	void preserveWithinReportsLintsOutsideFence() {
+		FormatterStep fence = FenceStep.named(FenceStep.defaultToggleName())
+				.openClose(FenceStep.defaultToggleOff(), FenceStep.defaultToggleOn())
+				.preserveWithin(Arrays.asList(ForbidWildcardImportsStep.create()));
+		StepHarnessWithFile.forStep(this, fence).expectLintsOfFileAndContent("Test.java", StringPrinter.buildStringFromLines(
+				"import java.util.*;",
+				"// spotless:off",
+				"import java.io.*;",
+				"// spotless:on",
+				"import static java.util.Collections.*;"))
+				.toBe("L1 toggle(import java.util.*;) Do not use wildcard imports (e.g. java.util.*) - replace with specific class imports (e.g. java.util.List) as 'spotlessApply' cannot auto-fix this",
+						"L5 toggle(import static java.util.Collections.*;) Do not use wildcard imports (e.g. java.util.*) - replace with specific class imports (e.g. java.util.List) as 'spotlessApply' cannot auto-fix this");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fix lint-only formatter steps being skipped when they are wrapped by `toggleOffOn` / `FenceStep.preserveWithin`.

`FenceStep` already applied formatting through its nested formatter, but it did not forward `lint(...)` calls to the nested steps. That meant steps such as `forbidWildcardImports` stopped reporting problems once `toggleOffOn` was configured.

This change forwards lint calls for preserved fences and filters out lints that fall inside the preserved off/on ranges.

## Validation

- `git diff --check`
- Added `FenceStepTest.preserveWithinReportsLintsOutsideFence`