### PR TITLE
fix: resolve expandWildcardImports classpath from Java source sets

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
+- `expandWildcardImports()` now builds its type-solver classpath from each Java source set's compile classpath instead of every resolvable configuration. Unrelated configurations (for example generated-code or custom resolvable configs that are not ready yet) are no longer resolved. ([#2998](https://github.com/diffplug/spotless/issues/2998))
 - `spotlessCheck` violation message now suggests the correct composite/included-build task path (e.g. `./gradlew :my-utils:spotlessApply`) instead of a bare `spotlessApply` / `:spotlessApply` that does not select included-build tasks. ([#2421](https://github.com/diffplug/spotless/issues/2421))
 - Parallel multi-project builds no longer intermittently fail with "Cannot fingerprint input property 'stepsInternalEquality': ConfigurationCacheHackList cannot be serialized" / "Failed to provision P2 dependencies" when using `eclipse()` (or other P2-backed steps). Subprojects now share one deduping P2 provisioner and P2 queries are serialized process-wide. ([#3004](https://github.com/diffplug/spotless/issues/3004))
 ### Changes

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JavaExtension.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
@@ -176,7 +175,10 @@ public class JavaExtension extends FormatExtension implements HasBuiltinDelimite
 	public void expandWildcardImports() {
 		SourceSetContainer sourceSets = getSourceSets(getProject(), "expansion of wildcards requires the 'java' plugin to be applied");
 		Set<File> typeSolverClasspath = sourceSets.stream().flatMap(s -> s.getAllJava().getSrcDirs().stream()).collect(toSet());
-		getProject().getConfigurations().stream().filter(Configuration::isCanBeResolved).flatMap(c -> c.getFiles().stream()).forEach(typeSolverClasspath::add);
+		sourceSets.stream()
+				.map(SourceSet::getCompileClasspath)
+				.flatMap(classpath -> classpath.getFiles().stream())
+				.forEach(typeSolverClasspath::add);
 		addStep(ExpandWildcardImportsStep.create(typeSolverClasspath, provisioner()));
 	}
 

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/JavaDefaultTargetTest.java
@@ -176,6 +176,38 @@ class JavaDefaultTargetTest extends GradleIntegrationHarness {
 		assertFile("src/main/java/foo/bar/JavaCodeWildcardsUnformatted.java").sameAsResource("java/expandwildcardimports/JavaClassWithWildcardsFormatted.test");
 	}
 
+	@Test
+	void expandWildcardImportsIgnoresUnrelatedConfigurations() throws IOException {
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'java'",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"",
+				"repositories { mavenCentral() }",
+				"",
+				"configurations {",
+				"    leftover {",
+				"        canBeResolved = true",
+				"        canBeConsumed = false",
+				"    }",
+				"}",
+				"",
+				"dependencies {",
+				"    leftover 'does.not:exist:1.0'",
+				"}",
+				"",
+				"spotless {",
+				"    java {",
+				"        target file('src/main/java/test.java')",
+				"        expandWildcardImports()",
+				"    }",
+				"}");
+		setFile("src/main/java/test.java").toResource("java/googlejavaformat/JavaCodeUnformatted.test");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/java/test.java").sameAsResource("java/googlejavaformat/JavaCodeUnformatted.test");
+	}
+
 	/**
 	 * Triggers the special case in {@link FormatExtension#setupTask(SpotlessTask)} with {@code toggleFence} and
 	 * {@code targetExcludeContentPattern} both being not {@code null}.


### PR DESCRIPTION
## Fixes

Fixes #2998

## Changes and Review

`expandWildcardImports()` resolved every Gradle configuration with `canBeResolved=true` when building the JavaParser type-solver classpath. That included leftover or generated-code configurations that are not part of compilation and may not be resolvable yet.

- Collect type-solver jars from each Java source set's `compileClasspath` (plus the existing source directories).
- Leave unrelated resolvable configurations alone.

## Test Plan

- [x] `./gradlew :plugin-gradle:test --tests com.diffplug.gradle.spotless.JavaDefaultTargetTest.expandWildcardImportsIgnoresUnrelatedConfigurations` — RED then GREEN
- [x] `./gradlew :plugin-gradle:test --tests com.diffplug.gradle.spotless.JavaDefaultTargetTest` — 10/10 GREEN
- [x] `./gradlew :plugin-gradle:spotlessCheck` — GREEN

Please **DO NOT FORCE PUSH**. Don't worry about messy history.