### PR TITLE
Fix version catalog data loss and string corruption from comments and quotes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `VersionCatalogStep` preserves entries when comments contain unmatched brackets, keeps line boundaries in multiline entries containing comments, and reports unfinished entries instead of returning a partial catalog.
+- `VersionCatalogStep` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, keeps significant line boundaries in multiline entries, and reports unfinished entries at their starting line instead of returning a partial catalog.
 
 ## [4.10.2] - 2026-09-04
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Fixed
+- `VersionCatalogStep` preserves entries when comments contain unmatched brackets, keeps line boundaries in multiline entries containing comments, and reports unfinished entries instead of returning a partial catalog.
+
 ## [4.10.2] - 2026-09-04
 ### Fixed
 - `ShortenFullyQualifiedTypesStep` now shortens fully-qualified types used in expression contexts (such as static method calls, static fields, and enum constants) while avoiding imports that would change how existing unqualified type references resolve. ([#3039](https://github.com/diffplug/spotless/pull/3039))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `VersionCatalogStep` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries.
-- `VersionCatalogStep` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss.
+- `VersionCatalogStep` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries. ([#3042](https://github.com/diffplug/spotless/pull/3042))
+- `VersionCatalogStep` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 
 ## [4.10.2] - 2026-09-04
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `VersionCatalogStep` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, keeps significant line boundaries in multiline entries, and reports unfinished entries at their starting line instead of returning a partial catalog.
+- `VersionCatalogStep` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries.
+- `VersionCatalogStep` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss.
 
 ## [4.10.2] - 2026-09-04
 ### Fixed

--- a/lib/src/main/java/com/diffplug/spotless/toml/TODO.md
+++ b/lib/src/main/java/com/diffplug/spotless/toml/TODO.md
@@ -11,6 +11,10 @@ Tracked issues found during review against the TOML v1.1.0 spec (https://toml.io
 - [x] Multi-line inline tables are not parsed correctly (split across lines and corrupted)
 - [x] Long lines can be split into multi-line inline tables (configurable `maxLineLength`)
 - [x] Short multi-line inline tables are joined into single lines when they fit
+- [x] Commas inside literal strings and triple-quoted strings are preserved by `splitTopLevel`
+- [x] Escaped backslashes before closing quotes no longer confuse `splitTopLevel`
+- [x] Single-line strings cannot consume following entries across a newline; unfinished
+      entries report a lint at their starting line instead of returning a partial catalog
 
 ## TODO — TOML spec edge cases
 
@@ -27,10 +31,9 @@ addressed for full TOML spec compliance.
       (`[section.subsection]`) and quoted table headers (`["quoted.key"]`).
       Their entries are silently dropped.
 
-### String handling in `splitTopLevel`
+### Scanner and formatting improvements
 
-- [ ] Single-quoted (literal) strings `'...'` are not recognized — commas or `=` inside
-      them will incorrectly split or match.
-- [ ] Multiline string delimiters (`"""`, `'''`) confuse the single-char quote toggle.
-- [ ] Double-backslash before closing quote (`"value\\"`) is misidentified as an escaped
-      quote. Needs odd/even backslash counting instead of single-char lookbehind.
+- [ ] Carry scanner state across lines instead of rescanning the accumulated multiline
+      entry after each line; the current approach is quadratic for long entries.
+- [ ] Normalize trailing whitespace outside strings in preserved multiline entries;
+      whitespace inside multiline strings must remain unchanged.

--- a/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.Lint;
 
 public final class VersionCatalogStep {
 	private VersionCatalogStep() {}
@@ -125,8 +126,11 @@ public final class VersionCatalogStep {
 		List<Entry> currentEntries = null;
 		List<String> pendingComments = new ArrayList<>();
 		StringBuilder multiLineAccumulator = null;
+		int lineNumber = 0;
+		int entryStartLine = 0;
 
 		for (String line : raw.split("\n", -1)) {
+			lineNumber++;
 			String trimmed = line.trim();
 
 			if (multiLineAccumulator != null) {
@@ -154,6 +158,7 @@ public final class VersionCatalogStep {
 					pendingComments.add(trimmed);
 				} else if (!isBalanced(trimmed)) {
 					multiLineAccumulator = new StringBuilder(line.stripLeading());
+					entryStartLine = lineNumber;
 				} else {
 					Entry entry = new Entry(trimmed, new ArrayList<>(pendingComments));
 					currentEntries.add(entry);
@@ -163,7 +168,8 @@ public final class VersionCatalogStep {
 		}
 
 		if (multiLineAccumulator != null) {
-			throw new IllegalArgumentException("Unterminated version catalog entry in " + currentHeader);
+			// Report the incomplete entry instead of silently returning a partially parsed catalog.
+			throw Lint.atLine(entryStartLine, "unterminatedEntry", "Unterminated version catalog entry in " + currentHeader).shortcut();
 		}
 		return sections;
 	}
@@ -195,10 +201,13 @@ public final class VersionCatalogStep {
 	/** Returns the closing quote's index, or the text length if the string is unfinished. */
 	private static int skipQuotedString(String text, int start) {
 		char quote = text.charAt(start);
-		boolean multiline = start + 2 < text.length() && text.charAt(start + 1) == quote && text.charAt(start + 2) == quote;
+		boolean multiline = isMultilineString(text, start);
 		for (int i = start + (multiline ? 3 : 1); i < text.length(); i++) {
 			char c = text.charAt(i);
-			if (quote == '"' && c == '\\') {
+			if (!multiline && c == '\n') {
+				return text.length();
+			}
+			if (quote == '"' && c == '\\' && i + 1 < text.length() && text.charAt(i + 1) != '\n') {
 				i++;
 			} else if (c == quote) {
 				if (!multiline) {
@@ -215,6 +224,27 @@ public final class VersionCatalogStep {
 			}
 		}
 		return text.length();
+	}
+
+	/** Called only at an opening quote. */
+	private static boolean isMultilineString(String text, int start) {
+		char quote = text.charAt(start);
+		return start + 2 < text.length() && text.charAt(start + 1) == quote && text.charAt(start + 2) == quote;
+	}
+
+	private static boolean hasCommentsOrMultilineStrings(String text) {
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+			if (c == '"' || c == '\'') {
+				if (isMultilineString(text, i)) {
+					return true;
+				}
+				i = skipQuotedString(text, i);
+			} else if (c == '#') {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static String extractKey(String formattedEntry) {
@@ -234,7 +264,7 @@ public final class VersionCatalogStep {
 	static String formatEntry(String entry, boolean stripQuotedKeys) {
 		int lineEnd = entry.indexOf('\n');
 		// Preserve line boundaries that can be significant to comments or multiline strings.
-		boolean preserveLines = lineEnd != -1 && (entry.indexOf('#') != -1 || entry.contains("\"\"\"") || entry.contains("'''"));
+		boolean preserveLines = lineEnd != -1 && hasCommentsOrMultilineStrings(entry);
 		if (lineEnd != -1 && !preserveLines) {
 			entry = String.join(" ", entry.lines().map(String::trim).toList());
 		}
@@ -251,6 +281,7 @@ public final class VersionCatalogStep {
 			}
 		}
 		if (preserveLines) {
+			// The first line starts at offset zero, so the match's value offset also applies to the full entry.
 			return key + " = " + entry.substring(matcher.start(2)).stripLeading();
 		}
 		String valueAndComment = matcher.group(2).trim();
@@ -357,22 +388,19 @@ public final class VersionCatalogStep {
 	private static String[] splitTopLevel(String input, char delimiter) {
 		List<String> parts = new ArrayList<>();
 		int depth = 0;
-		boolean inQuote = false;
 		int start = 0;
 
 		for (int i = 0; i < input.length(); i++) {
 			char c = input.charAt(i);
-			if (c == '"' && (i == 0 || input.charAt(i - 1) != '\\')) {
-				inQuote = !inQuote;
-			} else if (!inQuote) {
-				if (c == '{' || c == '[') {
-					depth++;
-				} else if (c == '}' || c == ']') {
-					depth--;
-				} else if (c == delimiter && depth == 0) {
-					parts.add(input.substring(start, i));
-					start = i + 1;
-				}
+			if (c == '"' || c == '\'') {
+				i = skipQuotedString(input, i);
+			} else if (c == '{' || c == '[') {
+				depth++;
+			} else if (c == '}' || c == ']') {
+				depth--;
+			} else if (c == delimiter && depth == 0) {
+				parts.add(input.substring(start, i));
+				start = i + 1;
 			}
 		}
 		parts.add(input.substring(start));
@@ -386,7 +414,7 @@ public final class VersionCatalogStep {
 	}
 
 	private static final class State implements Serializable {
-		private static final long serialVersionUID = 4L;
+		private static final long serialVersionUID = 5L;
 
 		private final boolean stripQuotedKeys;
 

--- a/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
@@ -130,7 +130,7 @@ public final class VersionCatalogStep {
 			String trimmed = line.trim();
 
 			if (multiLineAccumulator != null) {
-				multiLineAccumulator.append(' ').append(trimmed);
+				multiLineAccumulator.append('\n').append(line);
 				if (isBalanced(multiLineAccumulator.toString())) {
 					Entry entry = new Entry(multiLineAccumulator.toString(), new ArrayList<>(pendingComments));
 					currentEntries.add(entry);
@@ -153,7 +153,7 @@ public final class VersionCatalogStep {
 				if (trimmed.isEmpty() || trimmed.startsWith("#")) {
 					pendingComments.add(trimmed);
 				} else if (!isBalanced(trimmed)) {
-					multiLineAccumulator = new StringBuilder(trimmed);
+					multiLineAccumulator = new StringBuilder(line.stripLeading());
 				} else {
 					Entry entry = new Entry(trimmed, new ArrayList<>(pendingComments));
 					currentEntries.add(entry);
@@ -162,30 +162,65 @@ public final class VersionCatalogStep {
 			}
 		}
 
+		if (multiLineAccumulator != null) {
+			throw new IllegalArgumentException("Unterminated version catalog entry in " + currentHeader);
+		}
 		return sections;
 	}
 
 	private static boolean isBalanced(String text) {
 		int depth = 0;
-		boolean inQuote = false;
 
 		for (int i = 0; i < text.length(); i++) {
 			char c = text.charAt(i);
-			if (c == '"' && (i == 0 || text.charAt(i - 1) != '\\')) {
-				inQuote = !inQuote;
-			} else if (!inQuote) {
-				if (c == '{' || c == '[') {
-					depth++;
-				} else if (c == '}' || c == ']') {
-					depth--;
+			if (c == '"' || c == '\'') {
+				i = skipQuotedString(text, i);
+				if (i == text.length()) {
+					return false;
 				}
+			} else if (c == '#') {
+				i = text.indexOf('\n', i);
+				if (i == -1) {
+					break;
+				}
+			} else if (c == '{' || c == '[') {
+				depth++;
+			} else if (c == '}' || c == ']') {
+				depth--;
 			}
 		}
 		return depth == 0;
 	}
 
+	/** Returns the closing quote's index, or the text length if the string is unfinished. */
+	private static int skipQuotedString(String text, int start) {
+		char quote = text.charAt(start);
+		boolean multiline = start + 2 < text.length() && text.charAt(start + 1) == quote && text.charAt(start + 2) == quote;
+		for (int i = start + (multiline ? 3 : 1); i < text.length(); i++) {
+			char c = text.charAt(i);
+			if (quote == '"' && c == '\\') {
+				i++;
+			} else if (c == quote) {
+				if (!multiline) {
+					return i;
+				}
+				if (i + 2 < text.length() && text.charAt(i + 1) == quote && text.charAt(i + 2) == quote) {
+					i += 2;
+					// A multiline string may end with one or two additional literal quotes.
+					while (i + 1 < text.length() && text.charAt(i + 1) == quote) {
+						i++;
+					}
+					return i;
+				}
+			}
+		}
+		return text.length();
+	}
+
 	private static String extractKey(String formattedEntry) {
-		Matcher matcher = ENTRY_LINE.matcher(formattedEntry);
+		int lineEnd = formattedEntry.indexOf('\n');
+		String firstLine = lineEnd == -1 ? formattedEntry : formattedEntry.substring(0, lineEnd);
+		Matcher matcher = ENTRY_LINE.matcher(firstLine);
 		if (!matcher.matches()) {
 			return formattedEntry;
 		}
@@ -197,7 +232,13 @@ public final class VersionCatalogStep {
 	}
 
 	static String formatEntry(String entry, boolean stripQuotedKeys) {
-		Matcher matcher = ENTRY_LINE.matcher(entry);
+		int lineEnd = entry.indexOf('\n');
+		// Preserve line boundaries that can be significant to comments or multiline strings.
+		boolean preserveLines = lineEnd != -1 && (entry.indexOf('#') != -1 || entry.contains("\"\"\"") || entry.contains("'''"));
+		if (lineEnd != -1 && !preserveLines) {
+			entry = String.join(" ", entry.lines().map(String::trim).toList());
+		}
+		Matcher matcher = ENTRY_LINE.matcher(preserveLines ? entry.substring(0, lineEnd) : entry);
 		if (!matcher.matches()) {
 			return entry;
 		}
@@ -208,6 +249,9 @@ public final class VersionCatalogStep {
 			if (isBareKey(bare)) {
 				key = bare;
 			}
+		}
+		if (preserveLines) {
+			return key + " = " + entry.substring(matcher.start(2)).stripLeading();
 		}
 		String valueAndComment = matcher.group(2).trim();
 
@@ -225,21 +269,18 @@ public final class VersionCatalogStep {
 	}
 
 	private static String extractInlineComment(String valueAndComment) {
-		boolean inQuote = false;
 		int depth = 0;
 
 		for (int i = 0; i < valueAndComment.length(); i++) {
 			char c = valueAndComment.charAt(i);
-			if (c == '"' && (i == 0 || valueAndComment.charAt(i - 1) != '\\')) {
-				inQuote = !inQuote;
-			} else if (!inQuote) {
-				if (c == '{' || c == '[') {
-					depth++;
-				} else if (c == '}' || c == ']') {
-					depth--;
-				} else if (c == '#' && depth == 0) {
-					return valueAndComment.substring(i);
-				}
+			if (c == '"' || c == '\'') {
+				i = skipQuotedString(valueAndComment, i);
+			} else if (c == '{' || c == '[') {
+				depth++;
+			} else if (c == '}' || c == ']') {
+				depth--;
+			} else if (c == '#' && depth == 0) {
+				return valueAndComment.substring(i);
 			}
 		}
 		return null;
@@ -345,7 +386,7 @@ public final class VersionCatalogStep {
 	}
 
 	private static final class State implements Serializable {
-		private static final long serialVersionUID = 3L;
+		private static final long serialVersionUID = 4L;
 
 		private final boolean stripQuotedKeys;
 

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,7 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `versionCatalog()` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, keeps significant line boundaries in multiline entries, and reports unfinished entries at their starting line instead of returning a partial catalog.
+- `versionCatalog()` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries.
+- `versionCatalog()` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss.
 
 ## [8.10.2] - 2026-09-04
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,8 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `versionCatalog()` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries.
-- `versionCatalog()` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss.
+- `versionCatalog()` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries. ([#3042](https://github.com/diffplug/spotless/pull/3042))
+- `versionCatalog()` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 
 ## [8.10.2] - 2026-09-04
 ### Fixed

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Fixed
+- `versionCatalog()` preserves entries when comments contain unmatched brackets, keeps line boundaries in multiline entries containing comments, and reports unfinished entries instead of returning a partial catalog.
+
 ## [8.10.2] - 2026-09-04
 ### Fixed
 - `shortenFullyQualifiedTypes()` now shortens fully-qualified types used in expression contexts (such as static method calls, static fields, and enum constants) while avoiding imports that would change how existing unqualified type references resolve. ([#3039](https://github.com/diffplug/spotless/pull/3039))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `versionCatalog()` preserves entries when comments contain unmatched brackets, keeps line boundaries in multiline entries containing comments, and reports unfinished entries instead of returning a partial catalog.
+- `versionCatalog()` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, keeps significant line boundaries in multiline entries, and reports unfinished entries at their starting line instead of returning a partial catalog.
 
 ## [8.10.2] - 2026-09-04
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,8 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `<versionCatalog>` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries.
-- `<versionCatalog>` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss.
+- `<versionCatalog>` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries. ([#3042](https://github.com/diffplug/spotless/pull/3042))
+- `<versionCatalog>` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 
 ## [3.10.2] - 2026-09-04
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,7 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `<versionCatalog>` preserves entries when comments contain unmatched brackets, keeps line boundaries in multiline entries containing comments, and reports unfinished entries instead of returning a partial catalog.
+- `<versionCatalog>` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, keeps significant line boundaries in multiline entries, and reports unfinished entries at their starting line instead of returning a partial catalog.
 
 ## [3.10.2] - 2026-09-04
 ### Fixed

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -4,6 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 
 ## [Unreleased]
 
+### Fixed
+- `<versionCatalog>` preserves entries when comments contain unmatched brackets, keeps line boundaries in multiline entries containing comments, and reports unfinished entries instead of returning a partial catalog.
+
 ## [3.10.2] - 2026-09-04
 ### Fixed
 - `<shortenFullyQualifiedTypes>` now shortens fully-qualified types used in expression contexts (such as static method calls, static fields, and enum constants) while avoiding imports that would change how existing unqualified type references resolve. ([#3039](https://github.com/diffplug/spotless/pull/3039))

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,7 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
-- `<versionCatalog>` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, keeps significant line boundaries in multiline entries, and reports unfinished entries at their starting line instead of returning a partial catalog.
+- `<versionCatalog>` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries.
+- `<versionCatalog>` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss.
 
 ## [3.10.2] - 2026-09-04
 ### Fixed

--- a/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
@@ -15,6 +15,8 @@
  */
 package com.diffplug.spotless.toml;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.jupiter.api.Test;
 
 import com.diffplug.spotless.FormatterStep;
@@ -88,6 +90,67 @@ class VersionCatalogStepTest {
 		harness.test(
 				"[versions]\nfoo =\"1.0\" # latest stable\n",
 				"[versions]\nfoo = \"1.0\" # latest stable\n");
+	}
+
+	@Test
+	void bracketsInInlineCommentsDoNotConsumeFollowingEntries() throws Exception {
+		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create());
+		for (String comment : new String[]{"[planned update", "]", "{", "}", "[\"unfinished quote"}) {
+			harness.test(
+					"[versions]\nzoo = \"1.0\" # " + comment + "\nalpha = \"2.0\"\n",
+					"[versions]\nalpha = \"2.0\"\nzoo = \"1.0\" # " + comment + "\n");
+		}
+	}
+
+	@Test
+	void hashesAndBracketsInsideStringsAreNotComments() throws Exception {
+		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create());
+		for (String value : new String[]{"\"1.0#[\"", "'1.0#['", "\"1.0\\\"#[\""}) {
+			harness.testUnaffected("[versions]\nfoo = " + value + "\n");
+		}
+	}
+
+	@Test
+	void escapedBackslashBeforeClosingQuoteDoesNotHideComment() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[versions]\nzoo = \"1.0\\\\\" # [planned update\nalpha = \"2.0\"\n",
+				"[versions]\nalpha = \"2.0\"\nzoo = \"1.0\\\\\" # [planned update\n");
+	}
+
+	@Test
+	void multilineArrayCommentsKeepTheirLineBoundaries() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[bundles]\nzoo = [\"c\"]\n\"alpha\" = [\n  \"a\", # [keep this note\n  # } another note\n  \"b\"\n]\n",
+				"[bundles]\n\"alpha\" = [\n  \"a\", # [keep this note\n  # } another note\n  \"b\"\n]\nzoo = [ \"c\" ]\n");
+	}
+
+	@Test
+	void multilineArrayWithoutCommentsStillJoins() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[bundles]\nfoo = [\n  \"a\",\n  \"b\"\n]\n",
+				"[bundles]\nfoo = [ \"a\", \"b\" ]\n");
+	}
+
+	@Test
+	void preservedMultilineEntriesStillStripQuotedKeys() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create(true)).test(
+				"[bundles]\n\"foo\" = [\n  \"a#b\"\n]\n",
+				"[bundles]\nfoo = [\n  \"a#b\"\n]\n");
+	}
+
+	@Test
+	void multilineStringsKeepHashesBracketsAndWhitespace() throws Exception {
+		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create());
+		for (String delimiter : new String[]{"\"\"\"", "'''"}) {
+			harness.testUnaffected("[versions]\nfoo = " + delimiter + "1.0  \n# [literal text\n" + delimiter + "\n");
+		}
+	}
+
+	@Test
+	void unfinishedEntryDoesNotReturnPartialCatalog() {
+		assertThatThrownBy(() -> VersionCatalogStep.format("[bundles]\nalpha = [\"a\"]\nzoo = [\n  \"b\"\n", false))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Unterminated version catalog entry");
 	}
 
 	@Test

--- a/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
@@ -15,11 +15,18 @@
  */
 package com.diffplug.spotless.toml;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.diffplug.spotless.Formatter;
 import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.LineEnding;
+import com.diffplug.spotless.LintState;
 import com.diffplug.spotless.SerializableEqualityTester;
 import com.diffplug.spotless.StepHarness;
 
@@ -118,6 +125,60 @@ class VersionCatalogStepTest {
 	}
 
 	@Test
+	void literalStringCommasInArraysArePreserved() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[bundles]\nfoo=['a,b','c']\n",
+				"[bundles]\nfoo = [ 'a,b', 'c' ]\n");
+	}
+
+	@Test
+	void literalStringCommasInInlineTablesArePreserved() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[libraries]\nfoo={module='a,b',version=\"1.0\"}\n",
+				"[libraries]\nfoo = { module = 'a,b', version = \"1.0\" }\n");
+	}
+
+	@Test
+	void escapedBackslashBeforeArrayDelimiterDoesNotChangeStrings() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[bundles]\nfoo=[\"a\\\\\",\"b,c\"]\n",
+				"[bundles]\nfoo = [ \"a\\\\\", \"b,c\" ]\n");
+	}
+
+	@Test
+	void escapedBackslashBeforeTableDelimiterDoesNotChangeStrings() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[libraries]\nfoo={module=\"a\\\\\",version=\"b,c\"}\n",
+				"[libraries]\nfoo = { module = \"a\\\\\", version = \"b,c\" }\n");
+	}
+
+	@Test
+	void singleLineStringsCannotConsumeFollowingEntries() {
+		for (String quote : new String[]{"\"", "'"}) {
+			StepHarness.forStep(VersionCatalogStep.create())
+					.expectLintsOf("[versions]\nfoo = " + quote + "1.0\nbar = " + quote + "2.0\n")
+					.toBe("L2 versionCatalog(unterminatedEntry) Unterminated version catalog entry in [versions]");
+		}
+	}
+
+	@Test
+	void escapedNewlineCannotContinueSingleLineString() {
+		StepHarness.forStep(VersionCatalogStep.create())
+				.expectLintsOf("[versions]\nfoo = \"1.0\\\nbar = \"2.0\n")
+				.toBe("L2 versionCatalog(unterminatedEntry) Unterminated version catalog entry in [versions]");
+	}
+
+	@Test
+	void tripleQuotedStringCommasInArraysArePreserved() throws Exception {
+		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create());
+		for (String delimiter : new String[]{"\"\"\"", "'''"}) {
+			harness.test(
+					"[bundles]\nfoo=[" + delimiter + "a,b" + delimiter + ",'c']\n",
+					"[bundles]\nfoo = [ " + delimiter + "a,b" + delimiter + ", 'c' ]\n");
+		}
+	}
+
+	@Test
 	void multilineArrayCommentsKeepTheirLineBoundaries() throws Exception {
 		StepHarness.forStep(VersionCatalogStep.create()).test(
 				"[bundles]\nzoo = [\"c\"]\n\"alpha\" = [\n  \"a\", # [keep this note\n  # } another note\n  \"b\"\n]\n",
@@ -134,8 +195,24 @@ class VersionCatalogStepTest {
 	@Test
 	void preservedMultilineEntriesStillStripQuotedKeys() throws Exception {
 		StepHarness.forStep(VersionCatalogStep.create(true)).test(
-				"[bundles]\n\"foo\" = [\n  \"a#b\"\n]\n",
-				"[bundles]\nfoo = [\n  \"a#b\"\n]\n");
+				"[bundles]\n\"foo\" = [\n  \"a#b\" # keep this note\n]\n",
+				"[bundles]\nfoo = [\n  \"a#b\" # keep this note\n]\n");
+	}
+
+	@Test
+	void quotedCommentAndMultilineMarkersDoNotPreventJoiningArrays() throws Exception {
+		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create());
+		for (String value : new String[]{"\"a#b\"", "'a#b'", "\"'''\"", "'\"\"\"'"}) {
+			harness.test(
+					"[bundles]\nfoo = [\n  " + value + "\n]\n",
+					"[bundles]\nfoo = [ " + value + " ]\n");
+		}
+	}
+
+	@Test
+	void multilineBasicStringCanContinueAfterEscapedNewline() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).testUnaffected(
+				"[versions]\nfoo = \"\"\"1.0\\\n  continued\"\"\"\n");
 	}
 
 	@Test
@@ -147,10 +224,19 @@ class VersionCatalogStepTest {
 	}
 
 	@Test
-	void unfinishedEntryDoesNotReturnPartialCatalog() {
-		assertThatThrownBy(() -> VersionCatalogStep.format("[bundles]\nalpha = [\"a\"]\nzoo = [\n  \"b\"\n", false))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("Unterminated version catalog entry");
+	void unfinishedEntryDoesNotReturnPartialCatalog() throws Exception {
+		String input = "# Catalog\n\n[bundles]\nalpha=[\"a\"]\nzoo = [\n  \"b\"\n";
+		try (Formatter formatter = Formatter.builder()
+				.steps(List.of(VersionCatalogStep.create()))
+				.lineEndingsPolicy(LineEnding.UNIX.createPolicy())
+				.encoding(StandardCharsets.UTF_8)
+				.build()) {
+			StepHarness.forFormatter(formatter).expectLintsOf(input)
+					.toBe("L5 versionCatalog(unterminatedEntry) Unterminated version catalog entry in [bundles]");
+			LintState state = LintState.of(formatter, new File("libs.versions.toml"), input.getBytes(StandardCharsets.UTF_8));
+			assertThat(state.isHasLints()).isTrue();
+			assertThat(state.getDirtyState().isClean()).isTrue();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
These cases were found during a local review of `VersionCatalogStep` and reproduced against `dc2a4cb`. I could not find an existing issue covering them.

An unmatched bracket in a trailing comment can cause entries to disappear. For example:

```toml
[versions]
zoo = "1.0" # [planned update
alpha = "2.0"
```

Previously, formatting this input produced only `[versions]`, removing both entries. This change preserves both entries and the comment, with `alpha` sorted before `zoo`.

Closing quotes preceded by escaped backslashes can cause the same entry loss inside arrays and inline tables. For example, `foo = [ "a\\", "b" ]` also produces an empty `[bundles]` section.

Separately, array splitting changes `[ 'a,b', 'c' ]` into `[ 'a, b', 'c' ]`, modifying a string value.

### Changes

- Share quoted-string handling across entry balancing, comment detection, and array/inline-table splitting, preserving string contents and significant multiline boundaries.
- Prevent single-line strings from crossing raw newlines, including after a backslash.
- Report unfinished entries with an `unterminatedEntry` lint at their starting line.
- Increment the serialized state version to invalidate cached results.

Through `LintState.of`, unfinished entries produce a line-numbered lint while leaving this step's input unchanged, making incomplete formatting visible without returning a partial catalog. Direct calls to `Formatter.compute` rethrow the exception. These errors fail formatting by default, so affected catalogs may start failing after an upgrade.

Updated `CHANGES.md`, `plugin-gradle/CHANGES.md`, and `plugin-maven/CHANGES.md` to document the fixes and error-reporting behavior, including the PR link.

Quoted keys containing `=`, such as `"a=b"`, remain an existing parsing limitation outside this change and are tracked in `lib/src/main/java/com/diffplug/spotless/toml/TODO.md`.

### Validation

All 36 `VersionCatalogStepTest` tests pass, including existing resource fixtures, idempotence checks, string/comment regressions, line-numbered lint expectations, and unchanged-input checks through `LintState.of`.

Also passed:
- `:lib:spotlessJavaCheck`
- `:testlib:spotlessJavaCheck`
- `:lib:spotbugsMain`

English is not my first language, so I used AI to help polish the wording of this PR description.