### PR TITLE
Add regression test for forbidWildcardImports inside toggleOffOn

### DIFF
--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
@@ -103,6 +103,27 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 	}
 
 	@Test
+	void forbidWildcardImportsWithToggleOffOn() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"",
+				"spotless {",
+				"    java {",
+				"        target file('test.java')",
+				"        toggleOffOn()",
+				"        forbidWildcardImports()",
+				"    }",
+				"}");
+
+		setFile("test.java").toResource("java/forbidwildcardimports/JavaCodeWildcardsUnformatted.test");
+		gradleRunner().withArguments("spotlessApply").buildAndFail();
+		assertFile("test.java").sameAsResource("java/forbidwildcardimports/JavaCodeWildcardsFormatted.test");
+	}
+
+	@Test
 	void forbidModuleImports() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",


### PR DESCRIPTION
This PR adds a test against #2895, where lint-only steps like forbidWildcardImports stopped reporting once wrapped by toggleOffOn. The underlying bug was already fixed in #2962.

Closes #2895 