### PR TITLE
fix(spotless/gradle-plugin): Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - `FenceStep.preserveWithin` now forwards lints from nested steps while still suppressing lints inside preserved blocks. ([#2962](https://github.com/diffplug/spotless/pull/2962))
 - Support `ktfmt` 0.63 and use its new builder API for formatting options to better avoid future breaking changes.
 - Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
-- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace ([#2973](https://github.com/diffplug/spotless/pull/2973))
+- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace. ([#2973](https://github.com/diffplug/spotless/pull/2973))
 
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - `FenceStep.preserveWithin` now forwards lints from nested steps while still suppressing lints inside preserved blocks. ([#2962](https://github.com/diffplug/spotless/pull/2962))
 - Support `ktfmt` 0.63 and use its new builder API for formatting options to better avoid future breaking changes.
 - Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
+- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace ([#2973](https://github.com/diffplug/spotless/pull/2973))
 
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))

--- a/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/generic/LicenseHeaderStep.java
@@ -380,7 +380,7 @@ public final class LicenseHeaderStep {
 				String secondYear = null;
 				if (updateYearWithLatest) {
 					secondYear = firstYear.equals(yearToday) ? null : yearToday;
-				} else {
+				} else if (yearMatcher.end() + 1 < content.length()) {
 					String contentWithSecondYear = content.substring(yearMatcher.end() + 1);
 					int endOfLine = contentWithSecondYear.indexOf('\n');
 					if (endOfLine != -1) {

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -11,6 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - `toggleOffOn` no longer disables lint-only steps such as `forbidWildcardImports`. ([#2962](https://github.com/diffplug/spotless/pull/2962))
 - Prevent build caches from interfering when executing under the `-PspotlessIdeHook` mode. ([#2365](https://github.com/diffplug/spotless/issues/2365))
 - Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
+- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace ([#2973](https://github.com/diffplug/spotless/pull/2973))
 
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -11,7 +11,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - `toggleOffOn` no longer disables lint-only steps such as `forbidWildcardImports`. ([#2962](https://github.com/diffplug/spotless/pull/2962))
 - Prevent build caches from interfering when executing under the `-PspotlessIdeHook` mode. ([#2365](https://github.com/diffplug/spotless/issues/2365))
 - Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
-- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace ([#2973](https://github.com/diffplug/spotless/pull/2973))
+- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace. ([#2973](https://github.com/diffplug/spotless/pull/2973))
 
 ### Changes
 - Bump default `greclipse` version to latest `4.35` -> `4.39`. ([#2924](https://github.com/diffplug/spotless/pull/2924))

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
@@ -66,12 +66,12 @@ class LicenseHeaderTest extends GradleIntegrationHarness {
 			assertTransform("   2003-2005   ", "2003-" + NOW);
 		} else {
 			assertUnchanged("2003", "2003");
-			assertUnchanged("   2003", "2003"); // MSITARZ This one fails with clean 'main' code
+			assertUnchanged("   2003", "2003");
 			assertUnchanged("2003   ", "2003");
 			assertUnchanged("   2003   ", "2003");
 
 			assertUnchanged("2003-2005", "2003-2005");
-			assertUnchanged("   2003-2005", "2003-2005"); // MSITARZ This one fails with clean 'main' code
+			assertUnchanged("   2003-2005", "2003-2005");
 			assertUnchanged("2003-2005   ", "2003-2005");
 			assertUnchanged("   2003-2005   ", "2003-2005");
 		}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
@@ -43,8 +43,8 @@ class LicenseHeaderTest extends GradleIntegrationHarness {
 				"}");
 	}
 
-	private void assertUnchanged(String yearBefore, String yearAfter) throws IOException {
-		assertTransform(yearBefore, yearAfter);
+	private void assertUnchanged(String year) throws IOException {
+		assertTransform(year, year);
 	}
 
 	private void assertTransform(String yearBefore, String yearAfter) throws IOException {
@@ -65,20 +65,20 @@ class LicenseHeaderTest extends GradleIntegrationHarness {
 			assertTransform("2003-2005   ", "2003-" + NOW);
 			assertTransform("   2003-2005   ", "2003-" + NOW);
 		} else {
-			assertUnchanged("2003", "2003");
-			assertUnchanged("   2003", "2003");
-			assertUnchanged("2003   ", "2003");
-			assertUnchanged("   2003   ", "2003");
+			assertUnchanged("2003");
+			assertTransform("   2003", "2003");
+			assertTransform("2003   ", "2003");
+			assertTransform("   2003   ", "2003");
 
-			assertUnchanged("2003-2005", "2003-2005");
-			assertUnchanged("   2003-2005", "2003-2005");
-			assertUnchanged("2003-2005   ", "2003-2005");
-			assertUnchanged("   2003-2005   ", "2003-2005");
+			assertUnchanged("2003-2005");
+			assertTransform("   2003-2005", "2003-2005");
+			assertTransform("2003-2005   ", "2003-2005");
+			assertTransform("   2003-2005   ", "2003-2005");
 		}
-		assertUnchanged(NOW, NOW);
-		assertUnchanged("   " + NOW, NOW);
-		assertUnchanged(NOW + "   ", NOW);
-		assertUnchanged("   " + NOW + "   ", NOW);
+		assertUnchanged(NOW);
+		assertTransform("   " + NOW, NOW);
+		assertTransform(NOW + "   ", NOW);
+		assertTransform("   " + NOW + "   ", NOW);
 
 		assertTransform("", NOW);
 		assertTransform("   ", NOW);

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/LicenseHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,8 @@ class LicenseHeaderTest extends GradleIntegrationHarness {
 				"}");
 	}
 
-	private void assertUnchanged(String year) throws IOException {
-		assertTransform(year, year);
+	private void assertUnchanged(String yearBefore, String yearAfter) throws IOException {
+		assertTransform(yearBefore, yearAfter);
 	}
 
 	private void assertTransform(String yearBefore, String yearAfter) throws IOException {
@@ -56,13 +56,32 @@ class LicenseHeaderTest extends GradleIntegrationHarness {
 	private void testSuiteUpdateWithLatest(boolean update) throws IOException {
 		if (update) {
 			assertTransform("2003", "2003-" + NOW);
+			assertTransform("   2003", "2003-" + NOW);
+			assertTransform("2003   ", "2003-" + NOW);
+			assertTransform("   2003   ", "2003-" + NOW);
+
 			assertTransform("2003-2005", "2003-" + NOW);
+			assertTransform("   2003-2005", "2003-" + NOW);
+			assertTransform("2003-2005   ", "2003-" + NOW);
+			assertTransform("   2003-2005   ", "2003-" + NOW);
 		} else {
-			assertUnchanged("2003");
-			assertUnchanged("2003-2005");
+			assertUnchanged("2003", "2003");
+			assertUnchanged("   2003", "2003"); // MSITARZ This one fails with clean 'main' code
+			assertUnchanged("2003   ", "2003");
+			assertUnchanged("   2003   ", "2003");
+
+			assertUnchanged("2003-2005", "2003-2005");
+			assertUnchanged("   2003-2005", "2003-2005"); // MSITARZ This one fails with clean 'main' code
+			assertUnchanged("2003-2005   ", "2003-2005");
+			assertUnchanged("   2003-2005   ", "2003-2005");
 		}
-		assertUnchanged(NOW);
+		assertUnchanged(NOW, NOW);
+		assertUnchanged("   " + NOW, NOW);
+		assertUnchanged(NOW + "   ", NOW);
+		assertUnchanged("   " + NOW + "   ", NOW);
+
 		assertTransform("", NOW);
+		assertTransform("   ", NOW);
 	}
 
 	@Test

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,6 +6,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 - Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
 - `<toggleOffOn>` no longer disables lint-only steps such as `<forbidWildcardImports>`. ([#2962](https://github.com/diffplug/spotless/pull/2962))
+- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace ([#2973](https://github.com/diffplug/spotless/pull/2973))
+
 ### Added
 - Add support for AsciiDoc formatting via `adocfmt`. ([#2960](https://github.com/diffplug/spotless/pull/2960))
 - `<flexmark>` step now supports arbitrary formatter options via `<formatterOptions>`. ([#2968](https://github.com/diffplug/spotless/pull/2968))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -6,7 +6,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ### Fixed
 - Parse standard git year output in LicenseHeaderStep. ([#2940](https://github.com/diffplug/spotless/issues/2940))
 - `<toggleOffOn>` no longer disables lint-only steps such as `<forbidWildcardImports>`. ([#2962](https://github.com/diffplug/spotless/pull/2962))
-- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace ([#2973](https://github.com/diffplug/spotless/pull/2973))
+- Fix `StringIndexOutOfBoundsException` in scenarios where copyright year is surrounded by whitespace. ([#2973](https://github.com/diffplug/spotless/pull/2973))
 
 ### Added
 - Add support for AsciiDoc formatting via `adocfmt`. ([#2960](https://github.com/diffplug/spotless/pull/2960))


### PR DESCRIPTION
### Summary

When the line with Copyright year in the source file matches the one in the license header template, but the year number is surrounded with whitespace the code fails with `StringIndexOutOfBoundsException` exception:
```
2 actionable tasks: 2 executed
> Task :spotlessJava
> Task :spotlessJavaApply FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':spotlessJavaApply'.
> There were 1 lint error(s), they must be fixed or suppressed.
  src/main/java/pkg/Test.java:LINE_UNDEFINED com.diffplug.spotless.generic.LicenseHeaderStep(java.lang.StringIndexOutOfBoundsException) begin 8, end 7, length 7 (...)
  Resolve these lints or suppress with `suppressLintsFor`

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':spotlessJavaApply'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:149)
	at org.gradle.internal.Try$Failure.ifSuccessfulOrElse(Try.java:282)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:147)

(...)

Caused by: org.gradle.api.GradleException: There were 1 lint error(s), they must be fixed or suppressed.
src/main/java/pkg/Test.java:LINE_UNDEFINED com.diffplug.spotless.generic.LicenseHeaderStep(java.lang.StringIndexOutOfBoundsException) begin 8, end 7, length 7 (...)
Resolve these lints or suppress with `suppressLintsFor`
	at com.diffplug.gradle.spotless.SpotlessApply.performAction(SpotlessApply.java:60)
(...)
```

### Changes
1. Added unit test cases that test scenarios with year and year ranges having white-space before/after the year string. These tests reproduce the issue (first commit).
2. Implemented the fix for the failing cases (second commit).
3. Added info to changelogs (third commit).