### PR TITLE
Fix build on Gradle 9.5+ and restore publishing on 9.6+

### DIFF
--- a/gradle/java-publish.gradle
+++ b/gradle/java-publish.gradle
@@ -95,76 +95,74 @@ final MAVEN_PLUGIN_ARTIFACT_NAME = 'spotless-maven-plugin'
 boolean isExt = project.name.startsWith('eclipse-')
 boolean isPluginMaven = project.ext.artifactId == 'spotless-maven-plugin'
 
-model {
-	publishing {
-		publications {
-			pluginMaven(MavenPublication) {
-				if (project.ext.artifactId != 'spotless-plugin-gradle') {
-					from components.java
-				}
+publishing {
+	publications {
+		pluginMaven(MavenPublication) {
+			if (project.ext.artifactId != 'spotless-plugin-gradle') {
+				from components.java
+			}
 
-				groupId = project.group
-				artifactId = project.ext.artifactId
-				version = project.version
+			groupId = project.group
+			artifactId = project.ext.artifactId
+			version = project.version
 
-				def projectExtArtifactId = project.ext.artifactId
-				def projectDescription = project.description
-				def projectOrg = project.org
-				def rootProjectName = rootProject.name
+			def projectExtArtifactId = project.ext.artifactId
+			def projectDescription = project.description
+			def projectOrg = project.org
+			def rootProjectName = rootProject.name
 
-				pom.withXml {
-					// add MavenCentral requirements to the POM
-					asNode().children().last() + {
-						resolveStrategy = Closure.DELEGATE_FIRST
-						name projectExtArtifactId
-						description projectDescription
+			pom.withXml {
+				// add MavenCentral requirements to the POM
+				asNode().children().last() + {
+					resolveStrategy = Closure.DELEGATE_FIRST
+					name projectExtArtifactId
+					description projectDescription
+					url "https://github.com/${projectOrg}/${rootProjectName}"
+					scm {
 						url "https://github.com/${projectOrg}/${rootProjectName}"
-						scm {
-							url "https://github.com/${projectOrg}/${rootProjectName}"
-							connection "scm:git:https://github.com/${projectOrg}/${rootProjectName}.git"
-							developerConnection "scm:git:ssh:git@github.com/${projectOrg}/${rootProjectName}.git"
-						}
-						licenses {
-							if (isExt) {
-								license {
-									name 'Eclipse Public License - v 1.0'
-									url 'https://www.eclipse.org/legal/epl-v10.html'
-									distribution 'repo'
-								}
-							} else {
-								license {
-									name 'The Apache Software License, Version 2.0'
-									url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-									distribution 'repo'
-								}
+						connection "scm:git:https://github.com/${projectOrg}/${rootProjectName}.git"
+						developerConnection "scm:git:ssh:git@github.com/${projectOrg}/${rootProjectName}.git"
+					}
+					licenses {
+						if (isExt) {
+							license {
+								name 'Eclipse Public License - v 1.0'
+								url 'https://www.eclipse.org/legal/epl-v10.html'
+								distribution 'repo'
+							}
+						} else {
+							license {
+								name 'The Apache Software License, Version 2.0'
+								url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+								distribution 'repo'
 							}
 						}
-						if (isPluginMaven) {
-							// Maven plugin required Maven 3.1.0+ to run
-							prerequisites { maven '3.1.0' }
-						}
-						developers {
-							if (isExt) {
-								project.ext.developers.each { extId, extValues ->
-									developer {
-										id extId
-										name extValues['name']
-										email extValues['email']
-									}
-								}
-							} else {
-								if (isPluginMaven) {
-									developer {
-										id 'lutovich'
-										name 'Konstantin Lutovich'
-										email 'konstantin.lutovich@neotechnology.com'
-									}
-								}
+					}
+					if (isPluginMaven) {
+						// Maven plugin required Maven 3.1.0+ to run
+						prerequisites { maven '3.1.0' }
+					}
+					developers {
+						if (isExt) {
+							project.ext.developers.each { extId, extValues ->
 								developer {
-									id 'nedtwigg'
-									name 'Ned Twigg'
-									email 'ned.twigg@diffplug.com'
+									id extId
+									name extValues['name']
+									email extValues['email']
 								}
+							}
+						} else {
+							if (isPluginMaven) {
+								developer {
+									id 'lutovich'
+									name 'Konstantin Lutovich'
+									email 'konstantin.lutovich@neotechnology.com'
+								}
+							}
+							developer {
+								id 'nedtwigg'
+								name 'Ned Twigg'
+								email 'ned.twigg@diffplug.com'
 							}
 						}
 					}

--- a/testlib/build.gradle
+++ b/testlib/build.gradle
@@ -7,7 +7,6 @@ apply from: rootProject.file('gradle/java-setup.gradle')
 
 dependencies {
 	api projects.lib
-	api files(project(projects.lib.path).sourceSets.sortPom.output.classesDirs)
 	api libs.durian.core
 	api libs.durian.testlib
 	api libs.junit.jupiter


### PR DESCRIPTION
Unblocks #3016 (Gradle `9.4.1` → `9.7.0`). Bisecting that PR's failure turned up **two independent regressions**, not one — and fixing only the first would have converted a loud failure into a silent one.

| Breaks in | Symptom | File |
|---|---|---|
| **9.5.0** | `Could not get unknown property 'sourceSets' for project ':lib'` — hard failure | `testlib/build.gradle` |
| **9.6.0** | `publishToMavenLocal` silently becomes a no-op — **no error at all** | `gradle/java-publish.gradle` |

### 1. Gradle 9.5.0 — `project(path).sourceSets`

Inside a `dependencies { }` block, `project(path)` used to resolve to `Project.project(String)` and return a `Project`. As of 9.5.0 it resolves to `DependencyHandler.project(String)` and returns a `ProjectDependency`, which has no `sourceSets`. Same expression, same script:

```
9.4.1: project(String) -> ...project.LifecycleAwareProject_Decorated
9.5.0: project(String) -> ...dependencies.DefaultProjectDependency_Decorated
```

The line turns out to be unnecessary. `:lib`'s jar already bundles every glue source set (`jar { from sourceSets.getByName(glue).output.classesDirs }`), and that jar is on testlib's runtime classpath — which is where `FeatureClassLoader` resolves `com.diffplug.spotless.glue.*`. So it's simply dropped.

### 2. Gradle 9.6.0 — publishing silently stops

Publishing was wrapped in the legacy software-model `model { publishing { … } }` block. In 9.6.0 that rule no longer binds, so the `pluginMaven` publication is never created:

```
9.5.1: > Task :lib-extra:publishPluginMavenPublicationToMavenLocal   (13 tasks executed)
9.6.0: > Task :lib-extra:publishToMavenLocal UP-TO-DATE              (nothing)
```

Unwrapping to a plain `publishing { }` fixes it. Ignoring whitespace the diff is exactly two deleted lines. The software model is slated for removal in Gradle 10 regardless, so this was owed anyway.

Neither change is mentioned in Gradle's 9.5/9.6 release notes or the 9.x upgrade guide. Both look worth reporting upstream, especially the silent one.

### Verification at 9.7.0

- `./gradlew spotlessCheck` — the job that failed on #3016 — passes
- `./gradlew assemble testClasses` passes
- `./gradlew build -x spotlessCheck -PSPOTLESS_EXCLUDE_MAVEN=true` (CI's main job) — **748 tests, 0 failures**
- `publishToMavenLocal` runs the same 66 tasks as on 9.4.1
- Generated `pom-default.xml` + `module.json` are **byte-identical** before/after for all 4 published projects
- `signPluginMavenPublication` and `publishPluginMavenPublicationToSonatypeRepository` (which `changelogBump` depends on) still exist under `-Prelease=true`

Everything still passes on 9.4.1, so this lands safely ahead of the wrapper bump — #3016 should go green on rebase without changes of its own.

No `CHANGES.md` entry: build infrastructure only, nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
