### PR TITLE
Resolve interopability with spotless, lombok and VSCode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- `FeatureClassLoader` now provides stub implementations of `lombok.*` classes (and synthesises empty classes for any others) so that the Eclipse JDT formatter step no longer fails with `NoClassDefFoundError` when lombok is active as a JVM agent (e.g. `-javaagent:lombok.jar` in Eclipse/VS Code/Cursor). ([#2795](https://github.com/diffplug/spotless/issues/2795))
 
 ## [4.10.1] - 2026-08-27
 ### Fixed

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,6 +21,7 @@ def NEEDS_GLUE = [
 	'javaParser',
 	'ktfmt',
 	'ktlint',
+	'lombokStubs',
 	'palantirJavaFormat',
 	'princeOfSpace',
 	'scalafmt',

--- a/lib/src/lombokStubs/java/lombok/core/FieldAugment.java
+++ b/lib/src/lombokStubs/java/lombok/core/FieldAugment.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lombok.core;
+
+/**
+ * Stub implementation of {@code lombok.core.FieldAugment} used only within the
+ * {@code FeatureClassLoader} isolation boundary.  The real FieldAugment is
+ * loaded by the lombok java-agent and is never reachable from Spotless's
+ * feature class-loader; this stub satisfies the static references that ECJ's
+ * patched classes make when lombok is active as a JVM agent.
+ *
+ * <p>{@link #augment} returns a no-op instance rather than {@code null} so that
+ * callers such as {@code EcjAugments} can safely call {@code .get()},
+ * {@code .set()}, etc. on the returned object without a {@link NullPointerException}.
+ */
+@SuppressWarnings("unused")
+public abstract class FieldAugment<T, F> {
+
+	/** Returns a non-null no-op augment so callers can safely invoke instance methods on it. */
+	@SuppressWarnings("unchecked")
+	public static <T, F> FieldAugment<T, F> augment(Class<T> type, Class<? super F> fieldType, String name) {
+		return (FieldAugment<T, F>) NoopFieldAugment.INSTANCE;
+	}
+
+	/** Returns a non-null no-op augment so callers can safely invoke instance methods on it. */
+	@SuppressWarnings("unchecked")
+	public static <T, F> FieldAugment<T, F> circularSafeAugment(Class<T> type, Class<? super F> fieldType, String name) {
+		return (FieldAugment<T, F>) NoopFieldAugment.INSTANCE;
+	}
+
+	public abstract F get(T object);
+
+	public abstract void set(T object, F value);
+
+	public abstract F getAndSet(T object, F value);
+
+	public abstract F clear(T object);
+
+	public abstract F compareAndClear(T object, F expected);
+
+	public abstract F setIfAbsent(T object, F value);
+
+	public abstract F compareAndSet(T object, F expected, F value);
+
+	/** Singleton no-op implementation returned by {@link #augment} and {@link #circularSafeAugment}. */
+	@SuppressWarnings("rawtypes")
+	private static final class NoopFieldAugment extends FieldAugment {
+		static final NoopFieldAugment INSTANCE = new NoopFieldAugment();
+
+		@Override
+		public Object get(Object object) {
+			return null;
+		}
+
+		@Override
+		public void set(Object object, Object value) {}
+
+		@Override
+		public Object getAndSet(Object object, Object value) {
+			return null;
+		}
+
+		@Override
+		public Object clear(Object object) {
+			return null;
+		}
+
+		@Override
+		public Object compareAndClear(Object object, Object expected) {
+			return null;
+		}
+
+		@Override
+		public Object setIfAbsent(Object object, Object value) {
+			return null;
+		}
+
+		@Override
+		public Object compareAndSet(Object object, Object expected, Object value) {
+			return null;
+		}
+	}
+}

--- a/lib/src/lombokStubs/java/lombok/eclipse/EcjAugments.java
+++ b/lib/src/lombokStubs/java/lombok/eclipse/EcjAugments.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lombok.eclipse;
+
+import lombok.core.FieldAugment;
+
+/**
+ * Stub implementation of {@code lombok.eclipse.EcjAugments} used only within
+ * the {@code FeatureClassLoader} isolation boundary.
+ *
+ * <p>Each field is initialised via {@link FieldAugment#augment} so that callers
+ * (such as ECJ's patched {@code ASTConverter}) can safely invoke instance
+ * methods like {@code .get()} and {@code .set()} on them without a
+ * {@link NullPointerException}.  The augment instances are no-ops that always
+ * return {@code null}.
+ */
+@SuppressWarnings({"unused", "rawtypes"})
+public final class EcjAugments {
+
+	private EcjAugments() {
+		// prevent instantiation
+	}
+
+	public static final FieldAugment ASTNode_generatedBy = FieldAugment.augment(Object.class, Object.class, "$generatedBy");
+	public static final FieldAugment ASTNode_handled = FieldAugment.augment(Object.class, boolean.class, "lombok$handled");
+	public static final FieldAugment ASTNode_tokens = FieldAugment.augment(Object.class, Object.class, "lombok$tokens");
+	public static final FieldAugment FieldDeclaration_booleanLazyGetter = FieldAugment.augment(Object.class, boolean.class, "lombok$booleanLazyGetter");
+	public static final FieldAugment Annotation_applied = FieldAugment.augment(Object.class, boolean.class, "lombok$applied");
+	public static final FieldAugment CompilationUnit_javadoc = FieldAugment.augment(Object.class, Object.class, "$javadoc");
+	public static final FieldAugment CompilationUnitDeclaration_transformationState = FieldAugment.augment(Object.class, Object.class, "$transformationState");
+
+	/** Stub inner class mirroring {@code EcjAugments.EclipseAugments}. */
+	public static final class EclipseAugments {
+		private EclipseAugments() {}
+
+		public static final FieldAugment CompilationUnit_delegateMethods = FieldAugment.augment(Object.class, Object.class, "$delegateMethods");
+	}
+}

--- a/lib/src/lombokStubs/java/lombok/launch/PatchFixesHider.java
+++ b/lib/src/lombokStubs/java/lombok/launch/PatchFixesHider.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lombok.launch;
+
+/**
+ * Stub implementation of {@code lombok.launch.PatchFixesHider} used only
+ * within the {@code FeatureClassLoader} isolation boundary.
+ *
+ * <p>When lombok is loaded as a JVM agent (e.g. {@code -javaagent:lombok.jar}),
+ * it patches ECJ's {@code Parser} class so that its static initializer
+ * references inner classes of {@code PatchFixesHider} such as
+ * {@code ModuleClassLoading} and {@code Transform}.  Spotless's
+ * {@code FeatureClassLoader} isolates formatter JARs from the build-tool
+ * class-loader, so it cannot see the real {@code PatchFixesHider} that was
+ * injected by the agent.  Loading this stub instead allows ECJ's
+ * {@code Parser.<clinit>} to complete without a {@link NoClassDefFoundError}.
+ *
+ * <p>Every method in every inner class is a no-op stub.  No real formatting
+ * logic lives here.
+ */
+@SuppressWarnings("unused")
+final class PatchFixesHider {
+
+	private PatchFixesHider() {}
+
+	/** Stub for {@code PatchFixesHider.ModuleClassLoading}. */
+	public static final class ModuleClassLoading {
+		private ModuleClassLoading() {}
+
+		/** Stub – performs no class-loader manipulation. */
+		public static void parserClinit() {
+			// no-op stub
+		}
+	}
+
+	/** Stub for {@code PatchFixesHider.Transform}. */
+	public static final class Transform {
+		private Transform() {}
+
+		/** Stub – performs no AST transformation. */
+		public static void transform(Object parser, Object ast) {
+			// no-op stub
+		}
+
+		/** Stub – performs no AST transformation. */
+		public static void transform_swapped(Object ast, Object parser) {
+			// no-op stub
+		}
+	}
+
+	/** Stub for {@code PatchFixesHider.PatchFixes}. */
+	public static final class PatchFixes {
+		private PatchFixes() {}
+
+		/** Stub – always returns {@code false}. */
+		public static boolean isGenerated(Object node) {
+			return false;
+		}
+
+		/** Stub – always returns {@code false}. */
+		public static boolean returnFalse(Object object) {
+			return false;
+		}
+
+		/** Stub – always returns {@code true}. */
+		public static boolean returnTrue(Object object) {
+			return true;
+		}
+
+		/** Stub – always returns {@code false}. */
+		public static boolean isBlockedVisitorAndGenerated(Object node, Object visitor) {
+			return false;
+		}
+
+		/** Stub – returns 0-length array. */
+		public static Object[] listRewriteHandleGeneratedMethods(Object rewriteEvent) {
+			return new Object[0];
+		}
+
+		/** Stub – returns {@code sourceEnd} unchanged. */
+		public static int getSourceEndFixed(int sourceEnd, Object node) {
+			return sourceEnd;
+		}
+
+		/** Stub – returns {@code original} unchanged. */
+		public static int fixRetrieveStartingCatchPosition(int original, int start) {
+			return original == -1 ? start : original;
+		}
+
+		/** Stub – returns {@code original} unchanged. */
+		public static int fixRetrieveRightBraceOrSemiColonPosition(int original, int end) {
+			return original == -1 ? end : original;
+		}
+	}
+
+	/** Stub for {@code PatchFixesHider.ValPortal}. */
+	public static final class ValPortal {
+		private ValPortal() {}
+
+		/** Stub – no-op. */
+		public static void copyInitializationOfForEachIterable(Object parser) {}
+
+		/** Stub – no-op. */
+		public static void copyInitializationOfLocalDeclaration(Object parser) {}
+
+		/** Stub – no-op. */
+		public static void addFinalAndValAnnotationToVariableDeclarationStatement(Object converter, Object out, Object in) {}
+
+		/** Stub – no-op. */
+		public static void addFinalAndValAnnotationToSingleVariableDeclaration(Object converter, Object out, Object in) {}
+	}
+
+	/** Stub for {@code PatchFixesHider.Val}. */
+	public static final class Val {
+		private Val() {}
+
+		/** Stub – always returns {@code false}. */
+		public static boolean handleValForLocalDeclaration(Object local, Object scope) {
+			return false;
+		}
+
+		/** Stub – always returns {@code false}. */
+		public static boolean handleValForForEach(Object forEach, Object scope) {
+			return false;
+		}
+	}
+
+	/** Stub for {@code PatchFixesHider.ExtensionMethod}. */
+	public static final class ExtensionMethod {
+		private ExtensionMethod() {}
+
+		/** Stub – returns {@code resolvedType} unchanged. */
+		public static Object resolveType(Object resolvedType, Object methodCall, Object scope) {
+			return resolvedType;
+		}
+
+		/** Stub – no-op. */
+		public static void errorNoMethodFor(Object problemReporter, Object messageSend, Object recType, Object params) {}
+
+		/** Stub – no-op. */
+		public static void invalidMethod(Object problemReporter, Object messageSend, Object method) {}
+
+		/** Stub – no-op. */
+		public static void invalidMethod(Object problemReporter, Object messageSend, Object method, Object scope) {}
+
+		/** Stub – no-op. */
+		public static void nonStaticAccessToStaticMethod(Object problemReporter, Object location, Object method, Object messageSend) {}
+
+		/** Stub – returns {@code original} unchanged. */
+		public static Object modifyMethodPattern(Object original) {
+			return original;
+		}
+	}
+
+	/** Stub for {@code PatchFixesHider.Delegate}. */
+	public static final class Delegate {
+		private Delegate() {}
+
+		/** Stub – always returns {@code false}. */
+		public static boolean handleDelegateForType(Object classScope) {
+			return false;
+		}
+
+		/** Stub – returns an empty array. */
+		public static Object[] addGeneratedDelegateMethods(Object returnValue, Object javaElement) {
+			return new Object[0];
+		}
+
+		/** Stub – always returns {@code false}. */
+		public static boolean isDelegateSourceMethod(Object sourceMethod) {
+			return false;
+		}
+
+		/** Stub – always returns {@code null}. */
+		public static Object returnElementInfo(Object delegateSourceMethod) {
+			return null;
+		}
+	}
+
+	/** Stub for {@code PatchFixesHider.Util}. */
+	public static final class Util {
+		private Util() {}
+	}
+
+	/** Stub for {@code PatchFixesHider.LombokDeps}. */
+	public static final class LombokDeps {
+		private LombokDeps() {}
+	}
+
+	/** Stub for {@code PatchFixesHider.Javadoc}. */
+	public static final class Javadoc {
+		private Javadoc() {}
+
+		/** Stub – returns {@code original} unchanged. */
+		public static String getHTMLContentFromSource(String original, Object member) {
+			return original;
+		}
+	}
+}

--- a/lib/src/lombokStubs/java/lombok/patcher/Symbols.java
+++ b/lib/src/lombokStubs/java/lombok/patcher/Symbols.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lombok.patcher;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Stub implementation of {@code lombok.patcher.Symbols} used only within the
+ * {@code FeatureClassLoader} isolation boundary.
+ *
+ * <p>When lombok is active as a JVM agent it patches ECJ's
+ * {@code DefaultCodeFormatter} (and related classes) to call methods on
+ * {@code lombok.patcher.Symbols}.  That class lives inside the lombok jar
+ * under a shadow class-loader prefix ({@code SCL.lombok/}) and is never
+ * reachable as a normal class from {@code FeatureClassLoader}.  This stub
+ * satisfies the reference so that ECJ's patched code can load without a
+ * {@link NoClassDefFoundError}.  Every method is a safe no-op.
+ */
+@SuppressWarnings("unused")
+public class Symbols {
+
+	private Symbols() {}
+
+	/** Stub – no-op. */
+	public static void push(String symbol) {}
+
+	/** Stub – no-op. */
+	public static void pop() {}
+
+	/** Stub – always returns {@code true} (no symbols active). */
+	public static boolean isEmpty() {
+		return true;
+	}
+
+	/** Stub – always returns {@code 0}. */
+	public static int size() {
+		return 0;
+	}
+
+	/** Stub – always returns {@code false}. */
+	public static boolean hasSymbol(String symbol) {
+		return false;
+	}
+
+	/** Stub – always returns {@code false}. */
+	public static boolean hasTail(String symbol) {
+		return false;
+	}
+
+	/** Stub – always returns an empty list. */
+	public static List<String> getCopy() {
+		return Collections.emptyList();
+	}
+}

--- a/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
+++ b/lib/src/main/java/com/diffplug/spotless/FeatureClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 DiffPlug
+ * Copyright 2016-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 package com.diffplug.spotless;
 
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.ProtectionDomain;
 import java.util.Objects;
 
@@ -73,6 +75,34 @@ class FeatureClassLoader extends URLClassLoader {
 			} catch (IOException e) {
 				throw new ClassNotFoundException(name, e);
 			}
+		} else if (name.startsWith("lombok.")) {
+			// When lombok is active as a JVM agent it patches ECJ classes (Parser,
+			// ASTConverter, DefaultCodeFormatter, etc.) to reference lombok.* classes
+			// that live in lombok's shadow class-loader (SCL.lombok/) and are never
+			// reachable from this isolated FeatureClassLoader.
+			//
+			// Strategy:
+			//  1. Serve a hand-written stub if one is bundled in the lib jar
+			//     (covers FieldAugment, EcjAugments, PatchFixesHider, Symbols, ...).
+			//  2. Otherwise synthesise a minimal empty public class on the fly so that
+			//     ECJ's patched static initialisers can complete without
+			//     NoClassDefFoundError.  The synthesised class has no fields or methods
+			//     and performs no work; it purely satisfies the JVM's class-loading.
+			String path = name.replace('.', '/') + ".class";
+			URL url = findResource(path);
+			if (url != null) {
+				try {
+					return defineClass(name, urlToByteBuffer(url), (ProtectionDomain) null);
+				} catch (IOException e) {
+					throw new ClassNotFoundException(name, e);
+				}
+			}
+			// No bundled stub – synthesise a minimal empty class.
+			try {
+				return defineClass(name, ByteBuffer.wrap(synthesiseEmptyClass(name)), (ProtectionDomain) null);
+			} catch (IOException e) {
+				throw new ClassNotFoundException(name, e);
+			}
 		} else if (useBuildToolClassLoader(name)) {
 			return buildToolClassLoader.loadClass(name);
 		} else {
@@ -97,6 +127,132 @@ class FeatureClassLoader extends URLClassLoader {
 			return resource;
 		}
 		return buildToolClassLoader.getResource(name);
+	}
+
+	/**
+	 * Synthesises a minimal valid class file for a public class with the given
+	 * binary name, no superclass fields or methods beyond the default constructor
+	 * inherited from {@link Object}.  The result satisfies the JVM class-loader
+	 * contract so that references to the class can be resolved without a
+	 * {@link NoClassDefFoundError}, even though the class does nothing.
+	 *
+	 * <p>The bytecode is hand-assembled following the Java Virtual Machine
+	 * Specification §4 (class file format).  It requires no external libraries.
+	 */
+	private static byte[] synthesiseEmptyClass(String binaryName) throws IOException {
+		// Internal name uses '/' as separator; e.g. "lombok/eclipse/agent/PatchDiagnostics"
+		String internalName = binaryName.replace('.', '/');
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream(256);
+		DataOutputStream out = new DataOutputStream(baos);
+
+		// ---- Constant pool ----
+		// We need:
+		//  #1  Class_info  → #2   (this class)
+		//  #2  Utf8        internalName
+		//  #3  Class_info  → #4   (superclass: java/lang/Object)
+		//  #4  Utf8        "java/lang/Object"
+		//  #5  Utf8        "Code"       (attribute name used by <init>)
+		//  #6  Utf8        "<init>"
+		//  #7  Utf8        "()V"
+		//  #8  MethodRef   → #3, #9
+		//  #9  NameAndType → #6, #7
+		int constantPoolCount = 10; // indices 1..9
+
+		// magic
+		out.writeInt(0xCAFEBABE);
+		// minor version, major version (52 = Java 8, safe floor for --release 17 output)
+		out.writeShort(0);
+		out.writeShort(52);
+		// constant pool count (number of entries + 1)
+		out.writeShort(constantPoolCount);
+
+		// #1 CONSTANT_Class → #2
+		out.writeByte(7);
+		out.writeShort(2);
+		// #2 CONSTANT_Utf8  internalName
+		out.writeByte(1);
+		writeUtf8(out, internalName);
+		// #3 CONSTANT_Class → #4
+		out.writeByte(7);
+		out.writeShort(4);
+		// #4 CONSTANT_Utf8  "java/lang/Object"
+		out.writeByte(1);
+		writeUtf8(out, "java/lang/Object");
+		// #5 CONSTANT_Utf8  "Code"
+		out.writeByte(1);
+		writeUtf8(out, "Code");
+		// #6 CONSTANT_Utf8  "<init>"
+		out.writeByte(1);
+		writeUtf8(out, "<init>");
+		// #7 CONSTANT_Utf8  "()V"
+		out.writeByte(1);
+		writeUtf8(out, "()V");
+		// #8 CONSTANT_Methodref → class=#3, nameAndType=#9
+		out.writeByte(10);
+		out.writeShort(3);
+		out.writeShort(9);
+		// #9 CONSTANT_NameAndType → name=#6, descriptor=#7
+		out.writeByte(12);
+		out.writeShort(6);
+		out.writeShort(7);
+
+		// ---- Class declaration ----
+		// access flags: ACC_PUBLIC | ACC_SUPER
+		out.writeShort(0x0021);
+		// this_class = #1
+		out.writeShort(1);
+		// super_class = #3
+		out.writeShort(3);
+		// interfaces count
+		out.writeShort(0);
+		// fields count
+		out.writeShort(0);
+		// methods count: one method (<init>)
+		out.writeShort(1);
+
+		// ---- <init>()V method ----
+		// access: ACC_PUBLIC
+		out.writeShort(0x0001);
+		// name_index = #6 "<init>"
+		out.writeShort(6);
+		// descriptor_index = #7 "()V"
+		out.writeShort(7);
+		// attributes count: 1 (Code)
+		out.writeShort(1);
+
+		// Code attribute
+		// attribute_name_index = #5 "Code"
+		out.writeShort(5);
+		// attribute_length: max_stack(2) + max_locals(2) + code_length(4) + code(5) + exception_table_length(2) + attributes_count(2) = 17
+		out.writeInt(17);
+		// max_stack
+		out.writeShort(1);
+		// max_locals
+		out.writeShort(1);
+		// code_length
+		out.writeInt(5);
+		// aload_0, invokespecial #8, return
+		out.writeByte(0x2A); // aload_0
+		out.writeByte(0xB7); // invokespecial
+		out.writeShort(8);   // → #8 Object.<init>
+		out.writeByte(0xB1); // return
+		// exception_table_length
+		out.writeShort(0);
+		// attributes_count (for Code attribute)
+		out.writeShort(0);
+
+		// ---- Class attributes ----
+		out.writeShort(0);
+
+		out.flush();
+		return baos.toByteArray();
+	}
+
+	private static void writeUtf8(DataOutputStream out, String s) throws IOException {
+		byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+		out.writeShort(bytes.length);
+		out.write(bytes);
 	}
 
 	private static ByteBuffer urlToByteBuffer(URL url) throws IOException {

--- a/lib/src/test/java/com/diffplug/spotless/FeatureClassLoaderLombokStubsTest.java
+++ b/lib/src/test/java/com/diffplug/spotless/FeatureClassLoaderLombokStubsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link FeatureClassLoader} resolves the bundled lombok stubs
+ * for the three class families that ECJ references when lombok is active as a
+ * JVM agent.
+ *
+ * <p>The tests instantiate a {@code FeatureClassLoader} with an empty URL array
+ * (no feature JARs) and confirm that each stubbed class can be loaded and has
+ * the expected members so that ECJ's static initializers can complete without
+ * a {@link NoClassDefFoundError}.
+ */
+class FeatureClassLoaderLombokStubsTest {
+
+	private FeatureClassLoader loader;
+
+	@BeforeEach
+	void setUp() {
+		// Empty URL array – we only need the stubs that are bundled in the lib jar itself.
+		loader = new FeatureClassLoader(new URL[0], FeatureClassLoaderLombokStubsTest.class.getClassLoader());
+	}
+
+	// -------------------------------------------------------------------------
+	// lombok.core.FieldAugment
+	// -------------------------------------------------------------------------
+
+	@Test
+	void fieldAugment_canBeLoaded() throws ClassNotFoundException {
+		Class<?> clazz = loader.loadClass("lombok.core.FieldAugment");
+		assertThat(clazz).isNotNull();
+	}
+
+	@Test
+	void fieldAugment_augmentMethodExists() throws Exception {
+		Class<?> clazz = loader.loadClass("lombok.core.FieldAugment");
+		Method augment = clazz.getMethod("augment", Class.class, Class.class, String.class);
+		assertThat(Modifier.isStatic(augment.getModifiers())).isTrue();
+		// Must return a non-null instance so callers can safely invoke .get() etc.
+		assertThat(augment.invoke(null, String.class, String.class, "x")).isNotNull();
+	}
+
+	// -------------------------------------------------------------------------
+	// lombok.eclipse.EcjAugments
+	// -------------------------------------------------------------------------
+
+	@Test
+	void ecjAugments_canBeLoaded() throws ClassNotFoundException {
+		Class<?> clazz = loader.loadClass("lombok.eclipse.EcjAugments");
+		assertThat(clazz).isNotNull();
+	}
+
+	@Test
+	void ecjAugments_astNodeGeneratedByFieldExists() throws Exception {
+		Class<?> clazz = loader.loadClass("lombok.eclipse.EcjAugments");
+		Field field = clazz.getField("ASTNode_generatedBy");
+		assertThat(Modifier.isStatic(field.getModifiers())).isTrue();
+		// Must be non-null so ECJ's patched ASTConverter can call .get() on it without NPE.
+		assertThat(field.get(null)).isNotNull();
+	}
+
+	@Test
+	void ecjAugments_innerClassEclipseAugmentsExists() throws ClassNotFoundException {
+		assertThatNoException().isThrownBy(() -> loader.loadClass("lombok.eclipse.EcjAugments$EclipseAugments"));
+	}
+
+	// -------------------------------------------------------------------------
+	// lombok.launch.PatchFixesHider and inner classes
+	// -------------------------------------------------------------------------
+
+	@Test
+	void patchFixesHider_moduleClassLoadingCanBeLoaded() throws ClassNotFoundException {
+		Class<?> clazz = loader.loadClass("lombok.launch.PatchFixesHider$ModuleClassLoading");
+		assertThat(clazz).isNotNull();
+	}
+
+	@Test
+	void patchFixesHider_moduleClassLoading_parserClinitIsCallable() throws Exception {
+		Class<?> clazz = loader.loadClass("lombok.launch.PatchFixesHider$ModuleClassLoading");
+		Method m = clazz.getMethod("parserClinit");
+		assertThat(Modifier.isStatic(m.getModifiers())).isTrue();
+		// Must not throw – this is what ECJ's Parser.<clinit> calls.
+		assertThatNoException().isThrownBy(() -> m.invoke(null));
+	}
+
+	@Test
+	void patchFixesHider_transformCanBeLoaded() throws ClassNotFoundException {
+		assertThatNoException().isThrownBy(() -> loader.loadClass("lombok.launch.PatchFixesHider$Transform"));
+	}
+
+	@Test
+	void patchFixesHider_patchFixesCanBeLoaded() throws ClassNotFoundException {
+		assertThatNoException().isThrownBy(() -> loader.loadClass("lombok.launch.PatchFixesHider$PatchFixes"));
+	}
+
+	// -------------------------------------------------------------------------
+	// synthesiseEmptyClass fallback (no bundled stub available)
+	// -------------------------------------------------------------------------
+
+	@Test
+	void unknownLombokClass_isSynthesisedAsEmptyClass() throws ClassNotFoundException {
+		// PatchDiagnostics has no hand-written stub; the loader must synthesise one.
+		Class<?> clazz = loader.loadClass("lombok.eclipse.agent.PatchDiagnostics");
+		assertThat(clazz).isNotNull();
+		assertThat(clazz.getName()).isEqualTo("lombok.eclipse.agent.PatchDiagnostics");
+		// Synthesised class extends Object and declares no methods beyond <init>.
+		assertThat(clazz.getSuperclass()).isEqualTo(Object.class);
+		assertThat(clazz.getDeclaredMethods()).isEmpty();
+	}
+
+	@Test
+	void unknownLombokClass_canBeInstantiated() throws Exception {
+		Class<?> clazz = loader.loadClass("lombok.eclipse.agent.PatchDiagnostics");
+		// The synthesised class has a default public <init>; instantiation must succeed.
+		assertThatNoException().isThrownBy(() -> clazz.getDeclaredConstructor().newInstance());
+	}
+}

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Fixed
+- Eclipse JDT formatter step no longer fails with `NoClassDefFoundError` when lombok is active as a JVM agent (e.g. `-javaagent:lombok.jar` in Eclipse/VS Code/Cursor). ([#2795](https://github.com/diffplug/spotless/issues/2795))
 
 ## [8.10.1] - 2026-08-27
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Fixed
+- Eclipse JDT formatter step no longer fails with `NoClassDefFoundError` when lombok is active as a JVM agent (e.g. `-javaagent:lombok.jar` in Eclipse/VS Code/Cursor). ([#2795](https://github.com/diffplug/spotless/issues/2795))
 
 ## [3.10.1] - 2026-08-27
 ### Fixed


### PR DESCRIPTION
Please **DO NOT FORCE PUSH**. Don't worry about messy history, it's easier to do code review if we can tell what happened after the review, and force pushing breaks that.

Please make sure that your [PR allows edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).  Sometimes it's faster for us to just fix something than it is to describe how to fix it.

<img src="https://docs.github.com/assets/cb-87454/images/help/pull_requests/allow-edits-and-access-by-maintainers.png" height="297" alt="Allow edits from maintainers">

After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:

- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)

---

This fixes #2795 by reimplementing #2796 without byte-buddy. I have tested it locally in vscode and now I don't get spotless issues any more. Unfortunately without bytebuddy or JDK 24 the fix is considerably larger. 
