### PR TITLE
Bump tabletest-formatter to 1.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changes
 - Bump default `greclipse` version to latest `4.39` -> `4.40`. ([#2989](https://github.com/diffplug/spotless/pull/2989))
+- Bump default `tabletest-formatter` version `1.1.1` -> `1.1.2`.
 
 ## [4.8.0] - 2026-06-29
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ ktfmt = "com.facebook:ktfmt:0.63"
 palantir-java-format = "com.palantir.javaformat:palantir-java-format:1.1.0"
 scalafmt-core = "org.scalameta:scalafmt-core_2.13:3.8.1"
 sortpom-sorter = "com.github.ekryd.sortpom:sortpom-sorter:4.0.0"
-tabletest-formatter-core = "org.tabletest:tabletest-formatter-core:1.1.1"
+tabletest-formatter-core = "org.tabletest:tabletest-formatter-core:1.1.2"
 zjsonpatch = "com.flipkart.zjsonpatch:zjsonpatch:0.4.16"
 
 rewrite-recipe-migrate-java = "org.openrewrite.recipe:rewrite-migrate-java:3.36.0"

--- a/lib/src/main/java/com/diffplug/spotless/java/TableTestFormatterStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/java/TableTestFormatterStep.java
@@ -39,7 +39,7 @@ public final class TableTestFormatterStep implements Serializable {
 	private static final long serialVersionUID = 2L;
 	private static final String NAME = "tableTestFormatter";
 	private static final String MAVEN_COORDINATE = "org.tabletest:tabletest-formatter-core:";
-	private static final String DEFAULT_VERSION = "1.1.1";
+	private static final String DEFAULT_VERSION = "1.1.2";
 
 	/** Default fallback indent style ({@code "space"}) for Java/Kotlin files. */
 	public static final String DEFAULT_INDENT_STYLE = "space";

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 - Prevent parallel Gradle input fingerprinting from failing when `toggleOffOn()` wraps a slow lazy formatter step with no matching target files. ([#2994](https://github.com/diffplug/spotless/pull/2994))
 ### Changes
 - Bump default `greclipse` version to latest `4.39` -> `4.40`. ([#2989](https://github.com/diffplug/spotless/pull/2989))
+- Bump default `tabletest-formatter` version `1.1.1` -> `1.1.2`.
 
 ## [8.8.0] - 2026-06-29
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -441,7 +441,7 @@ spotless {
   java {
     tableTestFormatter()
     // optional: you can specify a specific version
-    tableTestFormatter('1.1.1')
+    tableTestFormatter('1.1.2')
 ```
 
 <a name="applying-to-groovy-source"></a>
@@ -618,7 +618,7 @@ spotless {
   kotlin {
     tableTestFormatter()
     // optional: you can specify a specific version
-    tableTestFormatter('1.1.1')
+    tableTestFormatter('1.1.2')
 ```
 
 <a name="applying-scalafmt-to-scala-files"></a>
@@ -1328,7 +1328,7 @@ spotless {
     target 'src/**/*.table'
     tableTestFormatter()
     // optional: you can specify a specific version
-    tableTestFormatter('1.1.1')
+    tableTestFormatter('1.1.2')
   }
 }
 ```

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 ### Changes
 - Bump default `greclipse` version to latest `4.39` -> `4.40`. ([#2989](https://github.com/diffplug/spotless/pull/2989))
+- Bump default `tabletest-formatter` version `1.1.1` -> `1.1.2`.
 
 ## [3.8.0] - 2026-06-29
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -409,7 +409,7 @@ These mechanisms already exist for the Gradle plugin.
 
 ```xml
 <tableTestFormatter>
-  <version>1.1.1</version> <!-- optional -->
+  <version>1.1.2</version> <!-- optional -->
 </tableTestFormatter>
 ```
 
@@ -545,7 +545,7 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 
 ```xml
 <tableTestFormatter>
-  <version>1.1.1</version> <!-- optional -->
+  <version>1.1.2</version> <!-- optional -->
 </tableTestFormatter>
 ```
 
@@ -1247,7 +1247,7 @@ When formatting shell scripts via `shfmt`, configure `shfmt` settings via `.edit
       <include>src/**/*.table</include>
     </includes>
     <tableTestFormatter>
-      <version>1.1.1</version> <!-- optional -->
+      <version>1.1.2</version> <!-- optional -->
     </tableTestFormatter>
   </tableTest>
 </configuration>

--- a/testlib/src/test/java/com/diffplug/spotless/java/TableTestFormatterStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/TableTestFormatterStepTest.java
@@ -25,7 +25,7 @@ import com.diffplug.spotless.TestProvisioner;
 
 class TableTestFormatterStepTest extends ResourceHarness {
 
-	private static final String VERSION = "1.1.1";
+	private static final String VERSION = "1.1.2";
 
 	@Test
 	void behavior() {


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
