### PR TITLE
Issue 650 872 multi license headers in maven-plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,6 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
-### Changes
-- Add support to apply alternate license header within same format ([#872](https://github.com/diffplug/spotless/issues/872))
-- Add support to skip license header application based on source file content pattern ([#650](https://github.com/diffplug/spotless/issues/650)).
-
 ## [4.9.0] - 2026-07-27
 ### Added
 - Add support for Java formatting via [`prince-of-space`](https://github.com/agustafson/prince-of-space). ([#2991](https://github.com/diffplug/spotless/pull/2991))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Changes
+- Add support to apply alternate license header within same format ([#872](https://github.com/diffplug/spotless/issues/872))
+- Add support to skip license header application based on source file content pattern ([#650](https://github.com/diffplug/spotless/issues/650)).
+
 ## [4.9.0] - 2026-07-27
 ### Added
 - Add support for Java formatting via [`prince-of-space`](https://github.com/agustafson/prince-of-space). ([#2991](https://github.com/diffplug/spotless/pull/2991))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Changes
+- Add support to apply alternate license header within same format ([#872](https://github.com/diffplug/spotless/issues/872))
+- Add support to skip license header application based on source file content pattern ([#650](https://github.com/diffplug/spotless/issues/650)).
+
 ## [3.9.0] - 2026-07-27
 ### Added
 - Add support for Java formatting via [`prince-of-space`](https://github.com/agustafson/prince-of-space) with the new `<princeOfSpace>` step. ([#2991](https://github.com/diffplug/spotless/pull/2991))

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -1953,6 +1953,25 @@ Some files have fixed header lines (e.g. `<?xml version="1.0" ...` in XMLs, or `
 
 To define what lines to skip at the beginning of such files, fill the `skipLinesMatching` option with a regular expression that matches them (e.g. `<skipLinesMatching>^#!.+?$</skipLinesMatching>` to skip shebangs).
 
+### Skip headers and multiple license headers
+
+Sometimes it may be necessary to disable a license rule for specific files, or to maintain dual licenses.
+
+To define alternate replacements: 
+
+```xml
+<licenseHeader>
+    <name>PrimaryHeaderLicense</name>
+    <content>/** Base License Header */</content>
+    <onlyIfContentMatches>Best</onlyIfContentMatches>
+</licenseHeader>
+<licenseHeader>
+  <name>SecondaryHeaderLicense</name>
+  <content>/** Alternate License Header */</content>
+  <onlyIfContentMatches>.*Test.+</onlyIfContentMatches>
+</licenseHeader>
+```
+
 <a name="invisible"></a>
 
 <a name="ratchet"></a>

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
@@ -64,9 +64,9 @@ public class LicenseHeader implements FormatterStepFactory {
 				yearMode = updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
 			}
 			LicenseHeaderStep builder = LicenseHeaderStep.headerDelimiter(() -> readFileOrContent(config), delimiterString)
-				.withYearMode(yearMode)
-				.withSkipLinesMatching(skipLinesMatching)
-				.withYearStingFormat(yearStrFmt);
+					.withYearMode(yearMode)
+					.withSkipLinesMatching(skipLinesMatching)
+					.withYearStingFormat(yearStrFmt);
 			if (name != null) {
 				builder = builder.withName(name);
 			}

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/generic/LicenseHeader.java
@@ -29,6 +29,12 @@ import com.diffplug.spotless.maven.FormatterStepFactory;
 public class LicenseHeader implements FormatterStepFactory {
 
 	@Parameter
+	private String name;
+
+	@Parameter
+	private String onlyIfContentMatches;
+
+	@Parameter
 	private String file;
 
 	@Parameter
@@ -57,12 +63,17 @@ public class LicenseHeader implements FormatterStepFactory {
 				boolean updateYear = config.getRatchetFrom().isPresent();
 				yearMode = updateYear ? YearMode.UPDATE_TO_TODAY : YearMode.PRESERVE;
 			}
-			return LicenseHeaderStep.headerDelimiter(() -> readFileOrContent(config), delimiterString)
-					.withYearMode(yearMode)
-					.withSkipLinesMatching(skipLinesMatching)
-					.withYearStingFormat(yearStrFmt)
-					.build()
-					.filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
+			LicenseHeaderStep builder = LicenseHeaderStep.headerDelimiter(() -> readFileOrContent(config), delimiterString)
+				.withYearMode(yearMode)
+				.withSkipLinesMatching(skipLinesMatching)
+				.withYearStingFormat(yearStrFmt);
+			if (name != null) {
+				builder = builder.withName(name);
+			}
+			if (onlyIfContentMatches != null) {
+				builder = builder.withContentPattern(onlyIfContentMatches);
+			}
+			return builder.build().filterByFile(LicenseHeaderStep.unsupportedJvmFilesFilter());
 		} else {
 			throw new IllegalArgumentException("Must specify exactly one of 'file' or 'content'.");
 		}

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,10 +41,10 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 	@Test
 	void onlyIfContentMatchesAppliesWhenPatternMatches() throws Exception {
 		writePomWithJavaSteps(
-			"<licenseHeader>",
-			"  <content>/** New License Header */</content>",
-			"  <onlyIfContentMatches>.+Test.+</onlyIfContentMatches>",
-			"</licenseHeader>");
+				"<licenseHeader>",
+				"  <content>/** New License Header */</content>",
+				"  <onlyIfContentMatches>.+Test.+</onlyIfContentMatches>",
+				"</licenseHeader>");
 
 		setFile(TEST_JAVA).toContent(CONTENT);
 		mavenRunner().withArguments("spotless:apply").runNoError();
@@ -58,10 +58,10 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 	@Test
 	void onlyIfContentMatchesSkipsWhenPatternDoesNotMatch() throws Exception {
 		writePomWithJavaSteps(
-			"<licenseHeader>",
-			"  <content>/** Should Not Be Applied */</content>",
-			"  <onlyIfContentMatches>missingString</onlyIfContentMatches>",
-			"</licenseHeader>");
+				"<licenseHeader>",
+				"  <content>/** Should Not Be Applied */</content>",
+				"  <onlyIfContentMatches>missingString</onlyIfContentMatches>",
+				"</licenseHeader>");
 
 		String existing = "/** This license header should be preserved */\n" + CONTENT;
 		setFile(TEST_JAVA).toContent(existing);
@@ -77,16 +77,16 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 	@Test
 	void multipleNamedLicenseHeadersSelectByContentPattern() throws Exception {
 		writePomWithJavaSteps(
-			"<licenseHeader>",
-			"  <name>PrimaryHeaderLicense</name>",
-			"  <content>/** Base License Header */</content>",
-			"  <onlyIfContentMatches>Best</onlyIfContentMatches>",
-			"</licenseHeader>",
-			"<licenseHeader>",
-			"  <name>SecondaryHeaderLicense</name>",
-			"  <content>/** Alternate License Header */</content>",
-			"  <onlyIfContentMatches>.*Test.+</onlyIfContentMatches>",
-			"</licenseHeader>");
+				"<licenseHeader>",
+				"  <name>PrimaryHeaderLicense</name>",
+				"  <content>/** Base License Header */</content>",
+				"  <onlyIfContentMatches>Best</onlyIfContentMatches>",
+				"</licenseHeader>",
+				"<licenseHeader>",
+				"  <name>SecondaryHeaderLicense</name>",
+				"  <content>/** Alternate License Header */</content>",
+				"  <onlyIfContentMatches>.*Test.+</onlyIfContentMatches>",
+				"</licenseHeader>");
 
 		setFile(TEST_JAVA).toContent("/** 2003 */\n" + CONTENT);
 		mavenRunner().withArguments("spotless:apply").runNoError();

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/generic/LicenseHeaderTest.java
@@ -22,6 +22,8 @@ import com.diffplug.spotless.maven.MavenIntegrationHarness;
 class LicenseHeaderTest extends MavenIntegrationHarness {
 	private static final String KEY_LICENSE = "license/TestLicense";
 	private static final String KOTLIN_LICENSE_HEADER = "// Hello, I'm Kotlin license header";
+	private static final String TEST_JAVA = "src/main/java/pkg/Test.java";
+	private static final String CONTENT = "package pkg;\npublic class Test {}";
 
 	@Test
 	void fromFileJava() throws Exception {
@@ -31,6 +33,64 @@ class LicenseHeaderTest extends MavenIntegrationHarness {
 				"  <file>${basedir}/license.txt</file>",
 				"</licenseHeader>");
 		runTest();
+	}
+
+	/**
+	 * When {@code onlyIfContentMatches} matches the file content, the license header is applied.
+	 */
+	@Test
+	void onlyIfContentMatchesAppliesWhenPatternMatches() throws Exception {
+		writePomWithJavaSteps(
+			"<licenseHeader>",
+			"  <content>/** New License Header */</content>",
+			"  <onlyIfContentMatches>.+Test.+</onlyIfContentMatches>",
+			"</licenseHeader>");
+
+		setFile(TEST_JAVA).toContent(CONTENT);
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(TEST_JAVA).hasContent("/** New License Header */\n" + CONTENT);
+	}
+
+	/**
+	 * When {@code onlyIfContentMatches} does not match the file content, the existing
+	 * content (including any existing header) is left unchanged.
+	 */
+	@Test
+	void onlyIfContentMatchesSkipsWhenPatternDoesNotMatch() throws Exception {
+		writePomWithJavaSteps(
+			"<licenseHeader>",
+			"  <content>/** Should Not Be Applied */</content>",
+			"  <onlyIfContentMatches>missingString</onlyIfContentMatches>",
+			"</licenseHeader>");
+
+		String existing = "/** This license header should be preserved */\n" + CONTENT;
+		setFile(TEST_JAVA).toContent(existing);
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(TEST_JAVA).hasContent(existing);
+	}
+
+	/**
+	 * Multiple named license-header steps with different {@code onlyIfContentMatches}
+	 * patterns: the step whose pattern matches is applied (parity with Gradle
+	 * {@code filterByContentPatternTest}).
+	 */
+	@Test
+	void multipleNamedLicenseHeadersSelectByContentPattern() throws Exception {
+		writePomWithJavaSteps(
+			"<licenseHeader>",
+			"  <name>PrimaryHeaderLicense</name>",
+			"  <content>/** Base License Header */</content>",
+			"  <onlyIfContentMatches>Best</onlyIfContentMatches>",
+			"</licenseHeader>",
+			"<licenseHeader>",
+			"  <name>SecondaryHeaderLicense</name>",
+			"  <content>/** Alternate License Header */</content>",
+			"  <onlyIfContentMatches>.*Test.+</onlyIfContentMatches>",
+			"</licenseHeader>");
+
+		setFile(TEST_JAVA).toContent("/** 2003 */\n" + CONTENT);
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(TEST_JAVA).hasContent("/** Alternate License Header */\n" + CONTENT);
 	}
 
 	@Test


### PR DESCRIPTION
Fix #650 
Fix #872 

This changeset addresses the same feature that was implemented in PR #990 for gradle, but for the maven-plugin.

