### PR TITLE
Bump adocfmt to 0.3.1 and add table formatting options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+- Bump default `adocfmt` version `0.2.0` -> `0.3.1`, which adds table formatting support (`formatTables`, `tableLayout`, `tableMaxLineWidth`, `tableBlankLines`).
 
 ## [4.9.0] - 2026-07-27
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtConfig.java
+++ b/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtConfig.java
@@ -34,6 +34,10 @@ public class AdocfmtConfig implements Serializable {
 	public boolean normalizeOrderedListMarkers = false;
 	public boolean ensureHeadingBlankLines = true;
 	public boolean ensureSourceDelimiters = false;
+	public boolean formatTables = true;
+	public String tableLayout = "AUTO";
+	public int tableMaxLineWidth = 120;
+	public String tableBlankLines = "ALL";
 
 	public AdocfmtConfig() {}
 
@@ -53,13 +57,18 @@ public class AdocfmtConfig implements Serializable {
 				&& normalizeListBullets == other.normalizeListBullets
 				&& normalizeOrderedListMarkers == other.normalizeOrderedListMarkers
 				&& ensureHeadingBlankLines == other.ensureHeadingBlankLines
-				&& ensureSourceDelimiters == other.ensureSourceDelimiters;
+				&& ensureSourceDelimiters == other.ensureSourceDelimiters
+				&& formatTables == other.formatTables
+				&& Objects.equals(tableLayout, other.tableLayout)
+				&& tableMaxLineWidth == other.tableMaxLineWidth
+				&& Objects.equals(tableBlankLines, other.tableBlankLines);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(normalizeSetextHeadings, collapseConsecutiveBlankLines, oneSentencePerLine,
 				normalizeBlockDelimiters, removeTrailingHeaderEqualsSign, titleCase, removeTrailingWhitespace,
-				normalizeListBullets, normalizeOrderedListMarkers, ensureHeadingBlankLines, ensureSourceDelimiters);
+				normalizeListBullets, normalizeOrderedListMarkers, ensureHeadingBlankLines, ensureSourceDelimiters,
+				formatTables, tableLayout, tableMaxLineWidth, tableBlankLines);
 	}
 }

--- a/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/asciidoc/AdocfmtStep.java
@@ -19,6 +19,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Locale;
 import java.util.Objects;
 
 import com.diffplug.spotless.FormatterFunc;
@@ -30,7 +31,7 @@ import com.diffplug.spotless.ThrowingEx;
 public final class AdocfmtStep implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
-	private static final String DEFAULT_VERSION = "0.2.0";
+	private static final String DEFAULT_VERSION = "0.3.1";
 	private static final String NAME = "adocfmt";
 	private static final String MAVEN_COORDINATE = "org.drjekyll:adocfmt:";
 
@@ -101,6 +102,20 @@ public final class AdocfmtStep implements Serializable {
 			builder = builderClass.getMethod("normalizeOrderedListMarkers", boolean.class).invoke(builder, config.normalizeOrderedListMarkers);
 			builder = builderClass.getMethod("ensureHeadingBlankLines", boolean.class).invoke(builder, config.ensureHeadingBlankLines);
 			builder = builderClass.getMethod("ensureSourceDelimiters", boolean.class).invoke(builder, config.ensureSourceDelimiters);
+			builder = builderClass.getMethod("formatTables", boolean.class).invoke(builder, config.formatTables);
+			if (config.tableLayout != null) {
+				final Class<?> tableLayoutClass = classLoader.loadClass("org.drjekyll.adocfmt.TableLayout");
+				@SuppressWarnings({"rawtypes", "unchecked"})
+				final Object layoutEnum = Enum.valueOf((Class<Enum>) tableLayoutClass, config.tableLayout.toUpperCase(Locale.ROOT));
+				builder = builderClass.getMethod("tableLayout", tableLayoutClass).invoke(builder, layoutEnum);
+			}
+			builder = builderClass.getMethod("tableMaxLineWidth", int.class).invoke(builder, config.tableMaxLineWidth);
+			if (config.tableBlankLines != null) {
+				final Class<?> tableBlankLinesClass = classLoader.loadClass("org.drjekyll.adocfmt.TableBlankLines");
+				@SuppressWarnings({"rawtypes", "unchecked"})
+				final Object blankLinesEnum = Enum.valueOf((Class<Enum>) tableBlankLinesClass, config.tableBlankLines.toUpperCase(Locale.ROOT));
+				builder = builderClass.getMethod("tableBlankLines", tableBlankLinesClass).invoke(builder, blankLinesEnum);
+			}
 			final Object adocfmtConfig = builderClass.getMethod("build").invoke(builder);
 
 			final Object formatter = formatterClass.getConstructor(configClass).newInstance(adocfmtConfig);

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Changes
+- Bump default `adocfmt` version `0.2.0` -> `0.3.1`, which adds table formatting support (`formatTables`, `tableLayout`, `tableMaxLineWidth`, `tableBlankLines`).
 
 ## [8.9.0] - 2026-07-27
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -871,7 +871,7 @@ spotless {
 [homepage](https://github.com/dheid/adocfmt). [available versions](https://search.maven.org/artifact/org.drjekyll/adocfmt).
 
 ```gradle
-adocfmt('0.2.0') // version is optional
+adocfmt('0.3.1') // version is optional
   .normalizeSetextHeadings(false)       // convert === underlines to ATX == (default: false)
   .collapseConsecutiveBlankLines(true)  // max 1 blank line (default: true)
   .oneSentencePerLine(false)            // each sentence on its own line (default: false)
@@ -883,6 +883,10 @@ adocfmt('0.2.0') // version is optional
   .normalizeOrderedListMarkers(false)   // 1. -> . (default: false)
   .ensureHeadingBlankLines(true)        // blank line before/after headings (default: true)
   .ensureSourceDelimiters(false)        // wrap [source] in ---- (default: false)
+  .formatTables(true)                   // format AsciiDoc tables (default: true)
+  .tableLayout('AUTO')                  // AUTO, EXPANDED, PRESERVE (default: AUTO)
+  .tableMaxLineWidth(120)               // max line width for compact table layout (default: 120)
+  .tableBlankLines('ALL')               // NONE, HEADER, ALL, PRESERVE (default: ALL)
 ```
 
 Options default to `true` or `false` as shown above. This formatter is designed to help you maintain a clean, consistent AsciiDoc structure. Surface-altering options like `oneSentencePerLine` and `normalizeSetextHeadings` default to `false` so that zero-config formatting is conservative; opt in explicitly if you want those transforms.

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/AsciidocExtension.java
@@ -110,6 +110,30 @@ public class AsciidocExtension extends FormatExtension {
 			replaceStep(AdocfmtStep.create(version, provisioner(), config));
 			return this;
 		}
+
+		public AdocfmtFormatterConfig formatTables(boolean formatTables) {
+			config.formatTables = formatTables;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig tableLayout(String tableLayout) {
+			config.tableLayout = tableLayout;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig tableMaxLineWidth(int tableMaxLineWidth) {
+			config.tableMaxLineWidth = tableMaxLineWidth;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
+
+		public AdocfmtFormatterConfig tableBlankLines(String tableBlankLines) {
+			config.tableBlankLines = tableBlankLines;
+			replaceStep(AdocfmtStep.create(version, provisioner(), config));
+			return this;
+		}
 	}
 
 	@Override

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/AsciidocExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/AsciidocExtensionTest.java
@@ -31,7 +31,7 @@ class AsciidocExtensionTest extends GradleIntegrationHarness {
 						repositories { mavenCentral() }
 						spotless {
 						    asciidoc {
-						        adocfmt('0.2.0')
+						        adocfmt('0.3.1')
 						    }
 						}
 						""");
@@ -52,7 +52,7 @@ class AsciidocExtensionTest extends GradleIntegrationHarness {
 								spotless {
 								    asciidoc {
 								        target 'test.adoc'
-										adocfmt('0.2.0')
+										adocfmt('0.3.1')
 										  .normalizeSetextHeadings(true)
 										  .collapseConsecutiveBlankLines(true)
 										  .oneSentencePerLine(true)
@@ -64,6 +64,10 @@ class AsciidocExtensionTest extends GradleIntegrationHarness {
 										  .normalizeOrderedListMarkers(true)
 										  .ensureHeadingBlankLines(true)
 										  .ensureSourceDelimiters(true)
+										  .formatTables(true)
+										  .tableLayout('AUTO')
+										  .tableMaxLineWidth(120)
+										  .tableBlankLines('ALL')
 								    }
 								}
 								""");

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Changes
+- Bump default `adocfmt` version `0.2.0` -> `0.3.1`, which adds table formatting support (`<formatTables>`, `<tableLayout>`, `<tableMaxLineWidth>`, `<tableBlankLines>`).
 
 ## [3.9.0] - 2026-07-27
 ### Added

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -744,7 +744,7 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
 
 ```xml
 <adocfmt>
-  <version>0.2.0</version> <!-- optional -->
+  <version>0.3.1</version> <!-- optional -->
   <normalizeSetextHeadings>true</normalizeSetextHeadings>       <!-- convert === underlines to ATX == (default: true) -->
   <collapseConsecutiveBlankLines>true</collapseConsecutiveBlankLines> <!-- max 1 blank line (default: true) -->
   <oneSentencePerLine>true</oneSentencePerLine>            <!-- each sentence on its own line (default: true) -->
@@ -756,6 +756,10 @@ Additionally, `editorConfigOverride` options will override what's supplied in `.
   <normalizeOrderedListMarkers>false</normalizeOrderedListMarkers>   <!-- 1. -> . (default: false) -->
   <ensureHeadingBlankLines>true</ensureHeadingBlankLines>       <!-- blank line before/after headings (default: true) -->
   <ensureSourceDelimiters>false</ensureSourceDelimiters>        <!-- wrap [source] in ---- (default: false) -->
+  <formatTables>true</formatTables>                  <!-- format AsciiDoc tables (default: true) -->
+  <tableLayout>AUTO</tableLayout>                   <!-- AUTO, EXPANDED, PRESERVE (default: AUTO) -->
+  <tableMaxLineWidth>120</tableMaxLineWidth>         <!-- max line width for compact table layout (default: 120) -->
+  <tableBlankLines>ALL</tableBlankLines>             <!-- NONE, HEADER, ALL, PRESERVE (default: ALL) -->
 </adocfmt>
 ```
 

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Adocfmt.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/asciidoc/Adocfmt.java
@@ -60,6 +60,18 @@ public class Adocfmt implements FormatterStepFactory {
 	@Parameter
 	private Boolean ensureSourceDelimiters;
 
+	@Parameter
+	private Boolean formatTables;
+
+	@Parameter
+	private String tableLayout;
+
+	@Parameter
+	private Integer tableMaxLineWidth;
+
+	@Parameter
+	private String tableBlankLines;
+
 	@Override
 	public FormatterStep newFormatterStep(FormatterStepConfig config) {
 		String version = this.version != null ? this.version : AdocfmtStep.defaultVersion();
@@ -86,6 +98,14 @@ public class Adocfmt implements FormatterStepFactory {
 			adocfmtConfig.ensureHeadingBlankLines = ensureHeadingBlankLines;
 		if (ensureSourceDelimiters != null)
 			adocfmtConfig.ensureSourceDelimiters = ensureSourceDelimiters;
+		if (formatTables != null)
+			adocfmtConfig.formatTables = formatTables;
+		if (tableLayout != null)
+			adocfmtConfig.tableLayout = tableLayout;
+		if (tableMaxLineWidth != null)
+			adocfmtConfig.tableMaxLineWidth = tableMaxLineWidth;
+		if (tableBlankLines != null)
+			adocfmtConfig.tableBlankLines = tableBlankLines;
 		return AdocfmtStep.create(version, config.getProvisioner(), adocfmtConfig);
 	}
 }

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/asciidoc/AdocfmtMavenTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/asciidoc/AdocfmtMavenTest.java
@@ -27,7 +27,7 @@ public class AdocfmtMavenTest extends MavenIntegrationHarness {
 	public void missingIncludesFails() throws Exception {
 		writePom(groupWithSteps("asciidoc",
 				"<adocfmt>",
-				"  <version>0.2.0</version>",
+				"  <version>0.3.1</version>",
 				"</adocfmt>"));
 		ProcessRunner.Result result = mavenRunner().withArguments("spotless:apply").runHasError();
 		assertThat(result.stdOutUtf8()).contains("You must specify some files to include");
@@ -38,7 +38,7 @@ public class AdocfmtMavenTest extends MavenIntegrationHarness {
 		writePomWithAsciidocSteps(
 				"""
 						<adocfmt>
-						  <version>0.2.0</version> <!-- optional -->
+						  <version>0.3.1</version> <!-- optional -->
 						  <normalizeSetextHeadings>true</normalizeSetextHeadings>
 						  <collapseConsecutiveBlankLines>true</collapseConsecutiveBlankLines>
 						  <oneSentencePerLine>true</oneSentencePerLine>
@@ -50,6 +50,10 @@ public class AdocfmtMavenTest extends MavenIntegrationHarness {
 						  <normalizeOrderedListMarkers>true</normalizeOrderedListMarkers>
 						  <ensureHeadingBlankLines>true</ensureHeadingBlankLines>
 						  <ensureSourceDelimiters>true</ensureSourceDelimiters>
+						  <formatTables>true</formatTables>
+						  <tableLayout>AUTO</tableLayout>
+						  <tableMaxLineWidth>120</tableMaxLineWidth>
+						  <tableBlankLines>ALL</tableBlankLines>
 						</adocfmt>
 						""");
 

--- a/testlib/src/test/java/com/diffplug/spotless/asciidoc/AdocfmtStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/asciidoc/AdocfmtStepTest.java
@@ -36,6 +36,10 @@ class AdocfmtStepTest extends ResourceHarness {
 		config.normalizeListBullets = true;
 		config.normalizeOrderedListMarkers = true;
 		config.ensureSourceDelimiters = true;
+		config.formatTables = true;
+		config.tableLayout = "AUTO";
+		config.tableMaxLineWidth = 120;
+		config.tableBlankLines = "ALL";
 		FormatterStep step = AdocfmtStep.create(AdocfmtStep.defaultVersion(), TestProvisioner.mavenCentral(), config);
 		StepHarness.forStep(step).testResource("asciidoc/adocfmt/dirty.adoc", "asciidoc/adocfmt/clean_complex.adoc");
 	}
@@ -56,6 +60,8 @@ class AdocfmtStepTest extends ResourceHarness {
 			// fields drive create(); never mutate a config object after passing it to create()
 			boolean titleCase = false;
 			boolean normalizeListBullets = false;
+			boolean formatTables = true;
+			String tableLayout = "AUTO";
 
 			@Override
 			protected void setupTest(API api) {
@@ -68,6 +74,12 @@ class AdocfmtStepTest extends ResourceHarness {
 				titleCase = false;
 				normalizeListBullets = true;
 				api.areDifferentThan();
+				normalizeListBullets = false;
+				formatTables = false;
+				api.areDifferentThan();
+				formatTables = true;
+				tableLayout = "EXPANDED";
+				api.areDifferentThan();
 			}
 
 			@Override
@@ -75,6 +87,8 @@ class AdocfmtStepTest extends ResourceHarness {
 				AdocfmtConfig config = new AdocfmtConfig();
 				config.titleCase = titleCase;
 				config.normalizeListBullets = normalizeListBullets;
+				config.formatTables = formatTables;
+				config.tableLayout = tableLayout;
 				return AdocfmtStep.create(AdocfmtStep.defaultVersion(), TestProvisioner.mavenCentral(), config);
 			}
 		}.testEquals();


### PR DESCRIPTION
This PR upgrades the default version of the `adocfmt` formatter from `0.2.0` to `0.3.1` and introduces support for the new table formatting options in Spotless's AsciiDoc integration.

# Key Changes
* **Dependency Upgrade**: Bumped the default `adocfmt` version to `0.3.1` in the `AdocfmtStep` class.
* **Configuration Expansion**: Added four new configuration options to `AdocfmtConfig`:
  * `formatTables` (default: `true`)
  * `tableLayout` (default: `"AUTO"`)
  * `tableMaxLineWidth` (default: `120`)
  * `tableBlankLines` (default: `"ALL"`)
* **Gradle Integration**:
  * Exposed the new settings in `AsciidocExtension`.
  * Documented usage and parameters in plugin-gradle/README.md.
  * Updated `AsciidocExtensionTest` to verify integration.
* **Maven Integration**:
  * Added corresponding parameters to the `Adocfmt` MOJO configuration.
  * Documented usage and parameters in plugin-maven/README.md.
  * Updated `AdocfmtMavenTest` to test configuration compatibility.
* **Testing**:
  * Added test cases to `AdocfmtStepTest` to assert formatting capabilities and correct handling of `equals()` and `hashCode()` for cache checks.

# PR Checklist

- [x] **No Force Push**: History has been preserved cleanly for review.
- [x] **Allows Edits from Maintainers**: Configured to permit quick fixes by maintainers.
- [x] **Changelog Updates**: Since this changes the `lib` in an end-user-visible way (updating default version, adding configuration options), the `[Unreleased]` sections of the following changelogs have been updated:
  - [x] `CHANGES.md` (lib changes)
  - [x] `plugin-gradle/CHANGES.md` (gradle plugin changes)
  - [x] `plugin-maven/CHANGES.md` (maven plugin changes)
- [x] **Step Equality & Hashcode**: Updated fields in `AdocfmtConfig` are included in `equals()` and `hashCode()`, and tested in `testEquals()` to support up-to-date checking and configuration caching correctly.
