### PR TITLE
Allow passing args for git hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ This document is intended for Spotless developers.
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+- `GitPrePushHookInstaller` now accepts extra executor arguments that are inserted before the Spotless goals in the generated pre-push hook (e.g. `-T1C` for Maven or `--parallel` for Gradle).
 
 ## [4.10.2] - 2026-09-04
 ### Fixed

--- a/gradle/changelog.gradle
+++ b/gradle/changelog.gradle
@@ -29,9 +29,9 @@ spotlessChangelog {
 if (project == rootProject) {
 	gradle.taskGraph.whenReady { taskGraph ->
 		def changelogPushTasks = taskGraph.allTasks.stream()
-		.filter { t -> t.name == 'changelogPush' }
-		.map { t -> t.path }
-		.toList()
+				.filter { t -> t.name == 'changelogPush' }
+				.map { t -> t.path }
+				.toList()
 		if (changelogPushTasks.size() > 1) {
 			// make sure only one changelog gets published per tag/commit
 			throw new IllegalArgumentException("Run changelogPush one at a time:\n" + changelogPushTasks.join('\n'))

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 DiffPlug
+ * Copyright 2025-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,14 +52,31 @@ public abstract class GitPrePushHookInstaller {
 	protected final File root;
 
 	/**
+	 * The extra arguments inserted before the Spotless goals in the generated hook.
+	 */
+	protected final String args;
+
+	/**
 	 * Constructor to initialize the GitPrePushHookInstaller with a logger and repository root path.
 	 *
 	 * @param logger The logger for recording messages.
 	 * @param root   The root directory of the Git repository.
 	 */
 	protected GitPrePushHookInstaller(GitPreHookLogger logger, File root) {
+		this(logger, root, "");
+	}
+
+	/**
+	 * Constructor to initialize the GitPrePushHookInstaller with a logger, repository root path and extra executor arguments.
+	 *
+	 * @param logger The logger for recording messages.
+	 * @param root   The root directory of the Git repository.
+	 * @param args   The extra arguments inserted before the Spotless goals in the generated hook.
+	 */
+	protected GitPrePushHookInstaller(GitPreHookLogger logger, File root, String args) {
 		this.logger = requireNonNull(logger, "logger can not be null");
 		this.root = requireNonNull(root, "root file can not be null");
+		this.args = args == null ? "" : args.trim();
 	}
 
 	/**
@@ -240,12 +257,14 @@ public abstract class GitPrePushHookInstaller {
 	protected String preHookTemplate(Executor executor, String commandCheck, String commandApply) {
 		var spotlessHook = "";
 
+		final var argsPrefix = args.isEmpty() ? "" : args + " ";
+
 		spotlessHook += "\n";
 		spotlessHook += "\n" + HOOK_HEADER;
 		spotlessHook += "\nSPOTLESS_EXECUTOR=" + executorPath(executor);
-		spotlessHook += "\nif ! $SPOTLESS_EXECUTOR " + commandCheck + " ; then";
+		spotlessHook += "\nif ! $SPOTLESS_EXECUTOR " + argsPrefix + commandCheck + " ; then";
 		spotlessHook += "\n    echo 1>&2 \"spotless found problems, running " + commandApply + "; commit the result and re-push\"";
-		spotlessHook += "\n    $SPOTLESS_EXECUTOR " + commandApply;
+		spotlessHook += "\n    $SPOTLESS_EXECUTOR " + argsPrefix + commandApply;
 		spotlessHook += "\n    exit 1";
 		spotlessHook += "\nfi";
 		spotlessHook += "\n" + HOOK_FOOTER;

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerGradle.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerGradle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 DiffPlug
+ * Copyright 2025-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@ public class GitPrePushHookInstallerGradle extends GitPrePushHookInstaller {
 
 	public GitPrePushHookInstallerGradle(GitPreHookLogger logger, File root) {
 		super(logger, root);
+	}
+
+	public GitPrePushHookInstallerGradle(GitPreHookLogger logger, File root, String args) {
+		super(logger, root, args);
 	}
 
 	/**

--- a/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerMaven.java
+++ b/lib/src/main/java/com/diffplug/spotless/GitPrePushHookInstallerMaven.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 DiffPlug
+ * Copyright 2025-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@ public class GitPrePushHookInstallerMaven extends GitPrePushHookInstaller {
 
 	public GitPrePushHookInstallerMaven(GitPreHookLogger logger, File root) {
 		super(logger, root);
+	}
+
+	public GitPrePushHookInstallerMaven(GitPreHookLogger logger, File root, String args) {
+		super(logger, root, args);
 	}
 
 	/**

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `3.27.0`).
 
 ## [Unreleased]
+### Added
+- `spotlessInstallGitPrePushHook` accepts a new `spotless.hook.args` project property, inserted before the Spotless tasks in the generated hook so the hook can run e.g. in parallel: `./gradlew spotlessInstallGitPrePushHook -Pspotless.hook.args=--parallel`.
 
 ## [8.10.2] - 2026-09-04
 ### Fixed

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessExtensionImpl.java
@@ -44,6 +44,9 @@ public class SpotlessExtensionImpl extends SpotlessExtension {
 			task.setDescription(INSTALL_GIT_PRE_PUSH_HOOK_DESCRIPTION);
 			task.getRootDir().set(project.getRootDir());
 			task.getIsRootExecution().set(project.equals(project.getRootProject()));
+			if (project.hasProperty("spotless.hook.args")) {
+				task.getArgs().set(String.valueOf(project.property("spotless.hook.args")));
+			}
 		});
 
 		project.afterEvaluate(unused -> {

--- a/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessInstallPrePushHookTask.java
+++ b/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/SpotlessInstallPrePushHookTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 DiffPlug
+ * Copyright 2025-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,12 @@ public abstract class SpotlessInstallPrePushHookTask extends DefaultTask {
 	abstract Property<Boolean> getIsRootExecution();
 
 	/**
+	 * The extra arguments inserted before the Spotless tasks in the generated pre-push hook.
+	 */
+	@Internal
+	abstract Property<String> getArgs();
+
+	/**
 	 * Executes the task to install the Git pre-push hook.
 	 *
 	 * <p>This method creates an instance of {@link GitPrePushHookInstallerGradle},
@@ -79,7 +85,7 @@ public abstract class SpotlessInstallPrePushHookTask extends DefaultTask {
 			}
 		};
 
-		final var installer = new GitPrePushHookInstallerGradle(logger, getRootDir().get());
+		final var installer = new GitPrePushHookInstallerGradle(logger, getRootDir().get(), getArgs().getOrElse(""));
 		installer.install();
 	}
 }

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (starting after version `1.27.0`).
 
 ## [Unreleased]
+### Added
+- `install-git-pre-push-hook` accepts a new `spotless.hook.args` argument, inserted before the Spotless goals in the generated hook so the hook can run e.g. in parallel: `mvn spotless:install-git-pre-push-hook -Dspotless.hook.args=-T1C`.
 
 ## [3.10.2] - 2026-09-04
 ### Fixed

--- a/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojo.java
+++ b/plugin-maven/src/main/java/com/diffplug/spotless/maven/SpotlessInstallPrePushHookMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 DiffPlug
+ * Copyright 2025-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,12 @@ public class SpotlessInstallPrePushHookMojo extends AbstractMojo {
 	private MavenProject project;
 
 	/**
+	 * The extra arguments inserted before the Spotless goals in the generated pre-push hook.
+	 */
+	@Parameter(property = "spotless.hook.args", defaultValue = "")
+	private String hookArgs;
+
+	/**
 	 * Executes the Mojo, installing the Git pre-push hook for the Spotless plugin.
 	 *
 	 * <p>This method creates an instance of {@link GitPrePushHookInstallerMaven},
@@ -75,7 +81,7 @@ public class SpotlessInstallPrePushHookMojo extends AbstractMojo {
 		};
 
 		try {
-			final var installer = new GitPrePushHookInstallerMaven(logger, project.getBasedir());
+			final var installer = new GitPrePushHookInstallerMaven(logger, project.getBasedir(), hookArgs);
 			installer.install();
 		} catch (Exception e) {
 			throw new MojoExecutionException("Unable to install pre-push hook", e);

--- a/testlib/src/main/resources/git_pre_hook/pre-push.created-args-tpl
+++ b/testlib/src/main/resources/git_pre_hook/pre-push.created-args-tpl
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+
+##### SPOTLESS HOOK START #####
+SPOTLESS_EXECUTOR=${executor}
+if ! $SPOTLESS_EXECUTOR ${args} ${checkCommand} ; then
+    echo 1>&2 "spotless found problems, running ${applyCommand}; commit the result and re-push"
+    $SPOTLESS_EXECUTOR ${args} ${applyCommand}
+    exit 1
+fi
+##### SPOTLESS HOOK END #####

--- a/testlib/src/test/java/com/diffplug/spotless/GitPrePushHookInstallerTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/GitPrePushHookInstallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 DiffPlug
+ * Copyright 2025-2026 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -229,6 +229,41 @@ class GitPrePushHookInstallerTest extends ResourceHarness {
 	}
 
 	@Test
+	public void should_include_extra_args_in_maven_hook_when_provided() throws Exception {
+		// given
+		final var maven = new GitPrePushHookInstallerMaven(logger, rootFolder(), "-T1C");
+		setFile("mvnw").toContent("");
+		setFile(".git/config").toContent("");
+
+		// when
+		maven.install();
+
+		// then
+		assertThat(logs).containsExactly(
+				"Installing git pre-push hook",
+				"Git pre-push hook not found, creating it",
+				"Git pre-push hook installed successfully to the file " + newFile(".git/hooks/pre-push").getAbsolutePath());
+
+		final var content = mavenHookContentWithArgs("git_pre_hook/pre-push.created-args-tpl", ExecutorType.WRAPPER, "-T1C");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	@Test
+	public void should_include_extra_args_in_gradle_hook_when_provided() throws Exception {
+		// given
+		final var gradle = new GitPrePushHookInstallerGradle(logger, rootFolder(), "--parallel");
+		setFile("gradlew").toContent("");
+		setFile(".git/config").toContent("");
+
+		// when
+		gradle.install();
+
+		// then
+		final var content = gradleHookContentWithArgs("git_pre_hook/pre-push.created-args-tpl", ExecutorType.WRAPPER, "--parallel");
+		assertFile(".git/hooks/pre-push").hasContent(content);
+	}
+
+	@Test
 	public void should_use_global_maven_when_maven_wrapper_is_not_installed() throws Exception {
 		// given
 		final var gradle = new GitPrePushHookInstallerMaven(logger, rootFolder());
@@ -377,6 +412,14 @@ class GitPrePushHookInstallerTest extends ResourceHarness {
 				.replace("${executor}", executorType == ExecutorType.WRAPPER ? fileAbsolutePath(newFile("mvnw")) : "mvn")
 				.replace("${checkCommand}", "spotless:check")
 				.replace("${applyCommand}", "spotless:apply");
+	}
+
+	private String mavenHookContentWithArgs(String resourcePath, ExecutorType executorType, String args) {
+		return mavenHookContent(resourcePath, executorType).replace("${args}", args);
+	}
+
+	private String gradleHookContentWithArgs(String resourcePath, ExecutorType executorType, String args) {
+		return gradleHookContent(resourcePath, executorType).replace("${args}", args);
 	}
 
 	private String fileAbsolutePath(File file) {


### PR DESCRIPTION
The problem with current git hook installation is that it runs spotless in single thread
For multi module projects it might take 30-40 sec and more

To speed this up better to use `-T1C` or something similar

current version does not allow this
of course could be edited manually, however in case of multiple people downloading sources and trying to contribute it is unreal

the PR to allow such configuration in pom