### PR TITLE
Preserve standalone version catalog comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
+- `VersionCatalogStep` preserves standalone comments at section boundaries and the end of the file. ([#3048](https://github.com/diffplug/spotless/issues/3048))
 - `VersionCatalogStep` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 - `VersionCatalogStep` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 

--- a/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
+++ b/lib/src/main/java/com/diffplug/spotless/toml/VersionCatalogStep.java
@@ -59,7 +59,7 @@ public final class VersionCatalogStep {
 			return raw;
 		}
 
-		Map<String, List<Entry>> sections = parseSections(raw);
+		Map<String, Section> sections = parseSections(raw);
 		List<String> preambleLines = extractPreamble(raw);
 
 		StringBuilder result = new StringBuilder();
@@ -83,7 +83,8 @@ public final class VersionCatalogStep {
 		}
 
 		for (String header : orderedKeys) {
-			List<Entry> entries = sections.get(header);
+			Section section = sections.get(header);
+			List<Entry> entries = section.entries;
 			if (!first) {
 				result.append('\n');
 			}
@@ -100,6 +101,9 @@ public final class VersionCatalogStep {
 					result.append(commentLine).append('\n');
 				}
 				result.append(entry.formatted).append('\n');
+			}
+			for (String commentLine : section.trailingComments) {
+				result.append(commentLine).append('\n');
 			}
 		}
 
@@ -120,10 +124,10 @@ public final class VersionCatalogStep {
 		return preamble;
 	}
 
-	private static Map<String, List<Entry>> parseSections(String raw) {
-		Map<String, List<Entry>> sections = new LinkedHashMap<>();
+	private static Map<String, Section> parseSections(String raw) {
+		Map<String, Section> sections = new LinkedHashMap<>();
 		String currentHeader = null;
-		List<Entry> currentEntries = null;
+		Section currentSection = null;
 		List<String> pendingComments = new ArrayList<>();
 		StringBuilder multiLineAccumulator = null;
 		int lineNumber = 0;
@@ -137,7 +141,7 @@ public final class VersionCatalogStep {
 				multiLineAccumulator.append('\n').append(line);
 				if (isBalanced(multiLineAccumulator.toString())) {
 					Entry entry = new Entry(multiLineAccumulator.toString(), new ArrayList<>(pendingComments));
-					currentEntries.add(entry);
+					currentSection.entries.add(entry);
 					pendingComments.clear();
 					multiLineAccumulator = null;
 				}
@@ -149,11 +153,11 @@ public final class VersionCatalogStep {
 			}
 			Matcher headerMatcher = TABLE_HEADER.matcher(trimmed);
 			if (headerMatcher.matches()) {
+				moveTrailingComments(currentSection, pendingComments);
 				currentHeader = "[" + headerMatcher.group(1) + "]";
-				currentEntries = new ArrayList<>();
-				sections.put(currentHeader, currentEntries);
-				pendingComments.clear();
-			} else if (currentEntries != null) {
+				currentSection = new Section();
+				sections.put(currentHeader, currentSection);
+			} else if (currentSection != null) {
 				if (trimmed.isEmpty() || trimmed.startsWith("#")) {
 					pendingComments.add(trimmed);
 				} else if (!isBalanced(trimmed)) {
@@ -161,7 +165,7 @@ public final class VersionCatalogStep {
 					entryStartLine = lineNumber;
 				} else {
 					Entry entry = new Entry(trimmed, new ArrayList<>(pendingComments));
-					currentEntries.add(entry);
+					currentSection.entries.add(entry);
 					pendingComments.clear();
 				}
 			}
@@ -171,7 +175,20 @@ public final class VersionCatalogStep {
 			// Report the incomplete entry instead of silently returning a partially parsed catalog.
 			throw Lint.atLine(entryStartLine, "unterminatedEntry", "Unterminated version catalog entry in " + currentHeader).shortcut();
 		}
+		moveTrailingComments(currentSection, pendingComments);
 		return sections;
+	}
+
+	private static void moveTrailingComments(Section section, List<String> pendingComments) {
+		if (section == null) {
+			return;
+		}
+		int lastNonBlank = pendingComments.size();
+		while (lastNonBlank > 0 && pendingComments.get(lastNonBlank - 1).isEmpty()) {
+			lastNonBlank--;
+		}
+		section.trailingComments.addAll(pendingComments.subList(0, lastNonBlank));
+		pendingComments.clear();
 	}
 
 	private static boolean isBalanced(String text) {
@@ -440,5 +457,10 @@ public final class VersionCatalogStep {
 		String sortKey() {
 			return extractKey(formatted != null ? formatted : content);
 		}
+	}
+
+	private static final class Section {
+		final List<Entry> entries = new ArrayList<>();
+		final List<String> trailingComments = new ArrayList<>();
 	}
 }

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
+- `versionCatalog()` preserves standalone comments at section boundaries and the end of the file. ([#3048](https://github.com/diffplug/spotless/issues/3048))
 - `versionCatalog()` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 - `versionCatalog()` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -5,6 +5,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 ## [Unreleased]
 
 ### Fixed
+- `<versionCatalog>` preserves standalone comments at section boundaries and the end of the file. ([#3048](https://github.com/diffplug/spotless/issues/3048))
 - `<versionCatalog>` preserves entries when comments contain unmatched brackets, preserves commas inside quoted strings, and keeps significant line boundaries in multiline entries. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 - `<versionCatalog>` now reports unfinished entries as lints at their starting line. These fail formatting by default, so upgrading may expose catalog errors that previously caused silent data loss. ([#3042](https://github.com/diffplug/spotless/pull/3042))
 

--- a/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
+++ b/testlib/src/test/java/com/diffplug/spotless/toml/VersionCatalogStepTest.java
@@ -92,6 +92,19 @@ class VersionCatalogStepTest {
 	}
 
 	@Test
+	void standaloneCommentsAtSectionBoundariesAndEofArePreserved() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).testUnaffected(
+				"[versions]\nzoo = \"1.0\"\n# keep this trailing comment\n\n[libraries]\nfoo = { module = \"g:a\", version.ref = \"zoo\" }\n# keep this final comment\n");
+	}
+
+	@Test
+	void trailingCommentsFollowTheirSectionWhenTablesAreSorted() throws Exception {
+		StepHarness.forStep(VersionCatalogStep.create()).test(
+				"[plugins]\nzoo = \"g:z:1\"\n# plugin note\n[versions]\nalpha = \"1.0\"\n# version note\n",
+				"[versions]\nalpha = \"1.0\"\n# version note\n\n[plugins]\nzoo = \"g:z:1\"\n# plugin note\n");
+	}
+
+	@Test
 	void inlineCommentsPreserved() throws Exception {
 		StepHarness harness = StepHarness.forStep(VersionCatalogStep.create());
 		harness.test(


### PR DESCRIPTION
Fixes #3048.

## Summary

- preserve standalone comments at section boundaries and EOF
- keep trailing comments attached to their originating section when tables are sorted
- ignore terminal blank lines so the formatter does not add extra newlines

## Testing

- `./gradlew.bat :testlib:test --tests com.diffplug.spotless.toml.VersionCatalogStepTest --no-daemon --no-configuration-cache --no-build-cache --max-workers=1` (38 tests passed)
- `./gradlew.bat :lib:spotlessJavaCheck :testlib:spotlessJavaCheck --no-daemon --no-configuration-cache --no-build-cache --max-workers=1`
- `git diff --check`