### PR TITLE
fix: drop --scripts-prepend-node-path from npm start

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- Prettier and other npm-based formatters no longer fail to start on npm 12 (`EUNKNOWNCONFIG` from `--scripts-prepend-node-path`). ([#3024](https://github.com/diffplug/spotless/issues/3024))
 
 ## [4.10.0] - 2026-08-17
 ### Added

--- a/lib/src/main/java/com/diffplug/spotless/npm/StandardNpmProcessFactory.java
+++ b/lib/src/main/java/com/diffplug/spotless/npm/StandardNpmProcessFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 DiffPlug
+ * Copyright 2023-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,10 +129,11 @@ public final class StandardNpmProcessFactory implements NpmProcessFactory {
 
 		@Override
 		protected List<String> commandLine() {
+			// npm 12 rejects --scripts-prepend-node-path (unknown CLI flag). Node is already
+			// on PATH via environmentVariables(), which is what that flag used to do.
 			return List.of(
 					npmExecutable(),
 					"start",
-					"--scripts-prepend-node-path=true",
 					"--",
 					"--node-server-instance-id=" + nodeServerInstanceId);
 		}

--- a/lib/src/test/java/com/diffplug/spotless/npm/StandardNpmProcessFactoryTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/npm/StandardNpmProcessFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.npm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class StandardNpmProcessFactoryTest {
+
+	@Test
+	void npmServeCommandLineOmitsRemovedScriptsPrependNodePathFlag(@TempDir Path tmp) {
+		File npm = tmp.resolve("npm").toFile();
+		File node = tmp.resolve("node").toFile();
+		File project = tmp.resolve("project").toFile();
+		File build = tmp.resolve("build").toFile();
+		project.mkdirs();
+		build.mkdirs();
+
+		NpmFormatterStepLocations locations = new NpmFormatterStepLocations(
+				project,
+				build,
+				null,
+				new NpmPathResolver(npm, node, null, List.of()));
+		NodeServerLayout layout = new NodeServerLayout(build, "{\"name\":\"spotless-prettier\"}", "console.log('hi');");
+		UUID serverId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+		NpmLongRunningProcess process = StandardNpmProcessFactory.INSTANCE.createNpmServeProcess(layout, locations, serverId);
+
+		assertThat(process.describe())
+				.contains("start")
+				.contains("--node-server-instance-id=" + serverId)
+				.doesNotContain("scripts-prepend-node-path");
+	}
+}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 ### Fixed
+- `prettier()` and other npm-based steps no longer fail to start on npm 12 (`EUNKNOWNCONFIG` from `--scripts-prepend-node-path`). ([#3024](https://github.com/diffplug/spotless/issues/3024))
 - `spotlessInternalRegisterDependencies` now writes its output under a build directory that is configured after the plugin is applied, instead of always under the default `build/`. ([#2114](https://github.com/diffplug/spotless/issues/2114))
 
 ## [8.10.0] - 2026-08-17

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- `<prettier>` and other npm-based steps no longer fail to start on npm 12 (`EUNKNOWNCONFIG` from `--scripts-prepend-node-path`). ([#3024](https://github.com/diffplug/spotless/issues/3024))
 
 ## [3.10.0] - 2026-08-17
 ### Added


### PR DESCRIPTION
## Fixes

Fixes #3024

## Changes and Review

`npm start` was launched with `--scripts-prepend-node-path=true`. npm 11 warns that this is an unknown CLI config; npm 12 fails with `EUNKNOWNCONFIG` and the prettier (and other npm-based) formatter server never starts.

Node is already prepended onto `PATH` in `environmentVariables()`, which is what that flag used to do. Drop the flag and keep `npm start -- --node-server-instance-id=...`.

## Test Plan

- [x] `./gradlew :lib:test --tests com.diffplug.spotless.npm.StandardNpmProcessFactoryTest` — RED then GREEN
- [x] `./gradlew :lib:test --tests 'com.diffplug.spotless.npm.*'` — 15/15 GREEN
- [x] `./gradlew :lib:spotlessJavaCheck` — GREEN

Please **DO NOT FORCE PUSH**. Don't worry about messy history.