### PR TITLE
fix #2983, expandWildcardImports triggers a full transitive reso…

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Added
 - Add support for custom string format for license header copyright year via `yearStringFormat()`. ([#2965](https://github.com/diffplug/spotless/pull/2965))
+### Fixed
+- `<expandWildcardImports>` no longer triggers a full transitive dependency resolution on every build. Dependency resolution is now deferred until the step actually runs, so projects that do not use `<expandWildcardImports>` (or that use version ranges) are no longer penalized. ([#2983](https://github.com/diffplug/spotless/issues/2983))
 
 ## [3.7.0] - 2026-06-16
 ### Fixed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -417,11 +417,12 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 		final Optional<String> userRatchetFrom = Optional.ofNullable((String) mavenSession.getUserProperties().get("ratchetFrom"));
 		final Optional<String> optionalRatchetFrom = Optional.ofNullable(this.ratchetFrom)
 				.filter(ratchet -> !RATCHETFROM_NONE.equals(ratchet));
-		Optional<Set<File>> projectClasspath = computeTypeSolverClasspath(resolver);
-		return new FormatterConfig(baseDir, encoding, lineEndings, userRatchetFrom, optionalRatchetFrom, provisioner, p2Provisioner, fileLocator, formatterStepFactories, Optional.ofNullable(setLicenseHeaderYearsFromGitHistory), lintSuppressions, projectClasspath);
+		// Lazy: only resolve dependencies when the expandWildcardImports step actually requests the classpath.
+		Supplier<Set<File>> projectClasspathSupplier = () -> computeTypeSolverClasspath(resolver);
+		return new FormatterConfig(baseDir, encoding, lineEndings, userRatchetFrom, optionalRatchetFrom, provisioner, p2Provisioner, fileLocator, formatterStepFactories, Optional.ofNullable(setLicenseHeaderYearsFromGitHistory), lintSuppressions, Optional.of(projectClasspathSupplier));
 	}
 
-	private Optional<Set<File>> computeTypeSolverClasspath(ArtifactResolver resolver) {
+	private Set<File> computeTypeSolverClasspath(ArtifactResolver resolver) {
 		Set<File> classpath = new LinkedHashSet<>();
 
 		// Add source roots (directories containing .java files for JavaParserTypeSolver)
@@ -446,7 +447,7 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 			getLog().warn("Could not resolve project dependencies for expandWildcardImports: " + e.getMessage());
 		}
 
-		return Optional.of(classpath);
+		return classpath;
 	}
 
 	private FileLocator getFileLocator() {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterConfig.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterConfig.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.diffplug.spotless.LineEnding;
 import com.diffplug.spotless.LintSuppression;
@@ -39,10 +40,10 @@ public class FormatterConfig {
 	private final List<FormatterStepFactory> globalStepFactories;
 	private final Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory;
 	private final List<LintSuppression> lintSuppressions;
-	private final Optional<Set<File>> projectClasspath;
+	private final Optional<Supplier<Set<File>>> projectClasspathSupplier;
 
 	public FormatterConfig(File baseDir, String encoding, LineEnding lineEndings, Optional<String> userRatchetFrom, Optional<String> ratchetFrom, Provisioner provisioner,
-			P2Provisioner p2Provisioner, FileLocator fileLocator, List<FormatterStepFactory> globalStepFactories, Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory, List<LintSuppression> lintSuppressions, Optional<Set<File>> projectClasspath) {
+			P2Provisioner p2Provisioner, FileLocator fileLocator, List<FormatterStepFactory> globalStepFactories, Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory, List<LintSuppression> lintSuppressions, Optional<Supplier<Set<File>>> projectClasspathSupplier) {
 		this.encoding = encoding;
 		this.lineEndings = lineEndings;
 		this.userRatchetFrom = userRatchetFrom;
@@ -53,7 +54,7 @@ public class FormatterConfig {
 		this.globalStepFactories = globalStepFactories;
 		this.spotlessSetLicenseHeaderYearsFromGitHistory = spotlessSetLicenseHeaderYearsFromGitHistory;
 		this.lintSuppressions = lintSuppressions;
-		this.projectClasspath = projectClasspath;
+		this.projectClasspathSupplier = projectClasspathSupplier;
 	}
 
 	public String getEncoding() {
@@ -96,7 +97,7 @@ public class FormatterConfig {
 		return unmodifiableList(lintSuppressions);
 	}
 
-	public Optional<Set<File>> getProjectClasspath() {
-		return projectClasspath;
+	public Optional<Supplier<Set<File>>> getProjectClasspathSupplier() {
+		return projectClasspathSupplier;
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterFactory.java
@@ -187,7 +187,7 @@ public abstract class FormatterFactory {
 	}
 
 	private FormatterStepConfig stepConfig(Charset encoding, FormatterConfig config) {
-		return new FormatterStepConfig(encoding, licenseHeaderDelimiter(), ratchetFrom(config), config.getProvisioner(), config.getP2Provisioner(), config.getFileLocator(), config.getSpotlessSetLicenseHeaderYearsFromGitHistory(), config.getProjectClasspath());
+		return new FormatterStepConfig(encoding, licenseHeaderDelimiter(), ratchetFrom(config), config.getProvisioner(), config.getP2Provisioner(), config.getFileLocator(), config.getSpotlessSetLicenseHeaderYearsFromGitHistory(), config.getProjectClasspathSupplier());
 	}
 
 	private static List<FormatterStepFactory> gatherStepFactories(List<FormatterStepFactory> allGlobal, List<FormatterStepFactory> allConfigured) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepConfig.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/FormatterStepConfig.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.diffplug.spotless.Provisioner;
 import com.diffplug.spotless.extra.P2Provisioner;
@@ -32,9 +33,9 @@ public class FormatterStepConfig {
 	private final P2Provisioner p2Provisioner;
 	private final FileLocator fileLocator;
 	private final Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory;
-	private final Optional<Set<File>> projectClasspath;
+	private final Optional<Supplier<Set<File>>> projectClasspathSupplier;
 
-	public FormatterStepConfig(Charset encoding, String licenseHeaderDelimiter, Optional<String> ratchetFrom, Provisioner provisioner, P2Provisioner p2Provisioner, FileLocator fileLocator, Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory, Optional<Set<File>> projectClasspath) {
+	public FormatterStepConfig(Charset encoding, String licenseHeaderDelimiter, Optional<String> ratchetFrom, Provisioner provisioner, P2Provisioner p2Provisioner, FileLocator fileLocator, Optional<String> spotlessSetLicenseHeaderYearsFromGitHistory, Optional<Supplier<Set<File>>> projectClasspathSupplier) {
 		this.encoding = encoding;
 		this.licenseHeaderDelimiter = licenseHeaderDelimiter;
 		this.ratchetFrom = ratchetFrom;
@@ -42,7 +43,7 @@ public class FormatterStepConfig {
 		this.p2Provisioner = p2Provisioner;
 		this.fileLocator = fileLocator;
 		this.spotlessSetLicenseHeaderYearsFromGitHistory = spotlessSetLicenseHeaderYearsFromGitHistory;
-		this.projectClasspath = projectClasspath;
+		this.projectClasspathSupplier = projectClasspathSupplier;
 	}
 
 	public Charset getEncoding() {
@@ -73,7 +74,7 @@ public class FormatterStepConfig {
 		return spotlessSetLicenseHeaderYearsFromGitHistory;
 	}
 
-	public Optional<Set<File>> getProjectClasspath() {
-		return projectClasspath;
+	public Optional<Supplier<Set<File>>> getProjectClasspathSupplier() {
+		return projectClasspathSupplier;
 	}
 }

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ExpandWildcardImports.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/java/ExpandWildcardImports.java
@@ -18,6 +18,7 @@ package com.diffplug.spotless.maven.java;
 import java.io.File;
 import java.util.Collections;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.diffplug.spotless.FormatterStep;
 import com.diffplug.spotless.java.ExpandWildcardImportsStep;
@@ -27,7 +28,9 @@ import com.diffplug.spotless.maven.FormatterStepFactory;
 public class ExpandWildcardImports implements FormatterStepFactory {
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
-		Set<File> classpath = config.getProjectClasspath().orElse(Collections.emptySet());
+		Set<File> classpath = config.getProjectClasspathSupplier()
+				.map(Supplier::get)
+				.orElse(Collections.emptySet());
 		return ExpandWildcardImportsStep.create(classpath, config.getProvisioner());
 	}
 }


### PR DESCRIPTION
…lution of the project's runtime dependencies — even when no formatter step needs it

Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [x] a summary of the change
- either
    - [x] a link to the issue you are resolving (for small changes)
    - [x] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
