### PR TITLE
Document and localize Maven skip properties

### DIFF
--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+- Document Maven skip properties `spotless.skip`, `spotless.check.skip`, and `spotless.apply.skip`. Goal-specific skips now live on their own mojos so they no longer leak across goals. ([#3009](https://github.com/diffplug/spotless/pull/3009))
 
 ## [3.9.0] - 2026-07-27
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -2077,17 +2077,17 @@ By default, `spotless:check` is bound to the `verify` phase. You might want to d
 
 | Property | Scope | Effect |
 | --- | --- | --- |
-| `spotless.skip` | all goals | Skips every Spotless goal (`check`, `apply`, …) |
+| `spotless.skip` | `spotless:check` and `spotless:apply` | Skips both formatting goals |
 | `spotless.check.skip` | `spotless:check` only | Skips only the check goal |
 | `spotless.apply.skip` | `spotless:apply` only | Skips only the apply goal |
 
 You can set them at the command line or in the `<properties>` section of the `pom.xml`:
 
-- `-Dspotless.skip=true` / `<spotless.skip>true</spotless.skip>` — skip all Spotless goals
+- `-Dspotless.skip=true` / `<spotless.skip>true</spotless.skip>` — skip both `spotless:check` and `spotless:apply`
 - `-Dspotless.check.skip=true` / `<spotless.check.skip>true</spotless.check.skip>` — skip only `spotless:check` (including when it is bound to `verify`)
 - `-Dspotless.apply.skip=true` / `<spotless.apply.skip>true</spotless.apply.skip>` — skip only `spotless:apply`
 
-`spotless.check.skip` does **not** skip `spotless:apply`, and `spotless.apply.skip` does **not** skip `spotless:check`. Use `spotless.skip` when you want both.
+`spotless.check.skip` does **not** skip `spotless:apply`, and `spotless.apply.skip` does **not** skip `spotless:check`. Use `spotless.skip` when you want both. These properties do **not** affect `spotless:install-git-pre-push-hook`.
 
 ### Suppressing lint errors
 

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -2071,12 +2071,23 @@ You can easily set the line endings of different files using [a `.gitattributes`
 
 <a name="enforceCheck"></a>
 
-## Disabling warnings and error messages
+## Disabling Spotless goals
 
-By default, `spotless:check` is bound to the `verify` phase.  You might want to disable this behavior.  We [recommend against this](https://github.com/diffplug/spotless/issues/79#issuecomment-290844602), but it's easy to do if you'd like:
+By default, `spotless:check` is bound to the `verify` phase. You might want to disable Spotless for some builds. We [recommend against this](https://github.com/diffplug/spotless/issues/79#issuecomment-290844602), but the following properties are available:
 
-- set `-Dspotless.check.skip=true` at the command line
-- set `spotless.check.skip` to `true` in the `<properties>` section of the `pom.xml`
+| Property | Scope | Effect |
+| --- | --- | --- |
+| `spotless.skip` | all goals | Skips every Spotless goal (`check`, `apply`, …) |
+| `spotless.check.skip` | `spotless:check` only | Skips only the check goal |
+| `spotless.apply.skip` | `spotless:apply` only | Skips only the apply goal |
+
+You can set them at the command line or in the `<properties>` section of the `pom.xml`:
+
+- `-Dspotless.skip=true` / `<spotless.skip>true</spotless.skip>` — skip all Spotless goals
+- `-Dspotless.check.skip=true` / `<spotless.check.skip>true</spotless.check.skip>` — skip only `spotless:check` (including when it is bound to `verify`)
+- `-Dspotless.apply.skip=true` / `<spotless.apply.skip>true</spotless.apply.skip>` — skip only `spotless:apply`
+
+`spotless.check.skip` does **not** skip `spotless:apply`, and `spotless.apply.skip` does **not** skip `spotless:check`. Use `spotless.skip` when you want both.
 
 ### Suppressing lint errors
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/AbstractSpotlessMojo.java
@@ -120,12 +120,6 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 	@Parameter(property = "spotless.skip", defaultValue = "false")
 	private boolean skip;
 
-	@Parameter(property = "spotless.apply.skip", defaultValue = "false")
-	private boolean applySkip;
-
-	@Parameter(property = "spotless.check.skip", defaultValue = "false")
-	private boolean checkSkip;
-
 	@Parameter(defaultValue = "${project}", required = true, readonly = true)
 	private MavenProject project;
 
@@ -305,16 +299,14 @@ public abstract class AbstractSpotlessMojo extends AbstractMojo {
 			getLog().debug("Skipping for incremental builds as parameter 'enableForIncrementalBuilds' is set to 'false'");
 			return true;
 		}
+		return isGoalSpecificSkip();
+	}
 
-		switch (goal) {
-		case GOAL_CHECK:
-			return checkSkip;
-		case GOAL_APPLY:
-			return applySkip;
-		default:
-			break;
-		}
-
+	/**
+	 * Goal-specific skip flags live on the concrete mojos (e.g. {@code spotless.check.skip}).
+	 * Override when a goal has its own property.
+	 */
+	protected boolean isGoalSpecificSkip() {
 		return false;
 	}
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessApplyMojo.java
@@ -47,6 +47,14 @@ public class SpotlessApplyMojo extends AbstractSpotlessMojo {
 	@Parameter(property = "spotlessIdeHookUseStdOut")
 	private boolean spotlessIdeHookUseStdOut;
 
+	@Parameter(property = "spotless.apply.skip", defaultValue = "false")
+	private boolean applySkip;
+
+	@Override
+	protected boolean isGoalSpecificSkip() {
+		return applySkip;
+	}
+
 	@Override
 	protected void process(String name, Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {
 		if (isIdeHook()) {

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessCheckMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,9 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 
 	private static final String INCREMENTAL_MESSAGE_PREFIX = "Spotless Violation: ";
 
+	@Parameter(property = "spotless.check.skip", defaultValue = "false")
+	private boolean checkSkip;
+
 	public enum MessageSeverity {
 		WARNING(BuildContext.SEVERITY_WARNING), ERROR(BuildContext.SEVERITY_ERROR);
 
@@ -62,6 +65,11 @@ public class SpotlessCheckMojo extends AbstractSpotlessMojo {
 	 */
 	@Parameter(defaultValue = "WARNING")
 	private MessageSeverity m2eIncrementalBuildMessageSeverity;
+
+	@Override
+	protected boolean isGoalSpecificSkip() {
+		return checkSkip;
+	}
 
 	@Override
 	protected void process(String name, Iterable<File> files, Formatter formatter, UpToDateChecker upToDateChecker) throws MojoExecutionException {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/SpotlessCheckMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ class SpotlessCheckMojoTest extends MavenIntegrationHarness {
 
 	private static final String UNFORMATTED_FILE = "license/MissingLicense.test";
 	private static final String FORMATTED_FILE = "license/HasLicense.test";
+	private static final String TARGET_JAVA = "src/main/java/com.github.youribonnaffe.gradle.format/Java8Test.java";
 
 	@Test
 	void testSpotlessCheckWithFormattingViolations() throws Exception {
@@ -44,6 +45,19 @@ class SpotlessCheckMojoTest extends MavenIntegrationHarness {
 	void testSkipSpotlessCheckWithFormattingViolations() throws Exception {
 		writePomWithJavaLicenseHeaderStep();
 		testSpotlessCheck(UNFORMATTED_FILE, "spotless:check -Dspotless.check.skip", false);
+	}
+
+	@Test
+	void testSkipAllGoalsWithSpotlessSkip() throws Exception {
+		writePomWithJavaLicenseHeaderStep();
+		testSpotlessCheck(UNFORMATTED_FILE, "spotless:check -Dspotless.skip", false);
+	}
+
+	@Test
+	void testApplySkipDoesNotSkipCheck() throws Exception {
+		writePomWithJavaLicenseHeaderStep();
+		// apply.skip must not suppress check
+		testSpotlessCheck(UNFORMATTED_FILE, "spotless:check -Dspotless.apply.skip", true);
 	}
 
 	@Test
@@ -68,9 +82,39 @@ class SpotlessCheckMojoTest extends MavenIntegrationHarness {
 		testSpotlessCheck(UNFORMATTED_FILE, "verify", true);
 	}
 
+	@Test
+	void testApplySkipLeavesFileUnformatted() throws Exception {
+		writePomWithJavaLicenseHeaderStep();
+		setFile("license.txt").toResource("license/TestLicense");
+		setFile(TARGET_JAVA).toResource(UNFORMATTED_FILE);
+
+		mavenRunner().withArguments("spotless:apply -Dspotless.apply.skip").runNoError();
+		assertFile(TARGET_JAVA).sameAsResource(UNFORMATTED_FILE);
+	}
+
+	@Test
+	void testSpotlessSkipLeavesApplyUnformatted() throws Exception {
+		writePomWithJavaLicenseHeaderStep();
+		setFile("license.txt").toResource("license/TestLicense");
+		setFile(TARGET_JAVA).toResource(UNFORMATTED_FILE);
+
+		mavenRunner().withArguments("spotless:apply -Dspotless.skip").runNoError();
+		assertFile(TARGET_JAVA).sameAsResource(UNFORMATTED_FILE);
+	}
+
+	@Test
+	void testCheckSkipDoesNotSkipApply() throws Exception {
+		writePomWithJavaLicenseHeaderStep();
+		setFile("license.txt").toResource("license/TestLicense");
+		setFile(TARGET_JAVA).toResource(UNFORMATTED_FILE);
+
+		mavenRunner().withArguments("spotless:apply -Dspotless.check.skip").runNoError();
+		assertFile(TARGET_JAVA).sameAsResource(FORMATTED_FILE);
+	}
+
 	private void testSpotlessCheck(String fileName, String command, boolean expectError) throws Exception {
 		setFile("license.txt").toResource("license/TestLicense");
-		setFile("src/main/java/com.github.youribonnaffe.gradle.format/Java8Test.java").toResource(fileName);
+		setFile(TARGET_JAVA).toResource(fileName);
 
 		MavenRunner mavenRunner = mavenRunner().withArguments(command);
 


### PR DESCRIPTION
## Fixes

Fixes #2981

## Changes and Review

The Maven README only documented `spotless.check.skip`, which made it look like a global switch. `spotless.skip` and `spotless.apply.skip` were already implemented but undocumented.

- Document `spotless.skip`, `spotless.check.skip`, and `spotless.apply.skip` (scope + CLI/`pom.xml` usage) in the Maven plugin README.
- Move the goal-specific skip parameters onto `SpotlessCheckMojo` / `SpotlessApplyMojo`; keep goal-agnostic `spotless.skip` on the shared base.
- Add regression tests covering cross-goal isolation (`check.skip` does not skip apply, and vice versa).

## Test Plan

- [x] `./gradlew :plugin-maven:test --tests 'com.diffplug.spotless.maven.SpotlessCheckMojoTest'` — 9/9 GREEN

Please **DO NOT FORCE PUSH**. Don't worry about messy history.