### PR TITLE
shortenFullyQualifiedTypes: skip FQNs whose simple name clashes with types declared in the same file

### DIFF
--- a/lib/src/javaParser/java/com/diffplug/spotless/glue/javaparser/ShortenQualifiedTypesFormatterFunc.java
+++ b/lib/src/javaParser/java/com/diffplug/spotless/glue/javaparser/ShortenQualifiedTypesFormatterFunc.java
@@ -33,6 +33,9 @@ import com.github.javaparser.Position;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
@@ -77,7 +80,13 @@ public class ShortenQualifiedTypesFormatterFunc implements FormatterFunc {
 			existingImportsBySimple.put(simple, fqn);
 		}
 
-		// 3. Walk the AST to find outermost fully-qualified type nodes
+		// 3. Collect type names declared in this file (top-level + nested)
+		Set<String> declaredTypeNames = new LinkedHashSet<>();
+		cu.findAll(ClassOrInterfaceDeclaration.class).forEach(c -> declaredTypeNames.add(c.getNameAsString()));
+		cu.findAll(EnumDeclaration.class).forEach(c -> declaredTypeNames.add(c.getNameAsString()));
+		cu.findAll(RecordDeclaration.class).forEach(c -> declaredTypeNames.add(c.getNameAsString()));
+
+		// 4. Walk the AST to find outermost fully-qualified type nodes
 		Map<String, Set<String>> simpleToFqns = new LinkedHashMap<>();
 		List<QualifiedTypeRef> qualifiedRefs = new ArrayList<>();
 
@@ -87,7 +96,7 @@ public class ShortenQualifiedTypesFormatterFunc implements FormatterFunc {
 			return rawUnix;
 		}
 
-		// 4. Determine which FQNs are safe to shorten
+		// 5. Determine which FQNs are safe to shorten
 		Set<String> safeToShorten = new LinkedHashSet<>();
 		for (Map.Entry<String, Set<String>> entry : simpleToFqns.entrySet()) {
 			String simple = entry.getKey();
@@ -100,6 +109,10 @@ public class ShortenQualifiedTypesFormatterFunc implements FormatterFunc {
 			if (existing != null && !existing.equals(fqn)) {
 				continue;
 			}
+			// Skip if simple name clashes with a type declared in this file
+			if (declaredTypeNames.contains(simple)) {
+				continue;
+			}
 			safeToShorten.add(fqn);
 		}
 
@@ -107,7 +120,7 @@ public class ShortenQualifiedTypesFormatterFunc implements FormatterFunc {
 			return rawUnix;
 		}
 
-		// 5. Convert line/column positions to string offsets and replace
+		// 6. Convert line/column positions to string offsets and replace
 		// Build line-start offset table
 		int[] lineOffsets = buildLineOffsets(rawUnix);
 
@@ -134,7 +147,7 @@ public class ShortenQualifiedTypesFormatterFunc implements FormatterFunc {
 			sb.delete(removal[0], removal[1]);
 		}
 
-		// 6. Add missing imports
+		// 7. Add missing imports
 		Set<String> newImports = new TreeSet<>();
 		for (String fqn : safeToShorten) {
 			if (fqn.startsWith("java.lang.") && fqn.indexOf('.', 10) == -1) {

--- a/testlib/src/test/java/com/diffplug/spotless/java/ShortenFullyQualifiedTypesStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/java/ShortenFullyQualifiedTypesStepTest.java
@@ -302,6 +302,49 @@ class ShortenFullyQualifiedTypesStepTest {
 	}
 
 	@Test
+	void fqnCollisionWithEnclosingClassName() throws Exception {
+		// dev.jbang.cli.Alias intentionally uses dev.jbang.catalog.Alias as FQN
+		// because the simple name "Alias" would clash with the enclosing class
+		String code = String.join("\n",
+				"package dev.jbang.cli;",
+				"",
+				"public class Alias {",
+				"    dev.jbang.catalog.Alias catalogAlias;",
+				"}",
+				"");
+		assertEquals(code, apply(code));
+	}
+
+	@Test
+	void fqnCollisionWithInnerClassName() throws Exception {
+		// FQN whose simple name matches an inner class declared in the same file
+		String code = String.join("\n",
+				"package com.example;",
+				"",
+				"public class Outer {",
+				"    static class Conflict {}",
+				"    com.other.Conflict externalConflict;",
+				"}",
+				"");
+		assertEquals(code, apply(code));
+	}
+
+	@Test
+	void fqnNoCollisionWithDifferentSimpleName() throws Exception {
+		// FQN whose simple name does NOT match the enclosing class — should still shorten
+		String before = String.join("\n",
+				"package dev.jbang.cli;",
+				"",
+				"public class Alias {",
+				"    java.util.List<String> items;",
+				"}",
+				"");
+		String result = apply(before);
+		assertFalse(codeBody(result).contains("java.util.List"), "non-conflicting FQN should be shortened");
+		assertTrue(result.contains("import java.util.List;"), "should import List");
+	}
+
+	@Test
 	void multipleAnnotationsWithFqn() throws Exception {
 		// FQNs used as annotation types should NOT be treated as type references
 		// (annotations start with @, not handled by ClassOrInterfaceType)


### PR DESCRIPTION
Turns out my original PR missed a case that affects my own projects — ironic! 😅

In [jbang](https://github.com/jbangdev/jbang), several packages have classes with the same simple name (e.g. `dev.jbang.cli.Alias` and `dev.jbang.catalog.Alias`). The code intentionally uses FQNs to disambiguate, but `shortenFullyQualifiedTypes()` was happily replacing them with the short name and adding an import that fails with *"Alias is already defined in this compilation unit"*. Sorry about that!

**Fix:** Before deciding which FQNs are safe to shorten, collect all type names declared in the file (classes, interfaces, enums, records — including nested ones). Skip any FQN whose simple name appears in that set.

**Tests added:**
- `fqnCollisionWithEnclosingClassName` — the jbang scenario
- `fqnCollisionWithInnerClassName` — simple name matches a nested class
- `fqnNoCollisionWithDifferentSimpleName` — confirms non-conflicting FQNs still shorten