### PR TITLE
Resolve registerDependencies output lazily so a custom build directory applies

### DIFF
--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+- `spotlessInternalRegisterDependencies` now writes its output under a build directory that is configured after the plugin is applied, instead of always under the default `build/`. ([#2114](https://github.com/diffplug/spotless/issues/2114))
 
 ## [8.10.0] - 2026-08-17
 ### Added

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/RegisterDependenciesTask.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -66,7 +67,8 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 		taskService = SpotlessTaskService.registerIfAbsent(getProject(), compositeBuildSuffix);
 		usesService(taskService);
 		getBuildEventsListenerRegistry().onTaskCompletion(taskService);
-		unitOutput = new File(getProject().getLayout().getBuildDirectory().getAsFile().get(), "tmp/spotless-register-dependencies");
+		// lazy, so a build directory set later in the buildscript still counts
+		getUnitOutput().set(getProject().getLayout().getBuildDirectory().file("tmp/spotless-register-dependencies"));
 	}
 
 	List<FormatterStep> steps = new ArrayList<>();
@@ -76,15 +78,12 @@ public abstract class RegisterDependenciesTask extends DefaultTask {
 		return steps;
 	}
 
-	File unitOutput;
-
 	@OutputFile
-	public File getUnitOutput() {
-		return unitOutput;
-	}
+	public abstract RegularFileProperty getUnitOutput();
 
 	@TaskAction
 	public void trivialFunction() throws IOException {
+		File unitOutput = getUnitOutput().get().getAsFile();
 		Files.createParentDirs(unitOutput);
 		Files.write(Integer.toString(1), unitOutput, StandardCharsets.UTF_8);
 	}

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskBuildDirTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/RegisterDependenciesTaskBuildDirTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.spotless;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RegisterDependenciesTaskBuildDirTest extends GradleIntegrationHarness {
+	@Test
+	void unitOutputFollowsCustomBuildDirectory() throws IOException {
+		setFile("settings.gradle").toLines(
+				"rootProject.name = 'buildDirTest'",
+				"include 'sub'");
+		setFile("build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"repositories { mavenCentral() }",
+				"spotless { predeclareDeps() }",
+				"",
+				"spotlessPredeclare {",
+				"    java { googleJavaFormat('1.17.0') }",
+				"}",
+				"",
+				"layout.buildDirectory = layout.projectDirectory.dir('custom-build')");
+		setFile("sub/build.gradle").toLines(
+				"plugins {",
+				"    id 'com.diffplug.spotless'",
+				"}",
+				"spotless {",
+				"    java {",
+				"        target 'src/main/java/**/*.java'",
+				"        googleJavaFormat('1.17.0')",
+				"    }",
+				"}");
+		setFile("sub/src/main/java/Hello.java").toLines(
+				"public class Hello {}");
+
+		gradleRunner().withArguments("spotlessApply").build();
+
+		Assertions.assertThat(newFile("custom-build/tmp/spotless-register-dependencies"))
+				.as("register-dependencies output should follow the configured build directory")
+				.exists();
+		Assertions.assertThat(newFile("build/tmp/spotless-register-dependencies"))
+				.as("nothing should be written under the default build directory")
+				.doesNotExist();
+	}
+}


### PR DESCRIPTION
Fixes #2114

`setup()` resolved the build directory eagerly and stored a plain `File` behind `@OutputFile`.
A `layout.buildDirectory` set later in the build script was therefore ignored. The marker file
stayed under the default `build/`.

`getUnitOutput()` is now a `RegularFileProperty` fed from `getBuildDirectory().file(...)`, so
it resolves at execution time. The field was only read inside this task, so nothing else
changes.

One note on the reproduction. On current `main` this task is only registered by
`SpotlessExtensionPredeclare`. The test therefore drives it through `spotlessPredeclare`, not
the plain `spotless { java {} }` from the original report. I could not reproduce it without
predeclare.